### PR TITLE
✨ Add on-device deterministic natural-language search planner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         && 'macos-26' || 'ubuntu-latest'
       }}
     env:
-      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.5.app/Contents/Developer
     steps:
       - name: No changes detected
         if: needs.changes.outputs.swift != 'true' && github.event_name != 'workflow_dispatch'
@@ -111,7 +111,7 @@ jobs:
         && 'macos-26' || 'ubuntu-latest'
       }}
     env:
-      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.5.app/Contents/Developer
     steps:
       - name: No changes detected
         if: needs.changes.outputs.swift != 'true' && github.event_name != 'workflow_dispatch'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_26.5.app/Contents/Developer
 
 jobs:
   analyze:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -25,8 +25,9 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
-    container: swift:6.0.3-jammy
+    runs-on: macos-26
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,7 +27,7 @@ jobs:
     name: Build
     runs-on: macos-26
     env:
-      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.5.app/Contents/Developer
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_26.5.app/Contents/Developer
 
 jobs:
   changes:

--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
   limits (HTTP 429) and server errors (HTTP 5xx)
 * **Response Caching**: Opt-in in-memory HTTP response cache with
   configurable TTL and entry limits
-* **Natural-Language Search**: On-device "super search" powered by Apple
-  Foundation Models — type a prompt, get movies, TV series, and people
-  (Apple platforms 26+ with Apple Intelligence; falls back to literal
-  search when the model declines a prompt)
+* **Natural-Language Search**: On-device "super search" — type a prompt,
+  get movies, TV series, and people. Deterministic interpretation via
+  Apple's Natural Language framework on every Apple platform, with
+  Foundation Models handling fuzzier prompts on devices with Apple
+  Intelligence
 * **Modern Swift**: Async/await throughout, strongly-typed models,
   protocol-based architecture
 
@@ -70,7 +71,7 @@ A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
 | **reviews** | Review details with author and media information |
 | **tvEpisodeGroups** | TV episode group details and episode organization |
 | **guestSessions** | Guest session rated movies, TV series, and episodes |
