### PR TITLE
🔧 Fix stale MCP tool references in Claude config

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -137,7 +137,7 @@ Use the `swift-concurrency` skill for detailed guidance. Key checks:
 - Verify new public API is exposed through `TMDbClient` and registered in `TMDbFactory`.
 - Check that DocC catalog is updated when public API changes (see DocC Catalog Sync below).
 - When reviewing model changes or fixture accuracy, verify properties against the live TMDb API (see Model Verification below).
-- When needing to verify Apple APIs (concurrency safety, availability, behavior), use `mcp__claude_ai_sosumi__searchAppleDocumentation` and `mcp__claude_ai_sosumi__fetchAppleDocumentation` to check official documentation.
+- When needing to verify Apple APIs (concurrency safety, availability, behavior), use `mcp__sosumi__searchAppleDocumentation` and `mcp__sosumi__fetchAppleDocumentation` to check official documentation.
 - For deep Swift Concurrency analysis (async/await patterns, actor isolation, Sendable conformance, data races), invoke the `swift-concurrency` skill.
 - For Swift Testing review (test structure, macros, traits, parameterized tests), invoke the `swift-testing-expert` skill.
 - After reviewing, remind to run `/format` to apply formatting fixes.

--- a/.claude/agents/documentation-writer.md
+++ b/.claude/agents/documentation-writer.md
@@ -11,8 +11,6 @@ autoApprove:
   - Grep
   - mcp__sosumi__searchAppleDocumentation
   - mcp__sosumi__fetchAppleDocumentation
-  - mcp__claude_ai_sosumi__searchAppleDocumentation
-  - mcp__claude_ai_sosumi__fetchAppleDocumentation
   - "Bash(git diff:*)"
   - "Bash(git log:*)"
   - "Bash(ls:*)"

--- a/.claude/skills/integration-test/SKILL.md
+++ b/.claude/skills/integration-test/SKILL.md
@@ -5,6 +5,6 @@ description: Run integration tests against the live TMDb API
 
 # Run integration tests
 
-Run `source ~/.zshrc 2>/dev/null && make integration-test` from the project root.
+Run `make integration-test` from the project root.
 
-This requires `TMDB_API_KEY`, `TMDB_USERNAME`, and `TMDB_PASSWORD` environment variables to be set. Sourcing `.zshrc` ensures they are available.
+This requires `TMDB_API_KEY`, `TMDB_USERNAME`, and `TMDB_PASSWORD` environment variables to be set. These are injected automatically via the `env` block in `.claude/settings.local.json`, so no sourcing is needed.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
   schedule:
     # Every Sunday at 12am
     - cron: '0 0 * * 0'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,11 +100,11 @@ for:
 
 ### When Xcode MCP is Available
 
-**ALWAYS prefer Xcode MCP tools** (`mcp__xcode-tools__*`) when available:
+**ALWAYS prefer Xcode MCP tools** (`mcp__xcode__*`) when available:
 
-- `mcp__xcode-tools__BuildProject` for building
-- `mcp__xcode-tools__RunAllTests` for running tests
-- `mcp__xcode-tools__XcodeRead`, `XcodeWrite`, `XcodeUpdate` for file
+- `mcp__xcode__BuildProject` for building
+- `mcp__xcode__RunAllTests` for running tests
+- `mcp__xcode__XcodeRead`, `XcodeWrite`, `XcodeUpdate` for file
   operations
 
 **Test Plan Selection:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,8 +104,8 @@ for:
 
 - `mcp__xcode__BuildProject` for building
 - `mcp__xcode__RunAllTests` for running tests
-- `mcp__xcode__XcodeRead`, `XcodeWrite`, `XcodeUpdate` for file
-  operations
+- `mcp__xcode__XcodeRead`, `mcp__xcode__XcodeWrite`,
+  `mcp__xcode__XcodeUpdate` for file operations
 
 **Test Plan Selection:**
 


### PR DESCRIPTION
## Summary

Corrects verified inconsistencies in the `.claude/` configuration that would
cause failed tool calls, and takes the slow CodeQL scan off the per-PR
critical path. Config/CI/docs only — no library source is affected.

## Changes

**`CLAUDE.md`:**
- 🔧 Xcode MCP tool prefix was `mcp__xcode-tools__*`; the connected server is
  `mcp__xcode__*` (matches `.claude/settings.local.json` and the existing
  skills). All three of `XcodeRead`/`XcodeWrite`/`XcodeUpdate` are now
  prefixed.

**Agents:**
- 🔧 `code-reviewer.md` and `documentation-writer.md` referenced a
  non-existent `mcp__claude_ai_sosumi__*` server; only `mcp__sosumi__*` is
  connected. Removed the dead references (kept the valid `mcp__sosumi__*`
  entries).

**Skill:**
- 🔧 `integration-test` skill dropped the `source ~/.zshrc` prefix that
  contradicted `CLAUDE.md` — the required env vars are injected via the `env`
  block in `.claude/settings.local.json`.

**CI:**
- 🔧 `codeql.yml` no longer runs on `pull_request`. CodeQL's value here is a
  baseline security scan, not a merge gate — the per-PR trigger forced a full
  cold-runner `swift build` on every PR (including docs-only changes) for
  minimal signal. Code merged to `main` is still scanned on push, plus the
  existing weekly cron sweep.

## Benefits

- **Correctness**: Following `CLAUDE.md` no longer points Claude at
  non-existent MCP tools.
- **Consistency**: Root docs, agents, and skills agree on tool names and the
  integration-test invocation.
- **Faster PRs**: CodeQL no longer blocks/slows every pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)