### PR TITLE
📝 Update swift-docc-plugin and fix documentation issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
     needs: changes
     if: always()
     runs-on: ubuntu-latest
-    container: swift:6.0.2-jammy
+    container: swift:6.0.3-jammy
     steps:
       - name: No changes detected
         if: needs.changes.outputs.swift != 'true' && github.event_name != 'workflow_dispatch'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,7 +26,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    container: swift:6.0.2-jammy
+    container: swift:6.0.3-jammy
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload documentation
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: 'docs'
   

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .docc-build
 .swiftpm
 /.build
+Package.resolved
 /*.xcodeproj
 xcuserdata/
 .vscode

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,6 +341,15 @@ After public API changes, verify all of the following are in sync:
 - Stale service count in README after adding services
 - `- Parameters name:` (plural) instead of `- Parameter name:`
   (singular)
+- Copy-paste errors in doc comments when creating similar models
+  (e.g., "movie" instead of "person", wrong parameter descriptions)
+- Initializer parameter types not matching property types (e.g.,
+  `Movie.ID` instead of `Person.ID`) — compiles when both resolve to
+  `Int` but is semantically wrong
+- Missing `///` doc comments on custom `init(from:)` and
+  `encode(to:)` methods in `public extension` blocks
+- Placeholder or incomplete doc comments (e.g., `/// ?`,
+  `Array of....`) — always write complete descriptions
 
 ## Completion Checklist
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ WATCHOS_DESTINATION = 'platform=watchOS Simulator,name=Apple Watch Series 11 (46
 TVOS_DESTINATION = 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.2'
 VISIONOS_DESTINATION = 'platform=visionOS Simulator,name=Apple Vision Pro,OS=26.2'
 
-SWIFT_CONTAINER_IMAGE = swift:6.0.2-jammy
+SWIFT_CONTAINER_IMAGE = swift:6.0.3-jammy
 
 .PHONY: clean
 clean:

--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,6 @@ let package = Package(
 
 if ProcessInfo.processInfo.environment["SWIFTCI_DOCC"] == "1" {
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.3")
+        .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.6")
     ]
 }

--- a/Sources/TMDb/Domain/Models/AnyCodable.swift
+++ b/Sources/TMDb/Domain/Models/AnyCodable.swift
@@ -12,14 +12,32 @@ import Foundation
 ///
 public enum AnyCodable: Codable, Equatable, Hashable, Sendable {
 
+    /// A string value.
     case string(String)
+
+    /// An integer value.
     case int(Int)
+
+    /// A double value.
     case double(Double)
+
+    /// A boolean value.
     case bool(Bool)
+
+    /// An array of ``AnyCodable`` values.
     case array([AnyCodable])
+
+    /// A dictionary of string keys to ``AnyCodable`` values.
     case dictionary([String: AnyCodable])
+
+    /// A null value.
     case null
 
+    ///
+    /// Creates a new instance by decoding from the given decoder.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    ///
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
 
@@ -45,6 +63,11 @@ public enum AnyCodable: Codable, Equatable, Hashable, Sendable {
         }
     }
 
+    ///
+    /// Encodes this value into the given encoder.
+    ///
+    /// - Parameter encoder: The encoder to write data to.
+    ///
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
 

--- a/Sources/TMDb/Domain/Models/ContentRating.swift
+++ b/Sources/TMDb/Domain/Models/ContentRating.swift
@@ -13,7 +13,7 @@ import Foundation
 public struct ContentRating: Codable, Equatable, Hashable, Sendable {
 
     ///
-    /// ?
+    /// Content descriptors for the rating (e.g. violence, language).
     ///
     public let descriptors: [String]
 
@@ -23,16 +23,16 @@ public struct ContentRating: Codable, Equatable, Hashable, Sendable {
     public let countryCode: String
 
     ///
-    /// The content rating of the tv show.
+    /// The content rating of the TV series.
     ///
     public let rating: String
 
     /// Creates a content rating object.
     ///
     /// - Parameters:
-    ///    - descriptors: Array of....
+    ///    - descriptors: Content descriptors for the rating.
     ///    - countryCode: ISO 3166-1 country code.
-    ///    - rating: The content rating of the tv show
+    ///    - rating: The content rating of the TV series.
     ///
     public init(descriptors: [String], countryCode: String, rating: String) {
         self.descriptors = descriptors

--- a/Sources/TMDb/Domain/Models/PersonExternalLinksCollection.swift
+++ b/Sources/TMDb/Domain/Models/PersonExternalLinksCollection.swift
@@ -43,12 +43,12 @@ public struct PersonExternalLinksCollection: Identifiable, Codable, Equatable, H
     public let twitter: TwitterLink?
 
     ///
-    /// TikTok llink.
+    /// TikTok link.
     ///
     public let tikTok: TikTokLink?
 
     ///
-    /// Creates an external links collection for a movie.
+    /// Creates an external links collection for a person.
     ///
     /// - Parameters:
     ///   - id: The TMDb person identifier.
@@ -60,7 +60,7 @@ public struct PersonExternalLinksCollection: Identifiable, Codable, Equatable, H
     ///   - tikTok: TikTok link.
     ///
     public init(
-        id: Movie.ID,
+        id: Person.ID,
         imdb: IMDbLink? = nil,
         wikiData: WikiDataLink? = nil,
         facebook: FacebookLink? = nil,

--- a/Sources/TMDb/Domain/Models/ProductionCompany.swift
+++ b/Sources/TMDb/Domain/Models/ProductionCompany.swift
@@ -39,7 +39,7 @@ public struct ProductionCompany: Identifiable, Codable, Equatable, Hashable, Sen
     ///
     /// - Parameters:
     ///    - id: Company identifier.
-    ///    - name: Company's country of origin.
+    ///    - name: Company's name.
     ///    - originCountry: Company's country of origin.
     ///    - logoPath: Company's logo path.
     ///

--- a/Sources/TMDb/Domain/Models/Review.swift
+++ b/Sources/TMDb/Domain/Models/Review.swift
@@ -136,6 +136,11 @@ extension Review {
         return formatter
     }()
 
+    ///
+    /// Creates a new instance by decoding from the given decoder.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    ///
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 

--- a/Sources/TMDb/Domain/Models/ShowWatchProvider.swift
+++ b/Sources/TMDb/Domain/Models/ShowWatchProvider.swift
@@ -82,6 +82,11 @@ public extension ShowWatchProvider {
         case ads
     }
 
+    ///
+    /// Creates a new instance by decoding from the given decoder.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    ///
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let linkString = try container.decodeIfPresent(
@@ -105,6 +110,11 @@ public extension ShowWatchProvider {
         )
     }
 
+    ///
+    /// Encodes this value into the given encoder.
+    ///
+    /// - Parameter encoder: The encoder to write data to.
+    ///
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(link?.absoluteString, forKey: .link)

--- a/Sources/TMDb/Domain/Models/Translation.swift
+++ b/Sources/TMDb/Domain/Models/Translation.swift
@@ -192,6 +192,7 @@ public struct TVSeriesTranslationData: Codable, Equatable, Hashable, Sendable {
 
 }
 
+///
 /// A model representing TV season-specific translation data.
 ///
 public struct TVSeasonTranslationData: Codable, Equatable, Hashable, Sendable {


### PR DESCRIPTION
## Summary

Update swift-docc-plugin from 1.4.3 to 1.4.6, bump CI dependencies, and fix documentation issues found during a full public API audit.

## Changes

**Dependencies:**
- ⬆️ swift-docc-plugin 1.4.3 → 1.4.6
- ⬆️ Swift container image 6.0.2 → 6.0.3 (Makefile, CI, docs workflows)
- ⬆️ `actions/upload-pages-artifact` v4 → v5

**Bug Fix:**
- 🐛 Fixed `PersonExternalLinksCollection` init parameter type from `Movie.ID` to `Person.ID`

**Documentation Fixes:**
- 📝 Fixed copy-paste error in `PersonExternalLinksCollection` ("movie" → "person")
- 📝 Fixed typo "llink" → "link" in `PersonExternalLinksCollection`
- 📝 Fixed wrong parameter description in `ProductionCompany` (`name` was documented as "country of origin")
- 📝 Fixed placeholder docs in `ContentRating` (`/// ?` and `Array of....`)
- 📝 Fixed "tv show" → "TV series" in `ContentRating` for consistency
- 📝 Added missing doc comments to `AnyCodable` enum cases, `init(from:)`, and `encode(to:)`
- 📝 Added missing doc comment to `Review.init(from:)`
- 📝 Added missing doc comments to `ShowWatchProvider.init(from:)` and `encode(to:)`
- 📝 Fixed missing `///` prefix on `TVSeasonTranslationData` doc comment

**Other:**
- 🔧 Added `Package.resolved` to `.gitignore`
- 📝 Updated `CLAUDE.md` common mistakes section with patterns found during audit

## Benefits

- **Correctness**: Fixes a semantic type bug in `PersonExternalLinksCollection`
- **Documentation Quality**: All public declarations now have complete, accurate doc comments
- **Up-to-date CI**: Latest swift-docc-plugin, Swift container, and GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)