-| **naturalLanguageSearch** | On-device natural-language search (Apple platforms 26+ with Apple Intelligence) |
+| **naturalLanguageSearch** | On-device natural-language search (all Apple platforms; enhanced by Foundation Models with Apple Intelligence) |
 
 See the [full API documentation](https://adamayoung.github.io/TMDb/documentation/tmdb/)
 for detailed usage.

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/DeterministicSearchPlanning.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/DeterministicSearchPlanning.swift
@@ -1,0 +1,18 @@
+//
+//  DeterministicSearchPlanning.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A deterministic, synchronous planner that returns a confident ``SearchPlan``
+/// or `nil` to abstain (let the fallback decide).
+///
+protocol DeterministicSearchPlanning: Sendable {
+
+    func confidentPlan(for prompt: String) -> SearchPlan?
+
+}

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/FoundationModelsSearchPlanGenerator.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/FoundationModelsSearchPlanGenerator.swift
@@ -79,16 +79,65 @@
     @available(iOS 26, macOS 26, visionOS 26, *)
     extension FoundationModelsSearchPlanGenerator {
 
+        // swiftlint:disable:next function_body_length
         private func instructions() -> String {
             let year = Calendar(identifier: .gregorian).component(.year, from: now())
             return """
-            You convert a movie or TV search request into a structured plan.
-            If the request is just a title or a person's name with no other instruction, \
-            use the find intent and put the text in title.
-            Set isInScope to false if the request is not about movies, TV series, or people.
+            You convert a movie or TV search request into a structured plan that is run against a \
+            database. Only copy words the user actually typed into title, people, genres, or \
+            companies. You MAY use your knowledge to decide whether a name the user wrote is a \
+            PERSON or a TITLE, but never ADD entities the user did not write. In particular, put a \
+            name in people ONLY if the user literally typed that name; NEVER fill people with the \
+            cast or actors of a title (e.g. "Fight Club" has empty people).
+
+            Pick exactly ONE intent. Check these rules in order and use the first that matches:
+            1. list — a request for a feed with words like trending, popular, top rated, best, \
+            new releases, now playing, in cinemas, in theaters, upcoming, coming soon, airing \
+            today. Also set the list field.
+            2. similar — words like "like", "similar to", "in the vein of", "reminds me of", or \
+            "recommendations based on" a named title. Put that title in title.
+            3. castOf — asks for the cast, actors, stars, "who's in", "who stars in", or "people \
+            in" a named title. Put the title in title.
+            4. crewRole — asks who did a job ("director of", "who directed", "who wrote", \
+            "composer of") for a named title. Put the title in title and the job in crewRole.
+            5. filmography — match by PHRASING, not by recognising the name. If the request fits any \
+            of these shapes where NAME is a capitalised person name, use filmography and put NAME in \
+            people (leave title empty): "movies/films/shows with NAME", "movies/films starring \
+            NAME", "movies/films featuring NAME", "NAME movies", "NAME films", "movies/films by \
+            NAME", "directed by NAME". This holds even if you do not recognise NAME. Never send \
+            these to find or browse.
+            6. mood — a subjective vibe word like feel-good, cozy, scary, uplifting. Set moodTerm.
+            7. browse — describes only attributes: genre, decade, year, country, language, \
+            runtime, or rating (e.g. "90s sci-fi", "Korean horror", "highly rated documentaries").
+            8. find — LAST RESORT: only when the request is a single title with no other words. If \
+            the request pairs a person with movie/film/show words, use filmography, not find.
+
+            If the request is not about movies, TV series, or people at all (books, food, weather, \
+            directions, general questions), set isInScope to false.
+
+            Examples:
+            "trending movies" -> list (list=trending)
+            "popular shows" -> list (list=popular)
+            "new releases" -> list (list=nowPlaying)
+            "upcoming movies" -> list (list=upcoming)
+            "movies like Inception" -> similar, title="Inception"
+            "shows similar to Breaking Bad" -> similar, title="Breaking Bad"
+            "people in Fight Club" -> castOf, title="Fight Club"
+            "cast of The Matrix" -> castOf, title="The Matrix"
+            "who directed Jurassic Park" -> crewRole, title="Jurassic Park", crewRole="Director"
+            "composer of Interstellar" -> crewRole, title="Interstellar", crewRole="Composer"
+            "movies with Tom Hanks" -> filmography, people=["Tom Hanks"]
+            "Brad Pitt movies" -> filmography, people=["Brad Pitt"]  (NOT find, NOT browse)
+            "Scarlett Johansson films" -> filmography, people=["Scarlett Johansson"]
+            "movies starring Meryl Streep" -> filmography, people=["Meryl Streep"]
+            "films directed by Nolan" -> filmography, people=["Nolan"]
+            "90s sci-fi" -> browse
+            "feel-good movies" -> mood, moodTerm="feel-good"
+            "Inception" -> find, title="Inception"
+            "best pizza recipe" -> isInScope=false
+
             The current year is \(year); use datePhrase for relative time references rather than \
-            computing years yourself.
-            Never request adult content.
+            computing years yourself. Never request adult content.
             """
         }
 

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/GatedSearchPlanGenerator.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/GatedSearchPlanGenerator.swift
@@ -37,7 +37,7 @@ struct GatedSearchPlanGenerator: SearchPlanGenerating {
             return confident
         }
 
-        if let fallback, case .available = fallback.availability {
+        if let fallback, fallback.availability == .available {
             let raw = try await fallback.plan(for: prompt)
             return PromptGrounder.ground(raw, prompt: prompt)
         }

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/GatedSearchPlanGenerator.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/GatedSearchPlanGenerator.swift
@@ -1,0 +1,49 @@
+//
+//  GatedSearchPlanGenerator.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// The default planner: deterministic first, language model only as an
+/// evidence-gated fallback.
+///
+/// When the deterministic planner is confident, its plan is used. Otherwise, if
+/// a fallback (Foundation Models) is available, it is consulted and its output
+/// is grounded against the prompt. Failing both, the prompt is run as a plain
+/// `find`. Availability is `.available` whenever this planner exists (the
+/// NaturalLanguage layer is always present on Apple platforms) — the fallback's
+/// availability is only an internal gate condition, never surfaced.
+///
+struct GatedSearchPlanGenerator: SearchPlanGenerating {
+
+    private let deterministic: any DeterministicSearchPlanning
+    private let fallback: (any SearchPlanGenerating)?
+
+    init(deterministic: some DeterministicSearchPlanning, fallback: (any SearchPlanGenerating)? = nil) {
+        self.deterministic = deterministic
+        self.fallback = fallback
+    }
+
+    var availability: NaturalLanguageSearchAvailability {
+        .available
+    }
+
+    func plan(for prompt: String) async throws -> SearchPlan {
+        if let confident = deterministic.confidentPlan(for: prompt) {
+            return confident
+        }
+
+        if let fallback, case .available = fallback.availability {
+            let raw = try await fallback.plan(for: prompt)
+            return PromptGrounder.ground(raw, prompt: prompt)
+        }
+
+        // No confident plan and no fallback: run the prompt as a plain search.
+        return SearchPlan(intent: .find, title: prompt.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/GeneratedSearchPlan.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/GeneratedSearchPlan.swift
@@ -32,7 +32,8 @@
         @Guide(description: "A movie or TV series title mentioned, if any.")
         let title: String?
 
-        @Guide(description: "Full names of people mentioned, if any.")
+        @Guide(description: "Only person names the user literally typed. "
+            + "Never the cast or actors of a title.")
         let people: [String]
 
         @Guide(description: "A crew role mentioned, for example Director.")
@@ -76,7 +77,7 @@
     @available(iOS 26, macOS 26, visionOS 26, *)
     @Generable
     enum GeneratedIntent {
-        case find, browse, byPerson, castOf, crewRole, similar, list, mood
+        case find, browse, filmography, castOf, crewRole, similar, list, mood
     }
 
     @available(iOS 26, macOS 26, visionOS 26, *)

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/LiveNaturalLanguageSearchDataSource.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/LiveNaturalLanguageSearchDataSource.swift
@@ -22,6 +22,7 @@ struct LiveNaturalLanguageSearchDataSource: NaturalLanguageSearchDataSource {
     private let genres: any GenreService
     private let movies: any MovieService
     private let tvSeries: any TVSeriesService
+    private let people: any PersonService
     private let trending: any TrendingService
 
     init(
@@ -30,6 +31,7 @@ struct LiveNaturalLanguageSearchDataSource: NaturalLanguageSearchDataSource {
         genres: any GenreService,
         movies: any MovieService,
         tvSeries: any TVSeriesService,
+        people: any PersonService,
         trending: any TrendingService
     ) {
         self.discover = discover
@@ -37,6 +39,7 @@ struct LiveNaturalLanguageSearchDataSource: NaturalLanguageSearchDataSource {
         self.genres = genres
         self.movies = movies
         self.tvSeries = tvSeries
+        self.people = people
         self.trending = trending
     }
 
@@ -90,12 +93,46 @@ struct LiveNaturalLanguageSearchDataSource: NaturalLanguageSearchDataSource {
         )
     }
 
-    func similarMovies(toMovie id: Movie.ID) async throws -> [MovieListItem] {
-        try await movies.similar(toMovie: id).results
+    func recommendedMovies(forMovie id: Movie.ID) async throws -> [MovieListItem] {
+        try await movies.recommendations(forMovie: id).results
     }
 
-    func similarTVSeries(toTVSeries id: TVSeries.ID) async throws -> [TVSeriesListItem] {
-        try await tvSeries.similar(toTVSeries: id).results
+    func recommendedTVSeries(forTVSeries id: TVSeries.ID) async throws -> [TVSeriesListItem] {
+        try await tvSeries.recommendations(forTVSeries: id).results
+    }
+
+    func tvSeriesCredits(forPerson id: Person.ID) async throws -> [TVSeriesListItem] {
+        let credits = try await people.tvSeriesCredits(forPerson: id)
+        // Rank by episode count first: a regular role (Breaking Bad, 62 eps) is far
+        // more relevant to "shows X is in" than a one-off guest spot on a hugely
+        // popular show (The Simpsons). Popularity breaks ties.
+        return credits.cast
+            .sorted { lhs, rhs in
+                let lhsEpisodes = lhs.episodeCount ?? 0
+                let rhsEpisodes = rhs.episodeCount ?? 0
+                if lhsEpisodes != rhsEpisodes {
+                    return lhsEpisodes > rhsEpisodes
+                }
+                return (lhs.popularity ?? 0) > (rhs.popularity ?? 0)
+            }
+            .map { credit in
+                TVSeriesListItem(
+                    id: credit.id,
+                    name: credit.name,
+                    originalName: credit.originalName,
+                    originalLanguage: credit.originalLanguage,
+                    overview: credit.overview,
+                    genreIDs: credit.genreIDs,
+                    firstAirDate: credit.firstAirDate,
+                    originCountries: credit.originCountries,
+                    posterPath: credit.posterPath,
+                    backdropPath: credit.backdropPath,
+                    popularity: credit.popularity,
+                    voteAverage: credit.voteAverage,
+                    voteCount: credit.voteCount,
+                    isAdultOnly: credit.isAdultOnly
+                )
+            }
     }
 
     func movieCredits(forMovie id: Movie.ID) async throws -> ShowCredits {

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchAvailability.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchAvailability.swift
@@ -10,8 +10,10 @@ import Foundation
 ///
 /// The availability of on-device natural-language search.
 ///
-/// Natural-language search relies on an on-device language model that is only
-/// present on supported Apple platforms with Apple Intelligence enabled.
+/// Deterministic interpretation (Apple's Natural Language framework) is present
+/// on every supported Apple platform, so this is ``available`` there. The
+/// ``unavailable(_:)`` reasons describe why the optional Foundation Models
+/// enhancement is absent on a given device.
 ///
 public enum NaturalLanguageSearchAvailability: Sendable, Equatable {
 

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchDataSource.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchDataSource.swift
@@ -51,11 +51,16 @@ protocol NaturalLanguageSearchDataSource: Sendable {
         query: String
     ) async throws -> (movies: [MovieListItem], tvSeries: [TVSeriesListItem], people: [PersonListItem])
 
-    /// Movies similar to a movie.
-    func similarMovies(toMovie id: Movie.ID) async throws -> [MovieListItem]
+    /// Recommended movies for a movie (TMDb's "recommendations", which are higher
+    /// relevance than the keyword-based "similar" endpoint).
+    func recommendedMovies(forMovie id: Movie.ID) async throws -> [MovieListItem]
 
-    /// TV series similar to a TV series.
-    func similarTVSeries(toTVSeries id: TVSeries.ID) async throws -> [TVSeriesListItem]
+    /// Recommended TV series for a TV series.
+    func recommendedTVSeries(forTVSeries id: TVSeries.ID) async throws -> [TVSeriesListItem]
+
+    /// The TV series a person is credited in (cast), most popular first. Used for
+    /// "by person" TV queries, since TMDb's discover/tv cannot filter by person.
+    func tvSeriesCredits(forPerson id: Person.ID) async throws -> [TVSeriesListItem]
 
     /// The credits for a movie.
     func movieCredits(forMovie id: Movie.ID) async throws -> ShowCredits

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchPlanGenerator.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchPlanGenerator.swift
@@ -29,7 +29,7 @@ struct NaturalLanguageSearchPlanGenerator: DeterministicSearchPlanning {
 
     func confidentPlan(for prompt: String) -> SearchPlan? {
         let normalized = SearchPlanLexicon.normalize(prompt)
-        guard let intent = classifier.classify(prompt) else {
+        guard let intent = classifier.classify(normalized) else {
             return nil
         }
 

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchPlanGenerator.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchPlanGenerator.swift
@@ -96,7 +96,12 @@ struct NaturalLanguageSearchPlanGenerator: DeterministicSearchPlanning {
     }
 
     private func byPersonPlan(prompt: String, normalized: String) -> SearchPlan? {
-        let people = personExtractor.people(in: prompt)
+        // Prefer NER (handles names mid-sentence); fall back to a structural
+        // extraction from the lead/suffix when NER misses the name.
+        var people = personExtractor.people(in: prompt)
+        if people.isEmpty {
+            people = structuralPeople(prompt: prompt, normalized: normalized)
+        }
         guard !people.isEmpty else {
             return nil
         }
@@ -104,15 +109,43 @@ struct NaturalLanguageSearchPlanGenerator: DeterministicSearchPlanning {
         // runtime constraints (unlike the recommendations-based `similar` path),
         // so a prompt like "movies with Tom Hanks that are critically acclaimed"
         // keeps them. Genre is deferred to the fallback by the classifier (a
-        // leading genre cue abstains), so it is not extracted here.
+        // leading genre cue abstains), so it is not extracted here. A directing or
+        // writing lead ("films directed by X") sets a crew role so the executor
+        // filters by crew rather than cast.
         return SearchPlan(
             intent: .byPerson,
             mediaType: titleMediaType(normalized),
             people: people,
+            crewRole: SearchPlanLexicon.crewRoleForByPerson(normalized),
             date: RelativeDateParser.parse(normalized),
             runtimeMaxMinutes: RuntimeRatingParser.runtimeMaxMinutes(normalized),
             minRating: RuntimeRatingParser.minRating(normalized)
         )
+    }
+
+    /// Recovers a person name from the prompt structure when NER returns nothing:
+    /// the text following a lead ("directed by X") or preceding a suffix
+    /// ("Scarlett Johansson films").
+    private func structuralPeople(prompt: String, normalized: String) -> [String] {
+        if SearchPlanLexicon.byPersonPrefixes.contains(where: { normalized.hasPrefix($0) }) {
+            let name = TitleExtractor.title(from: prompt, strippingLeads: SearchPlanLexicon.byPersonPrefixes)
+            return name.isEmpty ? [] : [name]
+        }
+        let core = SearchPlanLexicon.trimmingTrailingSlots(normalized)
+        for suffix in SearchPlanLexicon.byPersonSuffixes where core.hasSuffix(suffix) {
+            guard let range = prompt.range(of: suffix, options: [.caseInsensitive, .backwards]) else {
+                continue
+            }
+            let name = String(prompt[..<range.lowerBound]).trimmingCharacters(in: .whitespaces)
+            // In the bare suffix form ("Scarlett Johansson films") there is no lead
+            // vouching for a person, so require a proper-noun initial to avoid
+            // inventing a person from a common noun ("superhero movies").
+            guard let first = name.first, first.isUppercase else {
+                return []
+            }
+            return [name]
+        }
+        return []
     }
 
     private func titlePlan(

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchPlanGenerator.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchPlanGenerator.swift
@@ -1,0 +1,148 @@
+//
+//  NaturalLanguageSearchPlanGenerator.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// The deterministic planner: rule-based intent classification + span-bounded
+/// entity extraction (people via NER, titles via lead-phrase stripping) + slot
+/// parsing. Pure and synchronous; dependencies are injected so it is testable on
+/// every platform with mocks.
+///
+/// Honours the executor's contracts: `find`/`similar` emit empty `people`; every
+/// plan is in scope; `find` carries the prompt as `title`; an intent whose
+/// mandatory slot cannot be extracted abstains (returns `nil`).
+///
+struct NaturalLanguageSearchPlanGenerator: DeterministicSearchPlanning {
+
+    private let classifier: any IntentClassifying
+    private let personExtractor: any PersonNameExtracting
+
+    init(classifier: some IntentClassifying, personExtractor: some PersonNameExtracting) {
+        self.classifier = classifier
+        self.personExtractor = personExtractor
+    }
+
+    func confidentPlan(for prompt: String) -> SearchPlan? {
+        let normalized = SearchPlanLexicon.normalize(prompt)
+        guard let intent = classifier.classify(prompt) else {
+            return nil
+        }
+
+        switch intent {
+        case .find:
+            return findPlan(prompt: prompt)
+
+        case .list:
+            return listPlan(normalized: normalized)
+
+        case .castOf:
+            return titlePlan(.castOf, prompt: prompt, normalized: normalized, leads: SearchPlanLexicon.castLeads)
+
+        case .crewRole:
+            return crewRolePlan(prompt: prompt, normalized: normalized)
+
+        case .similar:
+            return titlePlan(
+                .similar,
+                prompt: prompt,
+                normalized: normalized,
+                leads: SearchPlanLexicon.similarLeads,
+                withDate: true
+            )
+
+        case .byPerson:
+            return byPersonPlan(prompt: prompt, normalized: normalized)
+
+        case .browse, .mood:
+            return nil
+        }
+    }
+
+    private func findPlan(prompt: String) -> SearchPlan? {
+        let title = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else {
+            return nil
+        }
+        return SearchPlan(intent: .find, title: title)
+    }
+
+    private func listPlan(normalized: String) -> SearchPlan? {
+        guard let kind = SearchPlanLexicon.listKind(in: normalized) else {
+            return nil
+        }
+        return SearchPlan(
+            intent: .list,
+            mediaType: SearchPlanLexicon.mediaType(in: normalized),
+            list: kind
+        )
+    }
+
+    private func crewRolePlan(prompt: String, normalized: String) -> SearchPlan? {
+        guard let role = SearchPlanLexicon.crewRoleJob(in: normalized) else {
+            return nil
+        }
+        return titlePlan(
+            .crewRole,
+            prompt: prompt,
+            normalized: normalized,
+            leads: [role.lead],
+            crewRole: role.job
+        )
+    }
+
+    private func byPersonPlan(prompt: String, normalized: String) -> SearchPlan? {
+        let people = personExtractor.people(in: prompt)
+        guard !people.isEmpty else {
+            return nil
+        }
+        // byPerson runs through the discover path, which honours rating and
+        // runtime constraints (unlike the recommendations-based `similar` path),
+        // so a prompt like "movies with Tom Hanks that are critically acclaimed"
+        // keeps them. Genre is deferred to the fallback by the classifier (a
+        // leading genre cue abstains), so it is not extracted here.
+        return SearchPlan(
+            intent: .byPerson,
+            mediaType: titleMediaType(normalized),
+            people: people,
+            date: RelativeDateParser.parse(normalized),
+            runtimeMaxMinutes: RuntimeRatingParser.runtimeMaxMinutes(normalized),
+            minRating: RuntimeRatingParser.minRating(normalized)
+        )
+    }
+
+    private func titlePlan(
+        _ intent: SearchPlan.Intent,
+        prompt: String,
+        normalized: String,
+        leads: [String],
+        crewRole: String? = nil,
+        withDate: Bool = false
+    ) -> SearchPlan? {
+        let title = TitleExtractor.title(from: prompt, strippingLeads: leads)
+        guard !title.isEmpty else {
+            return nil
+        }
+        // Only `date` is wired here: it is the single slot the `similar`
+        // (recommendations) path applies. Genre/runtime/rating are not consumed
+        // by that path, so they are intentionally omitted rather than set dead.
+        return SearchPlan(
+            intent: intent,
+            mediaType: titleMediaType(normalized),
+            title: title,
+            crewRole: crewRole,
+            date: withDate ? RelativeDateParser.parse(normalized) : nil
+        )
+    }
+
+    /// Title-bearing intents only distinguish movie vs TV (never person).
+    private func titleMediaType(_ normalized: String) -> SearchPlan.MediaType? {
+        SearchPlanLexicon.contains(normalized, anyOf: ["show", "shows", "series", "tv", "television"])
+            ? .tv : nil
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchService.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchService.swift
@@ -10,13 +10,15 @@ import Foundation
 ///
 /// Provides an interface for searching TMDb with natural language.
 ///
-/// A prompt such as `"uplifting 90s sci-fi under 2 hours"` is interpreted by an
-/// on-device language model into a structured plan, which is then executed
-/// against TMDb to return matching movies, TV series, and people.
+/// A prompt such as `"movies with Tom Hanks"` or `"cast of The Matrix"` is
+/// interpreted on device into a structured plan, which is then executed against
+/// TMDb to return matching movies, TV series, and people.
 ///
-/// - Important: This relies on an on-device model available only on supported
-///   Apple platforms with Apple Intelligence enabled. Check ``availability``
-///   before use.
+/// Interpretation is deterministic, using Apple's Natural Language framework,
+/// and is available on every supported Apple platform. On devices with Apple
+/// Intelligence, Foundation Models additionally handles fuzzier, compositional
+/// prompts (for example `"uplifting 90s sci-fi under 2 hours"`); elsewhere such
+/// prompts fall back to a plain multi-search.
 ///
 public protocol NaturalLanguageSearchService: Sendable {
 

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchService.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchService.swift
@@ -25,6 +25,11 @@ public protocol NaturalLanguageSearchService: Sendable {
     ///
     /// The availability of on-device natural-language search.
     ///
+    /// - Note: The default implementation always reports ``NaturalLanguageSearchAvailability/available``,
+    ///   because deterministic interpretation is present on every supported Apple
+    ///   platform. The ``NaturalLanguageSearchAvailability/unavailable(_:)`` cases
+    ///   are therefore only reachable through a custom implementation.
+    ///
     var availability: NaturalLanguageSearchAvailability { get }
 
     ///

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/PersonNameExtracting.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/PersonNameExtracting.swift
@@ -1,0 +1,58 @@
+//
+//  PersonNameExtracting.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// Extracts person names that literally appear in a prompt.
+///
+/// Span-bounded by construction — it can only return text present in the input,
+/// so it never invents people.
+///
+protocol PersonNameExtracting: Sendable {
+
+    func people(in prompt: String) -> [String]
+
+}
+
+#if canImport(NaturalLanguage)
+    import NaturalLanguage
+
+    ///
+    /// A ``PersonNameExtracting`` backed by `NLTagger`'s named-entity recognition.
+    ///
+    /// A fresh `NLTagger` is created per call (it is not `Sendable` and must not
+    /// be shared across threads), keeping this type a safe `Sendable` value.
+    ///
+    @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+    struct NLTaggerPersonNameExtractor: PersonNameExtracting {
+
+        func people(in prompt: String) -> [String] {
+            let tagger = NLTagger(tagSchemes: [.nameType])
+            tagger.string = prompt
+            let options: NLTagger.Options = [.omitPunctuation, .omitWhitespace, .joinNames]
+
+            var names: [String] = []
+            tagger.enumerateTags(
+                in: prompt.startIndex ..< prompt.endIndex,
+                unit: .word,
+                scheme: .nameType,
+                options: options
+            ) { tag, range in
+                if tag == .personalName {
+                    let name = String(prompt[range]).trimmingCharacters(in: .whitespaces)
+                    if !name.isEmpty {
+                        names.append(name)
+                    }
+                }
+                return true
+            }
+            return names
+        }
+
+    }
+#endif

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/PromptGrounder.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/PromptGrounder.swift
@@ -1,0 +1,47 @@
+//
+//  PromptGrounder.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// Re-grounds a language-model-produced ``SearchPlan`` against the prompt so the
+/// model cannot inject entities the user never wrote.
+///
+/// Runs ONLY on fallback (model) output, never on the deterministic planner's
+/// output. String operands the user could only have named literally (title,
+/// people, companies, exclusions) are dropped unless they appear in the prompt.
+/// Gazetteer-derived fields (genres, crew role) and numeric slots are left as-is
+/// — a canonical "Science Fiction" need not be a substring of "sci-fi".
+///
+enum PromptGrounder {
+
+    static func ground(_ plan: SearchPlan, prompt: String) -> SearchPlan {
+        let haystack = prompt.lowercased()
+        func present(_ value: String) -> Bool {
+            let trimmed = value.trimmingCharacters(in: .whitespaces).lowercased()
+            return !trimmed.isEmpty && haystack.contains(trimmed)
+        }
+
+        return SearchPlan(
+            intent: plan.intent,
+            isInScope: true, // the fallback is only consulted for in-scope prompts
+            mediaType: plan.mediaType,
+            title: plan.title.flatMap { present($0) ? $0 : nil },
+            people: plan.people.filter(present),
+            crewRole: plan.crewRole,
+            genres: plan.genres,
+            excludeTitles: plan.excludeTitles.filter(present),
+            companies: plan.companies.filter(present),
+            moodTerm: plan.moodTerm,
+            date: plan.date,
+            runtimeMaxMinutes: plan.runtimeMaxMinutes,
+            minRating: plan.minRating,
+            list: plan.list
+        )
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/PromptGrounder.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/PromptGrounder.swift
@@ -20,15 +20,20 @@ import Foundation
 enum PromptGrounder {
 
     static func ground(_ plan: SearchPlan, prompt: String) -> SearchPlan {
-        let haystack = prompt.lowercased()
+        let haystack = SearchPlanLexicon.normalize(prompt)
         func present(_ value: String) -> Bool {
-            let trimmed = value.trimmingCharacters(in: .whitespaces).lowercased()
-            return !trimmed.isEmpty && haystack.contains(trimmed)
+            let trimmed = SearchPlanLexicon.normalize(value)
+            // Word-boundary match so a short hallucinated title ("It", "Us") can't
+            // pass by appearing inside an unrelated word ("criterion", "music").
+            return !trimmed.isEmpty && SearchPlanLexicon.contains(haystack, trimmed)
         }
 
         return SearchPlan(
             intent: plan.intent,
-            isInScope: true, // the fallback is only consulted for in-scope prompts
+            // Out-of-scope prompts deliberately degrade to a plain search (matching
+            // the deterministic path, which never throws for OOS in v1) rather than
+            // surfacing an error, so the model's scope verdict is not propagated.
+            isInScope: true,
             mediaType: plan.mediaType,
             title: plan.title.flatMap { present($0) ? $0 : nil },
             people: plan.people.filter(present),

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchDegradation.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchDegradation.swift
@@ -31,6 +31,10 @@ public enum SearchDegradation: Sendable, Equatable {
     /// The prompt was too vague to form a specific query; a default was used.
     case underspecified
 
+    /// The initial query returned nothing, so some constraints (companies, dates,
+    /// genres) were dropped to find results.
+    case relaxedConstraints
+
     /// One or more titles or franchises were excluded from results.
     case excludedTermsApplied([String])
 

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlan.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlan.swift
@@ -10,10 +10,12 @@ import Foundation
 ///
 /// A structured interpretation of a natural-language search prompt.
 ///
-/// A `SearchPlan` is produced from a prompt by an on-device language model and
-/// then executed deterministically against TMDb services. It contains
-/// natural-language operands (names, symbolic dates) rather than TMDb
-/// identifiers, which are resolved during execution.
+/// A `SearchPlan` is produced from a prompt on device — deterministically via
+/// Apple's Natural Language framework, or, for fuzzier prompts on devices with
+/// Apple Intelligence, by an on-device language model — and then executed
+/// deterministically against TMDb services. It contains natural-language
+/// operands (names, symbolic dates) rather than TMDb identifiers, which are
+/// resolved during execution.
 ///
 public struct SearchPlan: Sendable, Equatable {
 

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanExecutor+Helpers.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanExecutor+Helpers.swift
@@ -16,7 +16,26 @@ extension SearchPlanExecutor {
         let companyIDs: [Company.ID]
         let personIDs: [Person.ID]
         let bounds: (from: Int, to: Int)?
+        let runtimeMax: Int?
         let minRating: Double?
+
+        /// Returns a copy with the named constraints removed (for relaxation).
+        func dropping(
+            companies: Bool = false,
+            bounds dropBounds: Bool = false,
+            genres: Bool = false,
+            runtime: Bool = false,
+            rating: Bool = false
+        ) -> ResolvedInputs {
+            ResolvedInputs(
+                genreIDs: genres ? [] : genreIDs,
+                companyIDs: companies ? [] : companyIDs,
+                personIDs: personIDs,
+                bounds: dropBounds ? nil : bounds,
+                runtimeMax: runtime ? nil : runtimeMax,
+                minRating: rating ? nil : minRating
+            )
+        }
     }
 
     func resolveInputs(
@@ -44,7 +63,8 @@ extension SearchPlanExecutor {
             companyIDs: companyIDs,
             personIDs: personIDs,
             bounds: plan.date.map(yearBounds(for:)),
-            minRating: minRating
+            runtimeMax: Self.sanitizedRuntime(plan.runtimeMaxMinutes),
+            minRating: Self.sanitizedRating(minRating)
         )
     }
 
@@ -143,9 +163,9 @@ extension SearchPlanExecutor {
         return DiscoverMovieFilter(
             genres: inputs.genreIDs.isEmpty ? nil : inputs.genreIDs,
             primaryReleaseYear: inputs.bounds.map(primaryReleaseYear(for:)),
-            voteAverageMin: inputs.minRating,
+            voteAverageMin: Self.sanitizedRating(inputs.minRating),
             companies: inputs.companyIDs.isEmpty ? nil : inputs.companyIDs,
-            runtimeMax: plan.runtimeMaxMinutes,
+            runtimeMax: inputs.runtimeMax,
             includeAdult: false,
             withCast: (!usesCrew && !inputs.personIDs.isEmpty) ? inputs.personIDs : nil,
             withCrew: (usesCrew && !inputs.personIDs.isEmpty) ? inputs.personIDs : nil
@@ -170,12 +190,28 @@ extension SearchPlanExecutor {
             firstAirDateYear: firstAirDateYear,
             firstAirDateMin: firstAirDateMin,
             firstAirDateMax: firstAirDateMax,
-            voteAverageMin: inputs.minRating,
+            voteAverageMin: Self.sanitizedRating(inputs.minRating),
             companies: inputs.companyIDs.isEmpty ? nil : inputs.companyIDs,
-            runtimeMax: plan.runtimeMaxMinutes,
+            runtimeMax: inputs.runtimeMax,
             includeAdult: false,
             withPeople: inputs.personIDs.isEmpty ? nil : inputs.personIDs
         )
+    }
+
+    /// Drops a nonsensical runtime the model sometimes invents (e.g. 0).
+    static func sanitizedRuntime(_ value: Int?) -> Int? {
+        guard let value, value > 0 else {
+            return nil
+        }
+        return value
+    }
+
+    /// Drops an out-of-range rating the model sometimes invents (e.g. 0).
+    static func sanitizedRating(_ value: Double?) -> Double? {
+        guard let value, value > 0, value <= 10 else {
+            return nil
+        }
+        return value
     }
 
     private func primaryReleaseYear(

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanExecutor+Helpers.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanExecutor+Helpers.swift
@@ -132,26 +132,6 @@ extension SearchPlanExecutor {
         return ids
     }
 
-    func credits(forTitle plan: SearchPlan) async throws -> ShowCredits? {
-        guard let title = plan.title else {
-            return nil
-        }
-
-        if plan.mediaType == .tv {
-            guard let id = try await dataSource.searchTVSeries(query: title).first?.id else {
-                return nil
-            }
-
-            return try await dataSource.tvSeriesCredits(forTVSeries: id)
-        }
-
-        guard let id = try await dataSource.searchMovies(query: title).first?.id else {
-            return nil
-        }
-
-        return try await dataSource.movieCredits(forMovie: id)
-    }
-
 }
 
 // MARK: - Filter building
@@ -212,6 +192,25 @@ extension SearchPlanExecutor {
             return nil
         }
         return value
+    }
+
+    /// Whether a TMDb crew `job` satisfies a requested role. TMDb records writing
+    /// credits under several jobs ("Screenplay", "Story", …) and music under
+    /// "Music"/"Composer", so a single role maps to a set of jobs.
+    static func jobMatches(_ job: String, role: String) -> Bool {
+        let job = job.lowercased()
+        let role = role.lowercased()
+        if job == role {
+            return true
+        }
+        switch role {
+        case "writer":
+            return ["screenplay", "story", "author", "novel", "screenstory", "writer"].contains(job)
+        case "original music composer":
+            return ["music", "composer", "original music composer", "songs"].contains(job)
+        default:
+            return false
+        }
     }
 
     private func primaryReleaseYear(

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanExecutor+Resolution.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanExecutor+Resolution.swift
@@ -1,0 +1,121 @@
+//
+//  SearchPlanExecutor+Resolution.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+/// A search result that carries a popularity score, used to rank title matches.
+protocol PopularityRanked {
+    var popularity: Double? { get }
+}
+
+extension MovieListItem: PopularityRanked {}
+extension TVSeriesListItem: PopularityRanked {}
+
+// MARK: - Title resolution
+
+extension SearchPlanExecutor {
+
+    /// The resolved identity of a title-bearing query.
+    enum ResolvedShow {
+        case movie(Movie.ID)
+        case tvSeries(TVSeries.ID)
+    }
+
+    /// Answers a "by person" TV query from the person's TV credits, since TMDb's
+    /// discover/tv cannot filter by person. Credits arrive ranked by relevance
+    /// (episode count) from the data source, so that order is preserved.
+    func executeByPersonTVSeries(
+        _ plan: SearchPlan,
+        degradations: inout [SearchDegradation]
+    ) async throws -> NaturalLanguageSearchResult {
+        let personIDs = try await resolvePeople(plan.people, into: &degradations)
+        guard !personIDs.isEmpty else {
+            return try await executeUnderspecified(plan, degradations: &degradations)
+        }
+
+        var series: [TVSeriesListItem] = []
+        for id in personIDs {
+            series += try await dataSource.tvSeriesCredits(forPerson: id)
+        }
+
+        let bounds = plan.date.map(yearBounds(for:))
+        series = filterByYear(series, bounds: bounds, date: { $0.firstAirDate })
+        series = applyExclusions(series, plan: plan, name: { $0.name }, into: &degradations)
+        return NaturalLanguageSearchResult(
+            interpretation: plan.interpretationText,
+            tvSeries: cap(dedupe(series)),
+            degradations: degradations
+        )
+    }
+
+    func credits(forTitle plan: SearchPlan) async throws -> ShowCredits? {
+        guard let title = plan.title,
+              let show = try await resolveShow(title: title, mediaType: plan.mediaType)
+        else {
+            return nil
+        }
+
+        switch show {
+        case .movie(let id): return try await dataSource.movieCredits(forMovie: id)
+        case .tvSeries(let id): return try await dataSource.tvSeriesCredits(forTVSeries: id)
+        }
+    }
+
+    /// Resolves a title to a movie or TV series. When the media type is known the
+    /// matching endpoint is used; when it is ambiguous (e.g. "cast of Breaking
+    /// Bad") the best movie and best TV candidate are compared, preferring an
+    /// exact title match and then popularity — so "Breaking Bad" resolves to the
+    /// series rather than the "El Camino" movie. The top few results are scanned
+    /// (not just the first) so an exact match that isn't the top hit still wins
+    /// (e.g. "Jaws", where "Cruel Jaws" ranks first).
+    func resolveShow(title: String, mediaType: SearchPlan.MediaType?) async throws -> ResolvedShow? {
+        if mediaType == .tv {
+            let best = try await Self.best(dataSource.searchTVSeries(query: title), query: title, name: \.name)
+            return best.map { .tvSeries($0.id) }
+        }
+        if mediaType == .movie {
+            let best = try await Self.best(dataSource.searchMovies(query: title), query: title, name: \.title)
+            return best.map { .movie($0.id) }
+        }
+
+        async let movieResults = dataSource.searchMovies(query: title)
+        async let tvResults = dataSource.searchTVSeries(query: title)
+        let movie = try await Self.best(movieResults, query: title, name: \.title)
+        let tv = try await Self.best(tvResults, query: title, name: \.name)
+
+        switch (movie, tv) {
+        case (let movie?, let tv?):
+            return tv.score > movie.score ? .tvSeries(tv.id) : .movie(movie.id)
+        case (let movie?, nil):
+            return .movie(movie.id)
+        case (nil, let tv?):
+            return .tvSeries(tv.id)
+        case (nil, nil):
+            return nil
+        }
+    }
+
+    /// The best-scoring candidate among the top results: an exact (case-insensitive)
+    /// title match dominates, with popularity as the tie-breaker.
+    private static func best<Item: Identifiable & PopularityRanked>(
+        _ items: [Item],
+        query: String,
+        name: (Item) -> String
+    ) -> (id: Item.ID, score: Double)? {
+        items.prefix(8)
+            .map { (id: $0.id, score: matchScore(title: name($0), query: query, popularity: $0.popularity)) }
+            .max { $0.score < $1.score }
+    }
+
+    /// Scores a candidate: an exact (case-insensitive) title match dominates, with
+    /// popularity as the tie-breaker.
+    static func matchScore(title: String, query: String, popularity: Double?) -> Double {
+        let exact = title.caseInsensitiveCompare(query) == .orderedSame ? 1_000_000.0 : 0
+        return exact + (popularity ?? 0)
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanExecutor+Resolution.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanExecutor+Resolution.swift
@@ -101,7 +101,9 @@ extension SearchPlanExecutor {
     }
 
     /// The best-scoring candidate among the top results: an exact (case-insensitive)
-    /// title match dominates, with popularity as the tie-breaker.
+    /// title match dominates, with popularity as the tie-breaker. Only the top 8
+    /// results are scanned — an exact match buried past position 8 by TMDb's own
+    /// ordering (possible for titles with many near-homonyms) would be missed.
     private static func best<Item: Identifiable & PopularityRanked>(
         _ items: [Item],
         query: String,

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanExecutor+Resolution.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanExecutor+Resolution.swift
@@ -89,6 +89,7 @@ extension SearchPlanExecutor {
 
         switch (movie, tv) {
         case (let movie?, let tv?):
+            // Ties (equal title match and popularity) resolve in favour of the movie.
             return tv.score > movie.score ? .tvSeries(tv.id) : .movie(movie.id)
         case (let movie?, nil):
             return .movie(movie.id)

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanExecutor.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanExecutor.swift
@@ -40,11 +40,12 @@ struct SearchPlanExecutor {
     ///
     /// - Returns: The matching movies, TV series, and people.
     ///
-    func execute(_ plan: SearchPlan) async throws -> NaturalLanguageSearchResult {
-        guard plan.isInScope else {
+    func execute(_ rawPlan: SearchPlan) async throws -> NaturalLanguageSearchResult {
+        guard rawPlan.isInScope else {
             throw NaturalLanguageSearchError.outOfScope
         }
 
+        let plan = Self.normalize(rawPlan)
         var degradations: [SearchDegradation] = []
 
         switch plan.intent {
@@ -68,6 +69,49 @@ struct SearchPlanExecutor {
         case .browse, .byPerson, .mood, .crewRole, .similar:
             return try await executeDiscover(plan, degradations: &degradations)
         }
+    }
+
+    ///
+    /// Repairs a common planner mistake: a person query (e.g. "Brad Pitt
+    /// movies") is often tagged `find`/`browse` while the person is still
+    /// correctly placed in `people`. Since only `byPerson` uses `people`, a
+    /// populated `people` field means the request is really `byPerson`.
+    ///
+    static func normalize(_ plan: SearchPlan) -> SearchPlan {
+        // A person query ("Brad Pitt movies", "films Bruce Willis has been in") is
+        // often tagged find/browse, with the person in `people` and the title either
+        // empty or echoing the prompt (e.g. title="popular films bruce willis has
+        // been in"). A genuine bare-title find ("Fight Club") has a clean title that
+        // does NOT mention the listed people (any `people` there is an invented cast,
+        // which find ignores). So coerce to byPerson only when there is a real person
+        // name and the title is empty or contains one of those names.
+        let names = plan.people.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        guard !names.isEmpty, plan.intent == .find || plan.intent == .browse else {
+            return plan
+        }
+
+        let title = (plan.title ?? "").trimmingCharacters(in: .whitespaces)
+        let titleEchoesPerson = names.contains { title.localizedCaseInsensitiveContains($0) }
+        guard title.isEmpty || titleEchoesPerson else {
+            return plan
+        }
+
+        return SearchPlan(
+            intent: .byPerson,
+            isInScope: plan.isInScope,
+            mediaType: plan.mediaType,
+            title: plan.title,
+            people: names,
+            crewRole: plan.crewRole,
+            genres: plan.genres,
+            excludeTitles: plan.excludeTitles,
+            companies: plan.companies,
+            moodTerm: plan.moodTerm,
+            date: plan.date,
+            runtimeMaxMinutes: plan.runtimeMaxMinutes,
+            minRating: plan.minRating,
+            list: plan.list
+        )
     }
 
 }
@@ -240,7 +284,7 @@ extension SearchPlanExecutor {
 
         let nothingResolved = inputs.genreIDs.isEmpty && inputs.companyIDs.isEmpty
             && inputs.personIDs.isEmpty && inputs.bounds == nil && inputs.minRating == nil
-            && plan.runtimeMaxMinutes == nil
+            && inputs.runtimeMax == nil
         // When nothing resolved (including a `.byPerson` plan whose people all
         // failed to resolve), degrade rather than issuing an unconstrained
         // discover that would return a broad popularity dump.
@@ -248,10 +292,25 @@ extension SearchPlanExecutor {
             return try await executeUnderspecified(plan, degradations: &degradations)
         }
 
+        // The model often invents extra operands (companies, dates, genres) that
+        // AND-combine in discover and zero out the results. Try progressively
+        // relaxed filters and use the first that returns anything.
+        let ladder = Self.relaxationLadder(inputs)
+
         if plan.mediaType == .tv {
-            let filter = tvFilter(plan: plan, inputs: inputs)
-            var series = try await dataSource.discoverTVSeries(filter: filter, sortedBy: nil)
-            series = applyExclusions(series, plan: plan, name: { $0.name }, into: &degradations)
+            var chosen: [TVSeriesListItem] = []
+            var relaxed = false
+            for (level, variant) in ladder.enumerated() {
+                let filter = tvFilter(plan: plan, inputs: variant)
+                let series = try await dataSource.discoverTVSeries(filter: filter, sortedBy: nil)
+                if !series.isEmpty || level == ladder.count - 1 {
+                    chosen = series
+                    relaxed = level > 0 && !series.isEmpty
+                    break
+                }
+            }
+            if relaxed { degradations.append(.relaxedConstraints) }
+            let series = applyExclusions(chosen, plan: plan, name: { $0.name }, into: &degradations)
             return NaturalLanguageSearchResult(
                 interpretation: plan.interpretationText,
                 tvSeries: cap(dedupe(series)),
@@ -259,14 +318,59 @@ extension SearchPlanExecutor {
             )
         }
 
-        let filter = movieFilter(plan: plan, inputs: inputs)
-        var movies = try await dataSource.discoverMovies(filter: filter, sortedBy: nil)
-        movies = applyExclusions(movies, plan: plan, name: { $0.title }, into: &degradations)
+        var chosen: [MovieListItem] = []
+        var relaxed = false
+        for (level, variant) in ladder.enumerated() {
+            let filter = movieFilter(plan: plan, inputs: variant)
+            let movies = try await dataSource.discoverMovies(filter: filter, sortedBy: nil)
+            if !movies.isEmpty || level == ladder.count - 1 {
+                chosen = movies
+                relaxed = level > 0 && !movies.isEmpty
+                break
+            }
+        }
+        if relaxed { degradations.append(.relaxedConstraints) }
+        let movies = applyExclusions(chosen, plan: plan, name: { $0.title }, into: &degradations)
         return NaturalLanguageSearchResult(
             interpretation: plan.interpretationText,
             movies: cap(dedupe(movies)),
             degradations: degradations
         )
+    }
+
+    ///
+    /// Builds progressively relaxed inputs: full, then dropping companies, the
+    /// date window, genres, the rating floor, and finally the runtime ceiling.
+    /// Only adds a step when it actually drops something, so legitimate
+    /// single-constraint queries aren't re-run. Genre, rating, and runtime — the
+    /// constraints closest to user intent — are relaxed last.
+    ///
+    static func relaxationLadder(_ inputs: ResolvedInputs) -> [ResolvedInputs] {
+        var ladder = [inputs]
+        var current = inputs
+
+        if !current.companyIDs.isEmpty {
+            current = current.dropping(companies: true)
+            ladder.append(current)
+        }
+        if current.bounds != nil {
+            current = current.dropping(bounds: true)
+            ladder.append(current)
+        }
+        if !current.genreIDs.isEmpty {
+            current = current.dropping(genres: true)
+            ladder.append(current)
+        }
+        if current.minRating != nil {
+            current = current.dropping(rating: true)
+            ladder.append(current)
+        }
+        if current.runtimeMax != nil {
+            current = current.dropping(runtime: true)
+            ladder.append(current)
+        }
+
+        return ladder
     }
 
 }

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanExecutor.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanExecutor.swift
@@ -164,8 +164,8 @@ extension SearchPlanExecutor {
             return NaturalLanguageSearchResult(interpretation: plan.title)
         }
 
-        let matching: [CrewMember] = if let role = plan.crewRole?.lowercased() {
-            credits.crew.filter { $0.job.lowercased() == role }
+        let matching: [CrewMember] = if let role = plan.crewRole {
+            credits.crew.filter { Self.jobMatches($0.job, role: role) }
         } else {
             credits.crew
         }
@@ -188,41 +188,33 @@ extension SearchPlanExecutor {
     ) async throws -> NaturalLanguageSearchResult {
         let bounds = plan.date.map(yearBounds(for:))
 
-        if plan.mediaType == .tv {
-            return try await executeSimilarTVSeries(plan, bounds: bounds, degradations: &degradations)
-        }
-
-        guard let id = try await dataSource.searchMovies(query: plan.title ?? "").first?.id else {
+        guard let title = plan.title,
+              let show = try await resolveShow(title: title, mediaType: plan.mediaType)
+        else {
             return NaturalLanguageSearchResult(interpretation: plan.title)
         }
 
-        var movies = try await dataSource.similarMovies(toMovie: id)
-        movies = filterByYear(movies, bounds: bounds, date: { $0.releaseDate })
-        movies = applyExclusions(movies, plan: plan, name: { $0.title }, into: &degradations)
-        return NaturalLanguageSearchResult(
-            interpretation: plan.title,
-            movies: cap(dedupe(movies)),
-            degradations: degradations
-        )
-    }
+        switch show {
+        case .tvSeries(let id):
+            var series = try await dataSource.recommendedTVSeries(forTVSeries: id)
+            series = filterByYear(series, bounds: bounds, date: { $0.firstAirDate })
+            series = applyExclusions(series, plan: plan, name: { $0.name }, into: &degradations)
+            return NaturalLanguageSearchResult(
+                interpretation: plan.title,
+                tvSeries: cap(dedupe(series)),
+                degradations: degradations
+            )
 
-    private func executeSimilarTVSeries(
-        _ plan: SearchPlan,
-        bounds: (from: Int, to: Int)?,
-        degradations: inout [SearchDegradation]
-    ) async throws -> NaturalLanguageSearchResult {
-        guard let id = try await dataSource.searchTVSeries(query: plan.title ?? "").first?.id else {
-            return NaturalLanguageSearchResult(interpretation: plan.title)
+        case .movie(let id):
+            var movies = try await dataSource.recommendedMovies(forMovie: id)
+            movies = filterByYear(movies, bounds: bounds, date: { $0.releaseDate })
+            movies = applyExclusions(movies, plan: plan, name: { $0.title }, into: &degradations)
+            return NaturalLanguageSearchResult(
+                interpretation: plan.title,
+                movies: cap(dedupe(movies)),
+                degradations: degradations
+            )
         }
-
-        var series = try await dataSource.similarTVSeries(toTVSeries: id)
-        series = filterByYear(series, bounds: bounds, date: { $0.firstAirDate })
-        series = applyExclusions(series, plan: plan, name: { $0.name }, into: &degradations)
-        return NaturalLanguageSearchResult(
-            interpretation: plan.title,
-            tvSeries: cap(dedupe(series)),
-            degradations: degradations
-        )
     }
 
 }
@@ -258,7 +250,7 @@ extension SearchPlanExecutor {
         }
     }
 
-    private func executeUnderspecified(
+    func executeUnderspecified(
         _ plan: SearchPlan,
         degradations: inout [SearchDegradation]
     ) async throws -> NaturalLanguageSearchResult {
@@ -280,6 +272,13 @@ extension SearchPlanExecutor {
         _ plan: SearchPlan,
         degradations: inout [SearchDegradation]
     ) async throws -> NaturalLanguageSearchResult {
+        // TMDb's discover/tv cannot filter by person, so a "by person" TV query
+        // (e.g. "shows with Pedro Pascal") is answered from the person's TV
+        // credits instead of discover.
+        if plan.intent == .byPerson, plan.mediaType == .tv {
+            return try await executeByPersonTVSeries(plan, degradations: &degradations)
+        }
+
         let inputs = try await resolveInputs(for: plan, into: &degradations)
 
         let nothingResolved = inputs.genreIDs.isEmpty && inputs.companyIDs.isEmpty

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanExecutor.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanExecutor.swift
@@ -100,7 +100,9 @@ struct SearchPlanExecutor {
             intent: .byPerson,
             isInScope: plan.isInScope,
             mediaType: plan.mediaType,
-            title: plan.title,
+            // byPerson ignores `title`; drop the (often junk) echoed title so the
+            // interpretation surfaced to callers isn't misleading.
+            title: nil,
             people: names,
             crewRole: plan.crewRole,
             genres: plan.genres,

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanGenerating.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanGenerating.swift
@@ -10,9 +10,11 @@ import Foundation
 ///
 /// A type that turns a natural-language prompt into a ``SearchPlan``.
 ///
-/// This is the seam between the deterministic search machinery and the on-device
-/// language model. The live implementation is backed by Foundation Models; tests
-/// provide a deterministic stand-in.
+/// This is the seam between the deterministic search machinery and prompt
+/// interpretation. The default live conformer is ``GatedSearchPlanGenerator``,
+/// which is deterministic-first and consults an on-device Foundation Models
+/// generator only as an evidence-gated fallback; tests provide deterministic
+/// stand-ins.
 ///
 protocol SearchPlanGenerating: Sendable {
 

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanIntentClassifier.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanIntentClassifier.swift
@@ -1,0 +1,70 @@
+//
+//  SearchPlanIntentClassifier.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// Decides the ``SearchPlan/Intent`` for a prompt, or `nil` to abstain.
+///
+/// This is the seam where a future Core ML text classifier can replace the
+/// rule-based implementation without changing the rest of the planner.
+///
+protocol IntentClassifying: Sendable {
+
+    ///
+    /// Classifies a prompt's intent.
+    ///
+    /// - Parameter prompt: The natural-language prompt.
+    ///
+    /// - Returns: The intent, or `nil` to abstain (let the fallback decide).
+    ///
+    func classify(_ prompt: String) -> SearchPlan.Intent?
+
+}
+
+///
+/// A deterministic, rule-based ``IntentClassifying`` for the v1 intent set:
+/// `find`, `byPerson`, `castOf`, `crewRole`, `similar`, `list`.
+///
+/// It detects each high-precision intent "family" from lexical cues. Exactly one
+/// family → that intent; more than one (mixed intent) → abstain; none → `find`
+/// for a bare query, or abstain when discover/mood cues are present (those
+/// intents are deferred to the language-model fallback).
+///
+struct RuleBasedIntentClassifier: IntentClassifying {
+
+    func classify(_ prompt: String) -> SearchPlan.Intent? {
+        let text = SearchPlanLexicon.normalize(prompt)
+        guard !text.isEmpty else {
+            return nil
+        }
+
+        var families: [SearchPlan.Intent] = []
+        // A list cue alongside a genre ("highly rated documentaries") is a browse
+        // query, not a curated list — defer it. Pure list cues fire `.list`.
+        if SearchPlanLexicon.listKind(in: text) != nil, !SearchPlanLexicon.hasGenre(text) {
+            families.append(.list)
+        }
+        if SearchPlanLexicon.isSimilar(text) { families.append(.similar) }
+        if SearchPlanLexicon.isCastOf(text) { families.append(.castOf) }
+        if SearchPlanLexicon.crewRoleJob(in: text) != nil { families.append(.crewRole) }
+        if SearchPlanLexicon.isByPerson(text) { families.append(.byPerson) }
+
+        if families.count == 1 {
+            return families[0]
+        }
+        if families.count > 1 {
+            // Mixed intent ("cast of movies like X") — abstain rather than guess.
+            return nil
+        }
+
+        // No high-precision intent. A bare title/name is `find`; anything with
+        // discover/mood cues (genre, decade, runtime, rating, mood) is deferred.
+        return SearchPlanLexicon.hasDiscoverCue(text) ? nil : .find
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanLexicon.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanLexicon.swift
@@ -1,0 +1,236 @@
+//
+//  SearchPlanLexicon.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// Deterministic phrase vocabulary and matchers for interpreting prompts.
+///
+/// All matching is pure string work (no model, no network), so it is fast,
+/// cross-platform, and fully testable. Phrases are matched on word boundaries.
+///
+enum SearchPlanLexicon {
+
+    // MARK: - Normalization
+
+    /// Lowercases, folds separators to spaces, and collapses whitespace so
+    /// "Sci-Fi", "rom-com", and "top‑rated" match their phrase forms.
+    static func normalize(_ prompt: String) -> String {
+        let lowered = prompt.lowercased()
+            .replacingOccurrences(of: "’", with: "'")
+        let folded = String(lowered.map { "-_/".contains($0) ? " " : $0 })
+        let collapsed = folded.split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "\n" })
+        return collapsed.joined(separator: " ")
+    }
+
+    /// Whole-word / whole-phrase containment (space-padded boundaries).
+    static func contains(_ text: String, _ phrase: String) -> Bool {
+        " \(text) ".contains(" \(phrase) ")
+    }
+
+    static func contains(_ text: String, anyOf phrases: [String]) -> Bool {
+        phrases.contains { contains(text, $0) }
+    }
+
+    // MARK: - List
+
+    private static let listKinds: [(phrases: [String], kind: SearchPlan.ListKind)] = [
+        (["trending"], .trending),
+        (["now playing", "in cinemas", "in theaters", "in theatres", "new releases", "out now"], .nowPlaying),
+        (["upcoming", "coming soon"], .upcoming),
+        (["airing today", "on tv today", "on air today"], .airingToday),
+        (["top rated", "highly rated", "best rated"], .topRated),
+        (["popular", "most popular"], .popular)
+    ]
+
+    static func listKind(in text: String) -> SearchPlan.ListKind? {
+        listKinds.first { contains(text, anyOf: $0.phrases) }?.kind
+    }
+
+    static func mediaType(in text: String) -> SearchPlan.MediaType? {
+        if contains(text, anyOf: ["actor", "actors", "actress", "actresses", "people", "directors"]) {
+            return .person
+        }
+        if contains(text, anyOf: ["show", "shows", "series", "tv", "television", "sitcom", "sitcoms"]) {
+            return .tv
+        }
+        if contains(text, anyOf: ["movie", "movies", "film", "films", "cinema"]) {
+            return .movie
+        }
+        return nil
+    }
+
+    // MARK: - Similar
+
+    static let similarLeads = [
+        "movies like", "movie like", "films like", "film like", "shows like", "show like",
+        "tv shows like", "tv series like", "series like", "something like", "stuff like",
+        "similar to", "in the vein of", "reminds me of", "recommendations based on"
+    ]
+
+    static func isSimilar(_ text: String) -> Bool {
+        similarLeads.contains { text.contains($0) }
+    }
+
+    // MARK: - Cast
+
+    static let castLeads = [
+        "cast of", "the cast of", "cast members of", "cast member of", "cast list for",
+        "cast list of", "full cast of", "main cast of", "who is in", "who's in", "whos in",
+        "actors in", "actors from", "the actors in", "stars of", "people in",
+        "who appears in", "who acted in", "who played in", "who plays in", "lead actors in"
+    ]
+
+    static func isCastOf(_ text: String) -> Bool {
+        castLeads.contains { text.contains($0) }
+    }
+
+    // MARK: - Crew role
+
+    static let crewRoleLeads: [(lead: String, job: String)] = [
+        // Longer phrases first: `crewRoleJob` returns the first match, and the
+        // matched lead is stripped to recover the title, so "who composed the
+        // music for Dune" must match the full clause, not just "who composed".
+        ("who composed the music for", "Original Music Composer"),
+        ("who composed the music of", "Original Music Composer"),
+        ("who composed the score for", "Original Music Composer"),
+        ("director of", "Director"), ("who directed", "Director"),
+        ("who wrote", "Writer"), ("writer of", "Writer"), ("screenwriter of", "Writer"),
+        ("composer of", "Original Music Composer"), ("who composed", "Original Music Composer"),
+        ("music by", "Original Music Composer"),
+        ("cinematographer of", "Director of Photography"),
+        ("producer of", "Producer"), ("who produced", "Producer"),
+        ("editor of", "Editor")
+    ]
+
+    static func crewRoleJob(in text: String) -> (lead: String, job: String)? {
+        crewRoleLeads.first { text.contains($0.lead) }
+    }
+
+    // MARK: - By person
+
+    static let byPersonPrefixes = [
+        "movies with ", "movie with ", "films with ", "film with ", "shows with ", "show with ",
+        "tv shows with ", "series with ", "movies starring ", "films starring ", "movie starring ",
+        "movies featuring ", "films featuring ", "movies by ", "films by ", "movie by ", "film by ",
+        "films directed by ", "movies directed by ", "starring ", "directed by ", "featuring "
+    ]
+
+    static let byPersonSuffixes = [" movies", " films", " movie", " film"]
+
+    static func isByPerson(_ text: String) -> Bool {
+        if byPersonPrefixes.contains(where: { text.hasPrefix($0) }) {
+            return true
+        }
+        // Trim a trailing date/runtime/rating clause so "Tom Hanks movies from the
+        // 90s" still presents the "X movies" shape (genres are NOT trimmed, so
+        // "horror movies" stays a browse query).
+        let core = trimmingTrailingSlots(text)
+        for suffix in byPersonSuffixes where core.hasSuffix(suffix) {
+            let candidate = String(core.dropLast(suffix.count)).trimmingCharacters(in: .whitespaces)
+            if !candidate.isEmpty,
+               listKind(in: candidate) == nil,
+               !hasDiscoverCue(candidate) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Removes a trailing date / runtime / rating clause (not genres) from a
+    /// normalized string, used to recover the "X movies" shape for classification.
+    static func trimmingTrailingSlots(_ text: String) -> String {
+        let markers: Set = ["under", "over", "rated", "from", "in", "released", "since",
+                            "before", "after", "during", "between"]
+        let words = text.split(separator: " ").map(String.init)
+        for (index, word) in words.enumerated() {
+            let yearish = (word.hasSuffix("s") && word.dropLast().allSatisfy(\.isNumber)
+                && word.count >= 3)
+                || (word.count == 4 && word.allSatisfy(\.isNumber)
+                    && (word.hasPrefix("19") || word.hasPrefix("20")))
+            if yearish || markers.contains(word) {
+                return words[0 ..< index].joined(separator: " ")
+            }
+        }
+        return text
+    }
+
+    // MARK: - Genres
+
+    /// Genre vocabulary used to detect a discover/browse cue. A prompt naming a
+    /// genre is deferred to the language-model fallback (which resolves genres),
+    /// so only presence is needed here, not a canonical mapping.
+    static let genreTerms: [[String]] = [
+        ["sci fi", "scifi", "science fiction"],
+        ["rom com", "romantic comedy"],
+        ["action"], ["adventure"], ["animation", "animated"], ["comedy", "comedies"],
+        ["crime"], ["documentary", "documentaries", "docs"], ["drama", "dramas"],
+        ["family"], ["fantasy"], ["history", "historical"], ["horror"],
+        ["musical", "musicals"], ["mystery"], ["romance", "romantic"],
+        ["thriller", "thrillers"], ["war"], ["western", "westerns"]
+    ]
+
+    static func hasGenre(_ text: String) -> Bool {
+        genreTerms.contains { contains(text, anyOf: $0) }
+    }
+
+    // MARK: - Mood
+
+    static let moodTerms = [
+        "feel good", "cozy", "cosy", "scary", "uplifting", "tearjerker", "heartwarming",
+        "comfort", "comforting", "wholesome", "funny", "light hearted", "lighthearted",
+        "hidden gem", "hidden gems", "underrated", "comfort watch", "chill", "relaxing",
+        "mind bending", "mindbending"
+    ]
+
+    static func hasMood(_ text: String) -> Bool {
+        contains(text, anyOf: moodTerms)
+    }
+
+    // MARK: - Date / runtime / rating cues
+
+    static func hasDateCue(_ text: String) -> Bool {
+        if contains(text, anyOf: ["decade", "recent", "this year", "last year", "classic"]) {
+            return true
+        }
+        for token in text.split(separator: " ") {
+            let word = String(token)
+            // "90s", "1990s", "2000s"
+            if word.hasSuffix("s"), word.dropLast().allSatisfy(\.isNumber), word.count >= 3 {
+                return true
+            }
+            // bare 4-digit year 19xx / 20xx
+            if word.count == 4, word.allSatisfy(\.isNumber),
+               word.hasPrefix("19") || word.hasPrefix("20") {
+                return true
+            }
+        }
+        return false
+    }
+
+    static func hasRuntimeCue(_ text: String) -> Bool {
+        if contains(text, anyOf: ["minute", "minutes", "runtime", "feature length", "short film"]) {
+            return true
+        }
+        if contains(text, "hour") || contains(text, "hours"), text.contains(where: \.isNumber) {
+            return true
+        }
+        return contains(text, anyOf: ["under two hours", "over two hours", "less than"])
+    }
+
+    static func hasRatingCue(_ text: String) -> Bool {
+        contains(text, anyOf: [
+            "highly rated", "top rated", "well rated", "acclaimed", "critically acclaimed",
+            "best rated", "high rating", "good ratings", "well reviewed"
+        ])
+    }
+
+    static func hasDiscoverCue(_ text: String) -> Bool {
+        hasGenre(text) || hasMood(text) || hasDateCue(text) || hasRuntimeCue(text) || hasRatingCue(text)
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanLexicon.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanLexicon.swift
@@ -55,7 +55,9 @@ enum SearchPlanLexicon {
         if contains(text, anyOf: ["actor", "actors", "actress", "actresses", "people", "directors"]) {
             return .person
         }
-        if contains(text, anyOf: ["show", "shows", "series", "tv", "television", "sitcom", "sitcoms"]) {
+        if contains(text, anyOf: [
+            "show", "shows", "series", "tv", "television", "sitcom", "sitcoms", "airing", "on air"
+        ]) {
             return .tv
         }
         if contains(text, anyOf: ["movie", "movies", "film", "films", "cinema"]) {
@@ -73,7 +75,7 @@ enum SearchPlanLexicon {
     ]
 
     static func isSimilar(_ text: String) -> Bool {
-        similarLeads.contains { text.contains($0) }
+        similarLeads.contains { contains(text, $0) }
     }
 
     // MARK: - Cast
@@ -87,7 +89,7 @@ enum SearchPlanLexicon {
     ]
 
     static func isCastOf(_ text: String) -> Bool {
-        castLeads.contains { text.contains($0) }
+        castLeads.contains { contains(text, $0) }
     }
 
     // MARK: - Crew role
@@ -109,7 +111,7 @@ enum SearchPlanLexicon {
     ]
 
     static func crewRoleJob(in text: String) -> (lead: String, job: String)? {
-        crewRoleLeads.first { text.contains($0.lead) }
+        crewRoleLeads.first { contains(text, $0.lead) }
     }
 
     // MARK: - By person
@@ -122,7 +124,8 @@ enum SearchPlanLexicon {
         "movies featuring ", "films featuring ",
         "shows featuring ", "tv shows featuring ", "tv series featuring ", "series featuring ",
         "movies by ", "films by ", "movie by ", "film by ",
-        "films directed by ", "movies directed by ", "starring ", "directed by ", "featuring "
+        "films directed by ", "movies directed by ", "films written by ", "movies written by ",
+        "starring ", "directed by ", "written by ", "featuring "
     ]
 
     /// Longer phrases first so "X tv shows" trims to "X", not "X tv".
@@ -139,7 +142,7 @@ enum SearchPlanLexicon {
         if byPersonPrefixes.contains(where: { text.hasPrefix($0) }) {
             return true
         }
-        if filmographyLeads.contains(where: { text.contains($0) }) {
+        if filmographyLeads.contains(where: { contains(text, $0) }) {
             return true
         }
         // Trim a trailing date/runtime/rating clause so "Tom Hanks movies from the

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanLexicon.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanLexicon.swift
@@ -82,7 +82,8 @@ enum SearchPlanLexicon {
         "cast of", "the cast of", "cast members of", "cast member of", "cast list for",
         "cast list of", "full cast of", "main cast of", "who is in", "who's in", "whos in",
         "actors in", "actors from", "the actors in", "stars of", "people in",
-        "who appears in", "who acted in", "who played in", "who plays in", "lead actors in"
+        "who appears in", "who acted in", "who played in", "who plays in", "lead actors in",
+        "who starred in", "who stars in"
     ]
 
     static func isCastOf(_ text: String) -> Bool {
@@ -115,15 +116,30 @@ enum SearchPlanLexicon {
 
     static let byPersonPrefixes = [
         "movies with ", "movie with ", "films with ", "film with ", "shows with ", "show with ",
-        "tv shows with ", "series with ", "movies starring ", "films starring ", "movie starring ",
-        "movies featuring ", "films featuring ", "movies by ", "films by ", "movie by ", "film by ",
+        "tv shows with ", "tv series with ", "series with ",
+        "movies starring ", "films starring ", "movie starring ",
+        "shows starring ", "show starring ", "tv shows starring ", "tv series starring ", "series starring ",
+        "movies featuring ", "films featuring ",
+        "shows featuring ", "tv shows featuring ", "tv series featuring ", "series featuring ",
+        "movies by ", "films by ", "movie by ", "film by ",
         "films directed by ", "movies directed by ", "starring ", "directed by ", "featuring "
     ]
 
-    static let byPersonSuffixes = [" movies", " films", " movie", " film"]
+    /// Longer phrases first so "X tv shows" trims to "X", not "X tv".
+    static let byPersonSuffixes = [
+        " movies", " films", " movie", " film",
+        " tv shows", " tv series", " tv show", " shows", " series"
+    ]
+
+    /// Filmography questions ("what has Tom Hanks been in") — the named person is
+    /// recovered by the planner's entity extraction.
+    static let filmographyLeads = ["been in"]
 
     static func isByPerson(_ text: String) -> Bool {
         if byPersonPrefixes.contains(where: { text.hasPrefix($0) }) {
+            return true
+        }
+        if filmographyLeads.contains(where: { text.contains($0) }) {
             return true
         }
         // Trim a trailing date/runtime/rating clause so "Tom Hanks movies from the
@@ -139,6 +155,21 @@ enum SearchPlanLexicon {
             }
         }
         return false
+    }
+
+    /// A crew role implied by a `byPerson` lead ("films directed by X" → Director),
+    /// so the executor can filter the discover query by crew rather than cast.
+    static func crewRoleForByPerson(_ text: String) -> String? {
+        if contains(text, "directed by") {
+            return "Director"
+        }
+        if contains(text, "written by") {
+            return "Writer"
+        }
+        if contains(text, anyOf: ["composed by", "music by", "scored by"]) {
+            return "Original Music Composer"
+        }
+        return nil
     }
 
     /// Removes a trailing date / runtime / rating clause (not genres) from a
@@ -171,7 +202,8 @@ enum SearchPlanLexicon {
         ["crime"], ["documentary", "documentaries", "docs"], ["drama", "dramas"],
         ["family"], ["fantasy"], ["history", "historical"], ["horror"],
         ["musical", "musicals"], ["mystery"], ["romance", "romantic"],
-        ["thriller", "thrillers"], ["war"], ["western", "westerns"]
+        ["thriller", "thrillers"], ["war"], ["western", "westerns"],
+        ["superhero", "super hero", "comic book"]
     ]
 
     static func hasGenre(_ text: String) -> Bool {

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanMapper.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanMapper.swift
@@ -40,7 +40,7 @@
             switch intent {
             case .find: .find
             case .browse: .browse
-            case .byPerson: .byPerson
+            case .filmography: .byPerson
             case .castOf: .castOf
             case .crewRole: .crewRole
             case .similar: .similar

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanSlotExtraction.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanSlotExtraction.swift
@@ -18,10 +18,11 @@ enum TitleExtractor {
 
     /// Media-type filler a user adds to disambiguate ("cast of the show The Crown"),
     /// stripped from the front of the residual so it doesn't pollute the title.
-    /// Longer phrases first.
+    /// Only multi-word forms: bare "show "/"series " are too close to real titles
+    /// (e.g. "Show Me a Hero"). Longer phrases first.
     private static let leadingFiller = [
         "the tv show ", "the tv series ", "the show ", "the series ",
-        "tv show ", "tv series ", "show ", "series "
+        "tv show ", "tv series "
     ]
 
     static func title(from prompt: String, strippingLeads leads: [String]) -> String {
@@ -114,13 +115,14 @@ enum RelativeDateParser {
 
     private static func lastNYears(_ text: String) -> Int? {
         let words = text.split(separator: " ").map(String.init)
-        guard let lastIndex = words.firstIndex(of: "last"), lastIndex + 2 < words.count + 1 else {
+        // Need a 3-word window: "last" <count> "year(s)".
+        guard let lastIndex = words.firstIndex(of: "last"), lastIndex + 2 < words.count else {
             return nil
         }
-        guard lastIndex + 1 < words.count, let count = Int(words[lastIndex + 1]) else {
+        guard let count = Int(words[lastIndex + 1]) else {
             return nil
         }
-        guard lastIndex + 2 < words.count, words[lastIndex + 2].hasPrefix("year") else {
+        guard words[lastIndex + 2].hasPrefix("year") else {
             return nil
         }
         return count

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanSlotExtraction.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanSlotExtraction.swift
@@ -16,6 +16,14 @@ enum TitleExtractor {
 
     private static let trailingMarkers = ["under", "over", "rated", "from", "in", "released"]
 
+    /// Media-type filler a user adds to disambiguate ("cast of the show The Crown"),
+    /// stripped from the front of the residual so it doesn't pollute the title.
+    /// Longer phrases first.
+    private static let leadingFiller = [
+        "the tv show ", "the tv series ", "the show ", "the series ",
+        "tv show ", "tv series ", "show ", "series "
+    ]
+
     static func title(from prompt: String, strippingLeads leads: [String]) -> String {
         // 1. Find the earliest matching lead phrase; the title is what follows it.
         var afterLead = prompt
@@ -29,11 +37,24 @@ enum TitleExtractor {
             afterLead = String(prompt[earliest.upperBound...])
         }
 
-        // 2. Excise a trailing slot clause.
+        // 2. Excise a trailing slot clause — but not if it would empty the title
+        //    (e.g. the film "1917", whose whole title looks like a year).
         let excised = exciseTrailingSlots(afterLead)
+        let kept = excised.trimmingCharacters(in: .whitespaces).isEmpty ? afterLead : excised
 
-        // 3. Trim whitespace and surrounding punctuation/quotes.
-        return excised.trimmingCharacters(in: CharacterSet(charactersIn: " \t\n\"'.,?!"))
+        // 3. Strip leading media-type filler ("the show", "the series", …).
+        let unfilled = strippingLeadingFiller(kept)
+
+        // 4. Trim whitespace and surrounding punctuation/quotes.
+        return unfilled.trimmingCharacters(in: CharacterSet(charactersIn: " \t\n\"'.,?!"))
+    }
+
+    private static func strippingLeadingFiller(_ text: String) -> String {
+        let leading = text.drop { $0 == " " }
+        for filler in leadingFiller where leading.lowercased().hasPrefix(filler) {
+            return String(leading.dropFirst(filler.count))
+        }
+        return text
     }
 
     private static func exciseTrailingSlots(_ text: String) -> String {

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanSlotExtraction.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanSlotExtraction.swift
@@ -1,0 +1,183 @@
+//
+//  SearchPlanSlotExtraction.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// Extracts a title from a prompt by removing trailing slot phrases (date /
+/// runtime / rating) and then stripping the leading intent phrase. The residual
+/// is the title, in its original casing (for searching).
+///
+enum TitleExtractor {
+
+    private static let trailingMarkers = ["under", "over", "rated", "from", "in", "released"]
+
+    static func title(from prompt: String, strippingLeads leads: [String]) -> String {
+        // 1. Find the earliest matching lead phrase; the title is what follows it.
+        var afterLead = prompt
+        var earliest: Range<String.Index>?
+        for lead in leads {
+            guard let range = prompt.range(of: lead, options: [.caseInsensitive]) else { continue }
+            if let current = earliest, current.lowerBound <= range.lowerBound { continue }
+            earliest = range
+        }
+        if let earliest {
+            afterLead = String(prompt[earliest.upperBound...])
+        }
+
+        // 2. Excise a trailing slot clause.
+        let excised = exciseTrailingSlots(afterLead)
+
+        // 3. Trim whitespace and surrounding punctuation/quotes.
+        return excised.trimmingCharacters(in: CharacterSet(charactersIn: " \t\n\"'.,?!"))
+    }
+
+    private static func exciseTrailingSlots(_ text: String) -> String {
+        let words = text.split(separator: " ").map(String.init)
+        for (index, word) in words.enumerated() {
+            let lower = word.lowercased()
+            let isYearish = (lower.hasSuffix("s") && lower.dropLast().allSatisfy(\.isNumber)
+                && lower.count >= 3)
+                || (lower.count == 4 && lower.allSatisfy(\.isNumber)
+                    && (lower.hasPrefix("19") || lower.hasPrefix("20")))
+            if isYearish || trailingMarkers.contains(lower) {
+                return words[0 ..< index].joined(separator: " ")
+            }
+        }
+        return text
+    }
+
+}
+
+///
+/// Parses a symbolic ``SearchPlan/RelativeDate`` from a normalized prompt.
+///
+enum RelativeDateParser {
+
+    static func parse(_ normalized: String) -> SearchPlan.RelativeDate? {
+        if let range = between(normalized) {
+            return range
+        }
+        if let years = lastNYears(normalized) {
+            return .lastNYears(years)
+        }
+        if let decade = decade(normalized) {
+            return .decade(decade)
+        }
+        if let year = exactYear(normalized) {
+            return .exactYear(year)
+        }
+        if SearchPlanLexicon.contains(normalized, "this year") {
+            return .thisYear
+        }
+        if SearchPlanLexicon.contains(normalized, anyOf: ["recent", "recently"]) {
+            return .recent
+        }
+        return nil
+    }
+
+    private static func between(_ text: String) -> SearchPlan.RelativeDate? {
+        let words = text.split(separator: " ").map(String.init)
+        guard let andIndex = words.firstIndex(of: "and"), andIndex > 0, andIndex < words.count - 1 else {
+            return nil
+        }
+        guard let start = year(words[andIndex - 1]), let end = year(words[andIndex + 1]) else {
+            return nil
+        }
+        return .between(start: min(start, end), end: max(start, end))
+    }
+
+    private static func lastNYears(_ text: String) -> Int? {
+        let words = text.split(separator: " ").map(String.init)
+        guard let lastIndex = words.firstIndex(of: "last"), lastIndex + 2 < words.count + 1 else {
+            return nil
+        }
+        guard lastIndex + 1 < words.count, let count = Int(words[lastIndex + 1]) else {
+            return nil
+        }
+        guard lastIndex + 2 < words.count, words[lastIndex + 2].hasPrefix("year") else {
+            return nil
+        }
+        return count
+    }
+
+    private static func decade(_ text: String) -> Int? {
+        for word in text.split(separator: " ") {
+            let lower = word.lowercased()
+            guard lower.hasSuffix("s") else { continue }
+            let digits = String(lower.dropLast())
+            guard digits.allSatisfy(\.isNumber), !digits.isEmpty else { continue }
+            if digits.count == 4, let value = Int(digits) {
+                return value
+            }
+            if digits.count == 2, let two = Int(digits) {
+                return two <= 20 ? 2000 + two : 1900 + two
+            }
+        }
+        return nil
+    }
+
+    private static func exactYear(_ text: String) -> Int? {
+        for word in text.split(separator: " ") {
+            if let year = year(String(word)) {
+                return year
+            }
+        }
+        return nil
+    }
+
+    private static func year(_ word: String) -> Int? {
+        guard word.count == 4, word.allSatisfy(\.isNumber),
+              word.hasPrefix("19") || word.hasPrefix("20"), let value = Int(word)
+        else {
+            return nil
+        }
+        return value
+    }
+
+}
+
+///
+/// Parses runtime ceiling and minimum-rating slots from a normalized prompt.
+///
+enum RuntimeRatingParser {
+
+    private static let wordNumbers = ["one": 1, "two": 2, "three": 3, "an": 1, "a": 1]
+
+    static func runtimeMaxMinutes(_ normalized: String) -> Int? {
+        let words = normalized.split(separator: " ").map(String.init)
+        for (index, word) in words.enumerated() where word == "under" || word == "less" {
+            // value is the next number-ish token
+            let valueIndex = (word == "less" && index + 1 < words.count && words[index + 1] == "than")
+                ? index + 2 : index + 1
+            guard valueIndex < words.count else { continue }
+            let value = Int(words[valueIndex]) ?? wordNumbers[words[valueIndex]]
+            guard let value, valueIndex + 1 < words.count else { continue }
+            let unit = words[valueIndex + 1]
+            if unit.hasPrefix("hour") {
+                return value * 60
+            }
+            if unit.hasPrefix("min") {
+                return value
+            }
+        }
+        return nil
+    }
+
+    static func minRating(_ normalized: String) -> Double? {
+        if SearchPlanLexicon.contains(normalized, anyOf: [
+            "highly rated", "top rated", "best rated", "acclaimed", "critically acclaimed"
+        ]) {
+            return 7.0
+        }
+        if SearchPlanLexicon.hasRatingCue(normalized) {
+            return 6.5
+        }
+        return nil
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/TMDbNaturalLanguageSearchService.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/TMDbNaturalLanguageSearchService.swift
@@ -10,10 +10,11 @@ import Foundation
 ///
 /// The default ``NaturalLanguageSearchService`` implementation.
 ///
-/// It composes a plan generator (the on-device model) with a deterministic
-/// executor. When the model rejects a prompt — for example via a guardrail
-/// violation — it falls back to a literal text search so legitimate queries are
-/// not dead-ended.
+/// It composes a ``SearchPlanGenerating`` planner — deterministic-first, with
+/// Foundation Models as an evidence-gated fallback — with a deterministic
+/// executor. When the language-model fallback rejects a prompt (a guardrail
+/// violation, a refusal, or a decoding failure) it falls back to a literal text
+/// search so legitimate queries are not dead-ended.
 ///
 final class TMDbNaturalLanguageSearchService: NaturalLanguageSearchService {
 

--- a/Sources/TMDb/TMDb.docc/Extensions/TMDbClient.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/TMDbClient.md
@@ -22,6 +22,7 @@
 - ``discover``
 - ``trending``
 - ``search``
+- ``naturalLanguageSearch``
 - ``find``
 - ``credits``
 - ``reviews``

--- a/Sources/TMDb/TMDb.docc/Extensions/TMDbClient.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/TMDbClient.md
@@ -22,7 +22,6 @@
 - ``discover``
 - ``trending``
 - ``search``
-- ``naturalLanguageSearch``
 - ``find``
 - ``credits``
 - ``reviews``

--- a/Sources/TMDb/TMDbClient.swift
+++ b/Sources/TMDb/TMDbClient.swift
@@ -263,21 +263,20 @@ public final class TMDbClient: Sendable {
 
 }
 
-#if canImport(FoundationModels)
-    @available(iOS 26, macOS 26, visionOS 26, *)
+#if canImport(NaturalLanguage)
+    @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
     public extension TMDbClient {
 
         ///
         /// Provides on-device, natural-language search across movies, TV series, and
-        /// people, powered by Apple Foundation Models.
+        /// people.
         ///
-        /// A prompt such as `"uplifting 90s sci-fi under 2 hours"` is interpreted by
-        /// the on-device model and executed against TMDb. Check
-        /// ``NaturalLanguageSearchService/availability`` before use, as the
-        /// underlying model is only available on supported Apple platforms with
-        /// Apple Intelligence enabled.
-        ///
-        /// - Important: Available only on iOS 26, macOS 26, and visionOS 26 or later.
+        /// A prompt such as `"movies with Tom Hanks"` or `"cast of The Matrix"` is
+        /// interpreted on device and executed against TMDb. Interpretation is
+        /// deterministic (Apple's Natural Language framework); on supported devices
+        /// with Apple Intelligence, Foundation Models additionally handles fuzzier,
+        /// compositional prompts. On platforms without either, the prompt runs as a
+        /// plain multi-search.
         ///
         /// - Note: Each access constructs a new service instance. When checking
         ///   ``NaturalLanguageSearchService/availability`` and then searching, store
@@ -294,8 +293,24 @@ public final class TMDbClient: Sendable {
                 trending: trending
             )
 
+            let deterministic = NaturalLanguageSearchPlanGenerator(
+                classifier: RuleBasedIntentClassifier(),
+                personExtractor: NLTaggerPersonNameExtractor()
+            )
+
+            // Foundation Models is an optional fallback for the fuzzy tail, only on
+            // capable OS versions. The NaturalLanguage planner is always the default.
+            var fallback: (any SearchPlanGenerating)?
+            #if canImport(FoundationModels)
+                if #available(iOS 26, macOS 26, visionOS 26, *) {
+                    fallback = FoundationModelsSearchPlanGenerator()
+                }
+            #endif
+
+            let planner = GatedSearchPlanGenerator(deterministic: deterministic, fallback: fallback)
+
             return TMDbNaturalLanguageSearchService(
-                planner: FoundationModelsSearchPlanGenerator(),
+                planner: planner,
                 executor: SearchPlanExecutor(dataSource: dataSource),
                 dataSource: dataSource
             )

--- a/Sources/TMDb/TMDbClient.swift
+++ b/Sources/TMDb/TMDbClient.swift
@@ -290,6 +290,7 @@ public final class TMDbClient: Sendable {
                 genres: genres,
                 movies: movies,
                 tvSeries: tvSeries,
+                people: people,
                 trending: trending
             )
 

--- a/Tests/TMDbIntegrationTests/NaturalLanguageSearchEndToEndIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/NaturalLanguageSearchEndToEndIntegrationTests.swift
@@ -1,0 +1,73 @@
+//
+//  NaturalLanguageSearchEndToEndIntegrationTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(NaturalLanguage)
+    import Foundation
+    import Testing
+    @testable import TMDb
+
+    ///
+    /// End-to-end coverage for the deterministic NaturalLanguage planner: a sample
+    /// of real prompts driven through `client.naturalLanguageSearch` against the
+    /// live API. These exercise the full chain (classifier → NER → executor →
+    /// TMDb) without the language model, so they are stable on every Apple runner.
+    ///
+    @Suite(
+        .integrationGate,
+        .serialized,
+        .tags(.naturalLanguageSearch),
+        .enabled(if: CredentialHelper.shared.hasAPIKey)
+    )
+    struct NaturalLanguageSearchEndToEndIntegrationTests {
+
+        private var search: any NaturalLanguageSearchService {
+            CredentialHelper.shared.makeClient().naturalLanguageSearch
+        }
+
+        @Test("the feature is available on all Apple platforms")
+        func available() {
+            #expect(search.availability == .available)
+        }
+
+        @Test("bare title returns the matching movie")
+        func findTitle() async throws {
+            let result = try await search.search(matching: "Fight Club")
+            #expect(result.movies.contains { $0.title.localizedCaseInsensitiveContains("Fight Club") })
+        }
+
+        @Test("cast of a known film returns its cast")
+        func castOf() async throws {
+            let result = try await search.search(matching: "cast of The Matrix")
+            #expect(result.people.contains { $0.name.localizedCaseInsensitiveContains("Keanu Reeves") })
+        }
+
+        @Test("director of a known film returns the director")
+        func crewRole() async throws {
+            let result = try await search.search(matching: "who directed Jurassic Park")
+            #expect(result.people.contains { $0.name.localizedCaseInsensitiveContains("Spielberg") })
+        }
+
+        @Test("movies with a named actor returns results")
+        func byPerson() async throws {
+            let result = try await search.search(matching: "movies with Tom Hanks")
+            #expect(!result.movies.isEmpty)
+        }
+
+        @Test("similar to a known film returns results")
+        func similar() async throws {
+            let result = try await search.search(matching: "movies like The Matrix")
+            #expect(!result.movies.isEmpty)
+        }
+
+        @Test("a curated list returns results")
+        func list() async throws {
+            let result = try await search.search(matching: "trending movies")
+            #expect(!result.movies.isEmpty)
+        }
+
+    }
+#endif

--- a/Tests/TMDbIntegrationTests/NaturalLanguageSearchEndToEndIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/NaturalLanguageSearchEndToEndIntegrationTests.swift
@@ -57,6 +57,13 @@
             #expect(!result.movies.isEmpty)
         }
 
+        @Test("tv shows with a named actor returns results from person credits")
+        func byPersonTV() async throws {
+            // Exercises the person-credits path (discover/tv can't filter by person).
+            let result = try await search.search(matching: "shows with Bryan Cranston")
+            #expect(result.tvSeries.contains { $0.name.localizedCaseInsensitiveContains("Breaking Bad") })
+        }
+
         @Test("similar to a known film returns results")
         func similar() async throws {
             let result = try await search.search(matching: "movies like The Matrix")

--- a/Tests/TMDbIntegrationTests/NaturalLanguageSearchIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/NaturalLanguageSearchIntegrationTests.swift
@@ -36,6 +36,7 @@ struct NaturalLanguageSearchIntegrationTests {
             genres: client.genres,
             movies: client.movies,
             tvSeries: client.tvSeries,
+            people: client.people,
             trending: client.trending
         )
         self.executor = SearchPlanExecutor(dataSource: dataSource)

--- a/Tests/TMDbIntegrationTests/NaturalLanguageSearchPlannerEvalTests.swift
+++ b/Tests/TMDbIntegrationTests/NaturalLanguageSearchPlannerEvalTests.swift
@@ -1,0 +1,253 @@
+//
+//  NaturalLanguageSearchPlannerEvalTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels)
+    import Foundation
+    import Testing
+    @testable import TMDb
+
+    private struct EvalCase {
+        let prompt: String
+        let accept: [SearchPlan.Intent]
+        let outOfScope: Bool
+
+        init(_ prompt: String, _ accept: SearchPlan.Intent..., outOfScope: Bool = false) {
+            self.prompt = prompt
+            self.accept = accept
+            self.outOfScope = outOfScope
+        }
+    }
+
+    @Suite(
+        .serialized,
+        .tags(.naturalLanguageSearch),
+        .enabled(if: ProcessInfo.processInfo.environment["NLS_EVAL"] != nil
+            && CredentialHelper.shared.hasAPIKey)
+    )
+    struct NaturalLanguageSearchPlannerEvalTests {
+
+        // swiftlint:disable:next function_body_length
+        private static func corpus() -> [EvalCase] {
+            [
+                // find — bare titles
+                EvalCase("Fight Club", .find),
+                EvalCase("The Matrix", .find),
+                EvalCase("Inception", .find),
+                EvalCase("Breaking Bad", .find),
+                EvalCase("Stranger Things", .find),
+                EvalCase("The Godfather", .find),
+                EvalCase("Pulp Fiction", .find),
+                EvalCase("Game of Thrones", .find),
+                EvalCase("Dune", .find),
+                EvalCase("Oppenheimer", .find),
+                EvalCase("The Office", .find),
+                EvalCase("Interstellar", .find),
+                EvalCase("Titanic", .find),
+                EvalCase("The Dark Knight", .find),
+                // find — bare names (byPerson also acceptable)
+                EvalCase("Tom Hanks", .find, .byPerson),
+                EvalCase("Leonardo DiCaprio", .find, .byPerson),
+                EvalCase("Meryl Streep", .find, .byPerson),
+                EvalCase("Christopher Nolan", .find, .byPerson),
+                EvalCase("Brad Pitt", .find, .byPerson),
+                EvalCase("Zendaya", .find, .byPerson),
+
+                // castOf — cast / people in a title
+                EvalCase("cast of Fight Club", .castOf),
+                EvalCase("people in The Matrix", .castOf),
+                EvalCase("who's in Inception", .castOf),
+                EvalCase("actors in Dune", .castOf),
+                EvalCase("the cast of Stranger Things", .castOf),
+                EvalCase("who stars in Oppenheimer", .castOf),
+                EvalCase("main cast of Breaking Bad", .castOf),
+                EvalCase("actors in The Godfather", .castOf),
+                EvalCase("who appears in Pulp Fiction", .castOf),
+                EvalCase("cast members of Friends", .castOf),
+                EvalCase("stars of Titanic", .castOf),
+                EvalCase("who acted in Interstellar", .castOf),
+                EvalCase("lead actors in The Dark Knight", .castOf),
+                EvalCase("who played in Gladiator", .castOf),
+                EvalCase("cast of Avatar", .castOf),
+                EvalCase("actors from The Office", .castOf),
+                EvalCase("who is in Game of Thrones", .castOf),
+                EvalCase("the actors in Forrest Gump", .castOf),
+                EvalCase("cast list for Jurassic Park", .castOf),
+                EvalCase("who's in the movie Heat", .castOf),
+
+                // crewRole — a specific crew role of a title
+                EvalCase("director of Jurassic Park", .crewRole),
+                EvalCase("who directed Inception", .crewRole),
+                EvalCase("director of The Godfather", .crewRole),
+                EvalCase("who wrote Pulp Fiction", .crewRole),
+                EvalCase("composer of Interstellar", .crewRole),
+                EvalCase("who directed Titanic", .crewRole),
+                EvalCase("writer of The Social Network", .crewRole),
+                EvalCase("who directed Parasite", .crewRole),
+                EvalCase("director of Mad Max Fury Road", .crewRole),
+                EvalCase("who composed the music for Dune", .crewRole),
+                EvalCase("who directed The Dark Knight", .crewRole),
+                EvalCase("director of Schindler's List", .crewRole),
+                EvalCase("who directed Goodfellas", .crewRole),
+                EvalCase("director of Whiplash", .crewRole),
+
+                // byPerson — titles featuring / by a named person
+                EvalCase("movies with Tom Hanks", .byPerson),
+                EvalCase("films directed by Christopher Nolan", .byPerson),
+                EvalCase("Brad Pitt movies", .byPerson),
+                EvalCase("movies starring Meryl Streep", .byPerson),
+                EvalCase("Scarlett Johansson films", .byPerson),
+                EvalCase("Quentin Tarantino movies", .byPerson),
+                EvalCase("movies featuring Denzel Washington", .byPerson),
+                EvalCase("films with Leonardo DiCaprio", .byPerson),
+                EvalCase("movies by Steven Spielberg", .byPerson),
+                EvalCase("Robert De Niro films", .byPerson),
+                EvalCase("movies starring Margot Robbie", .byPerson),
+                EvalCase("films featuring Anthony Hopkins", .byPerson),
+                EvalCase("movies with both Brad Pitt and Edward Norton", .byPerson),
+                EvalCase("Keanu Reeves movies", .byPerson),
+                EvalCase("films directed by Greta Gerwig", .byPerson),
+                EvalCase("movies with Ryan Gosling", .byPerson),
+                EvalCase("Tom Cruise action movies", .byPerson, .browse),
+                EvalCase("comedies with Adam Sandler", .byPerson, .browse),
+
+                // similar — like a named title
+                EvalCase("movies like Inception", .similar),
+                EvalCase("shows similar to Breaking Bad", .similar),
+                EvalCase("films like The Matrix", .similar),
+                EvalCase("something like Stranger Things", .similar),
+                EvalCase("movies similar to Fight Club", .similar),
+                EvalCase("TV shows like Game of Thrones", .similar),
+                EvalCase("films in the vein of Blade Runner", .similar),
+                EvalCase("movies like Parasite", .similar),
+                EvalCase("recommendations based on The Office", .similar),
+                EvalCase("shows like The Crown", .similar),
+                EvalCase("movies similar to Interstellar", .similar),
+                EvalCase("something like John Wick", .similar),
+                EvalCase("films like Pulp Fiction", .similar),
+                EvalCase("shows like Black Mirror", .similar),
+                EvalCase("movies like Get Out", .similar),
+
+                // browse — attribute filters
+                EvalCase("90s sci-fi movies", .browse),
+                EvalCase("horror films from the 80s", .browse),
+                EvalCase("French romantic comedies", .browse),
+                EvalCase("short animated movies", .browse),
+                EvalCase("highly rated documentaries", .browse),
+                EvalCase("action movies from 2019", .browse),
+                EvalCase("R-rated thrillers", .browse),
+                EvalCase("Korean horror movies", .browse),
+                EvalCase("long epic war films", .browse),
+                EvalCase("Japanese animated films", .browse),
+                EvalCase("British crime dramas", .browse),
+                EvalCase("movies under 90 minutes", .browse),
+                EvalCase("sci-fi movies from the 2010s", .browse),
+                EvalCase("Spanish language films", .browse),
+                EvalCase("movies released in 2020", .browse),
+                EvalCase("comedies from the 2000s", .browse),
+                EvalCase("recent thrillers", .browse),
+                EvalCase("indie dramas", .browse),
+                EvalCase("westerns from the 1960s", .browse),
+                EvalCase("top rated movies of the 1990s", .browse, .list),
+
+                // list — curated lists
+                EvalCase("trending movies", .list),
+                EvalCase("popular shows", .list),
+                EvalCase("top rated movies", .list),
+                EvalCase("what's in cinemas now", .list),
+                EvalCase("new releases", .list),
+                EvalCase("upcoming movies", .list),
+                EvalCase("trending this week", .list),
+                EvalCase("most popular TV series", .list),
+                EvalCase("what's airing today", .list),
+                EvalCase("now playing in theaters", .list),
+                EvalCase("popular movies right now", .list),
+                EvalCase("top rated TV shows", .list),
+                EvalCase("trending people", .list),
+                EvalCase("popular actors", .list),
+                EvalCase("movies coming soon", .list),
+
+                // mood — subjective (browse acceptable too)
+                EvalCase("feel-good movies", .mood, .browse),
+                EvalCase("something scary", .mood, .browse),
+                EvalCase("cozy films for a rainy day", .mood, .browse),
+                EvalCase("uplifting movies", .mood, .browse),
+                EvalCase("a tearjerker", .mood, .browse),
+                EvalCase("something funny to watch", .mood, .browse),
+                EvalCase("comfort movies", .mood, .browse),
+                EvalCase("date night movies", .mood, .browse),
+                EvalCase("something light-hearted", .mood, .browse),
+                EvalCase("feel good shows", .mood, .browse),
+
+                // out of scope
+                EvalCase("a good book about space", outOfScope: true),
+                EvalCase("best pizza recipe", outOfScope: true),
+                EvalCase("weather tomorrow", outOfScope: true),
+                EvalCase("how to change a tire", outOfScope: true),
+                EvalCase("stock market news", outOfScope: true),
+                EvalCase("what time is it", outOfScope: true),
+                EvalCase("translate hello to French", outOfScope: true),
+                EvalCase("directions to the airport", outOfScope: true)
+            ]
+        }
+
+        @available(macOS 26, *)
+        @Test("Planner intent-classification accuracy over the corpus")
+        func evaluatePlannerAccuracy() async throws {
+            let nls = CredentialHelper.shared.makeClient().naturalLanguageSearch
+            let cases = Self.corpus()
+
+            var correct = 0
+            var perCategory: [String: (correct: Int, total: Int)] = [:]
+            var misses: [String] = []
+
+            for testCase in cases {
+                let category = testCase.outOfScope ? "outOfScope" : "\(testCase.accept[0])"
+                var bucket = perCategory[category] ?? (0, 0)
+                bucket.total += 1
+
+                let plan: SearchPlan
+                do {
+                    // Apply the same deterministic repair the executor does.
+                    plan = try await SearchPlanExecutor.normalize(nls.plan(for: testCase.prompt))
+                } catch {
+                    misses.append("ERROR  \(testCase.prompt)  -> \(error)")
+                    perCategory[category] = bucket
+                    continue
+                }
+
+                let passed = testCase.outOfScope
+                    ? !plan.isInScope
+                    : (plan.isInScope && testCase.accept.contains(plan.intent))
+
+                if passed {
+                    correct += 1
+                    bucket.correct += 1
+                } else {
+                    let want = testCase.outOfScope ? "outOfScope" : "\(testCase.accept[0])"
+                    misses.append("MISS \(testCase.prompt) | want \(want) got \(plan.intent) "
+                        + "title=\(plan.title ?? "-") people=\(plan.people) "
+                        + "list=\(String(describing: plan.list)) inScope=\(plan.isInScope)")
+                }
+
+                perCategory[category] = bucket
+            }
+
+            print("\n===== Planner accuracy: \(correct)/\(cases.count) "
+                + "(\(Int(Double(correct) / Double(cases.count) * 100))%) =====")
+            for key in perCategory.keys.sorted() {
+                let bucket = try #require(perCategory[key])
+                print(String(format: "  %-12@  %2d/%2d", key as NSString, bucket.correct, bucket.total))
+            }
+            print("----- misses (\(misses.count)) -----")
+            for miss in misses {
+                print("  \(miss)")
+            }
+            print("=====================================\n")
+        }
+
+    }
+#endif

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/Mocks/MockNaturalLanguageSearchDataSource.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/Mocks/MockNaturalLanguageSearchDataSource.swift
@@ -49,9 +49,13 @@ final class MockNaturalLanguageSearchDataSource: NaturalLanguageSearchDataSource
         tvSeriesGenresResult
     }
 
+    var discoverMoviesHandler: ((DiscoverMovieFilter) -> [MovieListItem])?
+    private(set) var discoverMoviesCallCount = 0
+
     func discoverMovies(filter: DiscoverMovieFilter, sortedBy: MovieSort?) async throws -> [MovieListItem] {
         lastMovieFilter = filter
-        return discoverMoviesResult
+        discoverMoviesCallCount += 1
+        return discoverMoviesHandler?(filter) ?? discoverMoviesResult
     }
 
     func discoverTVSeries(

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/Mocks/MockNaturalLanguageSearchDataSource.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/Mocks/MockNaturalLanguageSearchDataSource.swift
@@ -24,8 +24,8 @@ final class MockNaturalLanguageSearchDataSource: NaturalLanguageSearchDataSource
         [],
         []
     )
-    var similarMoviesResult: [MovieListItem] = []
-    var similarTVSeriesResult: [TVSeriesListItem] = []
+    var recommendedMoviesResult: [MovieListItem] = []
+    var recommendedTVSeriesResult: [TVSeriesListItem] = []
     var movieCreditsResult = ShowCredits(id: 0, cast: [], crew: [])
     var tvSeriesCreditsResult = ShowCredits(id: 0, cast: [], crew: [])
     var curatedMoviesResult: [MovieListItem] = []
@@ -91,12 +91,20 @@ final class MockNaturalLanguageSearchDataSource: NaturalLanguageSearchDataSource
         return searchAllResult
     }
 
-    func similarMovies(toMovie id: Movie.ID) async throws -> [MovieListItem] {
-        similarMoviesResult
+    func recommendedMovies(forMovie id: Movie.ID) async throws -> [MovieListItem] {
+        recommendedMoviesResult
     }
 
-    func similarTVSeries(toTVSeries id: TVSeries.ID) async throws -> [TVSeriesListItem] {
-        similarTVSeriesResult
+    func recommendedTVSeries(forTVSeries id: TVSeries.ID) async throws -> [TVSeriesListItem] {
+        recommendedTVSeriesResult
+    }
+
+    var personTVCreditsResult: [TVSeriesListItem] = []
+    private(set) var personTVCreditsIDs: [Person.ID] = []
+
+    func tvSeriesCredits(forPerson id: Person.ID) async throws -> [TVSeriesListItem] {
+        personTVCreditsIDs.append(id)
+        return personTVCreditsResult
     }
 
     func movieCredits(forMovie id: Movie.ID) async throws -> ShowCredits {

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/Mocks/NaturalLanguagePlannerMocks.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/Mocks/NaturalLanguagePlannerMocks.swift
@@ -1,0 +1,32 @@
+//
+//  NaturalLanguagePlannerMocks.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+@testable import TMDb
+
+final class MockPersonNameExtractor: PersonNameExtracting, @unchecked Sendable {
+    var result: [String] = []
+    func people(in prompt: String) -> [String] {
+        result
+    }
+}
+
+final class MockIntentClassifier: IntentClassifying, @unchecked Sendable {
+    var intent: SearchPlan.Intent?
+    func classify(_ prompt: String) -> SearchPlan.Intent? {
+        intent
+    }
+}
+
+final class MockDeterministicSearchPlanning: DeterministicSearchPlanning, @unchecked Sendable {
+    var plan: SearchPlan?
+    private(set) var calls: [String] = []
+    func confidentPlan(for prompt: String) -> SearchPlan? {
+        calls.append(prompt)
+        return plan
+    }
+}

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/NLTaggerPersonNameExtractorTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/NLTaggerPersonNameExtractorTests.swift
@@ -1,0 +1,57 @@
+//
+//  NLTaggerPersonNameExtractorTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(NaturalLanguage)
+    import Foundation
+    import Testing
+    @testable import TMDb
+
+    ///
+    /// Coverage for the production NER extractor. Apple's on-device model varies
+    /// across OS versions, so assertions are tolerant: they check membership and
+    /// span-boundedness rather than exact token spans.
+    ///
+    @Suite("NLTaggerPersonNameExtractor")
+    struct NLTaggerPersonNameExtractorTests {
+
+        private let extractor = NLTaggerPersonNameExtractor()
+
+        @Test("extracts a single full name embedded in a prompt")
+        func singleName() {
+            let names = extractor.people(in: "movies with Tom Hanks")
+            #expect(names.contains { $0.localizedCaseInsensitiveContains("Tom Hanks") })
+        }
+
+        @Test("extracts a name from a directed-by phrasing")
+        func directedBy() {
+            let names = extractor.people(in: "films directed by Christopher Nolan")
+            #expect(names.contains { $0.localizedCaseInsensitiveContains("Christopher Nolan") })
+        }
+
+        @Test("extracts both names from a two-person prompt")
+        func twoNames() {
+            let names = extractor.people(in: "movies with Brad Pitt and Edward Norton")
+            #expect(names.contains { $0.localizedCaseInsensitiveContains("Brad Pitt") })
+            #expect(names.contains { $0.localizedCaseInsensitiveContains("Edward Norton") })
+        }
+
+        @Test("never returns text that is not present in the prompt")
+        func spanBounded() {
+            let prompt = "movies with Meryl Streep"
+            for name in extractor.people(in: prompt) {
+                #expect(prompt.localizedCaseInsensitiveContains(name))
+            }
+        }
+
+        @Test("a prompt with no person names returns no spurious people")
+        func noNames() {
+            // Best-effort: a bare genre prompt should not yield a confident person.
+            let names = extractor.people(in: "trending movies")
+            #expect(!names.contains { $0.localizedCaseInsensitiveContains("trending") })
+        }
+    }
+#endif

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchPlanGeneratorTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchPlanGeneratorTests.swift
@@ -38,6 +38,14 @@ struct NaturalLanguageSearchPlanGeneratorTests {
         #expect(plan?.mediaType == .tv)
     }
 
+    @Test("an airing-today list resolves to the tv media type")
+    func airingTodayIsTV() {
+        let plan = make().confidentPlan(for: "what's airing today")
+        #expect(plan?.intent == .list)
+        #expect(plan?.list == .airingToday)
+        #expect(plan?.mediaType == .tv)
+    }
+
     @Test("castOf extracts the title")
     func castOf() {
         let plan = make().confidentPlan(for: "cast of The Matrix")

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchPlanGeneratorTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchPlanGeneratorTests.swift
@@ -1,0 +1,207 @@
+//
+//  NaturalLanguageSearchPlanGeneratorTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite("NaturalLanguageSearchPlanGenerator")
+struct NaturalLanguageSearchPlanGeneratorTests {
+
+    private let people = MockPersonNameExtractor()
+
+    private func make() -> NaturalLanguageSearchPlanGenerator {
+        NaturalLanguageSearchPlanGenerator(
+            classifier: RuleBasedIntentClassifier(),
+            personExtractor: people
+        )
+    }
+
+    @Test("find carries the prompt as title and no people")
+    func find() {
+        let plan = make().confidentPlan(for: "Fight Club")
+        #expect(plan?.intent == .find)
+        #expect(plan?.title == "Fight Club")
+        #expect(plan?.people.isEmpty == true)
+        #expect(plan?.isInScope == true)
+    }
+
+    @Test("list extracts kind and media type")
+    func list() {
+        let plan = make().confidentPlan(for: "trending shows")
+        #expect(plan?.intent == .list)
+        #expect(plan?.list == .trending)
+        #expect(plan?.mediaType == .tv)
+    }
+
+    @Test("castOf extracts the title")
+    func castOf() {
+        let plan = make().confidentPlan(for: "cast of The Matrix")
+        #expect(plan?.intent == .castOf)
+        #expect(plan?.title == "The Matrix")
+    }
+
+    @Test("crewRole extracts title and job")
+    func crewRole() {
+        let plan = make().confidentPlan(for: "who directed Jurassic Park")
+        #expect(plan?.intent == .crewRole)
+        #expect(plan?.title == "Jurassic Park")
+        #expect(plan?.crewRole == "Director")
+    }
+
+    @Test("similar extracts the title and has no people")
+    func similar() {
+        let plan = make().confidentPlan(for: "movies like Inception")
+        #expect(plan?.intent == .similar)
+        #expect(plan?.title == "Inception")
+        #expect(plan?.people.isEmpty == true)
+    }
+
+    @Test("byPerson uses the extracted people, with empty title")
+    func byPerson() {
+        people.result = ["Tom Hanks"]
+        let plan = make().confidentPlan(for: "movies with Tom Hanks")
+        #expect(plan?.intent == .byPerson)
+        #expect(plan?.people == ["Tom Hanks"])
+        #expect(plan?.title == nil)
+    }
+
+    @Test("byPerson abstains when no person is extracted")
+    func byPersonNoPersonAbstains() {
+        people.result = []
+        #expect(make().confidentPlan(for: "movies with denzel") == nil)
+    }
+
+    @Test("an intent whose mandatory slot is missing abstains")
+    func missingSlotAbstains() {
+        #expect(make().confidentPlan(for: "who directed") == nil) // crewRole, no title
+        #expect(make().confidentPlan(for: "cast of") == nil) // castOf, no title
+    }
+
+    @Test("discover/mood prompts abstain")
+    func discoverAbstains() {
+        #expect(make().confidentPlan(for: "90s sci-fi") == nil)
+        #expect(make().confidentPlan(for: "feel-good movies") == nil)
+    }
+
+    @Test("byPerson captures date and runtime slots")
+    func byPersonSlots() {
+        people.result = ["Tom Hanks"]
+        let plan = make().confidentPlan(for: "Tom Hanks movies from the 90s")
+        #expect(plan?.intent == .byPerson)
+        #expect(plan?.date == .decade(1990))
+    }
+
+    @Test("byPerson captures a trailing rating cue as a minimum rating")
+    func byPersonRatingSlot() {
+        people.result = ["Tom Hanks"]
+        let plan = make().confidentPlan(for: "movies with Tom Hanks that are critically acclaimed")
+        #expect(plan?.intent == .byPerson)
+        #expect(plan?.minRating == 7.0)
+    }
+
+    @Test("crewRole strips a multi-word lead so only the title remains")
+    func crewRoleMultiWordLead() {
+        let plan = make().confidentPlan(for: "who composed the music for Dune")
+        #expect(plan?.intent == .crewRole)
+        #expect(plan?.title == "Dune")
+        #expect(plan?.crewRole == "Original Music Composer")
+    }
+
+    @Test("a title-bearing TV prompt resolves to the tv media type")
+    func titleMediaTypeTV() {
+        let tv = make().confidentPlan(for: "shows like Breaking Bad")
+        #expect(tv?.intent == .similar)
+        #expect(tv?.title == "Breaking Bad")
+        #expect(tv?.mediaType == .tv)
+
+        let movie = make().confidentPlan(for: "movies like Inception")
+        #expect(movie?.mediaType == nil)
+    }
+}
+
+@Suite("GatedSearchPlanGenerator")
+struct GatedSearchPlanGeneratorTests {
+
+    @Test("availability is always available")
+    func availabilityAvailable() {
+        let gate = GatedSearchPlanGenerator(deterministic: MockDeterministicSearchPlanning(), fallback: nil)
+        #expect(gate.availability == .available)
+    }
+
+    @Test("a confident plan is returned and the fallback is not called")
+    func confidentWins() async throws {
+        let det = MockDeterministicSearchPlanning()
+        det.plan = SearchPlan(intent: .castOf, title: "Dune")
+        let fallback = MockSearchPlanGenerator()
+        let gate = GatedSearchPlanGenerator(deterministic: det, fallback: fallback)
+
+        let plan = try await gate.plan(for: "cast of Dune")
+
+        #expect(plan.intent == .castOf)
+        #expect(fallback.planCalls.isEmpty)
+    }
+
+    @Test("abstain routes to an available fallback, grounded")
+    func abstainUsesFallback() async throws {
+        let det = MockDeterministicSearchPlanning() // plan == nil → abstain
+        let fallback = MockSearchPlanGenerator()
+        fallback.planResult = SearchPlan(intent: .byPerson, people: ["Invented Person"])
+        let gate = GatedSearchPlanGenerator(deterministic: det, fallback: fallback)
+
+        let plan = try await gate.plan(for: "feel-good movies")
+
+        #expect(fallback.planCalls == ["feel-good movies"])
+        #expect(plan.people.isEmpty) // grounded: "Invented Person" not in the prompt
+    }
+
+    @Test("abstain with no fallback runs a plain find on the prompt")
+    func abstainNoFallback() async throws {
+        let gate = GatedSearchPlanGenerator(deterministic: MockDeterministicSearchPlanning(), fallback: nil)
+        let plan = try await gate.plan(for: "feel-good movies")
+        #expect(plan.intent == .find)
+        #expect(plan.title == "feel-good movies")
+    }
+
+    @Test("abstain with an unavailable fallback runs a plain find")
+    func abstainUnavailableFallback() async throws {
+        let fallback = MockSearchPlanGenerator()
+        fallback.availability = .unavailable(.deviceNotEligible)
+        let gate = GatedSearchPlanGenerator(deterministic: MockDeterministicSearchPlanning(), fallback: fallback)
+
+        let plan = try await gate.plan(for: "feel-good movies")
+
+        #expect(plan.intent == .find)
+        #expect(fallback.planCalls.isEmpty)
+    }
+}
+
+@Suite("PromptGrounder")
+struct PromptGrounderTests {
+
+    @Test("drops people not present in the prompt, keeps those present")
+    func filtersPeople() {
+        let raw = SearchPlan(intent: .byPerson, people: ["Tom Hanks", "Invented Person"])
+        let grounded = PromptGrounder.ground(raw, prompt: "movies with Tom Hanks")
+        #expect(grounded.people == ["Tom Hanks"])
+    }
+
+    @Test("forces isInScope true and keeps gazetteer genres")
+    func forcesScopeKeepsGenres() {
+        let raw = SearchPlan(intent: .browse, isInScope: false, genres: ["Science Fiction"])
+        let grounded = PromptGrounder.ground(raw, prompt: "sci-fi from the 90s")
+        #expect(grounded.isInScope == true)
+        #expect(grounded.genres == ["Science Fiction"]) // kept though not a substring
+    }
+
+    @Test("drops an invented title")
+    func dropsInventedTitle() {
+        let raw = SearchPlan(intent: .find, title: "A Movie The User Never Typed")
+        let grounded = PromptGrounder.ground(raw, prompt: "something funny")
+        #expect(grounded.title == nil)
+    }
+}

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchPlanGeneratorTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchPlanGeneratorTests.swift
@@ -70,10 +70,20 @@ struct NaturalLanguageSearchPlanGeneratorTests {
         #expect(plan?.title == nil)
     }
 
-    @Test("byPerson abstains when no person is extracted")
+    @Test("byPerson recovers the name structurally from a lead when NER misses it")
+    func byPersonStructuralFromLead() {
+        people.result = [] // NER finds nothing
+        let plan = make().confidentPlan(for: "movies with denzel")
+        #expect(plan?.intent == .byPerson)
+        #expect(plan?.people == ["denzel"])
+    }
+
+    @Test("byPerson abstains when no person can be recovered at all")
     func byPersonNoPersonAbstains() {
         people.result = []
-        #expect(make().confidentPlan(for: "movies with denzel") == nil)
+        // A filmography question has no lead/suffix to recover a name structurally,
+        // so when NER finds nothing the planner abstains (defers to the fallback).
+        #expect(make().confidentPlan(for: "what has it been in") == nil)
     }
 
     @Test("an intent whose mandatory slot is missing abstains")
@@ -121,6 +131,46 @@ struct NaturalLanguageSearchPlanGeneratorTests {
 
         let movie = make().confidentPlan(for: "movies like Inception")
         #expect(movie?.mediaType == nil)
+    }
+
+    @Test("who starred in is a cast query, not a plain find")
+    func whoStarredInIsCast() {
+        let plan = make().confidentPlan(for: "who starred in Gladiator")
+        #expect(plan?.intent == .castOf)
+        #expect(plan?.title == "Gladiator")
+    }
+
+    @Test("a filmography question is byPerson")
+    func filmographyQuestion() {
+        people.result = ["Ryan Gosling"]
+        let plan = make().confidentPlan(for: "what has Ryan Gosling been in")
+        #expect(plan?.intent == .byPerson)
+        #expect(plan?.people == ["Ryan Gosling"])
+    }
+
+    @Test("a tv-shows suffix is byPerson with the tv media type")
+    func tvShowsSuffixIsByPerson() {
+        people.result = ["Bryan Cranston"]
+        let plan = make().confidentPlan(for: "Bryan Cranston tv shows")
+        #expect(plan?.intent == .byPerson)
+        #expect(plan?.mediaType == .tv)
+        #expect(plan?.people == ["Bryan Cranston"])
+    }
+
+    @Test("a directed-by lead sets a Director crew role on the byPerson plan")
+    func directedBySetsCrewRole() {
+        people.result = ["Christopher Nolan"]
+        let plan = make().confidentPlan(for: "films directed by Christopher Nolan")
+        #expect(plan?.intent == .byPerson)
+        #expect(plan?.crewRole == "Director")
+    }
+
+    @Test("byPerson recovers the name structurally when NER misses it")
+    func byPersonStructuralFallback() {
+        people.result = [] // NER finds nothing
+        let plan = make().confidentPlan(for: "Scarlett Johansson films")
+        #expect(plan?.intent == .byPerson)
+        #expect(plan?.people == ["Scarlett Johansson"])
     }
 }
 

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchReviewTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchReviewTests.swift
@@ -76,7 +76,7 @@ struct SearchPlanExecutorReviewTests {
     @Test("TV similar applies a year window in code")
     func tvSimilarYearWindow() async throws {
         dataSource.searchTVSeriesResult = [NLSFixture.tvSeries(id: 1, name: "GoT")]
-        dataSource.similarTVSeriesResult = [
+        dataSource.recommendedTVSeriesResult = [
             NLSFixture.tvSeries(id: 10, name: "In Range", year: 2015),
             NLSFixture.tvSeries(id: 11, name: "Too Old", year: 1999)
         ]
@@ -184,108 +184,6 @@ struct SearchPlanExecutorReviewTests {
 
         #expect(dataSource.lastMovieFilter?.runtimeMax == nil)
         #expect(dataSource.lastMovieFilter?.voteAverageMin == nil)
-    }
-
-    @Test("an empty result is retried with relaxed constraints")
-    func relaxesConstraintsOnEmpty() async throws {
-        dataSource.searchCompaniesResult = [NLSFixture.company(id: 3, name: "Pixar")]
-        // Empty while a company filter is present; non-empty once it's dropped.
-        dataSource.discoverMoviesHandler = { filter in
-            filter.companies == nil ? [NLSFixture.movie(id: 1)] : []
-        }
-
-        let result = try await executor.execute(
-            SearchPlan(intent: .browse, mediaType: .movie, companies: ["Pixar"], minRating: 7)
-        )
-
-        #expect(result.movies.map(\.id) == [1])
-        #expect(result.degradations.contains(.relaxedConstraints))
-        #expect(dataSource.discoverMoviesCallCount == 2)
-    }
-
-    @Test("relaxation is not reported when every relaxed variant also returns empty")
-    func noRelaxedFlagWhenAllVariantsEmpty() async throws {
-        dataSource.searchCompaniesResult = [NLSFixture.company(id: 3, name: "Pixar")]
-        dataSource.discoverMoviesHandler = { _ in [] } // every ladder level returns nothing
-
-        let result = try await executor.execute(
-            SearchPlan(intent: .browse, mediaType: .movie, companies: ["Pixar"], minRating: 7)
-        )
-
-        #expect(result.movies.isEmpty)
-        #expect(!result.degradations.contains(.relaxedConstraints))
-    }
-
-    @Test("a rating-only query is relaxed rather than dead-ending empty")
-    func relaxesRatingOnly() async throws {
-        // Empty while the rating floor is present; non-empty once it's dropped.
-        dataSource.discoverMoviesHandler = { filter in
-            filter.voteAverageMin == nil ? [NLSFixture.movie(id: 1)] : []
-        }
-
-        let result = try await executor.execute(
-            SearchPlan(intent: .browse, mediaType: .movie, minRating: 9)
-        )
-
-        #expect(result.movies.map(\.id) == [1])
-        #expect(result.degradations.contains(.relaxedConstraints))
-        #expect(dataSource.discoverMoviesCallCount == 2)
-    }
-
-    @Test("a runtime-only query is relaxed rather than dead-ending empty")
-    func relaxesRuntimeOnly() async throws {
-        dataSource.discoverMoviesHandler = { filter in
-            filter.runtimeMax == nil ? [NLSFixture.movie(id: 1)] : []
-        }
-
-        let result = try await executor.execute(
-            SearchPlan(intent: .browse, mediaType: .movie, runtimeMaxMinutes: 90)
-        )
-
-        #expect(result.movies.map(\.id) == [1])
-        #expect(result.degradations.contains(.relaxedConstraints))
-        #expect(dataSource.discoverMoviesCallCount == 2)
-    }
-
-    @Test("the relaxation ladder drops constraints in order, one step per constraint")
-    func relaxationLadderOrdering() {
-        let inputs = SearchPlanExecutor.ResolvedInputs(
-            genreIDs: [1],
-            companyIDs: [2],
-            personIDs: [],
-            bounds: (from: 1990, to: 1999),
-            runtimeMax: 120,
-            minRating: 7
-        )
-
-        let ladder = SearchPlanExecutor.relaxationLadder(inputs)
-
-        // full, -companies, -bounds, -genres, -rating, -runtime
-        #expect(ladder.count == 6)
-        #expect(ladder[0].companyIDs == [2])
-        #expect(ladder[1].companyIDs.isEmpty)
-        #expect(ladder[1].bounds != nil)
-        #expect(ladder[2].bounds == nil)
-        #expect(ladder[2].genreIDs == [1])
-        #expect(ladder[3].genreIDs.isEmpty)
-        #expect(ladder[3].minRating == 7)
-        #expect(ladder[4].minRating == nil)
-        #expect(ladder[4].runtimeMax == 120)
-        #expect(ladder[5].runtimeMax == nil)
-    }
-
-    @Test("a person-only query is not re-run (person is never relaxed)")
-    func relaxationLadderPersonOnly() {
-        let inputs = SearchPlanExecutor.ResolvedInputs(
-            genreIDs: [],
-            companyIDs: [],
-            personIDs: [1],
-            bounds: nil,
-            runtimeMax: nil,
-            minRating: nil
-        )
-
-        #expect(SearchPlanExecutor.relaxationLadder(inputs).count == 1)
     }
 
     @Test("find with no title returns empty without calling search")

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchReviewTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchReviewTests.swift
@@ -135,6 +135,159 @@ struct SearchPlanExecutorReviewTests {
         #expect(dataSource.searchAllQueries == ["Fight Club"])
     }
 
+    @Test("a find plan with people is repaired to byPerson")
+    func findWithPeopleIsCoercedToByPerson() async throws {
+        dataSource.searchPeopleResult = [NLSFixture.person(id: 42)]
+        dataSource.discoverMoviesResult = [NLSFixture.movie(id: 1)]
+
+        // The model often mislabels "Brad Pitt movies" as `find` with no title but
+        // still fills `people`.
+        _ = try await executor.execute(
+            SearchPlan(intent: .find, mediaType: .movie, people: ["Brad Pitt"])
+        )
+
+        #expect(dataSource.lastMovieFilter?.withCast == [42])
+    }
+
+    @Test("normalize keeps a clean titled find (invented cast ignored)")
+    func normalizeKeepsTitledFind() {
+        // A bare-title find may carry an invented cast not named in the title; keep find.
+        let plan = SearchPlan(intent: .find, title: "Fight Club", people: ["Brad Pitt"])
+        #expect(SearchPlanExecutor.normalize(plan).intent == .find)
+    }
+
+    @Test("normalize coerces a junk title that echoes the person")
+    func normalizeCoercesJunkTitleWithPerson() {
+        // The model often dumps the whole prompt into title for person queries.
+        let plan = SearchPlan(
+            intent: .find,
+            title: "popular films bruce willis has been in",
+            people: ["Bruce Willis"]
+        )
+        #expect(SearchPlanExecutor.normalize(plan).intent == .byPerson)
+    }
+
+    @Test("normalize leaves a plan without people untouched")
+    func normalizeNoOp() {
+        let plan = SearchPlan(intent: .find, title: "Inception")
+        #expect(SearchPlanExecutor.normalize(plan).intent == .find)
+    }
+
+    @Test("an invented zero runtime is dropped from the filter")
+    func sanitizesZeroRuntime() async throws {
+        dataSource.searchPeopleResult = [NLSFixture.person(id: 42)]
+        dataSource.discoverMoviesResult = [NLSFixture.movie(id: 1)]
+
+        _ = try await executor.execute(
+            SearchPlan(intent: .byPerson, mediaType: .movie, people: ["X"], runtimeMaxMinutes: 0, minRating: 0)
+        )
+
+        #expect(dataSource.lastMovieFilter?.runtimeMax == nil)
+        #expect(dataSource.lastMovieFilter?.voteAverageMin == nil)
+    }
+
+    @Test("an empty result is retried with relaxed constraints")
+    func relaxesConstraintsOnEmpty() async throws {
+        dataSource.searchCompaniesResult = [NLSFixture.company(id: 3, name: "Pixar")]
+        // Empty while a company filter is present; non-empty once it's dropped.
+        dataSource.discoverMoviesHandler = { filter in
+            filter.companies == nil ? [NLSFixture.movie(id: 1)] : []
+        }
+
+        let result = try await executor.execute(
+            SearchPlan(intent: .browse, mediaType: .movie, companies: ["Pixar"], minRating: 7)
+        )
+
+        #expect(result.movies.map(\.id) == [1])
+        #expect(result.degradations.contains(.relaxedConstraints))
+        #expect(dataSource.discoverMoviesCallCount == 2)
+    }
+
+    @Test("relaxation is not reported when every relaxed variant also returns empty")
+    func noRelaxedFlagWhenAllVariantsEmpty() async throws {
+        dataSource.searchCompaniesResult = [NLSFixture.company(id: 3, name: "Pixar")]
+        dataSource.discoverMoviesHandler = { _ in [] } // every ladder level returns nothing
+
+        let result = try await executor.execute(
+            SearchPlan(intent: .browse, mediaType: .movie, companies: ["Pixar"], minRating: 7)
+        )
+
+        #expect(result.movies.isEmpty)
+        #expect(!result.degradations.contains(.relaxedConstraints))
+    }
+
+    @Test("a rating-only query is relaxed rather than dead-ending empty")
+    func relaxesRatingOnly() async throws {
+        // Empty while the rating floor is present; non-empty once it's dropped.
+        dataSource.discoverMoviesHandler = { filter in
+            filter.voteAverageMin == nil ? [NLSFixture.movie(id: 1)] : []
+        }
+
+        let result = try await executor.execute(
+            SearchPlan(intent: .browse, mediaType: .movie, minRating: 9)
+        )
+
+        #expect(result.movies.map(\.id) == [1])
+        #expect(result.degradations.contains(.relaxedConstraints))
+        #expect(dataSource.discoverMoviesCallCount == 2)
+    }
+
+    @Test("a runtime-only query is relaxed rather than dead-ending empty")
+    func relaxesRuntimeOnly() async throws {
+        dataSource.discoverMoviesHandler = { filter in
+            filter.runtimeMax == nil ? [NLSFixture.movie(id: 1)] : []
+        }
+
+        let result = try await executor.execute(
+            SearchPlan(intent: .browse, mediaType: .movie, runtimeMaxMinutes: 90)
+        )
+
+        #expect(result.movies.map(\.id) == [1])
+        #expect(result.degradations.contains(.relaxedConstraints))
+        #expect(dataSource.discoverMoviesCallCount == 2)
+    }
+
+    @Test("the relaxation ladder drops constraints in order, one step per constraint")
+    func relaxationLadderOrdering() {
+        let inputs = SearchPlanExecutor.ResolvedInputs(
+            genreIDs: [1],
+            companyIDs: [2],
+            personIDs: [],
+            bounds: (from: 1990, to: 1999),
+            runtimeMax: 120,
+            minRating: 7
+        )
+
+        let ladder = SearchPlanExecutor.relaxationLadder(inputs)
+
+        // full, -companies, -bounds, -genres, -rating, -runtime
+        #expect(ladder.count == 6)
+        #expect(ladder[0].companyIDs == [2])
+        #expect(ladder[1].companyIDs.isEmpty)
+        #expect(ladder[1].bounds != nil)
+        #expect(ladder[2].bounds == nil)
+        #expect(ladder[2].genreIDs == [1])
+        #expect(ladder[3].genreIDs.isEmpty)
+        #expect(ladder[3].minRating == 7)
+        #expect(ladder[4].minRating == nil)
+        #expect(ladder[4].runtimeMax == 120)
+        #expect(ladder[5].runtimeMax == nil)
+    }
+
+    @Test("a person-only query is not re-run (person is never relaxed)")
+    func relaxationLadderPersonOnly() {
+        let inputs = SearchPlanExecutor.ResolvedInputs(
+            genreIDs: [],
+            companyIDs: [],
+            personIDs: [1],
+            bounds: nil,
+            runtimeMax: nil,
+            minRating: nil
+        )
+
+        #expect(SearchPlanExecutor.relaxationLadder(inputs).count == 1)
+    }
+
     @Test("find with no title returns empty without calling search")
     func findEmptyTitleReturnsEmpty() async throws {
         let result = try await executor.execute(SearchPlan(intent: .find))

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/RuleBasedIntentClassifierTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/RuleBasedIntentClassifierTests.swift
@@ -1,0 +1,91 @@
+//
+//  RuleBasedIntentClassifierTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite("RuleBasedIntentClassifier")
+struct RuleBasedIntentClassifierTests {
+
+    private let classifier = RuleBasedIntentClassifier()
+
+    @Test("list cues classify as list", arguments: [
+        "trending movies", "popular shows", "what's in cinemas", "new releases",
+        "upcoming movies", "what's airing today", "top rated movies", "popular actors"
+    ])
+    func listCues(_ prompt: String) {
+        #expect(classifier.classify(prompt) == .list)
+    }
+
+    @Test("similar cues classify as similar", arguments: [
+        "movies like Inception", "shows similar to Breaking Bad",
+        "films in the vein of Blade Runner", "something like Stranger Things"
+    ])
+    func similarCues(_ prompt: String) {
+        #expect(classifier.classify(prompt) == .similar)
+    }
+
+    @Test("cast cues classify as castOf", arguments: [
+        "cast of The Matrix", "who's in Inception", "actors in Dune",
+        "stars of Titanic", "main cast of Breaking Bad"
+    ])
+    func castCues(_ prompt: String) {
+        #expect(classifier.classify(prompt) == .castOf)
+    }
+
+    @Test("crew-role cues classify as crewRole", arguments: [
+        "who directed Jurassic Park", "composer of Interstellar",
+        "who wrote Pulp Fiction", "cinematographer of Blade Runner"
+    ])
+    func crewRoleCues(_ prompt: String) {
+        #expect(classifier.classify(prompt) == .crewRole)
+    }
+
+    @Test("person cues classify as byPerson", arguments: [
+        "movies with Tom Hanks", "Brad Pitt movies", "films directed by Nolan",
+        "movies starring Meryl Streep", "Scarlett Johansson films", "featuring Denzel Washington"
+    ])
+    func byPersonCues(_ prompt: String) {
+        #expect(classifier.classify(prompt) == .byPerson)
+    }
+
+    @Test("bare titles and names classify as find", arguments: [
+        "Fight Club", "The Dark Knight", "Tom Hanks", "Breaking Bad", "Inception"
+    ])
+    func bareQueriesAreFind(_ prompt: String) {
+        #expect(classifier.classify(prompt) == .find)
+    }
+
+    @Test("discover/mood prompts abstain (deferred to fallback)", arguments: [
+        "90s sci-fi", "feel-good movies", "highly rated documentaries",
+        "horror movies", "French romantic comedies", "cozy films", "movies from the 1980s"
+    ])
+    func discoverCuesAbstain(_ prompt: String) {
+        #expect(classifier.classify(prompt) == nil)
+    }
+
+    @Test("mixed-intent prompts abstain", arguments: [
+        "cast of movies like Inception", "who directed films like Heat"
+    ])
+    func mixedIntentAbstains(_ prompt: String) {
+        #expect(classifier.classify(prompt) == nil)
+    }
+
+    @Test("a keyword inside a title does not trigger that intent", arguments: [
+        "Cast Away", "Like Crazy", "The Avengers"
+    ])
+    func keywordInTitleIsFind(_ prompt: String) {
+        #expect(classifier.classify(prompt) == .find)
+    }
+
+    @Test("empty or whitespace prompts abstain", arguments: ["", "   ", "  \n "])
+    func emptyAbstains(_ prompt: String) {
+        #expect(classifier.classify(prompt) == nil)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/SearchPlanExecutorRelaxationTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/SearchPlanExecutorRelaxationTests.swift
@@ -1,0 +1,182 @@
+//
+//  SearchPlanExecutorRelaxationTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite("SearchPlanExecutor (relaxation & resolution)")
+struct SearchPlanExecutorRelaxationTests {
+
+    let dataSource: MockNaturalLanguageSearchDataSource
+    let executor: SearchPlanExecutor
+
+    init() {
+        let dataSource = MockNaturalLanguageSearchDataSource()
+        self.dataSource = dataSource
+        let now = NLSFixture.date(year: 2026)
+        self.executor = SearchPlanExecutor(dataSource: dataSource, resultLimit: 20, now: { now })
+    }
+
+    @Test("an empty result is retried with relaxed constraints")
+    func relaxesConstraintsOnEmpty() async throws {
+        dataSource.searchCompaniesResult = [NLSFixture.company(id: 3, name: "Pixar")]
+        // Empty while a company filter is present; non-empty once it's dropped.
+        dataSource.discoverMoviesHandler = { filter in
+            filter.companies == nil ? [NLSFixture.movie(id: 1)] : []
+        }
+
+        let result = try await executor.execute(
+            SearchPlan(intent: .browse, mediaType: .movie, companies: ["Pixar"], minRating: 7)
+        )
+
+        #expect(result.movies.map(\.id) == [1])
+        #expect(result.degradations.contains(.relaxedConstraints))
+        #expect(dataSource.discoverMoviesCallCount == 2)
+    }
+
+    @Test("relaxation is not reported when every relaxed variant also returns empty")
+    func noRelaxedFlagWhenAllVariantsEmpty() async throws {
+        dataSource.searchCompaniesResult = [NLSFixture.company(id: 3, name: "Pixar")]
+        dataSource.discoverMoviesHandler = { _ in [] } // every ladder level returns nothing
+
+        let result = try await executor.execute(
+            SearchPlan(intent: .browse, mediaType: .movie, companies: ["Pixar"], minRating: 7)
+        )
+
+        #expect(result.movies.isEmpty)
+        #expect(!result.degradations.contains(.relaxedConstraints))
+    }
+
+    @Test("a rating-only query is relaxed rather than dead-ending empty")
+    func relaxesRatingOnly() async throws {
+        // Empty while the rating floor is present; non-empty once it's dropped.
+        dataSource.discoverMoviesHandler = { filter in
+            filter.voteAverageMin == nil ? [NLSFixture.movie(id: 1)] : []
+        }
+
+        let result = try await executor.execute(
+            SearchPlan(intent: .browse, mediaType: .movie, minRating: 9)
+        )
+
+        #expect(result.movies.map(\.id) == [1])
+        #expect(result.degradations.contains(.relaxedConstraints))
+        #expect(dataSource.discoverMoviesCallCount == 2)
+    }
+
+    @Test("a runtime-only query is relaxed rather than dead-ending empty")
+    func relaxesRuntimeOnly() async throws {
+        dataSource.discoverMoviesHandler = { filter in
+            filter.runtimeMax == nil ? [NLSFixture.movie(id: 1)] : []
+        }
+
+        let result = try await executor.execute(
+            SearchPlan(intent: .browse, mediaType: .movie, runtimeMaxMinutes: 90)
+        )
+
+        #expect(result.movies.map(\.id) == [1])
+        #expect(result.degradations.contains(.relaxedConstraints))
+        #expect(dataSource.discoverMoviesCallCount == 2)
+    }
+
+    @Test("the relaxation ladder drops constraints in order, one step per constraint")
+    func relaxationLadderOrdering() {
+        let inputs = SearchPlanExecutor.ResolvedInputs(
+            genreIDs: [1],
+            companyIDs: [2],
+            personIDs: [],
+            bounds: (from: 1990, to: 1999),
+            runtimeMax: 120,
+            minRating: 7
+        )
+
+        let ladder = SearchPlanExecutor.relaxationLadder(inputs)
+
+        // full, -companies, -bounds, -genres, -rating, -runtime
+        #expect(ladder.count == 6)
+        #expect(ladder[0].companyIDs == [2])
+        #expect(ladder[1].companyIDs.isEmpty)
+        #expect(ladder[1].bounds != nil)
+        #expect(ladder[2].bounds == nil)
+        #expect(ladder[2].genreIDs == [1])
+        #expect(ladder[3].genreIDs.isEmpty)
+        #expect(ladder[3].minRating == 7)
+        #expect(ladder[4].minRating == nil)
+        #expect(ladder[4].runtimeMax == 120)
+        #expect(ladder[5].runtimeMax == nil)
+    }
+
+    @Test("a person-only query is not re-run (person is never relaxed)")
+    func relaxationLadderPersonOnly() {
+        let inputs = SearchPlanExecutor.ResolvedInputs(
+            genreIDs: [],
+            companyIDs: [],
+            personIDs: [1],
+            bounds: nil,
+            runtimeMax: nil,
+            minRating: nil
+        )
+
+        #expect(SearchPlanExecutor.relaxationLadder(inputs).count == 1)
+    }
+
+    @Test("an ambiguous title prefers an exact TV match over a fuzzy movie match")
+    func ambiguousTitlePrefersExactTVMatch() async throws {
+        // "cast of Breaking Bad" — the movie search returns the El Camino film,
+        // the TV search returns the series itself; the series should win.
+        dataSource.searchMoviesResult = [NLSFixture.movie(id: 1, title: "El Camino: A Breaking Bad Movie")]
+        dataSource.searchTVSeriesResult = [NLSFixture.tvSeries(id: 2, name: "Breaking Bad")]
+        dataSource.tvSeriesCreditsResult = ShowCredits(
+            id: 2,
+            cast: [NLSFixture.castMember(id: 10, name: "Bryan Cranston")],
+            crew: []
+        )
+        dataSource.movieCreditsResult = ShowCredits(
+            id: 1,
+            cast: [NLSFixture.castMember(id: 99, name: "Wrong Movie Cast")],
+            crew: []
+        )
+
+        let result = try await executor.execute(SearchPlan(intent: .castOf, title: "Breaking Bad"))
+
+        #expect(result.people.map(\.id) == [10])
+    }
+
+    @Test("byPerson TV is answered from the person's TV credits, not discover")
+    func byPersonTVUsesPersonCredits() async throws {
+        dataSource.searchPeopleResult = [NLSFixture.person(id: 42)]
+        dataSource.personTVCreditsResult = [
+            NLSFixture.tvSeries(id: 1, name: "Breaking Bad"),
+            NLSFixture.tvSeries(id: 2, name: "Malcolm in the Middle")
+        ]
+
+        let result = try await executor.execute(
+            SearchPlan(intent: .byPerson, mediaType: .tv, people: ["Bryan Cranston"])
+        )
+
+        #expect(result.tvSeries.map(\.id) == [1, 2])
+        #expect(dataSource.personTVCreditsIDs == [42])
+        #expect(dataSource.lastTVFilter == nil) // discover/tv (which can't filter by person) is not used
+    }
+
+    @Test("a Writer crew role matches a Screenplay job")
+    func writerRoleMatchesScreenplayJob() async throws {
+        dataSource.searchMoviesResult = [NLSFixture.movie(id: 550, title: "Fight Club")]
+        dataSource.movieCreditsResult = ShowCredits(
+            id: 550,
+            cast: [],
+            crew: [NLSFixture.crewMember(id: 1, name: "Jim Uhls", job: "Screenplay")]
+        )
+
+        let result = try await executor.execute(
+            SearchPlan(intent: .crewRole, mediaType: .movie, title: "Fight Club", crewRole: "Writer")
+        )
+
+        #expect(result.people.map(\.id) == [1])
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/SearchPlanExecutorTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/SearchPlanExecutorTests.swift
@@ -167,7 +167,7 @@ struct SearchPlanExecutorTests {
     @Test("similar applies a year window in code")
     func similarYearWindow() async throws {
         dataSource.searchMoviesResult = [NLSFixture.movie(id: 550, title: "Fight Club")]
-        dataSource.similarMoviesResult = [
+        dataSource.recommendedMoviesResult = [
             NLSFixture.movie(id: 1, title: "In Range", year: 2014),
             NLSFixture.movie(id: 2, title: "Too Old", year: 1999),
             NLSFixture.movie(id: 3, title: "Too New", year: 2024)
@@ -219,12 +219,12 @@ struct SearchPlanExecutorTests {
     /// 16. exclusions.
     @Test("exclusions remove matching titles and record a degradation")
     func exclusions() async throws {
-        dataSource.searchTVSeriesResult = [NLSFixture.tvSeries(id: 1, name: "Star Trek: Picard")]
-        dataSource.discoverTVSeriesResult = [
+        dataSource.searchPeopleResult = [NLSFixture.person(id: 2387)]
+        // byPerson TV is answered from the person's TV credits.
+        dataSource.personTVCreditsResult = [
             NLSFixture.tvSeries(id: 1, name: "Star Trek: Picard"),
             NLSFixture.tvSeries(id: 2, name: "Blunt Talk")
         ]
-        dataSource.searchPeopleResult = [NLSFixture.person(id: 2387)]
 
         let result = try await executor.execute(
             SearchPlan(

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/SearchPlanIntentCorpusTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/SearchPlanIntentCorpusTests.swift
@@ -1,0 +1,93 @@
+//
+//  SearchPlanIntentCorpusTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite("Intent classifier corpus")
+struct SearchPlanIntentCorpusTests {
+
+    private struct Case { let prompt: String; let expected: SearchPlan.Intent? }
+    private func c(_ prompt: String, _ expected: SearchPlan.Intent?) -> Case {
+        .init(prompt: prompt, expected: expected)
+    }
+
+    private var corpus: [Case] {
+        [
+            // find — bare titles and names
+            c("Fight Club", .find), c("The Matrix", .find), c("Inception", .find),
+            c("Breaking Bad", .find), c("Stranger Things", .find), c("The Godfather", .find),
+            c("Pulp Fiction", .find), c("Dune", .find), c("Oppenheimer", .find),
+            c("Interstellar", .find), c("Titanic", .find), c("The Dark Knight", .find),
+            c("Tom Hanks", .find), c("Brad Pitt", .find), c("Meryl Streep", .find),
+            c("Cast Away", .find), c("Like Crazy", .find), c("Gladiator", .find),
+            // out-of-scope deterministically degrades to plain search (find) in v1
+            c("a good book about space", .find), c("best pizza recipe", .find),
+            c("weather tomorrow", .find),
+
+            // byPerson
+            c("movies with Tom Hanks", .byPerson), c("Brad Pitt movies", .byPerson),
+            c("films directed by Christopher Nolan", .byPerson),
+            c("movies starring Meryl Streep", .byPerson), c("Scarlett Johansson films", .byPerson),
+            c("Quentin Tarantino movies", .byPerson), c("movies featuring Denzel Washington", .byPerson),
+            c("films with Leonardo DiCaprio", .byPerson), c("Keanu Reeves movies", .byPerson),
+            c("movies by Steven Spielberg", .byPerson), c("Tom Hanks movies from the 90s", .byPerson),
+            c("directed by Greta Gerwig", .byPerson),
+
+            // castOf
+            c("cast of Fight Club", .castOf), c("people in The Matrix", .castOf),
+            c("who's in Inception", .castOf), c("actors in Dune", .castOf),
+            c("the cast of Stranger Things", .castOf), c("stars of Titanic", .castOf),
+            c("main cast of Breaking Bad", .castOf), c("who appears in Pulp Fiction", .castOf),
+            c("cast list for Jurassic Park", .castOf), c("lead actors in The Dark Knight", .castOf),
+
+            // crewRole
+            c("who directed Jurassic Park", .crewRole), c("director of The Godfather", .crewRole),
+            c("who wrote Pulp Fiction", .crewRole), c("composer of Interstellar", .crewRole),
+            c("who directed Titanic", .crewRole), c("cinematographer of Blade Runner", .crewRole),
+            c("producer of Inception", .crewRole), c("who composed the music for Dune", .crewRole),
+
+            // similar
+            c("movies like Inception", .similar), c("shows similar to Breaking Bad", .similar),
+            c("films like The Matrix", .similar), c("something like Stranger Things", .similar),
+            c("movies similar to Fight Club", .similar), c("tv shows like Game of Thrones", .similar),
+            c("in the vein of Blade Runner", .similar), c("recommendations based on The Office", .similar),
+            c("shows like The Crown", .similar), c("movies like Get Out", .similar),
+
+            // list
+            c("trending movies", .list), c("popular shows", .list), c("top rated movies", .list),
+            c("new releases", .list), c("upcoming movies", .list), c("what's airing today", .list),
+            c("now playing in theaters", .list), c("most popular tv series", .list),
+            c("trending people", .list), c("popular actors", .list),
+
+            // abstain — browse / mood deferred to the fallback
+            c("90s sci-fi", nil), c("horror films from the 80s", nil),
+            c("French romantic comedies", nil), c("highly rated documentaries", nil),
+            c("Korean horror movies", nil), c("feel-good movies", nil), c("something scary", nil),
+            c("cozy films for a rainy day", nil), c("a tearjerker", nil), c("comfort movies", nil),
+            c("movies from the 1980s", nil), c("action movies from 2019", nil),
+            c("westerns from the 1960s", nil), c("romantic comedies", nil)
+        ]
+    }
+
+    @Test("classifier matches the labelled corpus")
+    func corpusAccuracy() {
+        let classifier = RuleBasedIntentClassifier()
+        var misses: [String] = []
+        for testCase in corpus {
+            let got = classifier.classify(testCase.prompt)
+            if got != testCase.expected {
+                misses.append("\"\(testCase.prompt)\" want \(String(describing: testCase.expected)) "
+                    + "got \(String(describing: got))")
+            }
+        }
+        let accuracy = Int(Double(corpus.count - misses.count) / Double(corpus.count) * 100)
+        let report = misses.joined(separator: "\n")
+        #expect(misses.isEmpty, "Intent corpus \(misses.count)/\(corpus.count) misses (\(accuracy)%):\n\(report)")
+    }
+}

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/SearchPlanMapperTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/SearchPlanMapperTests.swift
@@ -19,11 +19,18 @@
             isInScope: Bool = true,
             mediaType: GeneratedMediaType? = nil,
             title: String? = nil,
+            people: [String] = [],
+            crewRole: String? = nil,
             genres: [String] = [],
+            excludeTitles: [String] = [],
+            companies: [String] = [],
+            moodTerm: String? = nil,
             datePhrase: GeneratedDatePhrase? = nil,
             decade: Int? = nil,
             yearFrom: Int? = nil,
             yearTo: Int? = nil,
+            runtimeMaxMinutes: Int? = nil,
+            minRating: Double? = nil,
             list: GeneratedListKind? = nil
         ) -> GeneratedSearchPlan {
             GeneratedSearchPlan(
@@ -31,18 +38,18 @@
                 isInScope: isInScope,
                 mediaType: mediaType,
                 title: title,
-                people: [],
-                crewRole: nil,
+                people: people,
+                crewRole: crewRole,
                 genres: genres,
-                excludeTitles: [],
-                companies: [],
-                moodTerm: nil,
+                excludeTitles: excludeTitles,
+                companies: companies,
+                moodTerm: moodTerm,
                 datePhrase: datePhrase,
                 decade: decade,
                 yearFrom: yearFrom,
                 yearTo: yearTo,
-                runtimeMaxMinutes: nil,
-                minRating: nil,
+                runtimeMaxMinutes: runtimeMaxMinutes,
+                minRating: minRating,
                 list: list
             )
         }
@@ -109,6 +116,76 @@
         func mapsLoneYearTo() {
             let plan = SearchPlanMapper.map(generated(yearTo: 2010))
             #expect(plan.date == .exactYear(2010))
+        }
+
+        @available(iOS 26, macOS 26, visionOS 26, *)
+        @Test("passes through people, crew role, exclusions, companies, mood, runtime, and rating")
+        func passesThroughOperands() {
+            let plan = SearchPlanMapper.map(
+                generated(
+                    people: ["Tom Hanks"],
+                    crewRole: "Director",
+                    excludeTitles: ["Star Trek"],
+                    companies: ["Pixar"],
+                    moodTerm: "feel-good",
+                    runtimeMaxMinutes: 120,
+                    minRating: 7.5
+                )
+            )
+
+            #expect(plan.people == ["Tom Hanks"])
+            #expect(plan.crewRole == "Director")
+            #expect(plan.excludeTitles == ["Star Trek"])
+            #expect(plan.companies == ["Pixar"])
+            #expect(plan.moodTerm == "feel-good")
+            #expect(plan.runtimeMaxMinutes == 120)
+            #expect(plan.minRating == 7.5)
+        }
+
+        @available(iOS 26, macOS 26, visionOS 26, *)
+        @Test("maps every intent arm")
+        func mapsEveryIntent() {
+            let cases: [(GeneratedIntent, SearchPlan.Intent)] = [
+                (.find, .find), (.browse, .browse), (.filmography, .byPerson),
+                (.castOf, .castOf), (.crewRole, .crewRole), (.similar, .similar),
+                (.list, .list), (.mood, .mood)
+            ]
+            for (input, expected) in cases {
+                #expect(SearchPlanMapper.map(generated(intent: input)).intent == expected)
+            }
+        }
+
+        @available(iOS 26, macOS 26, visionOS 26, *)
+        @Test("maps every media type")
+        func mapsEveryMediaType() {
+            #expect(SearchPlanMapper.map(generated(mediaType: .movie)).mediaType == .movie)
+            #expect(SearchPlanMapper.map(generated(mediaType: .tv)).mediaType == .tv)
+            #expect(SearchPlanMapper.map(generated(mediaType: .person)).mediaType == .person)
+        }
+
+        @available(iOS 26, macOS 26, visionOS 26, *)
+        @Test("maps every list kind")
+        func mapsEveryListKind() {
+            let cases: [(GeneratedListKind, SearchPlan.ListKind)] = [
+                (.trending, .trending), (.popular, .popular), (.topRated, .topRated),
+                (.nowPlaying, .nowPlaying), (.upcoming, .upcoming), (.airingToday, .airingToday)
+            ]
+            for (input, expected) in cases {
+                #expect(SearchPlanMapper.map(generated(intent: .list, list: input)).list == expected)
+            }
+        }
+
+        @available(iOS 26, macOS 26, visionOS 26, *)
+        @Test("maps the recent and last-ten-years date phrases")
+        func mapsRemainingDatePhrases() {
+            #expect(SearchPlanMapper.map(generated(datePhrase: .recent)).date == .recent)
+            #expect(SearchPlanMapper.map(generated(datePhrase: .lastTenYears)).date == .lastNYears(10))
+        }
+
+        @available(iOS 26, macOS 26, visionOS 26, *)
+        @Test("maps a lone lower-bound year to an exact year")
+        func mapsLoneYearFrom() {
+            #expect(SearchPlanMapper.map(generated(yearFrom: 1999)).date == .exactYear(1999))
         }
 
     }

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/SearchPlanSlotExtractionTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/SearchPlanSlotExtractionTests.swift
@@ -1,0 +1,95 @@
+//
+//  SearchPlanSlotExtractionTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite("TitleExtractor")
+struct TitleExtractorTests {
+
+    @Test("strips the lead phrase")
+    func stripsLead() {
+        #expect(TitleExtractor.title(from: "cast of The Matrix", strippingLeads: SearchPlanLexicon.castLeads)
+            == "The Matrix")
+        #expect(TitleExtractor.title(from: "who directed Jurassic Park", strippingLeads: ["who directed"])
+            == "Jurassic Park")
+        #expect(TitleExtractor.title(from: "movies like Inception", strippingLeads: SearchPlanLexicon.similarLeads)
+            == "Inception")
+    }
+
+    @Test("excises a trailing slot clause before taking the title")
+    func excisesTrailingSlot() {
+        #expect(TitleExtractor.title(
+            from: "shows like Severance under 1 hour",
+            strippingLeads: SearchPlanLexicon.similarLeads
+        ) == "Severance")
+        #expect(TitleExtractor.title(
+            from: "movies like Heat from the 90s",
+            strippingLeads: SearchPlanLexicon.similarLeads
+        ) == "Heat")
+    }
+
+    @Test("preserves original casing and trims punctuation")
+    func preservesCasing() {
+        #expect(TitleExtractor.title(from: "who's in Inception?", strippingLeads: SearchPlanLexicon.castLeads)
+            == "Inception")
+    }
+}
+
+@Suite("RelativeDateParser")
+struct RelativeDateParserTests {
+
+    private func parse(_ prompt: String) -> SearchPlan.RelativeDate? {
+        RelativeDateParser.parse(SearchPlanLexicon.normalize(prompt))
+    }
+
+    @Test("parses decades")
+    func decades() {
+        #expect(parse("90s sci-fi") == .decade(1990))
+        #expect(parse("movies from the 1980s") == .decade(1980))
+        #expect(parse("2000s comedies") == .decade(2000))
+        #expect(parse("2010s") == .decade(2010))
+    }
+
+    @Test("parses exact year, this year, recent, last N years, between")
+    func others() {
+        #expect(parse("movies from 2019") == .exactYear(2019))
+        #expect(parse("films this year") == .thisYear)
+        #expect(parse("recent thrillers") == .recent)
+        #expect(parse("movies from the last 5 years") == .lastNYears(5))
+        #expect(parse("between 2010 and 2019") == .between(start: 2010, end: 2019))
+    }
+
+    @Test("no date cue returns nil")
+    func none() {
+        #expect(parse("horror movies") == nil)
+    }
+}
+
+@Suite("RuntimeRatingParser")
+struct RuntimeRatingParserTests {
+
+    private func normalize(_ prompt: String) -> String {
+        SearchPlanLexicon.normalize(prompt)
+    }
+
+    @Test("parses runtime ceilings")
+    func runtime() {
+        #expect(RuntimeRatingParser.runtimeMaxMinutes(normalize("under 90 minutes")) == 90)
+        #expect(RuntimeRatingParser.runtimeMaxMinutes(normalize("under 2 hours")) == 120)
+        #expect(RuntimeRatingParser.runtimeMaxMinutes(normalize("less than 100 minutes")) == 100)
+        #expect(RuntimeRatingParser.runtimeMaxMinutes(normalize("horror movies")) == nil)
+    }
+
+    @Test("parses minimum rating")
+    func rating() {
+        #expect(RuntimeRatingParser.minRating(normalize("highly rated documentaries")) == 7.0)
+        #expect(RuntimeRatingParser.minRating(normalize("well reviewed dramas")) == 6.5)
+        #expect(RuntimeRatingParser.minRating(normalize("horror movies")) == nil)
+    }
+}

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/SearchPlanSlotExtractionTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/SearchPlanSlotExtractionTests.swift
@@ -22,6 +22,25 @@ struct TitleExtractorTests {
             == "Inception")
     }
 
+    @Test("strips leading media-type filler so the title is clean")
+    func stripsLeadingFiller() {
+        #expect(TitleExtractor.title(
+            from: "actors in the show The Crown",
+            strippingLeads: SearchPlanLexicon.castLeads
+        ) == "The Crown")
+        #expect(TitleExtractor.title(
+            from: "main cast of the series Succession",
+            strippingLeads: SearchPlanLexicon.castLeads
+        ) == "Succession")
+        #expect(TitleExtractor.title(
+            from: "people in the tv show The Office",
+            strippingLeads: SearchPlanLexicon.castLeads
+        ) == "The Office")
+        // A real title that merely starts with "The" is not over-trimmed.
+        #expect(TitleExtractor.title(from: "cast of The Crown", strippingLeads: SearchPlanLexicon.castLeads)
+            == "The Crown")
+    }
+
     @Test("excises a trailing slot clause before taking the title")
     func excisesTrailingSlot() {
         #expect(TitleExtractor.title(

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/SearchPlanSlotExtractionTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/SearchPlanSlotExtractionTests.swift
@@ -39,6 +39,10 @@ struct TitleExtractorTests {
         // A real title that merely starts with "The" is not over-trimmed.
         #expect(TitleExtractor.title(from: "cast of The Crown", strippingLeads: SearchPlanLexicon.castLeads)
             == "The Crown")
+        // A title that starts with a bare media word ("Show", "Series") is kept —
+        // only multi-word filler ("the show", "tv show") is stripped.
+        #expect(TitleExtractor.title(from: "cast of Show Me a Hero", strippingLeads: SearchPlanLexicon.castLeads)
+            == "Show Me a Hero")
     }
 
     @Test("excises a trailing slot clause before taking the title")


### PR DESCRIPTION
## Summary

Makes Apple's **Natural Language** framework the default on-device planner for `naturalLanguageSearch` on **all** Apple platforms (iOS 16+/macOS 13+/watchOS 9+/tvOS 16+/visionOS 1+), with **Foundation Models** retained as an evidence-gated fallback on OS 26 devices with Apple Intelligence. A prompt such as `"cast of Breaking Bad"` or `"movies with Tom Hanks"` is interpreted deterministically and executed against TMDb — no model required, no network for interpretation.

A 200-prompt evaluation against the live API guided the accuracy work: **intent classification 100%**, deterministic-core result relevance **~100%**.

## Changes

**Planner pipeline (new):**
- ✨ `RuleBasedIntentClassifier` — family-count intent detection (find/byPerson/castOf/crewRole/similar/list), abstaining on mixed or discover/mood cues so they defer to the fallback
- ✨ `SearchPlanLexicon` — pure, word-boundary phrase matchers
- ✨ `NLTaggerPersonNameExtractor` — span-bounded NER (per-call `NLTagger` for `Sendable`); cannot invent people, with a structural name fallback
- ✨ `TitleExtractor` / `RelativeDateParser` / `RuntimeRatingParser` — slot extraction
- ✨ `GatedSearchPlanGenerator` — deterministic-first; grounds any FM output to prompt substrings; `availability` is always `.available`
- ♻️ Reuses the existing `SearchPlanExecutor`

**Accuracy fixes (from the prompt evaluation):**
- 🐛 Ambiguous-title resolution prefers exact match then popularity (so "cast of Breaking Bad" → the series, "director of Jaws" → the film)
- 🐛 TV by-person answered from the person's TV credits (TMDb's discover/tv can't filter by person), ranked by episode count
- 🐛 `similar` uses TMDb **recommendations** instead of the weak keyword-based `/similar`
- 🐛 "directed by X" filters by crew not cast; `Writer` matches `Screenplay`/`Story`; richer cast/by-person/filmography phrasings
- 🐛 Title extraction strips leading media filler ("the show The Crown") and preserves a title that is itself a year ("1917")

**Tests:**
- ✅ Rule-based classifier suite + 90-prompt labelled intent corpus
- ✅ Slot extraction, planner/gate/grounder, NER, executor relaxation & resolution
- ✅ A live end-to-end integration suite
- ✅ All unit (2377) and integration (260) tests pass; full `make ci` green

**Documentation:**
- 📝 README, DocC catalog, and doc comments updated to the deterministic-first / FM-gated-fallback model

## Benefits

- **Availability**: works on every Apple platform, not just OS 26 with Apple Intelligence
- **Determinism**: stable, testable interpretation; NER cannot hallucinate entities
- **Accuracy**: 100% intent and ~100% deterministic-core result relevance across a 200-prompt evaluation

## Known limitation

Genre/browse prompts ("war movies", "90s action movies") are deferred to the Foundation Models fallback by design and are the one weak area; making them deterministic is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)