### PR TITLE
🐛 Retry successful responses with malformed JSON bodies

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"907bf735-fe88-4310-8791-b869279b66da","pid":81152,"procStart":"Mon Jun  1 09:44:21 2026","acquiredAt":1780308473554}

--- a/Sources/TMDb/Domain/Models/RetryableErrors.swift
+++ b/Sources/TMDb/Domain/Models/RetryableErrors.swift
@@ -39,6 +39,10 @@ public struct RetryableErrors: OptionSet, Hashable, Sendable {
     public static let rateLimit = RetryableErrors(rawValue: 1 << 0)
 
     /// HTTP 5xx server errors.
+    ///
+    /// This also covers successful (2xx) responses whose body is not valid
+    /// JSON, which indicate a transient server-side or infrastructure error
+    /// (such as a proxy returning an error page with a 200 status).
     public static let serverErrors = RetryableErrors(rawValue: 1 << 1)
 
 }

--- a/Sources/TMDb/Networking/RetryHTTPClient.swift
+++ b/Sources/TMDb/Networking/RetryHTTPClient.swift
@@ -30,7 +30,7 @@ final class RetryHTTPClient: HTTPClient, Sendable {
                 continue
             }
 
-            guard isRetryableStatusCode(response.statusCode) else {
+            guard isRetryableResponse(response) else {
                 return response
             }
 
@@ -46,6 +46,37 @@ final class RetryHTTPClient: HTTPClient, Sendable {
 }
 
 extension RetryHTTPClient {
+
+    private func isRetryableResponse(_ response: HTTPResponse) -> Bool {
+        if isRetryableStatusCode(response.statusCode) {
+            return true
+        }
+
+        return isMalformedSuccessResponse(response)
+    }
+
+    private func isMalformedSuccessResponse(_ response: HTTPResponse) -> Bool {
+        guard configuration.retryableErrors.contains(.serverErrors) else {
+            return false
+        }
+
+        guard (200 ... 299).contains(response.statusCode) else {
+            return false
+        }
+
+        // A successful response whose non-empty body does not begin with a
+        // valid JSON token indicates a transient infrastructure error — for
+        // example a proxy or CDN returning an HTML or plain-text error page
+        // with a 200 status. Treat these as retryable server errors. An empty
+        // body is left alone, as some endpoints legitimately return no content.
+        guard let data = response.data,
+              let firstByte = data.first(where: { !$0.isJSONWhitespace })
+        else {
+            return false
+        }
+
+        return !firstByte.isJSONValueStart
+    }
 
     private func isRetryableStatusCode(_ statusCode: Int) -> Bool {
         if configuration.retryableErrors.contains(.rateLimit), statusCode == 429 {
@@ -94,6 +125,28 @@ extension RetryHTTPClient {
         let jitteredSeconds = Double.random(in: 0 ... cappedSeconds)
 
         try await Task.sleep(for: .seconds(jitteredSeconds))
+    }
+
+}
+
+private extension UInt8 {
+
+    /// Whether the byte is JSON insignificant whitespace.
+    var isJSONWhitespace: Bool {
+        self == 0x20 || self == 0x09 || self == 0x0A || self == 0x0D
+    }
+
+    /// Whether the byte can legally begin a JSON value.
+    var isJSONValueStart: Bool {
+        switch self {
+        case UInt8(ascii: "{"), UInt8(ascii: "["), UInt8(ascii: "\""),
+             UInt8(ascii: "-"), UInt8(ascii: "t"), UInt8(ascii: "f"),
+             UInt8(ascii: "n"), UInt8(ascii: "0") ... UInt8(ascii: "9"):
+            true
+
+        default:
+            false
+        }
     }
 
 }

--- a/Tests/TMDbTests/Networking/RetryHTTPClientMalformedResponseTests.swift
+++ b/Tests/TMDbTests/Networking/RetryHTTPClientMalformedResponseTests.swift
@@ -96,6 +96,57 @@ struct RetryHTTPClientMalformedResponseTests {
         #expect(mockClient.performCount == 1)
     }
 
+    @Test("200 with nil body is not retried")
+    func successWithNilBodyNotRetried() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 200)))
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.fastConfig
+        )
+        let request = try HTTPRequest(url: #require(URL(string: "https://example.com")))
+
+        let response = try await retryClient.perform(request: request)
+
+        #expect(response.statusCode == 200)
+        #expect(mockClient.performCount == 1)
+    }
+
+    @Test("200 with whitespace-only body is not retried")
+    func successWithWhitespaceOnlyBodyNotRetried() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 200, data: Data("   ".utf8))))
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.fastConfig
+        )
+        let request = try HTTPRequest(url: #require(URL(string: "https://example.com")))
+
+        let response = try await retryClient.perform(request: request)
+
+        #expect(response.statusCode == 200)
+        #expect(mockClient.performCount == 1)
+    }
+
+    @Test("non-2xx with non-JSON body is not retried via the malformed-body path")
+    func nonSuccessWithNonJSONBodyNotRetried() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 404, data: Data("Not Found".utf8))))
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.fastConfig
+        )
+        let request = try HTTPRequest(url: #require(URL(string: "https://example.com")))
+
+        let response = try await retryClient.perform(request: request)
+
+        #expect(response.statusCode == 404)
+        #expect(mockClient.performCount == 1)
+    }
+
     @Test("200 with non-JSON body is not retried when server errors disabled")
     func malformedSuccessBodyNotRetriedWhenServerErrorsDisabled() async throws {
         let mockClient = SequencingHTTPMockClient()

--- a/Tests/TMDbTests/Networking/RetryHTTPClientMalformedResponseTests.swift
+++ b/Tests/TMDbTests/Networking/RetryHTTPClientMalformedResponseTests.swift
@@ -1,0 +1,142 @@
+//
+//  RetryHTTPClientMalformedResponseTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+struct RetryHTTPClientMalformedResponseTests {
+
+    private static let fastConfig = RetryConfiguration(
+        maxRetries: 3,
+        initialDelay: .milliseconds(1),
+        maxDelay: .milliseconds(10),
+        retryableErrors: [.rateLimit, .serverErrors]
+    )
+
+    @Test("200 with non-JSON body is retried")
+    func malformedSuccessBodyIsRetried() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(
+            .success(HTTPResponse(statusCode: 200, data: Data("just a moment".utf8)))
+        )
+        mockClient.enqueue(
+            .success(HTTPResponse(statusCode: 200, data: Data("{\"page\":1}".utf8)))
+        )
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.fastConfig
+        )
+        let request = try HTTPRequest(url: #require(URL(string: "https://example.com")))
+
+        let response = try await retryClient.perform(request: request)
+
+        #expect(response.statusCode == 200)
+        #expect(response.data == Data("{\"page\":1}".utf8))
+        #expect(mockClient.performCount == 2)
+    }
+
+    @Test("200 with leading whitespace then valid JSON is not retried")
+    func successBodyWithLeadingWhitespaceNotRetried() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(
+            .success(HTTPResponse(statusCode: 200, data: Data("  \n{\"page\":1}".utf8)))
+        )
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.fastConfig
+        )
+        let request = try HTTPRequest(url: #require(URL(string: "https://example.com")))
+
+        let response = try await retryClient.perform(request: request)
+
+        #expect(response.statusCode == 200)
+        #expect(mockClient.performCount == 1)
+    }
+
+    @Test("200 with JSON array body is not retried")
+    func successBodyWithJSONArrayNotRetried() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(
+            .success(HTTPResponse(statusCode: 200, data: Data("[1,2,3]".utf8)))
+        )
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.fastConfig
+        )
+        let request = try HTTPRequest(url: #require(URL(string: "https://example.com")))
+
+        let response = try await retryClient.perform(request: request)
+
+        #expect(response.statusCode == 200)
+        #expect(mockClient.performCount == 1)
+    }
+
+    @Test("200 with empty body is not retried")
+    func successWithEmptyBodyNotRetried() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 200, data: Data())))
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.fastConfig
+        )
+        let request = try HTTPRequest(url: #require(URL(string: "https://example.com")))
+
+        let response = try await retryClient.perform(request: request)
+
+        #expect(response.statusCode == 200)
+        #expect(mockClient.performCount == 1)
+    }
+
+    @Test("200 with non-JSON body is not retried when server errors disabled")
+    func malformedSuccessBodyNotRetriedWhenServerErrorsDisabled() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(
+            .success(HTTPResponse(statusCode: 200, data: Data("just a moment".utf8)))
+        )
+
+        let config = RetryConfiguration(
+            maxRetries: 3,
+            initialDelay: .milliseconds(1),
+            maxDelay: .milliseconds(10),
+            retryableErrors: [.rateLimit]
+        )
+        let retryClient = RetryHTTPClient(httpClient: mockClient, configuration: config)
+        let request = try HTTPRequest(url: #require(URL(string: "https://example.com")))
+
+        let response = try await retryClient.perform(request: request)
+
+        #expect(response.statusCode == 200)
+        #expect(mockClient.performCount == 1)
+    }
+
+    @Test("200 with non-JSON body exhausts retries and returns last response")
+    func malformedSuccessBodyExhaustsRetries() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        for _ in 0 ... 3 {
+            mockClient.enqueue(
+                .success(HTTPResponse(statusCode: 200, data: Data("just a moment".utf8)))
+            )
+        }
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.fastConfig
+        )
+        let request = try HTTPRequest(url: #require(URL(string: "https://example.com")))
+
+        let response = try await retryClient.perform(request: request)
+
+        #expect(response.statusCode == 200)
+        #expect(mockClient.performCount == 4)
+    }
+
+}

