### PR TITLE
🔧 Add xcsift output formatting and fix TVEpisodeAirDate decoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,13 +132,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-swift-
 
+      - name: Install xcsift
+        if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
+        run: brew install xcsift
+
       - name: Build
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
-        run: swift build --build-tests -Xswiftc -warnings-as-errors
+        run: set -o pipefail && swift build --build-tests -Xswiftc -warnings-as-errors 2>&1 | xcsift -f github-actions --Werror
 
       - name: Test
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
-        run: swift test --filter TMDbTests --enable-code-coverage --xunit-output junit.xml
+        run: set -o pipefail && swift test --filter TMDbTests --enable-code-coverage --xunit-output junit.xml 2>&1 | xcsift -f github-actions
 
       - name: Prepare Code Coverage
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
@@ -170,7 +174,7 @@ jobs:
 
       - name: Build for Release
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
-        run: swift build -c release -Xswiftc -warnings-as-errors
+        run: set -o pipefail && swift build -c release -Xswiftc -warnings-as-errors 2>&1 | xcsift -f github-actions --Werror
 
   build-test-linux:
     name: Build and Test (Linux)

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -70,19 +70,26 @@ jobs:
           || github.event_name == 'schedule'
         uses: actions/checkout@v6
 
+      - name: Install xcsift
+        if: >-
+          needs.changes.outputs.swift == 'true'
+          || github.event_name == 'workflow_dispatch'
+          || github.event_name == 'schedule'
+        run: brew install xcsift
+
       - name: Build
         if: >-
           needs.changes.outputs.swift == 'true'
           || github.event_name == 'workflow_dispatch'
           || github.event_name == 'schedule'
-        run: swift build --build-tests
+        run: set -o pipefail && swift build --build-tests 2>&1 | xcsift -f github-actions
 
       - name: Test
         if: >-
           needs.changes.outputs.swift == 'true'
           || github.event_name == 'workflow_dispatch'
           || github.event_name == 'schedule'
-        run: swift test --skip-build --filter TMDbIntegrationTests --xunit-output junit.xml
+        run: set -o pipefail && swift test --skip-build --filter TMDbIntegrationTests --xunit-output junit.xml 2>&1 | xcsift -f github-actions
         env:
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
           TMDB_USERNAME: ${{ secrets.TMDB_USERNAME }}

--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,11 @@ lint-markdown:
 
 .PHONY: build
 build:
-	swift build -Xswiftc -warnings-as-errors
+	set -o pipefail && swift build -Xswiftc -warnings-as-errors 2>&1 | xcsift -f toon --Werror
 
 .PHONY: build-tests
 build-tests:
-	swift build --build-tests -Xswiftc -warnings-as-errors
+	set -o pipefail && swift build --build-tests -Xswiftc -warnings-as-errors 2>&1 | xcsift -f toon --Werror
 
 .PHONY: build-linux
 build-linux:
@@ -43,7 +43,7 @@ build-linux:
 
 .PHONY: build-release
 build-release:
-	swift build -c release -Xswiftc -warnings-as-errors
+	set -o pipefail && swift build -c release -Xswiftc -warnings-as-errors 2>&1 | xcsift -f toon --Werror
 
 .PHONY: build-linux-release
 build-linux-release:
@@ -69,28 +69,28 @@ generate-docs:
 
 .PHONY: test
 test:
-	swift build --build-tests -Xswiftc -warnings-as-errors
-	swift test --skip-build --filter $(TEST_TARGET)
+	set -o pipefail && swift build --build-tests -Xswiftc -warnings-as-errors 2>&1 | xcsift -f toon --Werror
+	set -o pipefail && swift test --skip-build --filter $(TEST_TARGET) 2>&1 | xcsift -f toon
 
 .PHONY: test-ios
 test-ios:
