### PR TITLE
🔧 Ignore Claude scheduled tasks lock file

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"907bf735-fe88-4310-8791-b869279b66da","pid":81152,"procStart":"Mon Jun  1 09:44:21 2026","acquiredAt":1780308473554}

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ junit-swift-testing.xml
 
 # Claude
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Git worktrees
 .worktrees/


### PR DESCRIPTION
## Summary

`.claude/scheduled_tasks.lock` is a session-specific Claude Code harness artifact (it records a session id and pid) that was accidentally committed in #298. This removes it from version control and adds it to `.gitignore` so it is never tracked again.

## Changes

- 🔧 Untracked `.claude/scheduled_tasks.lock`
- 🔧 Added `.claude/scheduled_tasks.lock` to `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)