--- a/Tests/TMDbTests/TMDbFactoryRetryTests.swift
+++ b/Tests/TMDbTests/TMDbFactoryRetryTests.swift
@@ -68,7 +68,7 @@ struct TMDbFactoryRetryTests {
     @Test("cache hit with both configurations skips retry and network")
     func cacheHitSkipsRetryAndNetwork() async throws {
         let mockClient = SequencingHTTPMockClient()
-        mockClient.enqueue(.success(HTTPResponse(statusCode: 200, data: Data("ok".utf8))))
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 200, data: Data("{\"ok\":true}".utf8))))
 
         let wrappedClient = TMDbFactory.httpClient(
             wrapping: mockClient,
@@ -82,7 +82,7 @@ struct TMDbFactoryRetryTests {
         let cached = try await wrappedClient.perform(request: request)
 
         #expect(mockClient.performCount == 1)
-        #expect(cached.data == Data("ok".utf8))
+        #expect(cached.data == Data("{\"ok\":true}".utf8))
     }
 
 }


### PR DESCRIPTION
## Summary

The scheduled [Integration CI run](https://github.com/adamayoung/TMDb/actions/runs/26702936129) failed on `SearchPaginationIntegrationTests` with:

```
decode(DecodingError.dataCorrupted: ... Unexpected character 'j' around line 1, column 1.)
```

The live TMDb API intermittently returns an HTTP **200** with a body that is **not valid JSON** (a transient proxy/CDN error page). `RetryHTTPClient` only retried based on HTTP **status codes**, so a malformed body on a successful response was never retried — it propagated straight to the decoder and failed the test.

## Changes

**Fix:**
- 🐛 `RetryHTTPClient` now treats a successful (2xx) response whose **non-empty** body does not begin with a valid JSON token as a retryable server error. This is gated on the existing `.serverErrors` category (enabled by default), so both production clients and the integration-test client benefit. Empty bodies are left untouched, since some endpoints legitimately return no content. Detection is a cheap first-byte check, so valid JSON is never falsely retried and genuine decode errors (valid JSON, wrong shape) are still surfaced immediately.

**Tests:**
- ✅ New `RetryHTTPClientMalformedResponseTests` covering: malformed 2xx retried then succeeds; leading-whitespace + valid JSON not retried; JSON array body not retried; empty body not retried; not retried when `.serverErrors` is disabled; exhausts retries and returns the last response.
- ✅ Updated `TMDbFactoryRetryTests` cache-hit test to use a JSON body (its placeholder `"ok"` body would otherwise trip the new retry path).

**Docs:**
- 📝 Clarified the `RetryableErrors.serverErrors` doc comment to note it also covers malformed successful responses.

## Verification

- `make ci` passes (lint, unit tests, release build, docs).
- `make integration-test` passes, including the previously-failing search pagination suite.

## Benefits

- **Resilience**: transient 200-with-garbage responses from the live API are now retried with backoff instead of failing outright.
- **No false retries**: valid JSON responses are never retried, and real model-mismatch decode errors still fail fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)