-	set -o pipefail && NSUnbufferedIO=YES xcodebuild clean build-for-testing -scheme $(TARGET) -only-testing $(TEST_TARGET) -destination $(IOS_DESTINATION)
-	set -o pipefail && NSUnbufferedIO=YES xcodebuild test-without-building -scheme $(TARGET) -only-testing $(TEST_TARGET) -destination $(IOS_DESTINATION)
+	set -o pipefail && NSUnbufferedIO=YES xcodebuild clean build-for-testing -scheme $(TARGET) -only-testing $(TEST_TARGET) -destination $(IOS_DESTINATION) 2>&1 | xcsift -f toon --Werror
+	set -o pipefail && NSUnbufferedIO=YES xcodebuild test-without-building -scheme $(TARGET) -only-testing $(TEST_TARGET) -destination $(IOS_DESTINATION) 2>&1 | xcsift -f toon
 
 .PHONY: test-watchos
 test-watchos:
-	set -o pipefail && NSUnbufferedIO=YES xcodebuild build-for-testing -scheme $(TARGET) -only-testing $(TEST_TARGET) -destination $(WATCHOS_DESTINATION)
-	set -o pipefail && NSUnbufferedIO=YES xcodebuild test-without-building -scheme $(TARGET) -only-testing $(TEST_TARGET) -destination $(WATCHOS_DESTINATION)
+	set -o pipefail && NSUnbufferedIO=YES xcodebuild build-for-testing -scheme $(TARGET) -only-testing $(TEST_TARGET) -destination $(WATCHOS_DESTINATION) 2>&1 | xcsift -f toon --Werror
+	set -o pipefail && NSUnbufferedIO=YES xcodebuild test-without-building -scheme $(TARGET) -only-testing $(TEST_TARGET) -destination $(WATCHOS_DESTINATION) 2>&1 | xcsift -f toon
 
 .PHONY: test-tvos
 test-tvos:
-	set -o pipefail && NSUnbufferedIO=YES xcodebuild build-for-testing -scheme $(TARGET) -only-testing $(TEST_TARGET) -destination $(TVOS_DESTINATION)
-	set -o pipefail && NSUnbufferedIO=YES xcodebuild test-without-building -scheme $(TARGET) -only-testing $(TEST_TARGET) -destination $(TVOS_DESTINATION)
+	set -o pipefail && NSUnbufferedIO=YES xcodebuild build-for-testing -scheme $(TARGET) -only-testing $(TEST_TARGET) -destination $(TVOS_DESTINATION) 2>&1 | xcsift -f toon --Werror
+	set -o pipefail && NSUnbufferedIO=YES xcodebuild test-without-building -scheme $(TARGET) -only-testing $(TEST_TARGET) -destination $(TVOS_DESTINATION) 2>&1 | xcsift -f toon
 
 .PHONY: test-visionos
 test-visionos:
-	set -o pipefail && NSUnbufferedIO=YES xcodebuild build-for-testing -scheme $(TARGET) -only-testing $(TEST_TARGET) -destination $(VISIONOS_DESTINATION)
-	set -o pipefail && NSUnbufferedIO=YES xcodebuild test-without-building -scheme $(TARGET) -only-testing $(TEST_TARGET) -destination $(VISIONOS_DESTINATION)
+	set -o pipefail && NSUnbufferedIO=YES xcodebuild build-for-testing -scheme $(TARGET) -only-testing $(TEST_TARGET) -destination $(VISIONOS_DESTINATION) 2>&1 | xcsift -f toon --Werror
+	set -o pipefail && NSUnbufferedIO=YES xcodebuild test-without-building -scheme $(TARGET) -only-testing $(TEST_TARGET) -destination $(VISIONOS_DESTINATION) 2>&1 | xcsift -f toon
 
 .PHONY: test-linux
 test-linux:
@@ -98,8 +98,8 @@ test-linux:
 
 .PHONY: integration-test
 integration-test: .check-env-vars
