### PR TITLE
✨ Add movie keywords, all trending, screened theatrically, and episode groups endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
 
 | Service | Description |
 | ------- | ----------- |
-| **movies** | Movie details, credits, images, videos, reviews, recommendations, similar, releases, watch providers |
-| **tvSeries** | TV show details, credits, images, videos, reviews, recommendations, similar, watch providers |
+| **movies** | Movie details, credits, keywords, images, videos, reviews, recommendations, similar, releases, watch providers |
+| **tvSeries** | TV show details, credits, images, videos, reviews, recommendations, similar, watch providers, screened theatrically, episode groups |
 | **tvSeasons** | Season-specific details, aggregate credits, credits, images, videos, translations, watch providers |
 | **tvEpisodes** | Episode-specific details, credits, images, videos, translations |
 | **people** | Person details, combined/movie/TV credits, images, external links, translations |
 | **search** | Multi-search across movies, TV shows, people, collections, companies, keywords |
 | **discover** | Advanced filtering for movies and TV shows with 30+ filter options |
-| **trending** | Trending movies, TV shows, and people (daily/weekly) |
+| **trending** | Trending movies, TV shows, people, and all media (daily/weekly) |
 | **find** | Find movies, TV shows, and people by external IDs (IMDb, TVDB, etc.) |
 | **account** | User favorites, watchlist, rated items (requires authentication) |
 | **authentication** | Session management, guest sessions, request tokens |

