### PR TITLE
🔧 Skip docs build and Claude review on non-relevant PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -3,6 +3,13 @@ name: Claude
 on:
   pull_request:
     types: [opened, synchronize]
+    # Skip automated review for docs/config-only PRs — these carry no
+    # Swift source to review. @claude can still be invoked manually via a
+    # comment (the claude-respond job), and CI/workflow changes are not
+    # ignored so they still get reviewed.
+    paths-ignore:
+      - '**/*.md'
+      - '.claude/**'
   issue_comment:
     types: [created]
   pull_request_review_comment:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -23,19 +23,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build
-    runs-on: macos-26
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_26.5.app/Contents/Developer
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Detect file changes
+        id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            docs:
+              - '**/*.swift'
+              - '**/*.docc/**'
+              - '.github/workflows/documentation.yml'
+
+  build:
+    name: Build
+    needs: changes
+    if: always()
+    runs-on: macos-26
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.5.app/Contents/Developer
+    steps:
+      - name: No changes detected
+        if: needs.changes.outputs.docs != 'true' && github.event_name != 'workflow_dispatch'
+        run: echo "No Swift or DocC changes detected, skipping documentation build"
+
+      - name: Checkout
+        if: needs.changes.outputs.docs == 'true' || github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v6
+
       - name: Setup Pages
+        if: needs.changes.outputs.docs == 'true' || github.event_name == 'workflow_dispatch'
         uses: actions/configure-pages@v6
-      
+
+      - name: Cache Swift packages
+        if: needs.changes.outputs.docs == 'true' || github.event_name == 'workflow_dispatch'
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build
+            ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-docs-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-docs-
+            ${{ runner.os }}-swift-
+
       - name: Build documentation
+        if: needs.changes.outputs.docs == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           swift package \
           --allow-writing-to-directory docs \
@@ -50,11 +92,13 @@ jobs:
           SWIFTCI_DOCC: 1
 
       - name: Upload documentation
-        if: github.ref == 'refs/heads/main'
+        if: >-
+          github.ref == 'refs/heads/main'
+          && (needs.changes.outputs.docs == 'true' || github.event_name == 'workflow_dispatch')
         uses: actions/upload-pages-artifact@v5
         with:
           path: 'docs'
-  
+
   deploy:
     name: Deploy
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary

Two CI optimisations that keep slow/expensive jobs off pull requests that
can't benefit from them. Follows the same change-detection pattern already
used in `ci.yml` and `integration.yml`, and mirrors the recent CodeQL change
(#302). Workflow-config only — no library source affected.

## Changes

**`documentation.yml`:**
- 🔧 Added a `Detect Changes` job so the macOS DocC build only runs when
  `**/*.swift` or `**/*.docc/**` files change. Previously **every** PR —
  including docs/config-only ones — triggered a full
  `swift package generate-documentation` on a `macos-26` runner (~1m20s of
  wasted compute per PR).
- ⚡️ Added a Swift package cache (`.build` + DerivedData) so the build is
  faster when it does run.
- The docs build **stays on macOS** — the package builds optimally against
  Apple-platform frameworks there, so a Linux migration was deliberately not
  pursued.

**`claude.yml`:**
- 🔧 Added `paths-ignore` (`**/*.md`, `.claude/**`) to the `claude-review`
  `pull_request` trigger, so the automated LLM review is skipped for
  docs/config-only PRs (it previously ran a full review on every push).
  `@claude` can still be invoked manually via comment (the `claude-respond`
  job), and CI/workflow changes are **not** ignored, so they still get
  reviewed.

## Behaviour preserved

- Push to `main` still builds and deploys docs (the existing `paths` filter on
  the push trigger already scopes this; the new job's step gating evaluates
  `true` for those pushes).
- `workflow_dispatch` always runs a full docs build.
- Deploy to GitHub Pages is unchanged and still gated on `main`.

## Benefits

- **Faster PRs**: docs-only and config-only PRs no longer wait on a macOS
  DocC build or a full Claude review.
- **Less wasted compute**: heavy jobs run only when relevant files change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)