-	swift build --build-tests
-	swift test --skip-build --filter $(INTEGRATION_TEST_TARGET)
+	set -o pipefail && swift build --build-tests 2>&1 | xcsift -f toon
+	set -o pipefail && swift test --skip-build --filter $(INTEGRATION_TEST_TARGET) 2>&1 | xcsift -f toon
 
 .PHONY: ci
 ci: .check-env-vars lint lint-markdown test test-ios test-watchos test-tvos test-visionos integration-test build-release build-docs

--- a/README.md
+++ b/README.md
@@ -253,9 +253,10 @@ Install [homebrew](https://brew.sh) and the following formulae
 * [swiftlint](https://github.com/realm/SwiftLint)
 * [swiftformat](https://github.com/nicklockwood/SwiftFormat)
 * [markdownlint](https://github.com/igorshubovych/markdownlint-cli)
+* [xcsift](https://github.com/ldomaradzki/xcsift)
 
 ```bash
-brew install swiftlint swiftformat markdownlint
+brew install swiftlint swiftformat markdownlint xcsift
 ```
 
 ### Before Submitting a PR

--- a/Sources/TMDb/Domain/Models/TVEpisodeAirDate.swift
+++ b/Sources/TMDb/Domain/Models/TVEpisodeAirDate.swift
@@ -58,7 +58,7 @@ public struct TVEpisodeAirDate: Identifiable, Codable, Equatable, Hashable, Send
     ///
     /// Identifier of the parent TV series.
     ///
-    public let showID: Int
+    public let showID: Int?
 
     ///
     /// TV episode production code.
@@ -109,7 +109,7 @@ public struct TVEpisodeAirDate: Identifiable, Codable, Equatable, Hashable, Send
         airDate: Date? = nil,
         episodeType: String? = nil,
         runtime: Int? = nil,
-        showID: Int,
+        showID: Int? = nil,
         productionCode: String? = nil,
         stillPath: URL? = nil,
         voteAverage: Double? = nil,
@@ -185,7 +185,7 @@ extension TVEpisodeAirDate {
 
         self.episodeType = try container.decodeIfPresent(String.self, forKey: .episodeType)
         self.runtime = try container.decodeIfPresent(Int.self, forKey: .runtime)
-        self.showID = try container.decode(Int.self, forKey: .showID)
+        self.showID = try container.decodeIfPresent(Int.self, forKey: .showID)
         self.productionCode = try container.decodeIfPresent(String.self, forKey: .productionCode)
         self.stillPath = try container.decodeIfPresent(URL.self, forKey: .stillPath)
         self.voteAverage = try container.decodeIfPresent(Double.self, forKey: .voteAverage)

--- a/Tests/TMDbIntegrationTests/TVSeriesServiceTests.swift
+++ b/Tests/TMDbIntegrationTests/TVSeriesServiceTests.swift
@@ -189,7 +189,9 @@ struct TVSeriesServiceTests {
             #expect(!lastEpisode.name.isEmpty)
             #expect(lastEpisode.episodeNumber > 0)
             #expect(lastEpisode.seasonNumber > 0)
-            #expect(lastEpisode.showID == tvSeriesID)
+            if let showID = lastEpisode.showID {
+                #expect(showID == tvSeriesID)
+            }
         }
 
         // nextEpisodeToAir may exist for currently airing shows
@@ -198,7 +200,9 @@ struct TVSeriesServiceTests {
             #expect(!nextEpisode.name.isEmpty)
             #expect(nextEpisode.episodeNumber > 0)
             #expect(nextEpisode.seasonNumber > 0)
-            #expect(nextEpisode.showID == tvSeriesID)
+            if let showID = nextEpisode.showID {
+                #expect(showID == tvSeriesID)
+            }
         }
     }
 
@@ -218,7 +222,9 @@ struct TVSeriesServiceTests {
             #expect(lastEpisode.name == "Felina")
             #expect(lastEpisode.episodeNumber == 16)
             #expect(lastEpisode.seasonNumber == 5)
-            #expect(lastEpisode.showID == tvSeriesID)
+            if let showID = lastEpisode.showID {
+                #expect(showID == tvSeriesID)
+            }
             #expect(lastEpisode.episodeType == "finale")
         }
 

--- a/Tests/TMDbTests/Domain/Models/TVEpisodeAirDateTests.swift
+++ b/Tests/TMDbTests/Domain/Models/TVEpisodeAirDateTests.swift
@@ -32,6 +32,18 @@ struct TVEpisodeAirDateTests {
         #expect(result.overview != nil)
     }
 
+    @Test("JSON decoding handles missing showId", .tags(.decoding))
+    func decodeHandlesMissingShowID() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            TVEpisodeAirDate.self,
+            fromResource: "tv-episode-air-date-without-show-id"
+        )
+
+        #expect(result.id == 62161)
+        #expect(result.name == "Felina")
+        #expect(result.showID == nil)
+    }
+
 }
 
 extension TVEpisodeAirDateTests {

--- a/Tests/TMDbTests/Resources/json/tv-episode-air-date-without-show-id.json
+++ b/Tests/TMDbTests/Resources/json/tv-episode-air-date-without-show-id.json
@@ -1,0 +1,14 @@
+{
+  "id": 62161,
+  "name": "Felina",
+  "episode_number": 16,
+  "season_number": 5,
+  "overview": "All bad things must come to an end.",
+  "air_date": "2013-09-29",
+  "episode_type": "finale",
+  "production_code": "",
+  "runtime": 56,
+  "still_path": "/pA0YwyhvdDXP3BEGL2grrIhq8aM.jpg",
+  "vote_average": 9.3,
+  "vote_count": 265
+}


### PR DESCRIPTION
## Summary

Integrate [xcsift](https://github.com/ldomaradzki/xcsift) to pipe all macOS build and test output through structured formatters, and fix a decoding issue where the TMDb API omits `show_id` from episode air date responses.

## Changes

**Build Tooling:**
- 🔧 Pipe all macOS `swift build`/`swift test` targets through `xcsift -f toon` in Makefile
- 🔧 Pipe all `xcodebuild` targets through `xcsift -f toon` with `--Werror` on build steps
- 🔧 Add `set -o pipefail` and `2>&1` to capture all output through the pipe
- 🔧 Linux/Docker targets left unchanged (no xcsift)

**CI Workflows:**
- 🔧 Add `brew install xcsift` step to `ci.yml` and `integration.yml`
- 🔧 Pipe Build, Test, and Build for Release steps through `xcsift -f github-actions`

**Bug Fix:**
- 🐛 Make `TVEpisodeAirDate.showID` optional (`Int?`) — the TMDb API omits `show_id` in some responses (e.g., latest TV series endpoint)
- 🐛 Update decoder to use `decodeIfPresent` for `showID`

**Tests:**
- ✅ Add JSON fixture `tv-episode-air-date-without-show-id.json` for missing `show_id` case
- ✅ Add unit test `decodeHandlesMissingShowID` for the new fixture
- ✅ Update integration test assertions to handle optional `showID`
- ✅ 1773 unit tests passing, 155 integration tests passing

**Documentation:**
- 📝 Update `CLAUDE.md` — restructure for clarity, fix stale service tree (20→25), update model count (84→~140), add xcsift docs, TDD guidance, self-review and documentation review steps, README update checklist
- 📝 Add xcsift to `README.md` Homebrew prerequisites

## Benefits

- **Structured Output**: Build/test output is structured TOON format locally and GitHub annotations in CI, reducing noise and improving readability
- **Token Efficiency**: xcsift TOON format is optimised for AI consumption
- **API Resilience**: Optional `showID` prevents decoding failures when the TMDb API omits the field
- **Better Developer Guidance**: Improved CLAUDE.md with accurate architecture info, TDD workflow, and comprehensive completion checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)