--- a/Sources/TMDb/Domain/Models/ScreenedTheatricallyCollection.swift
+++ b/Sources/TMDb/Domain/Models/ScreenedTheatricallyCollection.swift
@@ -1,0 +1,41 @@
+//
+//  ScreenedTheatricallyCollection.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A model representing a collection of TV episodes that have been screened theatrically.
+///
+public struct ScreenedTheatricallyCollection: Identifiable, Codable, Equatable,
+Hashable, Sendable {
+
+    ///
+    /// TV series identifier.
+    ///
+    public let id: Int
+
+    ///
+    /// Screened theatrically results.
+    ///
+    public let results: [ScreenedTheatricallyResult]
+
+    ///
+    /// Creates a screened theatrically collection object.
+    ///
+    /// - Parameters:
+    ///    - id: TV series identifier.
+    ///    - results: Screened theatrically results.
+    ///
+    public init(
+        id: Int,
+        results: [ScreenedTheatricallyResult]
+    ) {
+        self.id = id
+        self.results = results
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/ScreenedTheatricallyResult.swift
+++ b/Sources/TMDb/Domain/Models/ScreenedTheatricallyResult.swift
@@ -1,0 +1,49 @@
+//
+//  ScreenedTheatricallyResult.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A model representing a TV episode that has been screened theatrically.
+///
+public struct ScreenedTheatricallyResult: Identifiable, Codable, Equatable,
+Hashable, Sendable {
+
+    ///
+    /// Episode identifier.
+    ///
+    public let id: Int
+
+    ///
+    /// Episode number.
+    ///
+    public let episodeNumber: Int
+
+    ///
+    /// Season number.
+    ///
+    public let seasonNumber: Int
+
+    ///
+    /// Creates a screened theatrically result object.
+    ///
+    /// - Parameters:
+    ///    - id: Episode identifier.
+    ///    - episodeNumber: Episode number.
+    ///    - seasonNumber: Season number.
+    ///
+    public init(
+        id: Int,
+        episodeNumber: Int,
+        seasonNumber: Int
+    ) {
+        self.id = id
+        self.episodeNumber = episodeNumber
+        self.seasonNumber = seasonNumber
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/TVEpisodeGroupCollection.swift
+++ b/Sources/TMDb/Domain/Models/TVEpisodeGroupCollection.swift
@@ -1,0 +1,50 @@
+//
+//  TVEpisodeGroupCollection.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A model representing a collection of TV episode groups for a TV series.
+///
+public struct TVEpisodeGroupCollection: Identifiable, Codable, Equatable,
+Hashable, Sendable {
+
+    ///
+    /// TV series identifier.
+    ///
+    public let id: Int
+
+    ///
+    /// Episode groups.
+    ///
+    public let episodeGroups: [TVEpisodeGroup]
+
+    ///
+    /// Creates a TV episode group collection object.
+    ///
+    /// - Parameters:
+    ///    - id: TV series identifier.
+    ///    - episodeGroups: Episode groups.
+    ///
+    public init(
+        id: Int,
+        episodeGroups: [TVEpisodeGroup]
+    ) {
+        self.id = id
+        self.episodeGroups = episodeGroups
+    }
+
+}
+
+extension TVEpisodeGroupCollection {
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case episodeGroups = "results"
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/TrendingItem.swift
+++ b/Sources/TMDb/Domain/Models/TrendingItem.swift
@@ -1,0 +1,123 @@
+//
+//  TrendingItem.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A model representing a trending item, which can be a movie, TV series, or person.
+///
+public enum TrendingItem: Identifiable, Codable, Equatable, Hashable, Sendable {
+
+    ///
+    /// Trending item's identifier.
+    ///
+    public var id: Int {
+        switch self {
+        case .movie(let movie):
+            movie.id
+
+        case .tvSeries(let tvSeries):
+            tvSeries.id
+
+        case .person(let person):
+            person.id
+        }
+    }
+
+    ///
+    /// A trending movie.
+    ///
+    case movie(MovieListItem)
+
+    ///
+    /// A trending TV series.
+    ///
+    case tvSeries(TVSeriesListItem)
+
+    ///
+    /// A trending person.
+    ///
+    case person(PersonListItem)
+
+}
+
+extension TrendingItem {
+
+    private enum CodingKeys: String, CodingKey {
+        case mediaType
+    }
+
+    private enum MediaType: String, Codable, Equatable {
+        case movie
+        case tvSeries = "tv"
+        case person
+    }
+
+    ///
+    /// Creates a new instance by decoding from the given decoder.
+    ///
+    /// This initializer throws an error if reading from the decoder fails, or
+    /// if the data read is corrupted or otherwise invalid.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    ///
+    /// - Throws: `DecodingError.typeMismatch` if the encountered encoded value
+    /// is not convertible to the requested type.
+    /// - Throws: `DecodingError.keyNotFound` if self does not have an entry
+    /// for the given key.
+    /// - Throws: `DecodingError.valueNotFound` if self has a null entry for
+    /// the given key.
+    ///
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let mediaType = try container.decode(MediaType.self, forKey: .mediaType)
+
+        switch mediaType {
+        case .movie:
+            self = try .movie(MovieListItem(from: decoder))
+
+        case .tvSeries:
+            self = try .tvSeries(TVSeriesListItem(from: decoder))
+
+        case .person:
+            self = try .person(PersonListItem(from: decoder))
+        }
+    }
+
+    ///
+    /// Encodes this value into the given encoder.
+    ///
+    /// If the value fails to encode anything, `encoder` will encode an empty
+    /// keyed container in its place.
+    ///
+    /// This function throws an error if any values are invalid for the given
+    /// encoder's format.
+    ///
+    /// - Parameter encoder: The encoder to write data to.
+    ///
+    /// - Throws: `EncodingError.invalidValue` if the given value is invalid in
+    ///   the current context for this format.
+    ///
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .movie(let movie):
+            try container.encode(MediaType.movie, forKey: .mediaType)
+            try movie.encode(to: encoder)
+
+        case .tvSeries(let tvSeries):
+            try container.encode(MediaType.tvSeries, forKey: .mediaType)
+            try tvSeries.encode(to: encoder)
+
+        case .person(let person):
+            try container.encode(MediaType.person, forKey: .mediaType)
+            try person.encode(to: encoder)
+        }
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/TrendingPageableList.swift
+++ b/Sources/TMDb/Domain/Models/TrendingPageableList.swift
@@ -1,0 +1,13 @@
+//
+//  TrendingPageableList.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A pageable list of trending items.
+///
+public typealias TrendingPageableList = PageableListResult<TrendingItem>

--- a/Sources/TMDb/Domain/Services/Movies/MovieKeywordsResponse.swift
+++ b/Sources/TMDb/Domain/Services/Movies/MovieKeywordsResponse.swift
@@ -1,0 +1,23 @@
+//
+//  MovieKeywordsResponse.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+struct MovieKeywordsResponse: Decodable {
+
+    let id: Int
+    let keywords: [Keyword]
+
+}
+
+extension MovieKeywordsResponse {
+
+    var keywordCollection: KeywordCollection {
+        KeywordCollection(id: id, keywords: keywords)
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/Movies/MovieService.swift
+++ b/Sources/TMDb/Domain/Services/Movies/MovieService.swift
@@ -431,6 +431,19 @@ public protocol MovieService: Sendable {
         page: Int?
     ) async throws -> ChangedIDCollection
 
+    ///
+    /// Returns keywords for a movie.
+    ///
+    /// [TMDb API - Movies: Keywords](https://developer.themoviedb.org/reference/movie-keywords)
+    ///
+    /// - Parameter movieID: The identifier of the movie.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: A collection of keywords for the movie.
+    ///
+    func keywords(forMovie movieID: Movie.ID) async throws -> KeywordCollection
+
 }
 
 public extension MovieService {

--- a/Sources/TMDb/Domain/Services/Movies/Requests/MovieKeywordsRequest.swift
+++ b/Sources/TMDb/Domain/Services/Movies/Requests/MovieKeywordsRequest.swift
@@ -1,0 +1,18 @@
+//
+//  MovieKeywordsRequest.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+final class MovieKeywordsRequest: DecodableAPIRequest<MovieKeywordsResponse> {
+
+    init(id: Movie.ID) {
+        let path = "/movie/\(id)/keywords"
+
+        super.init(path: path)
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/Movies/TMDbMovieService.swift
+++ b/Sources/TMDb/Domain/Services/Movies/TMDbMovieService.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-// swiftlint:disable type_body_length
+// swiftlint:disable file_length type_body_length
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class TMDbMovieService: MovieService {
@@ -383,6 +383,19 @@ final class TMDbMovieService: MovieService {
         return changedIDCollection
     }
 
+    func keywords(forMovie movieID: Movie.ID) async throws -> KeywordCollection {
+        let request = MovieKeywordsRequest(id: movieID)
+
+        let response: MovieKeywordsResponse
+        do {
+            response = try await apiClient.perform(request)
+        } catch let error {
+            throw TMDbError(error: error)
+        }
+
+        return response.keywordCollection
+    }
+
 }
 
-// swiftlint:enable type_body_length
+// swiftlint:enable file_length type_body_length

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesEpisodeGroupsRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesEpisodeGroupsRequest.swift
@@ -1,0 +1,19 @@
+//
+//  TVSeriesEpisodeGroupsRequest.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+final class TVSeriesEpisodeGroupsRequest:
+DecodableAPIRequest<TVEpisodeGroupCollection> {
+
+    init(id: TVSeries.ID) {
+        let path = "/tv/\(id)/episode_groups"
+
+        super.init(path: path)
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesScreenedTheatricallyRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesScreenedTheatricallyRequest.swift
@@ -1,0 +1,19 @@
+//
+//  TVSeriesScreenedTheatricallyRequest.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+final class TVSeriesScreenedTheatricallyRequest:
+DecodableAPIRequest<ScreenedTheatricallyCollection> {
+
+    init(id: TVSeries.ID) {
+        let path = "/tv/\(id)/screened_theatrically"
+
+        super.init(path: path)
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/TVSeries/TMDbTVSeriesService+Metadata.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/TMDbTVSeriesService+Metadata.swift
@@ -113,4 +113,34 @@ extension TMDbTVSeriesService {
         return mediaList
     }
 
+    func screenedTheatrically(
+        forTVSeries tvSeriesID: TVSeries.ID
+    ) async throws -> ScreenedTheatricallyCollection {
+        let request = TVSeriesScreenedTheatricallyRequest(id: tvSeriesID)
+
+        let collection: ScreenedTheatricallyCollection
+        do {
+            collection = try await apiClient.perform(request)
+        } catch let error {
+            throw TMDbError(error: error)
+        }
+
+        return collection
+    }
+
+    func episodeGroups(
+        forTVSeries tvSeriesID: TVSeries.ID
+    ) async throws -> TVEpisodeGroupCollection {
+        let request = TVSeriesEpisodeGroupsRequest(id: tvSeriesID)
+
+        let collection: TVEpisodeGroupCollection
+        do {
+            collection = try await apiClient.perform(request)
+        } catch let error {
+            throw TMDbError(error: error)
+        }
+
+        return collection
+    }
+
 }

--- a/Sources/TMDb/Domain/Services/TVSeries/TVSeriesService.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/TVSeriesService.swift
@@ -466,6 +466,38 @@ public protocol TVSeriesService: Sendable {
         endDate: Date?,
         page: Int?
     ) async throws -> ChangedIDCollection
+
+    ///
+    /// Returns the seasons and episodes that have been screened theatrically for a TV series.
+    ///
+    /// [TMDb API - TV Series: Screened
+    /// Theatrically](https://developer.themoviedb.org/reference/tv-series-screened-theatrically)
+    ///
+    /// - Parameter tvSeriesID: The identifier of the TV series.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: A collection of screened theatrically results for the TV series.
+    ///
+    func screenedTheatrically(
+        forTVSeries tvSeriesID: TVSeries.ID
+    ) async throws -> ScreenedTheatricallyCollection
+
+    ///
+    /// Returns the episode groups for a TV series.
+    ///
+    /// [TMDb API - TV Series: Episode
+    /// Groups](https://developer.themoviedb.org/reference/tv-series-episode-groups)
+    ///
+    /// - Parameter tvSeriesID: The identifier of the TV series.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: A collection of episode groups for the TV series.
+    ///
+    func episodeGroups(
+        forTVSeries tvSeriesID: TVSeries.ID
+    ) async throws -> TVEpisodeGroupCollection
 }
 
 public extension TVSeriesService {

--- a/Sources/TMDb/Domain/Services/Trending/Requests/TrendingAllRequest.swift
+++ b/Sources/TMDb/Domain/Services/Trending/Requests/TrendingAllRequest.swift
@@ -1,0 +1,39 @@
+//
+//  TrendingAllRequest.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+final class TrendingAllRequest: DecodableAPIRequest<TrendingPageableList> {
+
+    init(
+        timeWindow: TrendingTimeWindowFilterType,
+        page: Int? = nil,
+        language: String? = nil
+    ) {
+        let path = "/trending/all/\(timeWindow.rawValue)"
+        let queryItems = APIRequestQueryItems(page: page, language: language)
+
+        super.init(path: path, queryItems: queryItems)
+    }
+
+}
+
+private extension APIRequestQueryItems {
+
+    init(page: Int?, language: String?) {
+        self.init()
+
+        if let page {
+            self[.page] = page
+        }
+
+        if let language {
+            self[.language] = language
+        }
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/Trending/TMDbTrendingService.swift
+++ b/Sources/TMDb/Domain/Services/Trending/TMDbTrendingService.swift
@@ -78,4 +78,24 @@ final class TMDbTrendingService: TrendingService {
         return peopleList
     }
 
+    func allTrending(
+        inTimeWindow timeWindow: TrendingTimeWindowFilterType = .day,
+        page: Int? = nil,
+        language: String? = nil
+    ) async throws -> TrendingPageableList {
+        let languageCode = language ?? configuration.defaultLanguage
+        let request = TrendingAllRequest(
+            timeWindow: timeWindow, page: page, language: languageCode
+        )
+
+        let trendingList: TrendingPageableList
+        do {
+            trendingList = try await apiClient.perform(request)
+        } catch let error {
+            throw TMDbError(error: error)
+        }
+
+        return trendingList
+    }
+
 }

--- a/Sources/TMDb/Domain/Services/Trending/TrendingService.swift
+++ b/Sources/TMDb/Domain/Services/Trending/TrendingService.swift
@@ -91,6 +91,32 @@ public protocol TrendingService: Sendable {
         language: String?
     ) async throws -> PersonPageableList
 
+    ///
+    /// Returns a list of the daily or weekly trending movies, TV series, and people.
+    ///
+    /// The daily trending list tracks items over the period of a day while items have a 24 hour
+    /// half life. The weekly list tracks items over a 7 day period, with a 7 day half life.
+    ///
+    /// [TMDb API - Trending: All](https://developer.themoviedb.org/reference/trending-all)
+    ///
+    /// - Precondition: `page` can be between `1` and `1000`.
+    ///
+    /// - Parameters:
+    ///    - timeWindow: Daily or weekly time window. Defaults to daily.
+    ///    - page: The page of results to return.
+    ///    - language: ISO 639-1 language code to display results in. Defaults to the client's
+    /// configured default language.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: Trending movies, TV series, and people in a time window as a pageable list.
+    ///
+    func allTrending(
+        inTimeWindow timeWindow: TrendingTimeWindowFilterType,
+        page: Int?,
+        language: String?
+    ) async throws -> TrendingPageableList
+
 }
 
 public extension TrendingService {
@@ -177,6 +203,34 @@ public extension TrendingService {
         language: String? = nil
     ) async throws -> PersonPageableList {
         try await people(inTimeWindow: timeWindow, page: page, language: language)
+    }
+
+    ///
+    /// Returns a list of the daily or weekly trending movies, TV series, and people.
+    ///
+    /// The daily trending list tracks items over the period of a day while items have a 24 hour
+    /// half life. The weekly list tracks items over a 7 day period, with a 7 day half life.
+    ///
+    /// [TMDb API - Trending: All](https://developer.themoviedb.org/reference/trending-all)
+    ///
+    /// - Precondition: `page` can be between `1` and `1000`.
+    ///
+    /// - Parameters:
+    ///    - timeWindow: Daily or weekly time window. Defaults to daily.
+    ///    - page: The page of results to return.
+    ///    - language: ISO 639-1 language code to display results in. Defaults to the client's
+    /// configured default language.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: Trending movies, TV series, and people in a time window as a pageable list.
+    ///
+    func allTrending(
+        inTimeWindow timeWindow: TrendingTimeWindowFilterType = .day,
+        page: Int? = nil,
+        language: String? = nil
+    ) async throws -> TrendingPageableList {
+        try await allTrending(inTimeWindow: timeWindow, page: page, language: language)
     }
 
 }

--- a/Sources/TMDb/TMDb.docc/Extensions/MovieService.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/MovieService.md
@@ -37,6 +37,7 @@
 
 ### Content Discovery
 
+- ``keywords(forMovie:)``
 - ``alternativeTitles(forMovie:country:language:)``
 - ``translations(forMovie:)``
 

--- a/Sources/TMDb/TMDb.docc/Extensions/TVSeriesService.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/TVSeriesService.md
@@ -50,6 +50,8 @@
 - ``watchProviders(forTVSeries:)``
 - ``externalLinks(forTVSeries:)``
 - ``contentRatings(forTVSeries:)``
+- ``screenedTheatrically(forTVSeries:)``
+- ``episodeGroups(forTVSeries:)``
 - ``airingToday(page:timezone:language:)``
 - ``onTheAir(page:timezone:language:)``
 - ``topRated(page:language:)``

--- a/Sources/TMDb/TMDb.docc/Extensions/TrendingService.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/TrendingService.md
@@ -13,3 +13,7 @@
 ### People
 
 - ``people(inTimeWindow:page:language:)``
+
+### All
+
+- ``allTrending(inTimeWindow:page:language:)``

--- a/Sources/TMDb/TMDb.docc/TMDb.md
+++ b/Sources/TMDb/TMDb.docc/TMDb.md
@@ -68,6 +68,7 @@ Watch providers provided by [JustWatch](https://www.justwatch.com).
 - ``MovieReleaseDatesByCountry``
 - ``ReleaseDate``
 - ``ReleaseType``
+- ``KeywordCollection``
 - ``AlternativeTitle``
 - ``AlternativeTitleCollection``
 - ``Translation``
@@ -105,6 +106,9 @@ Watch providers provided by [JustWatch](https://www.justwatch.com).
 - ``TranslationCollection``
 - ``Translation``
 - ``TVSeriesTranslationData``
+- ``ScreenedTheatricallyCollection``
+- ``ScreenedTheatricallyResult``
+- ``TVEpisodeGroupCollection``
 - ``ChangeCollection``
 - ``Change``
 - ``ChangeItem``
@@ -205,6 +209,8 @@ Watch providers provided by [JustWatch](https://www.justwatch.com).
 - ``PersonPageableList``
 - ``Person``
 - ``TrendingTimeWindowFilterType``
+- ``TrendingItem``
+- ``TrendingPageableList``
 
 ### Search
 

--- a/Tests/TMDbIntegrationTests/MovieIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/MovieIntegrationTests.swift
@@ -232,4 +232,14 @@ struct MovieIntegrationTests {
         #expect(changedIDCollection.totalResults > 0)
     }
 
+    @Test("keywords")
+    func keywords() async throws {
+        let movieID = 550 // Fight Club
+
+        let keywordCollection = try await movieService.keywords(forMovie: movieID)
+
+        #expect(keywordCollection.id == movieID)
+        #expect(!keywordCollection.keywords.isEmpty)
+    }
+
 }

--- a/Tests/TMDbIntegrationTests/TVSeriesServiceTests.swift
+++ b/Tests/TMDbIntegrationTests/TVSeriesServiceTests.swift
@@ -311,4 +311,24 @@ struct TVSeriesServiceTests {
 
         #expect(!changedIDCollection.results.isEmpty)
     }
+
+    @Test("screenedTheatrically")
+    func screenedTheatrically() async throws {
+        let tvSeriesID = 1399 // Game of Thrones
+
+        let collection = try await tvSeriesService.screenedTheatrically(forTVSeries: tvSeriesID)
+
+        #expect(collection.id == tvSeriesID)
+        #expect(!collection.results.isEmpty)
+    }
+
+    @Test("episodeGroups")
+    func episodeGroups() async throws {
+        let tvSeriesID = 1399 // Game of Thrones
+
+        let collection = try await tvSeriesService.episodeGroups(forTVSeries: tvSeriesID)
+
+        #expect(collection.id == tvSeriesID)
+        #expect(!collection.episodeGroups.isEmpty)
+    }
 }

--- a/Tests/TMDbIntegrationTests/TrendingIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/TrendingIntegrationTests.swift
@@ -64,4 +64,18 @@ struct TrendingIntegrationTests {
         #expect(!personList.results.isEmpty)
     }
 
+    @Test("all trending by day")
+    func allTrendingByDay() async throws {
+        let trendingList = try await trendingService.allTrending(inTimeWindow: .day)
+
+        #expect(!trendingList.results.isEmpty)
+    }
+
+    @Test("all trending by week")
+    func allTrendingByWeek() async throws {
+        let trendingList = try await trendingService.allTrending(inTimeWindow: .week)
+
+        #expect(!trendingList.results.isEmpty)
+    }
+
 }

--- a/Tests/TMDbTests/Domain/Models/TrendingItemTests.swift
+++ b/Tests/TMDbTests/Domain/Models/TrendingItemTests.swift
@@ -1,0 +1,149 @@
+//
+//  TrendingItemTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.models))
+struct TrendingItemTests {
+
+    @Test("id when movie returns movieID")
+    func idWhenMovieReturnsMovieID() {
+        let item = TrendingItem.movie(.theFirstOmen)
+
+        #expect(item.id == 437_342)
+    }
+
+    @Test("id when TV series returns tvSeriesID")
+    func idWhenTVSeriesReturnsTVSeriesID() {
+        let item = TrendingItem.tvSeries(.bigBrother)
+
+        #expect(item.id == 11366)
+    }
+
+    @Test("id when person returns personID")
+    func idWhenPersonReturnsPersonID() {
+        let item = TrendingItem.person(.bradPitt)
+
+        #expect(item.id == 287)
+    }
+
+    @Test("JSON decoding of TrendingItem", .tags(.decoding))
+    func decodeReturnsTrendingItems() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            TrendingPageableList.self, fromResource: "trending-all"
+        )
+
+        #expect(result.results.count == 3)
+    }
+
+    @Test("JSON decoding of TrendingItem movie", .tags(.decoding))
+    func decodeReturnsTrendingMovie() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            TrendingPageableList.self, fromResource: "trending-all"
+        )
+
+        guard case .movie(let movie) = result.results[0] else {
+            Issue.record("Expected movie trending item")
+            return
+        }
+
+        #expect(movie.id == 1_368_166)
+        #expect(movie.title == "The Housemaid")
+    }
+
+    @Test("JSON decoding of TrendingItem TV series", .tags(.decoding))
+    func decodeReturnsTrendingTVSeries() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            TrendingPageableList.self, fromResource: "trending-all"
+        )
+
+        guard case .tvSeries(let tvSeries) = result.results[1] else {
+            Issue.record("Expected TV series trending item")
+            return
+        }
+
+        #expect(tvSeries.id == 106_379)
+        #expect(tvSeries.name == "Fallout")
+    }
+
+    @Test("JSON decoding of TrendingItem person", .tags(.decoding))
+    func decodeReturnsTrendingPerson() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            TrendingPageableList.self, fromResource: "trending-all"
+        )
+
+        guard case .person(let person) = result.results[2] else {
+            Issue.record("Expected person trending item")
+            return
+        }
+
+        #expect(person.id == 12345)
+        #expect(person.name == "John Doe")
+    }
+
+    @Test(
+        "JSON encoding and decoding of TrendingItem round trips correctly",
+        .tags(.encoding, .decoding)
+    )
+    func encodeDecodeRoundTrip() throws {
+        let trendingItems: [TrendingItem] = [
+            .movie(.theFirstOmen),
+            .tvSeries(.bigBrother),
+            .person(.bradPitt)
+        ]
+
+        for item in trendingItems {
+            let data = try JSONEncoder.theMovieDatabase.encode(item)
+            let decoded = try JSONDecoder.theMovieDatabase.decode(
+                TrendingItem.self, from: data
+            )
+            #expect(decoded == item)
+        }
+    }
+
+    @Test("JSON encoding of movie trending item", .tags(.encoding))
+    func encodeMovieTrendingItem() throws {
+        let movie = MovieListItem.theFirstOmen
+        let item = TrendingItem.movie(movie)
+
+        let data = try JSONEncoder.theMovieDatabase.encode(item)
+        let decodedMovie = try JSONDecoder.theMovieDatabase.decode(
+            MovieListItem.self, from: data
+        )
+
+        #expect(decodedMovie == movie)
+    }
+
+    @Test("JSON encoding of TV series trending item", .tags(.encoding))
+    func encodeTVSeriesTrendingItem() throws {
+        let tvSeries = TVSeriesListItem.bigBrother
+        let item = TrendingItem.tvSeries(tvSeries)
+
+        let data = try JSONEncoder.theMovieDatabase.encode(item)
+        let decodedTVSeries = try JSONDecoder.theMovieDatabase.decode(
+            TVSeriesListItem.self, from: data
+        )
+
+        #expect(decodedTVSeries == tvSeries)
+    }
+
+    @Test("JSON encoding of person trending item", .tags(.encoding))
+    func encodePersonTrendingItem() throws {
+        let person = PersonListItem.bradPitt
+        let item = TrendingItem.person(person)
+
+        let data = try JSONEncoder.theMovieDatabase.encode(item)
+        let decodedPerson = try JSONDecoder.theMovieDatabase.decode(
+            PersonListItem.self, from: data
+        )
+
+        #expect(decodedPerson == person)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Movies/Requests/MovieKeywordsRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Movies/Requests/MovieKeywordsRequestTests.swift
@@ -1,0 +1,46 @@
+//
+//  MovieKeywordsRequestTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.requests, .movie))
+struct MovieKeywordsRequestTests {
+
+    var request: MovieKeywordsRequest!
+
+    init() {
+        self.request = MovieKeywordsRequest(id: 550)
+    }
+
+    @Test("path is correct")
+    func path() {
+        #expect(request.path == "/movie/550/keywords")
+    }
+
+    @Test("queryItems is empty")
+    func queryItemsIsEmpty() {
+        #expect(request.queryItems.isEmpty)
+    }
+
+    @Test("method is GET")
+    func methodIsGet() {
+        #expect(request.method == .get)
+    }
+
+    @Test("headers is empty")
+    func headersIsEmpty() {
+        #expect(request.headers.isEmpty)
+    }
+
+    @Test("body is nil")
+    func bodyIsNil() {
+        #expect(request.body == nil)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Movies/TMDbMovieServiceKeywordsTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Movies/TMDbMovieServiceKeywordsTests.swift
@@ -1,0 +1,72 @@
+//
+//  TMDbMovieServiceKeywordsTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.services, .movie))
+struct TMDbMovieServiceKeywordsTests {
+
+    var service: TMDbMovieService!
+    var apiClient: MockAPIClient!
+
+    init() {
+        self.apiClient = MockAPIClient()
+        self.service = TMDbMovieService(apiClient: apiClient)
+    }
+
+    @Test("keywords returns keyword collection")
+    func keywordsReturnsKeywordCollection() async throws {
+        let movieID = 550
+        let response = MovieKeywordsResponse(
+            id: movieID,
+            keywords: [
+                Keyword(id: 851, name: "dual identity"),
+                Keyword(id: 818, name: "based on novel or book")
+            ]
+        )
+        apiClient.addResponse(.success(response))
+        let expectedRequest = MovieKeywordsRequest(id: movieID)
+
+        let result = try await service.keywords(forMovie: movieID)
+
+        #expect(result.id == movieID)
+        #expect(result.keywords.count == 2)
+        #expect(result.keywords[0].id == 851)
+        #expect(result.keywords[0].name == "dual identity")
+        #expect(apiClient.lastRequest as? MovieKeywordsRequest == expectedRequest)
+    }
+
+    @Test("keywords when errors throws error")
+    func keywordsWhenErrorsThrowsError() async throws {
+        let movieID = 1
+        apiClient.addResponse(.failure(.unknown))
+
+        await #expect(throws: TMDbError.unknown) {
+            _ = try await service.keywords(forMovie: movieID)
+        }
+    }
+
+    @Test("JSON decoding of MovieKeywordsResponse", .tags(.decoding))
+    func decodeMovieKeywordsResponse() throws {
+        let response = try JSONDecoder.theMovieDatabase.decode(
+            MovieKeywordsResponse.self,
+            fromResource: "movie-keywords"
+        )
+
+        #expect(response.id == 550)
+        #expect(response.keywords.count == 2)
+        #expect(response.keywords[0].id == 851)
+        #expect(response.keywords[0].name == "dual identity")
+
+        let collection = response.keywordCollection
+        #expect(collection.id == 550)
+        #expect(collection.keywords.count == 2)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/TVSeries/Requests/TVSeriesEpisodeGroupsRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/TVSeries/Requests/TVSeriesEpisodeGroupsRequestTests.swift
@@ -1,0 +1,50 @@
+//
+//  TVSeriesEpisodeGroupsRequestTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.requests, .tvSeries))
+struct TVSeriesEpisodeGroupsRequestTests {
+
+    @Test("path is correct")
+    func path() {
+        let request = TVSeriesEpisodeGroupsRequest(id: 1)
+
+        #expect(request.path == "/tv/1/episode_groups")
+    }
+
+    @Test("queryItems is empty")
+    func queryItemsIsEmpty() {
+        let request = TVSeriesEpisodeGroupsRequest(id: 1)
+
+        #expect(request.queryItems.isEmpty)
+    }
+
+    @Test("method is GET")
+    func methodIsGet() {
+        let request = TVSeriesEpisodeGroupsRequest(id: 1)
+
+        #expect(request.method == .get)
+    }
+
+    @Test("headers is empty")
+    func headersIsEmpty() {
+        let request = TVSeriesEpisodeGroupsRequest(id: 1)
+
+        #expect(request.headers.isEmpty)
+    }
+
+    @Test("body is nil")
+    func bodyIsNil() {
+        let request = TVSeriesEpisodeGroupsRequest(id: 1)
+
+        #expect(request.body == nil)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/TVSeries/Requests/TVSeriesScreenedTheatricallyRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/TVSeries/Requests/TVSeriesScreenedTheatricallyRequestTests.swift
@@ -1,0 +1,50 @@
+//
+//  TVSeriesScreenedTheatricallyRequestTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.requests, .tvSeries))
+struct TVSeriesScreenedTheatricallyRequestTests {
+
+    @Test("path is correct")
+    func path() {
+        let request = TVSeriesScreenedTheatricallyRequest(id: 1)
+
+        #expect(request.path == "/tv/1/screened_theatrically")
+    }
+
+    @Test("queryItems is empty")
+    func queryItemsIsEmpty() {
+        let request = TVSeriesScreenedTheatricallyRequest(id: 1)
+
+        #expect(request.queryItems.isEmpty)
+    }
+
+    @Test("method is GET")
+    func methodIsGet() {
+        let request = TVSeriesScreenedTheatricallyRequest(id: 1)
+
+        #expect(request.method == .get)
+    }
+
+    @Test("headers is empty")
+    func headersIsEmpty() {
+        let request = TVSeriesScreenedTheatricallyRequest(id: 1)
+
+        #expect(request.headers.isEmpty)
+    }
+
+    @Test("body is nil")
+    func bodyIsNil() {
+        let request = TVSeriesScreenedTheatricallyRequest(id: 1)
+
+        #expect(request.body == nil)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/TVSeries/TMDbTVSeriesServiceEpisodeGroupsTests.swift
+++ b/Tests/TMDbTests/Domain/Services/TVSeries/TMDbTVSeriesServiceEpisodeGroupsTests.swift
@@ -1,0 +1,70 @@
+//
+//  TMDbTVSeriesServiceEpisodeGroupsTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.services, .tvSeries))
+struct TMDbTVSeriesServiceEpisodeGroupsTests {
+
+    var service: TMDbTVSeriesService!
+    var apiClient: MockAPIClient!
+
+    init() {
+        self.apiClient = MockAPIClient()
+        self.service = TMDbTVSeriesService(apiClient: apiClient)
+    }
+
+    @Test("episodeGroups returns episode group collection")
+    func episodeGroupsReturnsCollection() async throws {
+        let expectedResult = TVEpisodeGroupCollection.mock()
+        let tvSeriesID = 1
+        apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = TVSeriesEpisodeGroupsRequest(id: tvSeriesID)
+
+        let result = try await service.episodeGroups(forTVSeries: tvSeriesID)
+
+        #expect(result == expectedResult)
+        #expect(
+            apiClient.lastRequest as? TVSeriesEpisodeGroupsRequest == expectedRequest
+        )
+    }
+
+    @Test("episodeGroups when errors throws error")
+    func episodeGroupsWhenErrorsThrowsError() async throws {
+        let tvSeriesID = 1
+        apiClient.addResponse(.failure(.unknown))
+
+        await #expect(throws: TMDbError.unknown) {
+            _ = try await service.episodeGroups(forTVSeries: tvSeriesID)
+        }
+    }
+
+    @Test("JSON decoding of TVEpisodeGroupCollection", .tags(.decoding))
+    func decodeTVEpisodeGroupCollection() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            TVEpisodeGroupCollection.self,
+            fromResource: "tv-series-episode-groups"
+        )
+
+        #expect(result.id == 1399)
+        #expect(result.episodeGroups.count == 1)
+        #expect(result.episodeGroups[0].id == "5acf93e60e0a26346c00000b")
+        #expect(result.episodeGroups[0].name == "Aired Order")
+
+        let episodeCount = try #require(result.episodeGroups[0].episodeCount)
+        #expect(episodeCount == 73)
+
+        let groupCount = try #require(result.episodeGroups[0].groupCount)
+        #expect(groupCount == 8)
+
+        let type = try #require(result.episodeGroups[0].type)
+        #expect(type == 1)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/TVSeries/TMDbTVSeriesServiceScreenedTheatricallyTests.swift
+++ b/Tests/TMDbTests/Domain/Services/TVSeries/TMDbTVSeriesServiceScreenedTheatricallyTests.swift
@@ -1,0 +1,62 @@
+//
+//  TMDbTVSeriesServiceScreenedTheatricallyTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.services, .tvSeries))
+struct TMDbTVSeriesServiceScreenedTheatricallyTests {
+
+    var service: TMDbTVSeriesService!
+    var apiClient: MockAPIClient!
+
+    init() {
+        self.apiClient = MockAPIClient()
+        self.service = TMDbTVSeriesService(apiClient: apiClient)
+    }
+
+    @Test("screenedTheatrically returns screened theatrically collection")
+    func screenedTheatricallyReturnsCollection() async throws {
+        let expectedResult = ScreenedTheatricallyCollection.mock()
+        let tvSeriesID = 1
+        apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = TVSeriesScreenedTheatricallyRequest(id: tvSeriesID)
+
+        let result = try await service.screenedTheatrically(forTVSeries: tvSeriesID)
+
+        #expect(result == expectedResult)
+        #expect(
+            apiClient.lastRequest as? TVSeriesScreenedTheatricallyRequest == expectedRequest
+        )
+    }
+
+    @Test("screenedTheatrically when errors throws error")
+    func screenedTheatricallyWhenErrorsThrowsError() async throws {
+        let tvSeriesID = 1
+        apiClient.addResponse(.failure(.unknown))
+
+        await #expect(throws: TMDbError.unknown) {
+            _ = try await service.screenedTheatrically(forTVSeries: tvSeriesID)
+        }
+    }
+
+    @Test("JSON decoding of ScreenedTheatricallyCollection", .tags(.decoding))
+    func decodeScreenedTheatricallyCollection() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            ScreenedTheatricallyCollection.self,
+            fromResource: "tv-series-screened-theatrically"
+        )
+
+        #expect(result.id == 1399)
+        #expect(result.results.count == 5)
+        #expect(result.results[0].id == 62085)
+        #expect(result.results[0].episodeNumber == 1)
+        #expect(result.results[0].seasonNumber == 1)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Trending/Requests/TrendingAllRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Trending/Requests/TrendingAllRequestTests.swift
@@ -1,0 +1,78 @@
+//
+//  TrendingAllRequestTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.requests, .trending))
+struct TrendingAllRequestTests {
+
+    @Test("path with day time window")
+    func pathWithDayTimeWindow() {
+        let request = TrendingAllRequest(timeWindow: .day)
+
+        #expect(request.path == "/trending/all/day")
+    }
+
+    @Test("path with week time window")
+    func pathWithWeekTimeWindow() {
+        let request = TrendingAllRequest(timeWindow: .week)
+
+        #expect(request.path == "/trending/all/week")
+    }
+
+    @Test("queryItems is empty")
+    func queryItemsIsEmpty() {
+        let request = TrendingAllRequest(timeWindow: .day)
+
+        #expect(request.queryItems.isEmpty)
+    }
+
+    @Test("queryItems with page")
+    func queryItemsWithPage() {
+        let request = TrendingAllRequest(timeWindow: .day, page: 1)
+
+        #expect(request.queryItems == ["page": "1"])
+    }
+
+    @Test("queryItems with language")
+    func queryItemsWithLanguage() {
+        let request = TrendingAllRequest(timeWindow: .day, language: "en")
+
+        #expect(request.queryItems == ["language": "en"])
+    }
+
+    @Test("queryItems with page and language")
+    func queryItemsWithPageAndLanguage() {
+        let request = TrendingAllRequest(timeWindow: .day, page: 1, language: "en")
+
+        #expect(request.queryItems == ["page": "1", "language": "en"])
+    }
+
+    @Test("method is GET")
+    func methodIsGet() {
+        let request = TrendingAllRequest(timeWindow: .day)
+
+        #expect(request.method == .get)
+    }
+
+    @Test("headers is empty")
+    func headersIsEmpty() {
+        let request = TrendingAllRequest(timeWindow: .day)
+
+        #expect(request.headers.isEmpty)
+    }
+
+    @Test("body is nil")
+    func bodyIsNil() {
+        let request = TrendingAllRequest(timeWindow: .day)
+
+        #expect(request.body == nil)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Trending/TMDbTrendingServiceAllTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Trending/TMDbTrendingServiceAllTests.swift
@@ -1,0 +1,69 @@
+//
+//  TMDbTrendingServiceAllTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.services, .trending))
+struct TMDbTrendingServiceAllTests {
+
+    var service: TMDbTrendingService!
+    var apiClient: MockAPIClient!
+
+    init() {
+        self.apiClient = MockAPIClient()
+        self.service = TMDbTrendingService(apiClient: apiClient)
+    }
+
+    @Test("allTrending with default parameter values returns trending items")
+    func allTrendingWithDefaultParameterValuesReturnsTrendingItems() async throws {
+        let timeWindow = TrendingTimeWindowFilterType.day
+        let expectedResult = TrendingPageableList.mock()
+        apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = TrendingAllRequest(
+            timeWindow: timeWindow, page: nil, language: nil
+        )
+
+        let result = try await (service as TrendingService).allTrending(
+            inTimeWindow: timeWindow
+        )
+
+        #expect(result == expectedResult)
+        #expect(apiClient.lastRequest as? TrendingAllRequest == expectedRequest)
+    }
+
+    @Test("allTrending with page and language returns trending items")
+    func allTrendingWithPageAndLanguageReturnsTrendingItems() async throws {
+        let timeWindow = TrendingTimeWindowFilterType.week
+        let page = 2
+        let language = "en"
+        let expectedResult = TrendingPageableList.mock()
+        apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = TrendingAllRequest(
+            timeWindow: timeWindow, page: page, language: language
+        )
+
+        let result = try await service.allTrending(
+            inTimeWindow: timeWindow, page: page, language: language
+        )
+
+        #expect(result == expectedResult)
+        #expect(apiClient.lastRequest as? TrendingAllRequest == expectedRequest)
+    }
+
+    @Test("allTrending when errors throws error")
+    func allTrendingWhenErrorsThrowsError() async throws {
+        let timeWindow = TrendingTimeWindowFilterType.day
+        apiClient.addResponse(.failure(.unknown))
+
+        await #expect(throws: TMDbError.unknown) {
+            _ = try await service.allTrending(inTimeWindow: timeWindow)
+        }
+    }
+
+}

--- a/Tests/TMDbTests/Mocks/Models/ScreenedTheatricallyCollection+Mocks.swift
+++ b/Tests/TMDbTests/Mocks/Models/ScreenedTheatricallyCollection+Mocks.swift
@@ -1,0 +1,26 @@
+//
+//  ScreenedTheatricallyCollection+Mocks.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import TMDb
+
+extension ScreenedTheatricallyCollection {
+
+    static func mock(
+        id: Int = 1,
+        results: [ScreenedTheatricallyResult] = [
+            ScreenedTheatricallyResult(id: 1, episodeNumber: 1, seasonNumber: 1),
+            ScreenedTheatricallyResult(id: 2, episodeNumber: 2, seasonNumber: 1)
+        ]
+    ) -> ScreenedTheatricallyCollection {
+        ScreenedTheatricallyCollection(
+            id: id,
+            results: results
+        )
+    }
+
+}

--- a/Tests/TMDbTests/Mocks/Models/TVEpisodeGroupCollection+Mocks.swift
+++ b/Tests/TMDbTests/Mocks/Models/TVEpisodeGroupCollection+Mocks.swift
@@ -1,0 +1,32 @@
+//
+//  TVEpisodeGroupCollection+Mocks.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import TMDb
+
+extension TVEpisodeGroupCollection {
+
+    static func mock(
+        id: Int = 1,
+        episodeGroups: [TVEpisodeGroup] = [
+            TVEpisodeGroup(
+                id: "5acf93e60e0a26346c00000b",
+                name: "Aired Order",
+                description: "",
+                episodeCount: 73,
+                groupCount: 8,
+                type: 1
+            )
+        ]
+    ) -> TVEpisodeGroupCollection {
+        TVEpisodeGroupCollection(
+            id: id,
+            episodeGroups: episodeGroups
+        )
+    }
+
+}

--- a/Tests/TMDbTests/Mocks/Models/TrendingItem+Mocks.swift
+++ b/Tests/TMDbTests/Mocks/Models/TrendingItem+Mocks.swift
@@ -1,0 +1,25 @@
+//
+//  TrendingItem+Mocks.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import TMDb
+
+extension TrendingItem {
+
+    static func mockMovie() -> TrendingItem {
+        .movie(.mock())
+    }
+
+    static func mockTVSeries() -> TrendingItem {
+        .tvSeries(.mock())
+    }
+
+    static func mockPerson() -> TrendingItem {
+        .person(.mock(originalName: "Person Name"))
+    }
+
+}

--- a/Tests/TMDbTests/Mocks/Models/TrendingPageableList+Mocks.swift
+++ b/Tests/TMDbTests/Mocks/Models/TrendingPageableList+Mocks.swift
@@ -1,0 +1,27 @@
+//
+//  TrendingPageableList+Mocks.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import TMDb
+
+extension TrendingPageableList {
+
+    static func mock(
+        page: Int = 1,
+        results: [TrendingItem] = [.mockMovie(), .mockTVSeries(), .mockPerson()],
+        totalResults: Int = 3,
+        totalPages: Int = 1
+    ) -> TrendingPageableList {
+        TrendingPageableList(
+            page: page,
+            results: results,
+            totalResults: totalResults,
+            totalPages: totalPages
+        )
+    }
+
+}

--- a/Tests/TMDbTests/Resources/json/movie-keywords.json
+++ b/Tests/TMDbTests/Resources/json/movie-keywords.json
@@ -1,0 +1,13 @@
+{
+    "id": 550,
+    "keywords": [
+        {
+            "id": 851,
+            "name": "dual identity"
+        },
+        {
+            "id": 818,
+            "name": "based on novel or book"
+        }
+    ]
+}

--- a/Tests/TMDbTests/Resources/json/trending-all.json
+++ b/Tests/TMDbTests/Resources/json/trending-all.json
@@ -1,0 +1,60 @@
+{
+    "page": 1,
+    "results": [
+        {
+            "adult": false,
+            "backdrop_path": "/tNONILTe9OJz574KZWaLze4v6RC.jpg",
+            "id": 1368166,
+            "title": "The Housemaid",
+            "original_title": "The Housemaid",
+            "original_language": "en",
+            "overview": "Trying to escape her past, Millie Calloway accepts a job.",
+            "poster_path": "/cWsBscZzwu5brg9YjNkGewRUvJX.jpg",
+            "media_type": "movie",
+            "genre_ids": [
+                9648,
+                53
+            ],
+            "popularity": 353.14,
+            "release_date": "2025-12-18",
+            "video": false,
+            "vote_average": 7.1,
+            "vote_count": 743
+        },
+        {
+            "adult": false,
+            "backdrop_path": "/cIgHBLTMbcIkS0yvIrUUVVKLdOz.jpg",
+            "id": 106379,
+            "name": "Fallout",
+            "original_name": "Fallout",
+            "original_language": "en",
+            "overview": "The story of haves and have-nots in a world.",
+            "poster_path": "/c15BtJxCXMrISLVmysdsnZUPQft.jpg",
+            "media_type": "tv",
+            "genre_ids": [
+                10759,
+                10765
+            ],
+            "popularity": 188.24,
+            "first_air_date": "2024-04-10",
+            "vote_average": 8.144,
+            "vote_count": 2501,
+            "origin_country": [
+                "US"
+            ]
+        },
+        {
+            "adult": false,
+            "id": 12345,
+            "name": "John Doe",
+            "original_name": "John Doe",
+            "media_type": "person",
+            "gender": 2,
+            "known_for_department": "Acting",
+            "popularity": 100.5,
+            "profile_path": "/path.jpg"
+        }
+    ],
+    "total_pages": 500,
+    "total_results": 10000
+}

--- a/Tests/TMDbTests/Resources/json/tv-series-episode-groups.json
+++ b/Tests/TMDbTests/Resources/json/tv-series-episode-groups.json
@@ -1,0 +1,14 @@
+{
+    "id": 1399,
+    "results": [
+        {
+            "description": "",
+            "episode_count": 73,
+            "group_count": 8,
+            "id": "5acf93e60e0a26346c00000b",
+            "name": "Aired Order",
+            "network": null,
+            "type": 1
+        }
+    ]
+}

--- a/Tests/TMDbTests/Resources/json/tv-series-screened-theatrically.json
+++ b/Tests/TMDbTests/Resources/json/tv-series-screened-theatrically.json
@@ -1,0 +1,30 @@
+{
+    "id": 1399,
+    "results": [
+        {
+            "id": 62085,
+            "episode_number": 1,
+            "season_number": 1
+        },
+        {
+            "id": 62086,
+            "episode_number": 2,
+            "season_number": 1
+        },
+        {
+            "id": 1019560,
+            "episode_number": 1,
+            "season_number": 3
+        },
+        {
+            "id": 1019561,
+            "episode_number": 2,
+            "season_number": 3
+        },
+        {
+            "id": 1019562,
+            "episode_number": 3,
+            "season_number": 3
+        }
+    ]
+}

--- a/prd/PRD-001-complete-api-parity.md
+++ b/prd/PRD-001-complete-api-parity.md
@@ -4,7 +4,7 @@
 |----------|----------------------------------------|
 | Priority | High                                   |
 | Effort   | Small                                  |
-| Status   | Draft                                  |
+| Status   | Complete                               |
 
 ## Problem Statement
 
@@ -260,21 +260,21 @@ test methods to the existing files:
 
 ## Acceptance Criteria
 
-- [ ] `MovieService.keywords(forMovie:)` returns a `KeywordCollection`
+- [x] `MovieService.keywords(forMovie:)` returns a `KeywordCollection`
       with the correct keywords for a given movie
-- [ ] `TrendingService.allTrending(inTimeWindow:page:language:)` returns
+- [x] `TrendingService.allTrending(inTimeWindow:page:language:)` returns
       a pageable list of mixed media results
-- [ ] `TVSeriesService.screenedTheatrically(forTVSeries:)` returns
+- [x] `TVSeriesService.screenedTheatrically(forTVSeries:)` returns
       theatrical screening data
-- [ ] `TVSeriesService.episodeGroups(forTVSeries:)` returns episode
+- [x] `TVSeriesService.episodeGroups(forTVSeries:)` returns episode
       group data for a TV series
-- [ ] All new methods have `///` doc comments with parameters, throws,
+- [x] All new methods have `///` doc comments with parameters, throws,
       and returns
-- [ ] DocC extension files reference the new methods
-- [ ] `TMDb.docc/TMDb.md` topic sections include new model types
-- [ ] Unit tests pass with JSON fixtures
-- [ ] Integration tests pass against the live TMDb API
-- [ ] `make ci` passes
+- [x] DocC extension files reference the new methods
+- [x] `TMDb.docc/TMDb.md` topic sections include new model types
+- [x] Unit tests pass with JSON fixtures
+- [x] Integration tests pass against the live TMDb API
+- [x] `make ci` passes
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

Implements PRD-001 (Complete API Parity) by adding the four remaining TMDb API v3 endpoints, closing the asymmetries in the public API surface.

## Changes

**New Endpoints:**
- ✨ `MovieService.keywords(forMovie:)` — returns keywords for a movie via `GET /3/movie/{id}/keywords`
- ✨ `TrendingService.allTrending(inTimeWindow:page:language:)` — returns trending movies, TV series, and people via `GET /3/trending/all/{time_window}`
- ✨ `TVSeriesService.screenedTheatrically(forTVSeries:)` — returns theatrically screened episodes via `GET /3/tv/{id}/screened_theatrically`
- ✨ `TVSeriesService.episodeGroups(forTVSeries:)` — returns episode groups via `GET /3/tv/{id}/episode_groups`

**New Models:**
- ✨ `TrendingItem` — polymorphic enum (movie/tvSeries/person) decoded via `media_type` discriminator
- ✨ `TrendingPageableList` — typealias for `PageableListResult<TrendingItem>`
- ✨ `ScreenedTheatricallyCollection` and `ScreenedTheatricallyResult`
- ✨ `TVEpisodeGroupCollection` — reuses existing `TVEpisodeGroup` model
- ✨ `MovieKeywordsResponse` — internal model bridging movie keywords JSON (`"keywords"` key) to `KeywordCollection` (`"results"` key)

**Tests:**
- ✅ Unit tests for all 4 service methods (success + error cases)
- ✅ Request tests for all 4 request classes (path, queryItems, method, headers, body)
- ✅ JSON fixture decode tests for all new models
- ✅ `TrendingItem` encoding/decoding round-trip tests
- ✅ Integration tests for all 4 endpoints against live TMDb API
- ✅ `make ci` passes (1979 tests, 0 failures)

**Documentation:**
- 📚 Updated `MovieService.md`, `TrendingService.md`, `TVSeriesService.md` DocC extension files
- 📚 Added new model types to `TMDb.md` topic sections
- 📚 Updated `README.md` service descriptions
- 📝 Marked PRD-001 as complete

## Benefits

- **Complete API Parity**: All TMDb API v3 endpoints are now covered
- **Symmetric API Surface**: `MovieService` now has `keywords()` matching `TVSeriesService`; `TrendingService` has `allTrending()` alongside movies/tvSeries/people
- **Unblocks PRD-003**: The `allTrending` method is a dependency for PRD-003's pagination helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)