### PR TITLE
FIXED: no content found

### DIFF
--- a/Sources/TMDb/Extensions/URL+QueryItem.swift
+++ b/Sources/TMDb/Extensions/URL+QueryItem.swift
@@ -23,20 +23,11 @@ extension URL {
     }
 
     func appendingLanguage(locale: Locale = .current) -> Self {
-        var parts = [String]()
         if let languageCode = locale.languageCode {
-            parts.append(languageCode)
-
-            if let regionCode = locale.regionCode {
-                parts.append(regionCode)
-            }
-        }
-
-        guard !parts.isEmpty else {
+            return languageCode
+        } else {
             return self
         }
-
-        return appendingLanguage(parts.joined(separator: "-"))
     }
 
     func appendingLanguage(_ language: String) -> Self {

--- a/Sources/TMDb/Extensions/URL+QueryItem.swift
+++ b/Sources/TMDb/Extensions/URL+QueryItem.swift
@@ -26,7 +26,7 @@ extension URL {
         guard let languageCode = locale.languageCode else {
             return self
         }
-        
+
         return appendingQueryItem(name: "language", value: languageCode)
     }
 

--- a/Sources/TMDb/Extensions/URL+QueryItem.swift
+++ b/Sources/TMDb/Extensions/URL+QueryItem.swift
@@ -23,14 +23,6 @@ extension URL {
     }
 
     func appendingLanguage(locale: Locale = .current) -> Self {
-        if let languageCode = locale.languageCode {
-            return appendingLanguage(languageCode)
-        } else {
-            return self
-        }
-    }
-
-    func appendingLanguage(_ language: String) -> Self {
         guard let languageCode = locale.languageCode else {
             return self
         }

--- a/Sources/TMDb/Extensions/URL+QueryItem.swift
+++ b/Sources/TMDb/Extensions/URL+QueryItem.swift
@@ -24,7 +24,7 @@ extension URL {
 
     func appendingLanguage(locale: Locale = .current) -> Self {
         if let languageCode = locale.languageCode {
-            return languageCode
+            return appendingLanguage(languageCode)
         } else {
             return self
         }

--- a/Sources/TMDb/Extensions/URL+QueryItem.swift
+++ b/Sources/TMDb/Extensions/URL+QueryItem.swift
@@ -31,7 +31,11 @@ extension URL {
     }
 
     func appendingLanguage(_ language: String) -> Self {
-        return appendingQueryItem(name: "language", value: language)
+        guard let languageCode = locale.languageCode else {
+            return self
+        }
+        
+        return appendingQueryItem(name: "language", value: languageCode)
     }
 
     func appendingPage(_ page: Int?) -> Self {

--- a/Tests/TMDbTests/Extensions/URL+QueryItemTests.swift
+++ b/Tests/TMDbTests/Extensions/URL+QueryItemTests.swift
@@ -79,15 +79,6 @@ final class URLQueryItemTests: XCTestCase {
         XCTAssertEqual(result, expectedResult)
     }
 
-    func testAppendingLanguageReturnsURL() {
-        let language = "en"
-        let expectedResult = URL(string: "/some/path?language=en")!
-
-        let result = URL(string: "/some/path")!.appendingLanguage(language)
-
-        XCTAssertEqual(result, expectedResult)
-    }
-
     func testAppendingPageWhenNoQueryItemsAndPageIsNilReturnsURL() {
         let expectedResult = URL(string: "/some/path")!
 

--- a/Tests/TMDbTests/Extensions/URL+QueryItemTests.swift
+++ b/Tests/TMDbTests/Extensions/URL+QueryItemTests.swift
@@ -45,7 +45,7 @@ final class URLQueryItemTests: XCTestCase {
 
     func testAppendingLanguageWithLocaleReturnsURL() {
         let locale = Locale(identifier: "en_GB")
-        let expectedResult = URL(string: "/some/path?language=en-GB")!
+        let expectedResult = URL(string: "/some/path?language=en")!
 
         let result = URL(string: "/some/path")!.appendingLanguage(locale: locale)
 
@@ -72,7 +72,7 @@ final class URLQueryItemTests: XCTestCase {
 
     func testAppendingLanguageWithLocaleWhenContainsQueryItemsReturnsURL() {
         let locale = Locale(identifier: "en_GB")
-        let expectedResult = URL(string: "/some/path?a=b&language=en-GB")!
+        let expectedResult = URL(string: "/some/path?a=b&language=en")!
 
         let result = URL(string: "/some/path?a=b")!.appendingLanguage(locale: locale)
 
@@ -80,8 +80,8 @@ final class URLQueryItemTests: XCTestCase {
     }
 
     func testAppendingLanguageReturnsURL() {
-        let language = "en-GB"
-        let expectedResult = URL(string: "/some/path?language=en-GB")!
+        let language = "en"
+        let expectedResult = URL(string: "/some/path?language=en")!
 
         let result = URL(string: "/some/path")!.appendingLanguage(language)
 


### PR DESCRIPTION
Most content (e.g. images) on TMDb only have a language code specified. Currently the API request also include the region code. Therefore most requests for such content returns empty. I changed it so the API request only includes the language code as this should suffice for most applications.