### PR TITLE
image and video language

### DIFF
--- a/Sources/TMDb/Extensions/URL+QueryItem.swift
+++ b/Sources/TMDb/Extensions/URL+QueryItem.swift
@@ -41,22 +41,22 @@ extension URL {
         return appendingQueryItem(name: QueryItemName.language, value: languageCode)
     }
 
-	func appendingImageLanguage(local: Locale = .current) -> Self {
+	func appendingImageLanguage(locale: Locale = .current) -> Self {
 		guard let languageCode = locale.languageCode else {
 			return self
 		}
 
-		return appendingQueryItem(name: QueryItemName.imageLanguage, value: languageCode.append(",null"))
+		return appendingQueryItem(name: QueryItemName.imageLanguage, value: languageCode + ",null")
 	}
-	
-	func appendingVideoLanguage(local: Locale = .current) -> Self {
+
+	func appendingVideoLanguage(locale: Locale = .current) -> Self {
 		guard let languageCode = locale.languageCode else {
 			return self
 		}
 
-		return appendingQueryItem(name: QueryItemName.videoLanguage, value: languageCode.append(",null"))
+		return appendingQueryItem(name: QueryItemName.videoLanguage, value: languageCode + ",null")
 	}
-	
+
     func appendingPage(_ page: Int?) -> Self {
         guard var page = page else {
             return self

--- a/Sources/TMDb/Extensions/URL+QueryItem.swift
+++ b/Sources/TMDb/Extensions/URL+QueryItem.swift
@@ -21,6 +21,8 @@ extension URL {
     private enum QueryItemName {
         static let apiKey = "api_key"
         static let language = "language"
+		static let imageLanguage = "include_image_language"
+		static let videoLanguage = "include_video_language"
         static let page = "page"
         static let year = "year"
         static let firstAirDateYear = "first_air_date_year"
@@ -39,6 +41,22 @@ extension URL {
         return appendingQueryItem(name: QueryItemName.language, value: languageCode)
     }
 
+	func appendingImageLanguage(local: Locale = .current) -> Self {
+		guard let languageCode = locale.languageCode else {
+			return self
+		}
+
+		return appendingQueryItem(name: QueryItemName.imageLanguage, value: languageCode.append(",null"))
+	}
+	
+	func appendingVideoLanguage(local: Locale = .current) -> Self {
+		guard let languageCode = locale.languageCode else {
+			return self
+		}
+
+		return appendingQueryItem(name: QueryItemName.videoLanguage, value: languageCode.append(",null"))
+	}
+	
     func appendingPage(_ page: Int?) -> Self {
         guard var page = page else {
             return self

--- a/Sources/TMDb/Services/Movies/MoviesEndpoint.swift
+++ b/Sources/TMDb/Services/Movies/MoviesEndpoint.swift
@@ -41,11 +41,13 @@ extension MoviesEndpoint: Endpoint {
             return Self.basePath
                 .appendingPathComponent(movieID)
                 .appendingPathComponent("images")
+				.appendingImageLanguage()
 
         case .videos(let movieID):
             return Self.basePath
                 .appendingPathComponent(movieID)
                 .appendingPathComponent("videos")
+				.appendingVideoLanguage()
 
         case .recommendations(let movieID, let page):
             return Self.basePath

--- a/Sources/TMDb/Services/TVShowSeasons/TVShowSeasonsEndpoint.swift
+++ b/Sources/TMDb/Services/TVShowSeasons/TVShowSeasonsEndpoint.swift
@@ -25,11 +25,13 @@ extension TVShowSeasonsEndpoint: Endpoint {
             return Self.basePath(for: tvShowID)
                 .appendingPathComponent(seasonNumber)
                 .appendingPathComponent("images")
+				.appendingImageLanguage()
 
         case .videos(let tvShowID, let seasonNumber):
             return Self.basePath(for: tvShowID)
                 .appendingPathComponent(seasonNumber)
                 .appendingPathComponent("videos")
+				.appendingVideoLanguage()
         }
     }
 

--- a/Sources/TMDb/Services/TVShows/TVShowsEndpoint.swift
+++ b/Sources/TMDb/Services/TVShows/TVShowsEndpoint.swift
@@ -38,11 +38,13 @@ extension TVShowsEndpoint: Endpoint {
             return Self.basePath
                 .appendingPathComponent(tvShowID)
                 .appendingPathComponent("images")
+				.appendingImageLanguage()
 
         case .videos(let tvShowID):
             return Self.basePath
                 .appendingPathComponent(tvShowID)
                 .appendingPathComponent("videos")
+				.appendingVideoLanguage()
 
         case .recommendations(let tvShowID, let page):
             return Self.basePath

--- a/Tests/TMDbTests/Extensions/URL+QueryItemTests.swift
+++ b/Tests/TMDbTests/Extensions/URL+QueryItemTests.swift
@@ -79,6 +79,78 @@ final class URLQueryItemTests: XCTestCase {
         XCTAssertEqual(result, expectedResult)
     }
 
+	func testAppendingImageLanguageWithLocaleReturnsURL() {
+		let locale = Locale(identifier: "en_GB")
+		let expectedResult = URL(string: "/some/path?include_image_language=en,null")
+
+		let result = URL(string: "/some/path")!.appendingImageLanguage(locale: locale)
+
+		XCTAssertEqual(result, expectedResult)
+	}
+
+	func testAppendingImageLanguageWithLocaleWithoutLanguageCodeReturnsURL() {
+		let locale = Locale(identifier: "")
+		let expectedResult = URL(string: "/some/path")!
+
+		let result = URL(string: "/some/path")!.appendingImageLanguage(locale: locale)
+
+		XCTAssertEqual(result, expectedResult)
+	}
+
+	func testAppendingImageLanguageWithLocaleWithoutRegionCodeReturnsURL() {
+		let locale = Locale(identifier: "en")
+		let expectedResult = URL(string: "/some/path?include_image_language=en,null")!
+
+		let result = URL(string: "/some/path")!.appendingImageLanguage(locale: locale)
+
+		XCTAssertEqual(result, expectedResult)
+	}
+
+	func testAppendingImageLanguageWithLocaleWhenContainsQueryItemsReturnsURL() {
+		let locale = Locale(identifier: "en_GB")
+		let expectedResult = URL(string: "/some/path?a=b&include_image_language=en,null")!
+
+		let result = URL(string: "/some/path?a=b")!.appendingImageLanguage(locale: locale)
+
+		XCTAssertEqual(result, expectedResult)
+	}
+
+	func testAppendingVideoLanguageWithLocaleReturnsURL() {
+		let locale = Locale(identifier: "en_GB")
+		let expectedResult = URL(string: "/some/path?include_video_language=en,null")
+
+		let result = URL(string: "/some/path")!.appendingVideoLanguage(locale: locale)
+
+		XCTAssertEqual(result, expectedResult)
+	}
+
+	func testAppendingVideoLanguageWithLocaleWithoutLanguageCodeReturnsURL() {
+		let locale = Locale(identifier: "")
+		let expectedResult = URL(string: "/some/path")!
+
+		let result = URL(string: "/some/path")!.appendingVideoLanguage(locale: locale)
+
+		XCTAssertEqual(result, expectedResult)
+	}
+
+	func testAppendingVideoLanguageWithLocaleWithoutRegionCodeReturnsURL() {
+		let locale = Locale(identifier: "en")
+		let expectedResult = URL(string: "/some/path?include_video_language=en,null")!
+
+		let result = URL(string: "/some/path")!.appendingVideoLanguage(locale: locale)
+
+		XCTAssertEqual(result, expectedResult)
+	}
+
+	func testAppendingVideoLanguageWithLocaleWhenContainsQueryItemsReturnsURL() {
+		let locale = Locale(identifier: "en_GB")
+		let expectedResult = URL(string: "/some/path?a=b&include_video_language=en,null")!
+
+		let result = URL(string: "/some/path?a=b")!.appendingVideoLanguage(locale: locale)
+
+		XCTAssertEqual(result, expectedResult)
+	}
+
     func testAppendingPageWhenNoQueryItemsAndPageIsNilReturnsURL() {
         let expectedResult = URL(string: "/some/path")!
 

--- a/Tests/TMDbTests/Services/Movies/MoviesEndpointTests.swift
+++ b/Tests/TMDbTests/Services/Movies/MoviesEndpointTests.swift
@@ -36,7 +36,7 @@ final class MoviesEndpointTests: XCTestCase {
     }
 
     func testMovieImagesEndpointReturnsURL() {
-        let expectedURL = URL(string: "/movie/1/images")!
+        let expectedURL = URL(string: "/movie/1/images?include_image_language=en,null")!
 
         let url = MoviesEndpoint.images(movieID: 1).path
 
@@ -44,7 +44,7 @@ final class MoviesEndpointTests: XCTestCase {
     }
 
     func testMovieVideosEndpointReturnsURL() {
-        let expectedURL = URL(string: "/movie/1/videos")!
+        let expectedURL = URL(string: "/movie/1/videos?include_video_language=en,null")!
 
         let url = MoviesEndpoint.videos(movieID: 1).path
 

--- a/Tests/TMDbTests/Services/TVShowSeasons/TVShowSeasonsEndpointTests.swift
+++ b/Tests/TMDbTests/Services/TVShowSeasons/TVShowSeasonsEndpointTests.swift
@@ -12,7 +12,7 @@ final class TVShowSeaonsEndpointTests: XCTestCase {
     }
 
     func testTVShowSeasonImagesEndpointReturnsURL() {
-        let expectedURL = URL(string: "/tv/1/season/2/images")!
+        let expectedURL = URL(string: "/tv/1/season/2/images?include_image_language=en,null")!
 
         let url = TVShowSeasonsEndpoint.images(tvShowID: 1, seasonNumber: 2).path
 
@@ -20,7 +20,7 @@ final class TVShowSeaonsEndpointTests: XCTestCase {
     }
 
     func testTVShowSeasonVideosEndpointReturnsURL() {
-        let expectedURL = URL(string: "/tv/1/season/2/videos")!
+        let expectedURL = URL(string: "/tv/1/season/2/videos?include_video_language=en,null")!
 
         let url = TVShowSeasonsEndpoint.videos(tvShowID: 1, seasonNumber: 2).path
 

--- a/Tests/TMDbTests/Services/TVShows/TVShowsEndpointTests.swift
+++ b/Tests/TMDbTests/Services/TVShows/TVShowsEndpointTests.swift
@@ -36,7 +36,7 @@ final class TVShowsEndpointTests: XCTestCase {
     }
 
     func testTVShowImagesEndpointReturnsURL() {
-        let expectedURL = URL(string: "/tv/1/images")!
+        let expectedURL = URL(string: "/tv/1/images?include_image_language=en,null")!
 
         let url = TVShowsEndpoint.images(tvShowID: 1).path
 
@@ -44,7 +44,7 @@ final class TVShowsEndpointTests: XCTestCase {
     }
 
     func testTVShowVideosEndpointReturnsURL() {
-        let expectedURL = URL(string: "/tv/1/videos")!
+        let expectedURL = URL(string: "/tv/1/videos?include_video_language=en,null")!
 
         let url = TVShowsEndpoint.videos(tvShowID: 1).path
 


### PR DESCRIPTION
Currently request for images / videos often lead to empty results as the query includes a language component. To also include images / videos with no language, I added the `include_image_language` / `include_video_language` component with the current language code (also used in the language component) and `null`.

Reference:
[API Documentation](https://developers.themoviedb.org/3/getting-started/image-languages)