### PR TITLE
✨ Add Company and Configuration service endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
 | **watchProviders** | Streaming availability by region |
 | **certifications** | Content ratings (G, PG, R, etc.) |
 | **collections** | Movie collection details, images, translations |
-| **companies** | Production company information |
+| **companies** | Production company details, alternative names, logos |
 | **lists** | Custom list management (requires authentication) |
-| **configurations** | API configuration and image URL generation |
+| **configurations** | API configuration, countries, languages, primary translations, timezones |
 | **changes** | Track changes to movies, TV series, people, seasons, and episodes |
 
 See the [full API documentation](https://adamayoung.github.io/TMDb/documentation/tmdb/)

--- a/Sources/TMDb/Domain/Models/CompanyAlternativeName.swift
+++ b/Sources/TMDb/Domain/Models/CompanyAlternativeName.swift
@@ -1,0 +1,37 @@
+//
+//  CompanyAlternativeName.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A model representing an alternative name for a company.
+///
+public struct CompanyAlternativeName: Codable, Equatable, Hashable, Sendable {
+
+    ///
+    /// Alternative name of the company.
+    ///
+    public let name: String
+
+    ///
+    /// Type of the alternative name.
+    ///
+    public let type: String
+
+    ///
+    /// Creates a company alternative name object.
+    ///
+    /// - Parameters:
+    ///   - name: Alternative name of the company.
+    ///   - type: Type of the alternative name.
+    ///
+    public init(name: String, type: String) {
+        self.name = name
+        self.type = type
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/CompanyAlternativeNameCollection.swift
+++ b/Sources/TMDb/Domain/Models/CompanyAlternativeNameCollection.swift
@@ -1,0 +1,38 @@
+//
+//  CompanyAlternativeNameCollection.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A model representing a collection of alternative names for a company.
+///
+public struct CompanyAlternativeNameCollection: Identifiable, Codable, Equatable,
+Hashable, Sendable {
+
+    ///
+    /// Company identifier.
+    ///
+    public let id: Int
+
+    ///
+    /// Alternative names.
+    ///
+    public let results: [CompanyAlternativeName]
+
+    ///
+    /// Creates a company alternative name collection object.
+    ///
+    /// - Parameters:
+    ///   - id: Company identifier.
+    ///   - results: Alternative names.
+    ///
+    public init(id: Int, results: [CompanyAlternativeName]) {
+        self.id = id
+        self.results = results
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/CompanyImageCollection.swift
+++ b/Sources/TMDb/Domain/Models/CompanyImageCollection.swift
@@ -1,0 +1,38 @@
+//
+//  CompanyImageCollection.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A model representing a collection of images for a company.
+///
+public struct CompanyImageCollection: Identifiable, Codable, Equatable,
+Hashable, Sendable {
+
+    ///
+    /// Company identifier.
+    ///
+    public let id: Int
+
+    ///
+    /// Company logos.
+    ///
+    public let logos: [ImageMetadata]
+
+    ///
+    /// Creates a company image collection object.
+    ///
+    /// - Parameters:
+    ///   - id: Company identifier.
+    ///   - logos: Company logos.
+    ///
+    public init(id: Int, logos: [ImageMetadata]) {
+        self.id = id
+        self.logos = logos
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/Timezone.swift
+++ b/Sources/TMDb/Domain/Models/Timezone.swift
@@ -1,0 +1,37 @@
+//
+//  Timezone.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A model representing a timezone.
+///
+public struct Timezone: Codable, Equatable, Hashable, Sendable {
+
+    ///
+    /// ISO 3166-1 country code.
+    ///
+    public let iso31661: String
+
+    ///
+    /// Timezone zone names.
+    ///
+    public let zones: [String]
+
+    ///
+    /// Creates a timezone object.
+    ///
+    /// - Parameters:
+    ///   - iso31661: ISO 3166-1 country code.
+    ///   - zones: Timezone zone names.
+    ///
+    public init(iso31661: String, zones: [String]) {
+        self.iso31661 = iso31661
+        self.zones = zones
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/Companies/CompanyService.swift
+++ b/Sources/TMDb/Domain/Services/Companies/CompanyService.swift
@@ -26,4 +26,34 @@ public protocol CompanyService: Sendable {
     ///
     func details(forCompany id: Company.ID) async throws -> Company
 
+    ///
+    /// Returns a company's alternative names.
+    ///
+    /// [TMDb API - Companies: Alternative Names](https://developer.themoviedb.org/reference/company-alternative-names)
+    ///
+    /// - Parameter id: The identifier of the company.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: Matching company's alternative names.
+    ///
+    func alternativeNames(
+        forCompany id: Company.ID
+    ) async throws -> CompanyAlternativeNameCollection
+
+    ///
+    /// Returns a company's images (logos).
+    ///
+    /// [TMDb API - Companies: Images](https://developer.themoviedb.org/reference/company-images)
+    ///
+    /// - Parameter id: The identifier of the company.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: Matching company's image collection.
+    ///
+    func images(
+        forCompany id: Company.ID
+    ) async throws -> CompanyImageCollection
+
 }

--- a/Sources/TMDb/Domain/Services/Companies/Requests/CompanyAlternativeNamesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Companies/Requests/CompanyAlternativeNamesRequest.swift
@@ -1,0 +1,18 @@
+//
+//  CompanyAlternativeNamesRequest.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+final class CompanyAlternativeNamesRequest: DecodableAPIRequest<CompanyAlternativeNameCollection> {
+
+    init(id: Company.ID) {
+        let path = "/company/\(id)/alternative_names"
+
+        super.init(path: path)
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/Companies/Requests/CompanyImagesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Companies/Requests/CompanyImagesRequest.swift
@@ -1,0 +1,18 @@
+//
+//  CompanyImagesRequest.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+final class CompanyImagesRequest: DecodableAPIRequest<CompanyImageCollection> {
+
+    init(id: Company.ID) {
+        let path = "/company/\(id)/images"
+
+        super.init(path: path)
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/Companies/TMDbCompanyService.swift
+++ b/Sources/TMDb/Domain/Services/Companies/TMDbCompanyService.swift
@@ -29,4 +29,34 @@ final class TMDbCompanyService: CompanyService {
         return company
     }
 
+    func alternativeNames(
+        forCompany id: Company.ID
+    ) async throws -> CompanyAlternativeNameCollection {
+        let request = CompanyAlternativeNamesRequest(id: id)
+
+        let result: CompanyAlternativeNameCollection
+        do {
+            result = try await apiClient.perform(request)
+        } catch let error {
+            throw TMDbError(error: error)
+        }
+
+        return result
+    }
+
+    func images(
+        forCompany id: Company.ID
+    ) async throws -> CompanyImageCollection {
+        let request = CompanyImagesRequest(id: id)
+
+        let result: CompanyImageCollection
+        do {
+            result = try await apiClient.perform(request)
+        } catch let error {
+            throw TMDbError(error: error)
+        }
+
+        return result
+    }
+
 }

--- a/Sources/TMDb/Domain/Services/Configuration/ConfigurationService.swift
+++ b/Sources/TMDb/Domain/Services/Configuration/ConfigurationService.swift
@@ -60,6 +60,29 @@ public protocol ConfigurationService: Sendable {
     ///
     func languages() async throws -> [Language]
 
+    ///
+    /// Returns a list of the officially supported translations on TMDb.
+    ///
+    /// [TMDb API - Configuration: Primary
+    /// Translations](https://developer.themoviedb.org/reference/configuration-primary-translations)
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: Primary translations used throughout TMDb.
+    ///
+    func primaryTranslations() async throws -> [String]
+
+    ///
+    /// Returns the list of timezones used throughout TMDb.
+    ///
+    /// [TMDb API - Configuration: Timezones](https://developer.themoviedb.org/reference/configuration-timezones)
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: Timezones used throughout TMDb.
+    ///
+    func timezones() async throws -> [Timezone]
+
 }
 
 public extension ConfigurationService {

--- a/Sources/TMDb/Domain/Services/Configuration/Requests/ConfigurationPrimaryTranslationsRequest.swift
+++ b/Sources/TMDb/Domain/Services/Configuration/Requests/ConfigurationPrimaryTranslationsRequest.swift
@@ -1,0 +1,18 @@
+//
+//  ConfigurationPrimaryTranslationsRequest.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+final class ConfigurationPrimaryTranslationsRequest: DecodableAPIRequest<[String]> {
+
+    init() {
+        let path = "/configuration/primary_translations"
+
+        super.init(path: path)
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/Configuration/Requests/ConfigurationTimezonesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Configuration/Requests/ConfigurationTimezonesRequest.swift
@@ -1,0 +1,18 @@
+//
+//  ConfigurationTimezonesRequest.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+final class ConfigurationTimezonesRequest: DecodableAPIRequest<[Timezone]> {
+
+    init() {
+        let path = "/configuration/timezones"
+
+        super.init(path: path)
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/Configuration/TMDbConfigurationService.swift
+++ b/Sources/TMDb/Domain/Services/Configuration/TMDbConfigurationService.swift
@@ -68,4 +68,30 @@ final class TMDbConfigurationService: ConfigurationService {
         return languages
     }
 
+    func primaryTranslations() async throws -> [String] {
+        let request = ConfigurationPrimaryTranslationsRequest()
+
+        let primaryTranslations: [String]
+        do {
+            primaryTranslations = try await apiClient.perform(request)
+        } catch let error {
+            throw TMDbError(error: error)
+        }
+
+        return primaryTranslations
+    }
+
+    func timezones() async throws -> [Timezone] {
+        let request = ConfigurationTimezonesRequest()
+
+        let timezones: [Timezone]
+        do {
+            timezones = try await apiClient.perform(request)
+        } catch let error {
+            throw TMDbError(error: error)
+        }
+
+        return timezones
+    }
+
 }

--- a/Sources/TMDb/TMDb.docc/Extensions/CompanyService.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/CompanyService.md
@@ -5,3 +5,11 @@
 ### Company Details
 
 - ``details(forCompany:)``
+
+### Alternative Names
+
+- ``alternativeNames(forCompany:)``
+
+### Images
+
+- ``images(forCompany:)``

--- a/Sources/TMDb/TMDb.docc/Extensions/ConfigurationService.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/ConfigurationService.md
@@ -11,3 +11,5 @@
 - ``countries(language:)``
 - ``jobsByDepartment()``
 - ``languages()``
+- ``primaryTranslations()``
+- ``timezones()``

--- a/Sources/TMDb/TMDb.docc/TMDb.md
+++ b/Sources/TMDb/TMDb.docc/TMDb.md
@@ -252,6 +252,9 @@ Watch providers provided by [JustWatch](https://www.justwatch.com).
 - ``CompanyService``
 - ``Company``
 - ``Company/Parent``
+- ``CompanyAlternativeNameCollection``
+- ``CompanyAlternativeName``
+- ``CompanyImageCollection``
 
 ### Genres
 
@@ -286,6 +289,7 @@ Watch providers provided by [JustWatch](https://www.justwatch.com).
 - ``Country``
 - ``Department``
 - ``Language``
+- ``Timezone``
 
 ### Account
 

--- a/Tests/TMDbIntegrationTests/CompanyIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/CompanyIntegrationTests.swift
@@ -32,4 +32,24 @@ struct CompanyIntegrationTests {
         #expect(company.name == "LuckyChap Entertainment")
     }
 
+    @Test("alternativeNames")
+    func alternativeNames() async throws {
+        let companyID = 82968
+
+        let result = try await companyService.alternativeNames(
+            forCompany: companyID
+        )
+
+        #expect(result.id == companyID)
+    }
+
+    @Test("images")
+    func images() async throws {
+        let companyID = 82968
+
+        let result = try await companyService.images(forCompany: companyID)
+
+        #expect(result.id == companyID)
+    }
+
 }

--- a/Tests/TMDbIntegrationTests/ConfigurationIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/ConfigurationIntegrationTests.swift
@@ -55,4 +55,19 @@ struct ConfigurationIntegrationTests {
         #expect(!languages.isEmpty)
     }
 
+    @Test("primaryTranslations")
+    func primaryTranslations() async throws {
+        let translations = try await configurationService
+            .primaryTranslations()
+
+        #expect(!translations.isEmpty)
+    }
+
+    @Test("timezones")
+    func timezones() async throws {
+        let timezones = try await configurationService.timezones()
+
+        #expect(!timezones.isEmpty)
+    }
+
 }

--- a/Tests/TMDbTests/Domain/Models/CompanyAlternativeNameCollectionTests.swift
+++ b/Tests/TMDbTests/Domain/Models/CompanyAlternativeNameCollectionTests.swift
@@ -1,0 +1,31 @@
+//
+//  CompanyAlternativeNameCollectionTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.models))
+struct CompanyAlternativeNameCollectionTests {
+
+    @Test("JSON decoding of CompanyAlternativeNameCollection", .tags(.decoding))
+    func decodeReturnsCompanyAlternativeNameCollection() throws {
+        let result = try JSONDecoder.theMovieDatabase
+            .decode(
+                CompanyAlternativeNameCollection.self,
+                fromResource: "company-alternative-names"
+            )
+
+        #expect(result.id == 3)
+        #expect(result.results.count == 2)
+        #expect(result.results[0].name == "Pixar Animation Studios")
+        #expect(result.results[0].type == "doing business as")
+        #expect(result.results[1].name == "DisneyPixar")
+        #expect(result.results[1].type == "")
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Models/CompanyImageCollectionTests.swift
+++ b/Tests/TMDbTests/Domain/Models/CompanyImageCollectionTests.swift
@@ -1,0 +1,31 @@
+//
+//  CompanyImageCollectionTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.models))
+struct CompanyImageCollectionTests {
+
+    @Test("JSON decoding of CompanyImageCollection", .tags(.decoding))
+    func decodeReturnsCompanyImageCollection() throws {
+        let result = try JSONDecoder.theMovieDatabase
+            .decode(
+                CompanyImageCollection.self,
+                fromResource: "company-images"
+            )
+
+        #expect(result.id == 3)
+        #expect(result.logos.count == 2)
+        #expect(result.logos[0].width == 887)
+        #expect(result.logos[0].height == 186)
+        #expect(result.logos[1].width == 667)
+        #expect(result.logos[1].height == 108)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Models/TimezoneTests.swift
+++ b/Tests/TMDbTests/Domain/Models/TimezoneTests.swift
@@ -1,0 +1,32 @@
+//
+//  TimezoneTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.models))
+struct TimezoneTests {
+
+    @Test("JSON decoding of Timezone", .tags(.decoding))
+    func decodeReturnsTimezones() throws {
+        let result = try JSONDecoder.theMovieDatabase
+            .decode(
+                [Timezone].self,
+                fromResource: "configuration-timezones"
+            )
+
+        #expect(result.count == 3)
+        #expect(result[0].iso31661 == "AD")
+        #expect(result[0].zones == ["Europe/Andorra"])
+        #expect(result[1].iso31661 == "US")
+        #expect(result[1].zones.count == 4)
+        #expect(result[2].iso31661 == "GB")
+        #expect(result[2].zones == ["Europe/London"])
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Companies/Requests/CompanyAlternativeNamesRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Companies/Requests/CompanyAlternativeNamesRequestTests.swift
@@ -1,0 +1,46 @@
+//
+//  CompanyAlternativeNamesRequestTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.requests, .company))
+struct CompanyAlternativeNamesRequestTests {
+
+    var request: CompanyAlternativeNamesRequest!
+
+    init() {
+        self.request = CompanyAlternativeNamesRequest(id: 1)
+    }
+
+    @Test("path is correct")
+    func path() {
+        #expect(request.path == "/company/1/alternative_names")
+    }
+
+    @Test("queryItems is empty")
+    func queryItemsIsEmpty() {
+        #expect(request.queryItems.isEmpty)
+    }
+
+    @Test("method is GET")
+    func methodIsGet() {
+        #expect(request.method == .get)
+    }
+
+    @Test("headers is empty")
+    func headersIsEmpty() {
+        #expect(request.headers.isEmpty)
+    }
+
+    @Test("body is nil")
+    func bodyIsNil() {
+        #expect(request.body == nil)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Companies/Requests/CompanyImagesRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Companies/Requests/CompanyImagesRequestTests.swift
@@ -1,0 +1,46 @@
+//
+//  CompanyImagesRequestTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.requests, .company))
+struct CompanyImagesRequestTests {
+
+    var request: CompanyImagesRequest!
+
+    init() {
+        self.request = CompanyImagesRequest(id: 1)
+    }
+
+    @Test("path is correct")
+    func path() {
+        #expect(request.path == "/company/1/images")
+    }
+
+    @Test("queryItems is empty")
+    func queryItemsIsEmpty() {
+        #expect(request.queryItems.isEmpty)
+    }
+
+    @Test("method is GET")
+    func methodIsGet() {
+        #expect(request.method == .get)
+    }
+
+    @Test("headers is empty")
+    func headersIsEmpty() {
+        #expect(request.headers.isEmpty)
+    }
+
+    @Test("body is nil")
+    func bodyIsNil() {
+        #expect(request.body == nil)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Companies/TMDbCompanyServiceTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Companies/TMDbCompanyServiceTests.swift
@@ -44,4 +44,58 @@ struct TMDbCompanyServiceTests {
         }
     }
 
+    @Test("alternativeNames returns alternative names")
+    func alternativeNamesReturnsAlternativeNames() async throws {
+        let expectedResult = CompanyAlternativeNameCollection.mock()
+        let companyID = expectedResult.id
+        let expectedRequest = CompanyAlternativeNamesRequest(id: companyID)
+
+        apiClient.addResponse(.success(expectedResult))
+
+        let result = try await service.alternativeNames(forCompany: companyID)
+
+        #expect(result == expectedResult)
+        #expect(
+            apiClient.lastRequest as? CompanyAlternativeNamesRequest
+                == expectedRequest
+        )
+    }
+
+    @Test("alternativeNames when errors throws error")
+    func alternativeNamesWhenErrorsThrowsError() async throws {
+        let companyID = 1
+        apiClient.addResponse(.failure(.unknown))
+
+        await #expect(throws: TMDbError.unknown) {
+            _ = try await service.alternativeNames(forCompany: companyID)
+        }
+    }
+
+    @Test("images returns company images")
+    func imagesReturnsCompanyImages() async throws {
+        let expectedResult = CompanyImageCollection.mock()
+        let companyID = expectedResult.id
+        let expectedRequest = CompanyImagesRequest(id: companyID)
+
+        apiClient.addResponse(.success(expectedResult))
+
+        let result = try await service.images(forCompany: companyID)
+
+        #expect(result == expectedResult)
+        #expect(
+            apiClient.lastRequest as? CompanyImagesRequest
+                == expectedRequest
+        )
+    }
+
+    @Test("images when errors throws error")
+    func imagesWhenErrorsThrowsError() async throws {
+        let companyID = 1
+        apiClient.addResponse(.failure(.unknown))
+
+        await #expect(throws: TMDbError.unknown) {
+            _ = try await service.images(forCompany: companyID)
+        }
+    }
+
 }

--- a/Tests/TMDbTests/Domain/Services/Configuration/Requests/ConfigurationPrimaryTranslationsRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Configuration/Requests/ConfigurationPrimaryTranslationsRequestTests.swift
@@ -1,0 +1,46 @@
+//
+//  ConfigurationPrimaryTranslationsRequestTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.requests, .configuration))
+struct ConfigurationPrimaryTranslationsRequestTests {
+
+    var request: ConfigurationPrimaryTranslationsRequest!
+
+    init() {
+        self.request = ConfigurationPrimaryTranslationsRequest()
+    }
+
+    @Test("path is correct")
+    func path() {
+        #expect(request.path == "/configuration/primary_translations")
+    }
+
+    @Test("queryItems is empty")
+    func queryItemsIsEmpty() {
+        #expect(request.queryItems.isEmpty)
+    }
+
+    @Test("method is GET")
+    func methodIsGet() {
+        #expect(request.method == .get)
+    }
+
+    @Test("headers is empty")
+    func headersIsEmpty() {
+        #expect(request.headers.isEmpty)
+    }
+
+    @Test("body is nil")
+    func bodyIsNil() {
+        #expect(request.body == nil)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Configuration/Requests/ConfigurationTimezonesRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Configuration/Requests/ConfigurationTimezonesRequestTests.swift
@@ -1,0 +1,46 @@
+//
+//  ConfigurationTimezonesRequestTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.requests, .configuration))
+struct ConfigurationTimezonesRequestTests {
+
+    var request: ConfigurationTimezonesRequest!
+
+    init() {
+        self.request = ConfigurationTimezonesRequest()
+    }
+
+    @Test("path is correct")
+    func path() {
+        #expect(request.path == "/configuration/timezones")
+    }
+
+    @Test("queryItems is empty")
+    func queryItemsIsEmpty() {
+        #expect(request.queryItems.isEmpty)
+    }
+
+    @Test("method is GET")
+    func methodIsGet() {
+        #expect(request.method == .get)
+    }
+
+    @Test("headers is empty")
+    func headersIsEmpty() {
+        #expect(request.headers.isEmpty)
+    }
+
+    @Test("body is nil")
+    func bodyIsNil() {
+        #expect(request.body == nil)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Configuration/TMDbConfigurationServiceTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Configuration/TMDbConfigurationServiceTests.swift
@@ -117,4 +117,53 @@ struct TMDbConfigurationServiceTests {
         }
     }
 
+    @Test("primaryTranslations returns translations")
+    func primaryTranslationsReturnsTranslations() async throws {
+        let expectedResult = ["en-US", "fr-FR", "de-DE"]
+        apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = ConfigurationPrimaryTranslationsRequest()
+
+        let result = try await service.primaryTranslations()
+
+        #expect(result == expectedResult)
+        #expect(
+            apiClient.lastRequest
+                as? ConfigurationPrimaryTranslationsRequest
+                == expectedRequest
+        )
+    }
+
+    @Test("primaryTranslations when errors throws error")
+    func primaryTranslationsWhenErrorsThrowsError() async throws {
+        apiClient.addResponse(.failure(.unknown))
+
+        await #expect(throws: TMDbError.unknown) {
+            _ = try await service.primaryTranslations()
+        }
+    }
+
+    @Test("timezones returns timezones")
+    func timezonesReturnsTimezones() async throws {
+        let expectedResult = [Timezone].mocks
+        apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = ConfigurationTimezonesRequest()
+
+        let result = try await service.timezones()
+
+        #expect(result == expectedResult)
+        #expect(
+            apiClient.lastRequest as? ConfigurationTimezonesRequest
+                == expectedRequest
+        )
+    }
+
+    @Test("timezones when errors throws error")
+    func timezonesWhenErrorsThrowsError() async throws {
+        apiClient.addResponse(.failure(.unknown))
+
+        await #expect(throws: TMDbError.unknown) {
+            _ = try await service.timezones()
+        }
+    }
+
 }

--- a/Tests/TMDbTests/Mocks/Models/CompanyAlternativeName+Mocks.swift
+++ b/Tests/TMDbTests/Mocks/Models/CompanyAlternativeName+Mocks.swift
@@ -1,0 +1,31 @@
+//
+//  CompanyAlternativeName+Mocks.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import TMDb
+
+extension CompanyAlternativeName {
+
+    static func mock(
+        name: String = "Some Alternative Name",
+        type: String = "doing business as"
+    ) -> CompanyAlternativeName {
+        CompanyAlternativeName(
+            name: name,
+            type: type
+        )
+    }
+
+}
+
+extension [CompanyAlternativeName] {
+
+    static var mocks: [Element] {
+        [.mock(), .mock()]
+    }
+
+}

--- a/Tests/TMDbTests/Mocks/Models/CompanyAlternativeNameCollection+Mocks.swift
+++ b/Tests/TMDbTests/Mocks/Models/CompanyAlternativeNameCollection+Mocks.swift
@@ -1,0 +1,23 @@
+//
+//  CompanyAlternativeNameCollection+Mocks.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import TMDb
+
+extension CompanyAlternativeNameCollection {
+
+    static func mock(
+        id: Int = 1,
+        results: [CompanyAlternativeName] = [.mock(), .mock()]
+    ) -> CompanyAlternativeNameCollection {
+        CompanyAlternativeNameCollection(
+            id: id,
+            results: results
+        )
+    }
+
+}

--- a/Tests/TMDbTests/Mocks/Models/CompanyImageCollection+Mocks.swift
+++ b/Tests/TMDbTests/Mocks/Models/CompanyImageCollection+Mocks.swift
@@ -1,0 +1,23 @@
+//
+//  CompanyImageCollection+Mocks.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import TMDb
+
+extension CompanyImageCollection {
+
+    static func mock(
+        id: Int = 1,
+        logos: [ImageMetadata] = [.mock(), .mock()]
+    ) -> CompanyImageCollection {
+        CompanyImageCollection(
+            id: id,
+            logos: logos
+        )
+    }
+
+}

--- a/Tests/TMDbTests/Mocks/Models/Timezone+Mocks.swift
+++ b/Tests/TMDbTests/Mocks/Models/Timezone+Mocks.swift
@@ -1,0 +1,31 @@
+//
+//  Timezone+Mocks.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import TMDb
+
+extension Timezone {
+
+    static func mock(
+        iso31661: String = "US",
+        zones: [String] = ["America/New_York", "America/Los_Angeles"]
+    ) -> Timezone {
+        Timezone(
+            iso31661: iso31661,
+            zones: zones
+        )
+    }
+
+}
+
+extension [Timezone] {
+
+    static var mocks: [Element] {
+        [.mock(), .mock(iso31661: "GB", zones: ["Europe/London"])]
+    }
+
+}

--- a/Tests/TMDbTests/Resources/json/company-alternative-names.json
+++ b/Tests/TMDbTests/Resources/json/company-alternative-names.json
@@ -1,0 +1,13 @@
+{
+    "id": 3,
+    "results": [
+        {
+            "name": "Pixar Animation Studios",
+            "type": "doing business as"
+        },
+        {
+            "name": "DisneyPixar",
+            "type": ""
+        }
+    ]
+}

--- a/Tests/TMDbTests/Resources/json/company-images.json
+++ b/Tests/TMDbTests/Resources/json/company-images.json
@@ -1,0 +1,25 @@
+{
+    "id": 3,
+    "logos": [
+        {
+            "aspect_ratio": 4.768817204301075,
+            "file_path": "/1TjvGVDMYsj6JBxOAkUHpPEwLf7.png",
+            "height": 186,
+            "id": "5aa7e2580e0a263dc101e6f4",
+            "file_type": ".svg",
+            "vote_average": 2.278,
+            "vote_count": 3,
+            "width": 887
+        },
+        {
+            "aspect_ratio": 6.175925925925926,
+            "file_path": "/6eo6VIItCDKKQ2IZTygcDqc4QPL.png",
+            "height": 108,
+            "id": "67d78cde25f01d54167c0d34",
+            "file_type": ".svg",
+            "vote_average": 1.75,
+            "vote_count": 2,
+            "width": 667
+        }
+    ]
+}

--- a/Tests/TMDbTests/Resources/json/configuration-primary-translations.json
+++ b/Tests/TMDbTests/Resources/json/configuration-primary-translations.json
@@ -1,0 +1,17 @@
+[
+    "af-ZA",
+    "ar-AE",
+    "ar-SA",
+    "en-AU",
+    "en-GB",
+    "en-US",
+    "es-ES",
+    "es-MX",
+    "fr-FR",
+    "de-DE",
+    "it-IT",
+    "ja-JP",
+    "ko-KR",
+    "pt-BR",
+    "zh-CN"
+]

--- a/Tests/TMDbTests/Resources/json/configuration-timezones.json
+++ b/Tests/TMDbTests/Resources/json/configuration-timezones.json
@@ -1,0 +1,23 @@
+[
+    {
+        "iso_3166_1": "AD",
+        "zones": [
+            "Europe/Andorra"
+        ]
+    },
+    {
+        "iso_3166_1": "US",
+        "zones": [
+            "America/New_York",
+            "America/Chicago",
+            "America/Denver",
+            "America/Los_Angeles"
+        ]
+    },
+    {
+        "iso_3166_1": "GB",
+        "zones": [
+            "Europe/London"
+        ]
+    }
+]


### PR DESCRIPTION
## Summary

Adds 4 new endpoints to 2 existing services (CompanyService and ConfigurationService) with 4 new models, expanding the coverage of company and configuration-related TMDb API data.

## Changes

**New Models:**
- ✨ `CompanyAlternativeName` - Alternative name for a production company
- ✨ `CompanyAlternativeNameCollection` - Collection of company alternative names
- ✨ `CompanyImageCollection` - Collection of company logos/images
- ✨ `Timezone` - Timezone data with ISO 3166-1 country code and zone list

**CompanyService (2 new endpoints):**
- ✨ `alternativeNames(forCompany:)` - Get alternative names for a company (`GET /3/company/{id}/alternative_names`)
- ✨ `images(forCompany:)` - Get logos/images for a company (`GET /3/company/{id}/images`)

**ConfigurationService (2 new endpoints):**
- ✨ `primaryTranslations()` - Get officially supported translations (`GET /3/configuration/primary_translations`)
- ✨ `timezones()` - Get list of timezones used throughout TMDb (`GET /3/configuration/timezones`)

**Documentation:**
- 📝 Updated `CompanyService.md` and `ConfigurationService.md` DocC extensions
- 📝 Added new models to `TMDb.md` catalog (Companies and Configuration sections)
- 📝 Updated `README.md` service descriptions

**Tests:**
- ✅ Unit tests: 1712 tests passing - all new methods have success + error test cases
- ✅ Integration tests: 141 tests passing - all 4 new endpoints validated against live API
- ✅ Model decode tests with JSON fixtures for all new types
- ✅ Request tests for all 4 new request classes

## Benefits

- **Expanded Company Data**: Users can now retrieve alternative names and logos for production companies
- **Configuration Completeness**: Primary translations and timezone data now accessible
- **Full Test Coverage**: Every new code path has unit and integration test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)