### PR TITLE
Add query parameter languageCode to movie details endpoint

### DIFF
--- a/Sources/TMDb/Services/Movies/MovieService.swift
+++ b/Sources/TMDb/Services/Movies/MovieService.swift
@@ -57,10 +57,10 @@ public final class MovieService {
     ///
     /// - Returns: The matching movie.
     ///
-    public func details(forMovie id: Movie.ID) async throws -> Movie {
+    public func details(forMovie id: Movie.ID, languageCode: String? = nil) async throws -> Movie {
         let movie: Movie
         do {
-            movie = try await apiClient.get(endpoint: MoviesEndpoint.details(movieID: id))
+            movie = try await apiClient.get(endpoint: MoviesEndpoint.details(movieID: id, languageCode: languageCode))
         } catch let error {
             throw TMDbError(error: error)
         }

--- a/Sources/TMDb/Services/Movies/MoviesEndpoint.swift
+++ b/Sources/TMDb/Services/Movies/MoviesEndpoint.swift
@@ -21,7 +21,7 @@ import Foundation
 
 enum MoviesEndpoint {
 
-    case details(movieID: Movie.ID)
+    case details(movieID: Movie.ID, languageCode: String?)
     case credits(movieID: Movie.ID)
     case reviews(movieID: Movie.ID, page: Int? = nil)
     case images(movieID: Movie.ID, languageCode: String?)
@@ -43,10 +43,10 @@ extension MoviesEndpoint: Endpoint {
 
     var path: URL {
         switch self {
-        case let .details(movieID):
+        case let .details(movieID, languageCode):
             Self.basePath
                 .appendingPathComponent(movieID)
-
+                .appendingLanguage(languageCode)
         case let .credits(movieID):
             Self.basePath
                 .appendingPathComponent(movieID)

--- a/Tests/TMDbTests/Services/Movies/MovieServiceTests.swift
+++ b/Tests/TMDbTests/Services/Movies/MovieServiceTests.swift
@@ -44,12 +44,13 @@ final class MovieServiceTests: XCTestCase {
     func testDetailsReturnsMovie() async throws {
         let expectedResult = Movie.thorLoveAndThunder
         let movieID = expectedResult.id
+        let languageCode = localeProvider.languageCode
         apiClient.addResponse(.success(expectedResult))
 
-        let result = try await service.details(forMovie: movieID)
+        let result = try await service.details(forMovie: movieID, languageCode: languageCode)
 
         XCTAssertEqual(result, expectedResult)
-        XCTAssertEqual(apiClient.lastRequestURL, MoviesEndpoint.details(movieID: movieID).path)
+        XCTAssertEqual(apiClient.lastRequestURL, MoviesEndpoint.details(movieID: movieID, languageCode: localeProvider.languageCode).path)
         XCTAssertEqual(apiClient.lastRequestMethod, .get)
     }
 

--- a/Tests/TMDbTests/Services/Movies/MoviesEndpointTests.swift
+++ b/Tests/TMDbTests/Services/Movies/MoviesEndpointTests.swift
@@ -23,9 +23,10 @@ import XCTest
 final class MoviesEndpointTests: XCTestCase {
 
     func testMovieDetailsEndpointReturnsURL() throws {
-        let expectedURL = try XCTUnwrap(URL(string: "/movie/1"))
+        let languageCode = "en"
+        let expectedURL = try XCTUnwrap(URL(string: "/movie/1?language=\(languageCode)"))
 
-        let url = MoviesEndpoint.details(movieID: 1).path
+        let url = MoviesEndpoint.details(movieID: 1, languageCode: languageCode).path
 
         XCTAssertEqual(url, expectedURL)
     }


### PR DESCRIPTION
I am not sure if I have done everything correct. 
The details endpoint for movies is missing the language endpoint  
I have added it.