### PR TITLE
Cleanup from my prior changes

### DIFF
--- a/Sources/TMDb/TMDbFactory.swift
+++ b/Sources/TMDb/TMDbFactory.swift
@@ -69,10 +69,6 @@ extension TMDbFactory {
 
     private static func urlSessionConfiguration() -> URLSessionConfiguration {
         let configuration = URLSessionConfiguration.default
-        #if os(iOS)
-            configuration.multipathServiceType = .none
-        #endif
-
         configuration.requestCachePolicy = .useProtocolCachePolicy
         configuration.timeoutIntervalForRequest = 30
 


### PR DESCRIPTION
Remove unnecessarily setting url session configuration `multipathServiceType = .none` due to being the default value.

Unrelated to this change but I noticed `@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)` is throughout the codebase but these match the versions specified in `package.swift` so the compiler already catches any discrepancies. How do you feel about their removal? I can take care of that in this PR and reduce a bit of future maintenance.