### PR TITLE
🐛 Parse review dates without fractional seconds

### DIFF
--- a/Sources/TMDb/Domain/Models/Review.swift
+++ b/Sources/TMDb/Domain/Models/Review.swift
@@ -128,13 +128,24 @@ extension Review {
         case updatedAt
     }
 
-    private nonisolated(unsafe) static let iso8601Formatter: ISO8601DateFormatter = {
+    private nonisolated(unsafe) static let iso8601FractionalFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [
             .withInternetDateTime, .withFractionalSeconds
         ]
         return formatter
     }()
+
+    private nonisolated(unsafe) static let iso8601Formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    private static func parseDate(_ string: String) -> Date? {
+        iso8601FractionalFormatter.date(from: string)
+            ?? iso8601Formatter.date(from: string)
+    }
 
     ///
     /// Creates a new instance by decoding from the given decoder.
@@ -165,9 +176,7 @@ extension Review {
         if let createdAtString = try container.decodeIfPresent(
             String.self, forKey: .createdAt
         ) {
-            self.createdAt = Self.iso8601Formatter.date(
-                from: createdAtString
-            )
+            self.createdAt = Self.parseDate(createdAtString)
         } else {
             self.createdAt = nil
         }
@@ -175,9 +184,7 @@ extension Review {
         if let updatedAtString = try container.decodeIfPresent(
             String.self, forKey: .updatedAt
         ) {
-            self.updatedAt = Self.iso8601Formatter.date(
-                from: updatedAtString
-            )
+            self.updatedAt = Self.parseDate(updatedAtString)
         } else {
             self.updatedAt = nil
         }

--- a/Tests/TMDbTests/Domain/Models/ReviewTests.swift
+++ b/Tests/TMDbTests/Domain/Models/ReviewTests.swift
@@ -55,6 +55,51 @@ struct ReviewTests {
     }
 
     @Test(
+        "JSON decoding of Review with non-fractional second dates",
+        .tags(.decoding)
+    )
+    func decodeWithNonFractionalSecondDatesReturnsReview() throws {
+        let json = """
+        {
+            "id": "abc123",
+            "author": "Test Author",
+            "content": "Test content",
+            "created_at": "2014-12-10T22:00:59Z",
+            "updated_at": "2021-06-23T15:57:31Z"
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+        let result = try JSONDecoder.theMovieDatabase
+            .decode(Review.self, from: data)
+
+        let createdAt = try #require(result.createdAt)
+        let createdAtComponents = try Calendar(identifier: .gregorian)
+            .dateComponents(
+                in: #require(TimeZone(identifier: "UTC")),
+                from: createdAt
+            )
+        #expect(createdAtComponents.year == 2014)
+        #expect(createdAtComponents.month == 12)
+        #expect(createdAtComponents.day == 10)
+        #expect(createdAtComponents.hour == 22)
+        #expect(createdAtComponents.minute == 0)
+        #expect(createdAtComponents.second == 59)
+
+        let updatedAt = try #require(result.updatedAt)
+        let updatedAtComponents = try Calendar(identifier: .gregorian)
+            .dateComponents(
+                in: #require(TimeZone(identifier: "UTC")),
+                from: updatedAt
+            )
+        #expect(updatedAtComponents.year == 2021)
+        #expect(updatedAtComponents.month == 6)
+        #expect(updatedAtComponents.day == 23)
+        #expect(updatedAtComponents.hour == 15)
+        #expect(updatedAtComponents.minute == 57)
+        #expect(updatedAtComponents.second == 31)
+    }
+
+    @Test(
         "JSON decoding of Review without optional data",
         .tags(.decoding)
     )


### PR DESCRIPTION
## Summary

The scheduled Integration CI run [#25268952923](https://github.com/adamayoung/TMDb/actions/runs/25268952923) failed: `MovieIntegrationTests.reviews` and `ReviewIntegrationTests.details` both asserted `review.updatedAt != nil` and got `nil`.

The TMDb API returns review timestamps in two ISO8601 forms:

- with fractional seconds — `2021-06-23T15:57:54.428Z`
- without fractional seconds — `2014-12-10T22:00:59Z`

The custom `Review.init(from:)` decoder used a single `ISO8601DateFormatter` configured with `[.withInternetDateTime, .withFractionalSeconds]`, which strictly requires fractional seconds and silently returned `nil` for the second form.

## Changes

**Bug Fix:**
- 🐛 `Review.swift` — added a second `ISO8601DateFormatter` without `.withFractionalSeconds` and a `parseDate(_:)` helper that tries fractional first, then falls back to non-fractional. Both `createdAt` and `updatedAt` use the helper.

**Tests:**
- ✅ Added `decodeWithNonFractionalSecondDatesReturnsReview` — pins both timestamp shapes by asserting full date components (year, month, day, hour, minute, second).
- ✅ Existing fixture (with fractional seconds) and "without optional data" test continue to cover the other branches.

## Verification

- `make ci` — all checks pass: 2247 unit tests + 242 integration tests
- `swift test --filter "ReviewIntegrationTests"` — passes
- `swift test --filter "MovieIntegrationTests/reviews"` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)