### PR TITLE
Change multipathServiceType to none

### DIFF
--- a/Sources/TMDb/TMDbFactory.swift
+++ b/Sources/TMDb/TMDbFactory.swift
@@ -70,7 +70,7 @@ extension TMDbFactory {
     private static func urlSessionConfiguration() -> URLSessionConfiguration {
         let configuration = URLSessionConfiguration.default
         #if os(iOS)
-            configuration.multipathServiceType = .handover
+            configuration.multipathServiceType = .none
         #endif
 
         configuration.requestCachePolicy = .useProtocolCachePolicy


### PR DESCRIPTION
I tried out this SDK for the first time today but spent hours trying to determine why I wasn't getting a response. Drilling down I came across `configuration.multipathServiceType = .handover`. I was curious what that is since I have not used it before and reading the docs I saw that it **Requires the com.apple.developer.networking.multipath entitlement**. 

**Using these service types requires the appropriate entitlement.  Any connection attempt will fail if the process does not have the required entitlement.**

This explained all of my problems and confirmed as such with the change of this PR.

My suggestion, given this SDK will likely be most used by developers working on hobby projects, is to switch this to `.none` so that the entitlement is not required. However, if this setting is a hard requirement for the SDK I can change this PR to instead emphasize the need for the entitlement in the README.