### PR TITLE
✨ Add TV discovery lists: airingToday, onTheAir, topRated

### DIFF
--- a/Sources/TMDb/Domain/APIClient/APIRequestQueryItem.swift
+++ b/Sources/TMDb/Domain/APIClient/APIRequestQueryItem.swift
@@ -66,5 +66,6 @@ extension APIRequestQueryItem.Name {
     static let primaryReleaseDateLessThan = APIRequestQueryItem.Name("primary_release_date.lte")
 
     static let apiKey = APIRequestQueryItem.Name("api_key")
+    static let timezone = APIRequestQueryItem.Name("timezone")
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesAiringTodayRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesAiringTodayRequest.swift
@@ -1,0 +1,51 @@
+//
+//  TVSeriesAiringTodayRequest.swift
+//  TMDb
+//
+//  Copyright © 2025 Adam Young.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an AS IS BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+final class TVSeriesAiringTodayRequest: DecodableAPIRequest<TVSeriesPageableList> {
+
+    init(page: Int? = nil, timezone: String? = nil, language: String? = nil) {
+        let path = "/tv/airing_today"
+        let queryItems = APIRequestQueryItems(page: page, timezone: timezone, language: language)
+
+        super.init(path: path, queryItems: queryItems)
+    }
+
+}
+
+extension APIRequestQueryItems {
+
+    fileprivate init(page: Int?, timezone: String?, language: String?) {
+        self.init()
+
+        if let page {
+            self[.page] = page
+        }
+
+        if let timezone {
+            self[.timezone] = timezone
+        }
+
+        if let language {
+            self[.language] = language
+        }
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesOnTheAirRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesOnTheAirRequest.swift
@@ -1,0 +1,51 @@
+//
+//  TVSeriesOnTheAirRequest.swift
+//  TMDb
+//
+//  Copyright © 2025 Adam Young.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an AS IS BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+final class TVSeriesOnTheAirRequest: DecodableAPIRequest<TVSeriesPageableList> {
+
+    init(page: Int? = nil, timezone: String? = nil, language: String? = nil) {
+        let path = "/tv/on_the_air"
+        let queryItems = APIRequestQueryItems(page: page, timezone: timezone, language: language)
+
+        super.init(path: path, queryItems: queryItems)
+    }
+
+}
+
+extension APIRequestQueryItems {
+
+    fileprivate init(page: Int?, timezone: String?, language: String?) {
+        self.init()
+
+        if let page {
+            self[.page] = page
+        }
+
+        if let timezone {
+            self[.timezone] = timezone
+        }
+
+        if let language {
+            self[.language] = language
+        }
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/TopRatedTVSeriesRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/TopRatedTVSeriesRequest.swift
@@ -1,0 +1,47 @@
+//
+//  TopRatedTVSeriesRequest.swift
+//  TMDb
+//
+//  Copyright © 2025 Adam Young.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an AS IS BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+final class TopRatedTVSeriesRequest: DecodableAPIRequest<TVSeriesPageableList> {
+
+    init(page: Int? = nil, language: String? = nil) {
+        let path = "/tv/top_rated"
+        let queryItems = APIRequestQueryItems(page: page, language: language)
+
+        super.init(path: path, queryItems: queryItems)
+    }
+
+}
+
+extension APIRequestQueryItems {
+
+    fileprivate init(page: Int?, language: String? = nil) {
+        self.init()
+
+        if let page {
+            self[.page] = page
+        }
+
+        if let language {
+            self[.language] = language
+        }
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/TVSeries/TMDbTVSeriesService.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/TMDbTVSeriesService.swift
@@ -178,6 +178,64 @@ final class TMDbTVSeriesService: TVSeriesService {
         return tvSeriesList
     }
 
+    func airingToday(
+        page: Int? = nil,
+        timezone: String? = nil,
+        language: String? = nil
+    ) async throws -> TVSeriesPageableList {
+        let languageCode = language ?? configuration.defaultLanguage
+        let request = TVSeriesAiringTodayRequest(
+            page: page,
+            timezone: timezone,
+            language: languageCode
+        )
+
+        let tvSeriesList: TVSeriesPageableList
+        do {
+            tvSeriesList = try await apiClient.perform(request)
+        } catch let error {
+            throw TMDbError(error: error)
+        }
+
+        return tvSeriesList
+    }
+
+    func onTheAir(
+        page: Int? = nil,
+        timezone: String? = nil,
+        language: String? = nil
+    ) async throws -> TVSeriesPageableList {
+        let languageCode = language ?? configuration.defaultLanguage
+        let request = TVSeriesOnTheAirRequest(
+            page: page,
+            timezone: timezone,
+            language: languageCode
+        )
+
+        let tvSeriesList: TVSeriesPageableList
+        do {
+            tvSeriesList = try await apiClient.perform(request)
+        } catch let error {
+            throw TMDbError(error: error)
+        }
+
+        return tvSeriesList
+    }
+
+    func topRated(page: Int? = nil, language: String? = nil) async throws -> TVSeriesPageableList {
+        let languageCode = language ?? configuration.defaultLanguage
+        let request = TopRatedTVSeriesRequest(page: page, language: languageCode)
+
+        let tvSeriesList: TVSeriesPageableList
+        do {
+            tvSeriesList = try await apiClient.perform(request)
+        } catch let error {
+            throw TMDbError(error: error)
+        }
+
+        return tvSeriesList
+    }
+
     func watchProviders(
         forTVSeries tvSeriesID: TVSeries.ID
     ) async throws -> [ShowWatchProvidersByCountry] {

--- a/Sources/TMDb/Domain/Services/TVSeries/TVSeriesService.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/TVSeriesService.swift
@@ -199,6 +199,63 @@ public protocol TVSeriesService: Sendable {
     func popular(page: Int?, language: String?) async throws -> TVSeriesPageableList
 
     ///
+    /// Returns a list of TV series that are airing today.
+    ///
+    /// [TMDb API - TV Series Lists: Airing Today](https://developer.themoviedb.org/reference/tv-series-airing-today-list)
+    ///
+    /// - Precondition: `page` can be between `1` and `1000`.
+    ///
+    /// - Parameters:
+    ///    - page: The page of results to return.
+    ///    - timezone: A valid timezone to filter the day by. Defaults to "America/New_York".
+    ///    - language: ISO 639-1 language code to display results in. Defaults to the client's configured default language.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: TV series airing today as a pageable list.
+    ///
+    func airingToday(page: Int?, timezone: String?, language: String?) async throws
+        -> TVSeriesPageableList
+
+    ///
+    /// Returns a list of TV series that are currently on the air.
+    ///
+    /// This returns TV series that have episodes airing within the next 7 days.
+    ///
+    /// [TMDb API - TV Series Lists: On The Air](https://developer.themoviedb.org/reference/tv-series-on-the-air-list)
+    ///
+    /// - Precondition: `page` can be between `1` and `1000`.
+    ///
+    /// - Parameters:
+    ///    - page: The page of results to return.
+    ///    - timezone: A valid timezone to filter the day by. Defaults to "America/New_York".
+    ///    - language: ISO 639-1 language code to display results in. Defaults to the client's configured default language.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: TV series on the air as a pageable list.
+    ///
+    func onTheAir(page: Int?, timezone: String?, language: String?) async throws
+        -> TVSeriesPageableList
+
+    ///
+    /// Returns a list of top rated TV series.
+    ///
+    /// [TMDb API - TV Series Lists: Top Rated](https://developer.themoviedb.org/reference/tv-series-top-rated-list)
+    ///
+    /// - Precondition: `page` can be between `1` and `1000`.
+    ///
+    /// - Parameters:
+    ///    - page: The page of results to return.
+    ///    - language: ISO 639-1 language code to display results in. Defaults to the client's configured default language.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: Top rated TV series as a pageable list.
+    ///
+    func topRated(page: Int?, language: String?) async throws -> TVSeriesPageableList
+
+    ///
     /// Returns watch providers for a TV series in all available countries.
     ///
     /// [TMDb API - TVSeries: Watch providers](https://developer.themoviedb.org/reference/tv-series-watch-providers)
@@ -444,6 +501,78 @@ extension TVSeriesService {
         language: String? = nil
     ) async throws -> TVSeriesPageableList {
         try await popular(page: page, language: language)
+    }
+
+    ///
+    /// Returns a list of TV series that are airing today.
+    ///
+    /// [TMDb API - TV Series Lists: Airing Today](https://developer.themoviedb.org/reference/tv-series-airing-today-list)
+    ///
+    /// - Precondition: `page` can be between `1` and `1000`.
+    ///
+    /// - Parameters:
+    ///    - page: The page of results to return.
+    ///    - timezone: A valid timezone to filter the day by. Defaults to "America/New_York".
+    ///    - language: ISO 639-1 language code to display results in. Defaults to the client's configured default language.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: TV series airing today as a pageable list.
+    ///
+    public func airingToday(
+        page: Int? = nil,
+        timezone: String? = nil,
+        language: String? = nil
+    ) async throws -> TVSeriesPageableList {
+        try await airingToday(page: page, timezone: timezone, language: language)
+    }
+
+    ///
+    /// Returns a list of TV series that are currently on the air.
+    ///
+    /// This returns TV series that have episodes airing within the next 7 days.
+    ///
+    /// [TMDb API - TV Series Lists: On The Air](https://developer.themoviedb.org/reference/tv-series-on-the-air-list)
+    ///
+    /// - Precondition: `page` can be between `1` and `1000`.
+    ///
+    /// - Parameters:
+    ///    - page: The page of results to return.
+    ///    - timezone: A valid timezone to filter the day by. Defaults to "America/New_York".
+    ///    - language: ISO 639-1 language code to display results in. Defaults to the client's configured default language.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: TV series on the air as a pageable list.
+    ///
+    public func onTheAir(
+        page: Int? = nil,
+        timezone: String? = nil,
+        language: String? = nil
+    ) async throws -> TVSeriesPageableList {
+        try await onTheAir(page: page, timezone: timezone, language: language)
+    }
+
+    ///
+    /// Returns a list of top rated TV series.
+    ///
+    /// [TMDb API - TV Series Lists: Top Rated](https://developer.themoviedb.org/reference/tv-series-top-rated-list)
+    ///
+    /// - Precondition: `page` can be between `1` and `1000`.
+    ///
+    /// - Parameters:
+    ///    - page: The page of results to return.
+    ///    - language: ISO 639-1 language code to display results in. Defaults to the client's configured default language.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: Top rated TV series as a pageable list.
+    ///
+    public func topRated(
+        page: Int? = nil,
+        language: String? = nil
+    ) async throws -> TVSeriesPageableList {
+        try await topRated(page: page, language: language)
     }
 
 }

--- a/Tests/TMDbIntegrationTests/TVSeriesServiceTests.swift
+++ b/Tests/TMDbIntegrationTests/TVSeriesServiceTests.swift
@@ -121,6 +121,27 @@ struct TVSeriesServiceTests {
         #expect(!tvSeriesList.results.isEmpty)
     }
 
+    @Test("airingToday")
+    func airingToday() async throws {
+        let tvSeriesList = try await tvSeriesService.airingToday()
+
+        #expect(!tvSeriesList.results.isEmpty)
+    }
+
+    @Test("onTheAir")
+    func onTheAir() async throws {
+        let tvSeriesList = try await tvSeriesService.onTheAir()
+
+        #expect(!tvSeriesList.results.isEmpty)
+    }
+
+    @Test("topRated")
+    func topRated() async throws {
+        let tvSeriesList = try await tvSeriesService.topRated()
+
+        #expect(!tvSeriesList.results.isEmpty)
+    }
+
     @Test("externalLinks")
     func externalLinks() async throws {
         let tvSeriesID = 86423

--- a/Tests/TMDbTests/Domain/Services/TVSeries/Requests/TVSeriesAiringTodayRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/TVSeries/Requests/TVSeriesAiringTodayRequestTests.swift
@@ -1,0 +1,91 @@
+//
+//  TVSeriesAiringTodayRequestTests.swift
+//  TMDb
+//
+//  Copyright © 2025 Adam Young.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an AS IS BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Testing
+
+@testable import TMDb
+
+@Suite(.tags(.requests, .tvSeries))
+struct TVSeriesAiringTodayRequestTests {
+
+    @Test("path is correct")
+    func path() {
+        let request = TVSeriesAiringTodayRequest()
+
+        #expect(request.path == "/tv/airing_today")
+    }
+
+    @Test("queryItems is empty")
+    func queryItemsIsEmpty() {
+        let request = TVSeriesAiringTodayRequest()
+
+        #expect(request.queryItems.isEmpty)
+    }
+
+    @Test("queryItems with page")
+    func queryItemsWithPage() {
+        let request = TVSeriesAiringTodayRequest(page: 3)
+
+        #expect(request.queryItems == ["page": "3"])
+    }
+
+    @Test("queryItems with timezone")
+    func queryItemsWithTimezone() {
+        let request = TVSeriesAiringTodayRequest(timezone: "America/New_York")
+
+        #expect(request.queryItems == ["timezone": "America/New_York"])
+    }
+
+    @Test("queryItems with language")
+    func queryItemsWithLanguage() {
+        let request = TVSeriesAiringTodayRequest(language: "en")
+
+        #expect(request.queryItems == ["language": "en"])
+    }
+
+    @Test("queryItems with page, timezone and language")
+    func queryItemsWithPageTimezoneAndLanguage() {
+        let request = TVSeriesAiringTodayRequest(page: 3, timezone: "Europe/London", language: "en")
+
+        #expect(request.queryItems == ["page": "3", "timezone": "Europe/London", "language": "en"])
+    }
+
+    @Test("method is GET")
+    func methodIsGet() {
+        let request = TVSeriesAiringTodayRequest()
+
+        #expect(request.method == .get)
+    }
+
+    @Test("headers is empty")
+    func headersIsEmpty() {
+        let request = TVSeriesAiringTodayRequest()
+
+        #expect(request.headers.isEmpty)
+    }
+
+    @Test("body is nil")
+    func bodyIsNil() {
+        let request = TVSeriesAiringTodayRequest()
+
+        #expect(request.body == nil)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/TVSeries/Requests/TVSeriesOnTheAirRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/TVSeries/Requests/TVSeriesOnTheAirRequestTests.swift
@@ -1,0 +1,91 @@
+//
+//  TVSeriesOnTheAirRequestTests.swift
+//  TMDb
+//
+//  Copyright © 2025 Adam Young.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an AS IS BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Testing
+
+@testable import TMDb
+
+@Suite(.tags(.requests, .tvSeries))
+struct TVSeriesOnTheAirRequestTests {
+
+    @Test("path is correct")
+    func path() {
+        let request = TVSeriesOnTheAirRequest()
+
+        #expect(request.path == "/tv/on_the_air")
+    }
+
+    @Test("queryItems is empty")
+    func queryItemsIsEmpty() {
+        let request = TVSeriesOnTheAirRequest()
+
+        #expect(request.queryItems.isEmpty)
+    }
+
+    @Test("queryItems with page")
+    func queryItemsWithPage() {
+        let request = TVSeriesOnTheAirRequest(page: 3)
+
+        #expect(request.queryItems == ["page": "3"])
+    }
+
+    @Test("queryItems with timezone")
+    func queryItemsWithTimezone() {
+        let request = TVSeriesOnTheAirRequest(timezone: "America/New_York")
+
+        #expect(request.queryItems == ["timezone": "America/New_York"])
+    }
+
+    @Test("queryItems with language")
+    func queryItemsWithLanguage() {
+        let request = TVSeriesOnTheAirRequest(language: "en")
+
+        #expect(request.queryItems == ["language": "en"])
+    }
+
+    @Test("queryItems with page, timezone and language")
+    func queryItemsWithPageTimezoneAndLanguage() {
+        let request = TVSeriesOnTheAirRequest(page: 3, timezone: "Europe/London", language: "en")
+
+        #expect(request.queryItems == ["page": "3", "timezone": "Europe/London", "language": "en"])
+    }
+
+    @Test("method is GET")
+    func methodIsGet() {
+        let request = TVSeriesOnTheAirRequest()
+
+        #expect(request.method == .get)
+    }
+
+    @Test("headers is empty")
+    func headersIsEmpty() {
+        let request = TVSeriesOnTheAirRequest()
+
+        #expect(request.headers.isEmpty)
+    }
+
+    @Test("body is nil")
+    func bodyIsNil() {
+        let request = TVSeriesOnTheAirRequest()
+
+        #expect(request.body == nil)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/TVSeries/Requests/TopRatedTVSeriesRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/TVSeries/Requests/TopRatedTVSeriesRequestTests.swift
@@ -1,0 +1,84 @@
+//
+//  TopRatedTVSeriesRequestTests.swift
+//  TMDb
+//
+//  Copyright © 2025 Adam Young.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an AS IS BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Testing
+
+@testable import TMDb
+
+@Suite(.tags(.requests, .tvSeries))
+struct TopRatedTVSeriesRequestTests {
+
+    @Test("path is correct")
+    func path() {
+        let request = TopRatedTVSeriesRequest()
+
+        #expect(request.path == "/tv/top_rated")
+    }
+
+    @Test("queryItems is empty")
+    func queryItemsIsEmpty() {
+        let request = TopRatedTVSeriesRequest()
+
+        #expect(request.queryItems.isEmpty)
+    }
+
+    @Test("queryItems with page")
+    func queryItemsWithPage() {
+        let request = TopRatedTVSeriesRequest(page: 3)
+
+        #expect(request.queryItems == ["page": "3"])
+    }
+
+    @Test("queryItems with language")
+    func queryItemsWithLanguage() {
+        let request = TopRatedTVSeriesRequest(language: "en")
+
+        #expect(request.queryItems == ["language": "en"])
+    }
+
+    @Test("queryItems with page and language")
+    func queryItemsWithPageAndLanguage() {
+        let request = TopRatedTVSeriesRequest(page: 3, language: "en")
+
+        #expect(request.queryItems == ["page": "3", "language": "en"])
+    }
+
+    @Test("method is GET")
+    func methodIsGet() {
+        let request = TopRatedTVSeriesRequest()
+
+        #expect(request.method == .get)
+    }
+
+    @Test("headers is empty")
+    func headersIsEmpty() {
+        let request = TopRatedTVSeriesRequest()
+
+        #expect(request.headers.isEmpty)
+    }
+
+    @Test("body is nil")
+    func bodyIsNil() {
+        let request = TopRatedTVSeriesRequest()
+
+        #expect(request.body == nil)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/TVSeries/TMDbTVSeriesServiceListsTests.swift
+++ b/Tests/TMDbTests/Domain/Services/TVSeries/TMDbTVSeriesServiceListsTests.swift
@@ -151,4 +151,127 @@ struct TMDbTVSeriesServiceListsTests {
         }
     }
 
+    @Test("airingToday with default parameter values returns TV series")
+    func airingTodayWithDefaultParameterValuesReturnsTVSeries() async throws {
+        let expectedResult = TVSeriesPageableList.mock()
+        apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = TVSeriesAiringTodayRequest(page: nil, timezone: nil, language: nil)
+
+        let result = try await (service as TVSeriesService).airingToday()
+
+        #expect(result == expectedResult)
+        #expect(apiClient.lastRequest as? TVSeriesAiringTodayRequest == expectedRequest)
+    }
+
+    @Test("airingToday with page, timezone and language returns TV series")
+    func airingTodayWithPageTimezoneAndLanguageReturnsTVSeries() async throws {
+        let page = 2
+        let timezone = "America/New_York"
+        let language = "en"
+        let expectedResult = TVSeriesPageableList.mock()
+        apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = TVSeriesAiringTodayRequest(
+            page: page,
+            timezone: timezone,
+            language: language
+        )
+
+        let result = try await service.airingToday(
+            page: page,
+            timezone: timezone,
+            language: language
+        )
+
+        #expect(result == expectedResult)
+        #expect(apiClient.lastRequest as? TVSeriesAiringTodayRequest == expectedRequest)
+    }
+
+    @Test("airingToday when errors throws error")
+    func airingTodayWhenErrorsThrowsError() async throws {
+        apiClient.addResponse(.failure(.unknown))
+
+        await #expect(throws: TMDbError.unknown) {
+            _ = try await service.airingToday()
+        }
+    }
+
+    @Test("onTheAir with default parameter values returns TV series")
+    func onTheAirWithDefaultParameterValuesReturnsTVSeries() async throws {
+        let expectedResult = TVSeriesPageableList.mock()
+        apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = TVSeriesOnTheAirRequest(page: nil, timezone: nil, language: nil)
+
+        let result = try await (service as TVSeriesService).onTheAir()
+
+        #expect(result == expectedResult)
+        #expect(apiClient.lastRequest as? TVSeriesOnTheAirRequest == expectedRequest)
+    }
+
+    @Test("onTheAir with page, timezone and language returns TV series")
+    func onTheAirWithPageTimezoneAndLanguageReturnsTVSeries() async throws {
+        let page = 2
+        let timezone = "Europe/London"
+        let language = "en"
+        let expectedResult = TVSeriesPageableList.mock()
+        apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = TVSeriesOnTheAirRequest(
+            page: page,
+            timezone: timezone,
+            language: language
+        )
+
+        let result = try await service.onTheAir(
+            page: page,
+            timezone: timezone,
+            language: language
+        )
+
+        #expect(result == expectedResult)
+        #expect(apiClient.lastRequest as? TVSeriesOnTheAirRequest == expectedRequest)
+    }
+
+    @Test("onTheAir when errors throws error")
+    func onTheAirWhenErrorsThrowsError() async throws {
+        apiClient.addResponse(.failure(.unknown))
+
+        await #expect(throws: TMDbError.unknown) {
+            _ = try await service.onTheAir()
+        }
+    }
+
+    @Test("topRated with default parameter values returns TV series")
+    func topRatedWithDefaultParameterValuesReturnsTVSeries() async throws {
+        let expectedResult = TVSeriesPageableList.mock()
+        apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = TopRatedTVSeriesRequest(page: nil, language: nil)
+
+        let result = try await (service as TVSeriesService).topRated()
+
+        #expect(result == expectedResult)
+        #expect(apiClient.lastRequest as? TopRatedTVSeriesRequest == expectedRequest)
+    }
+
+    @Test("topRated with page and language returns TV series")
+    func topRatedWithPageAndLanguageReturnsTVSeries() async throws {
+        let page = 2
+        let language = "en"
+        let expectedResult = TVSeriesPageableList.mock()
+        apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = TopRatedTVSeriesRequest(page: page, language: language)
+
+        let result = try await service.topRated(page: page, language: language)
+
+        #expect(result == expectedResult)
+        #expect(apiClient.lastRequest as? TopRatedTVSeriesRequest == expectedRequest)
+    }
+
+    @Test("topRated when errors throws error")
+    func topRatedWhenErrorsThrowsError() async throws {
+        apiClient.addResponse(.failure(.unknown))
+
+        await #expect(throws: TMDbError.unknown) {
+            _ = try await service.topRated()
+        }
+    }
+
 }

--- a/Tests/TMDbTests/Resources/json/tv-series-airing-today.json
+++ b/Tests/TMDbTests/Resources/json/tv-series-airing-today.json
@@ -1,0 +1,52 @@
+{
+    "page": 1,
+    "results": [
+        {
+            "adult": false,
+            "backdrop_path": "/gmECX1DvFgdUPjtio2zaL8BPYPu.jpg",
+            "genre_ids": [
+                16,
+                10759,
+                10765
+            ],
+            "id": 95479,
+            "origin_country": [
+                "JP"
+            ],
+            "original_language": "ja",
+            "original_name": "呪術廻戦",
+            "overview": "Yuji Itadori is a boy with tremendous physical strength, though he lives a completely ordinary high school life. One day, to save a classmate who has been attacked by curses, he eats the finger of Ryomen Sukuna, taking the curse into his own soul. From then on, he shares one body with Ryomen Sukuna. Guided by the most powerful of sorcerers, Satoru Gojo, Itadori is admitted to Tokyo Jujutsu High School, an organization that fights the curses... and thus begins the heroic tale of a boy who became a curse to exorcise a curse, a life from which he could never turn back.",
+            "popularity": 178.3607,
+            "poster_path": "/fHpKWq9ayzSk8nSwqRuaAUemRKh.jpg",
+            "first_air_date": "2020-10-03",
+            "name": "JUJUTSU KAISEN",
+            "vote_average": 8.565,
+            "vote_count": 4119
+        },
+        {
+            "adult": false,
+            "backdrop_path": "/rBOnrVlck7BIlGeWVlzYiZeg4l2.jpg",
+            "genre_ids": [
+                16,
+                10759,
+                18,
+                10765
+            ],
+            "id": 209867,
+            "origin_country": [
+                "JP"
+            ],
+            "original_language": "ja",
+            "original_name": "葬送のフリーレン",
+            "overview": "Decades after her party defeated the Demon King, an old friend's funeral launches the elf wizard Frieren on a journey of self-discovery.",
+            "popularity": 112.1469,
+            "poster_path": "/dqZENchTd7lp5zht7BdlqM7RBhD.jpg",
+            "first_air_date": "2023-09-29",
+            "name": "Frieren: Beyond Journey's End",
+            "vote_average": 8.7,
+            "vote_count": 646
+        }
+    ],
+    "total_pages": 17,
+    "total_results": 336
+}

--- a/Tests/TMDbTests/Resources/json/tv-series-on-the-air.json
+++ b/Tests/TMDbTests/Resources/json/tv-series-on-the-air.json
@@ -1,0 +1,51 @@
+{
+    "page": 1,
+    "results": [
+        {
+            "adult": false,
+            "backdrop_path": "/7mkUu1F2hVUNgz24xO8HPx0D6mK.jpg",
+            "genre_ids": [
+                18,
+                10765,
+                10759
+            ],
+            "id": 224372,
+            "origin_country": [
+                "US"
+            ],
+            "original_language": "en",
+            "original_name": "A Knight of the Seven Kingdoms",
+            "overview": "A century before the events of Game of Thrones, two unlikely heroes wandered Westeros: a young, naive but courageous knight, Ser Duncan the Tall, and his diminutive squire, Egg. Set in an age when the Targaryen line still holds the Iron Throne and the last dragon has not yet passed from living memory, great destinies, powerful foes, and dangerous exploits await these improbable and incomparable friends.",
+            "popularity": 319.9827,
+            "poster_path": "/6igvNs5VJB4ryBLgjjXksDVs0Fm.jpg",
+            "first_air_date": "2026-01-18",
+            "name": "A Knight of the Seven Kingdoms",
+            "vote_average": 8.1,
+            "vote_count": 93
+        },
+        {
+            "adult": false,
+            "backdrop_path": "/6iNWfGVCEfASDdlNb05TP5nG0ll.jpg",
+            "genre_ids": [
+                80,
+                18,
+                35
+            ],
+            "id": 79744,
+            "origin_country": [
+                "US"
+            ],
+            "original_language": "en",
+            "original_name": "The Rookie",
+            "overview": "Starting over isn't easy, especially for small-town guy John Nolan who, after a life-altering incident, is pursuing his dream of being an LAPD officer. As the force's oldest rookie, he's met with skepticism from some higher-ups who see him as just a walking midlife crisis.",
+            "popularity": 258.899,
+            "poster_path": "/70kTz0OmjjZe7zHvIDrq2iKW7PJ.jpg",
+            "first_air_date": "2018-10-16",
+            "name": "The Rookie",
+            "vote_average": 8.536,
+            "vote_count": 2907
+        }
+    ],
+    "total_pages": 64,
+    "total_results": 1280
+}

--- a/Tests/TMDbTests/Resources/json/tv-series-top-rated.json
+++ b/Tests/TMDbTests/Resources/json/tv-series-top-rated.json
@@ -1,0 +1,49 @@
+{
+    "page": 1,
+    "results": [
+        {
+            "adult": false,
+            "backdrop_path": "/tsRy63Mu5cu8etL1X7ZLyf7UP1M.jpg",
+            "genre_ids": [
+                18,
+                80
+            ],
+            "id": 1396,
+            "origin_country": [
+                "US"
+            ],
+            "original_language": "en",
+            "original_name": "Breaking Bad",
+            "overview": "Walter White, a New Mexico chemistry teacher, is diagnosed with Stage III cancer and given a prognosis of only two years left to live. He becomes filled with a sense of fearlessness and an unrelenting desire to secure his family's financial future at any cost as he enters the dangerous world of drugs and crime.",
+            "popularity": 120.676,
+            "poster_path": "/ztkUQFLlC19CCMYHW9o1zWhJRNq.jpg",
+            "first_air_date": "2008-01-20",
+            "name": "Breaking Bad",
+            "vote_average": 8.936,
+            "vote_count": 16928
+        },
+        {
+            "adult": false,
+            "backdrop_path": "/q8eejQcg1bAqImEV8jh8RtBD4uH.jpg",
+            "genre_ids": [
+                16,
+                10759
+            ],
+            "id": 94605,
+            "origin_country": [
+                "US"
+            ],
+            "original_language": "en",
+            "original_name": "Arcane",
+            "overview": "Amid the stark discord of twin cities Piltover and Zaun, two sisters fight on rival sides of a war between magic technologies and clashing convictions.",
+            "popularity": 31.2672,
+            "poster_path": "/wwbHr8MPErMbmiYNaxDgTWyewOX.jpg",
+            "first_air_date": "2021-11-06",
+            "name": "Arcane",
+            "vote_average": 8.752,
+            "vote_count": 5618
+        }
+    ],
+    "total_pages": 118,
+    "total_results": 2350
+}


### PR DESCRIPTION
## Summary

Add three new methods to TVSeriesService for discovering TV series: `airingToday()`, `onTheAir()`, and `topRated()`. These methods provide access to popular TMDb TV discovery lists.

## Changes

**New Request Classes:**
- ✨ Created `TVSeriesAiringTodayRequest` for `/tv/airing_today` endpoint
- ✨ Created `TVSeriesOnTheAirRequest` for `/tv/on_the_air` endpoint  
- ✨ Created `TopRatedTVSeriesRequest` for `/tv/top_rated` endpoint

**Protocol Updates:**
- 📝 Added `airingToday(page:timezone:language:)` method to `TVSeriesService`
- 📝 Added `onTheAir(page:timezone:language:)` method to `TVSeriesService`
- 📝 Added `topRated(page:language:)` method to `TVSeriesService`
- 📝 Added default parameter extensions for all three methods

**Implementation:**
- 🔧 Added `timezone` query item to `APIRequestQueryItem`
- 🔧 Implemented all three methods in `TMDbTVSeriesService`

**Tests:**
- ✅ Added unit tests for all three request classes
- ✅ Added unit tests for all three service methods in `TMDbTVSeriesServiceListsTests`
- ✅ Added integration tests for `airingToday`, `onTheAir`, and `topRated`
- ✅ All 1316 unit tests passing
- ✅ All 87 integration tests passing

**JSON Fixtures:**
- 📄 Added `tv-series-airing-today.json` with real API response data
- 📄 Added `tv-series-on-the-air.json` with real API response data
- 📄 Added `tv-series-top-rated.json` with real API response data

## Benefits

- **Complete TV Discovery**: Users can now access all major TV series discovery lists from TMDb
- **Timezone Support**: `airingToday` and `onTheAir` methods support timezone filtering
- **Consistent API**: Methods follow existing patterns in TVSeriesService for familiarity
- **Full Test Coverage**: Comprehensive unit and integration tests ensure reliability

🤖 Generated with [Claude Code](https://claude.com/claude-code)