### PR TITLE
✨ Add display FormatStyles for runtime and vote average

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
   size optimization
 * **Display Formatting**: Foundation `FormatStyle` conformances for
   rendering runtimes (`"2h 15m"`, `"139 min"`, `"2 hours, 15 minutes"`)
-  and vote averages as percentages (`"85%"`)
+  and vote averages as percentages (e.g. `"85%"` in English locales)
 * **Swift 6 Ready**: Full strict concurrency support with Sendable types
 * **Cross-Platform**: iOS 16+, macOS 13+, watchOS 9+, tvOS 16+,
   visionOS 1+, Linux, Windows

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
   providers
 * **Image Generation**: Built-in URL generation for all image types with
   size optimization
+* **Display Formatting**: Foundation `FormatStyle` conformances for
+  rendering runtimes (`"2h 15m"`, `"139 min"`, `"2 hours, 15 minutes"`)
+  and vote averages as percentages (`"85%"`)
 * **Swift 6 Ready**: Full strict concurrency support with Sendable types
 * **Cross-Platform**: iOS 16+, macOS 13+, watchOS 9+, tvOS 16+,
   visionOS 1+, Linux, Windows

--- a/Sources/TMDb/Domain/Formatting/RuntimeFormatStyle.swift
+++ b/Sources/TMDb/Domain/Formatting/RuntimeFormatStyle.swift
@@ -1,0 +1,229 @@
+//
+//  RuntimeFormatStyle.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A format style that renders a runtime, given in whole minutes, as a
+/// human-readable string.
+///
+/// TMDb exposes movie and television episode runtimes as an integer number of
+/// minutes (for example ``Movie/runtime`` and ``TVEpisode/runtime``). This
+/// format style turns that integer into a localized, display-ready string.
+///
+/// Use it directly:
+///
+/// ```swift
+/// let style = RuntimeFormatStyle(style: .abbreviated, displayUnit: .hourMinute)
+/// style.format(135)
+/// // "2h 15m"
+/// ```
+///
+/// Or via the ``Foundation/FormatStyle`` convenience on `Int`:
+///
+/// ```swift
+/// movie.runtime?.formatted(.runtimeStyle(.full, displayUnit: .hourMinute))
+/// // "2 hours, 15 minutes"
+///
+/// movie.runtime?.formatted(.runtimeStyle(.abbreviated, displayUnit: .minutesOnly))
+/// // "139 min"
+/// ```
+///
+public struct RuntimeFormatStyle: FormatStyle {
+
+    ///
+    /// The runtime, in minutes, to be formatted.
+    ///
+    public typealias FormatInput = Int
+
+    ///
+    /// The formatted, human-readable runtime string.
+    ///
+    public typealias FormatOutput = String
+
+    ///
+    /// The level of abbreviation applied to the formatted units.
+    ///
+    public enum Style: String, Codable, Hashable, Sendable {
+
+        ///
+        /// Abbreviated units, for example `"2h 15m"` or `"139 min"`.
+        ///
+        case abbreviated
+
+        ///
+        /// Full, spelled-out units, for example `"2 hours, 15 minutes"`.
+        ///
+        case full
+    }
+
+    ///
+    /// The units used to express a runtime.
+    ///
+    public enum DisplayUnit: String, Codable, Hashable, Sendable {
+
+        ///
+        /// Express the runtime as hours and minutes.
+        ///
+        /// The hours component is omitted when the runtime is under one hour,
+        /// and the minutes component is omitted when the runtime is an exact
+        /// number of hours.
+        ///
+        case hourMinute
+
+        ///
+        /// Express the runtime as a total number of minutes.
+        ///
+        case minutesOnly
+    }
+
+    ///
+    /// The level of abbreviation applied to the formatted units.
+    ///
+    public let style: Style
+
+    ///
+    /// The units used to express the runtime.
+    ///
+    public let displayUnit: DisplayUnit
+
+    ///
+    /// The locale used when formatting numbers and unit labels.
+    ///
+    public var locale: Locale
+
+    ///
+    /// Creates a runtime format style.
+    ///
+    /// - Parameters:
+    ///   - style: The level of abbreviation applied to the formatted units.
+    ///     Defaults to ``Style/abbreviated``.
+    ///   - displayUnit: The units used to express the runtime. Defaults to
+    ///     ``DisplayUnit/hourMinute``.
+    ///   - locale: The locale used when formatting. Defaults to
+    ///     `.autoupdatingCurrent`.
+    ///
+    public init(
+        style: Style = .abbreviated,
+        displayUnit: DisplayUnit = .hourMinute,
+        locale: Locale = .autoupdatingCurrent
+    ) {
+        self.style = style
+        self.displayUnit = displayUnit
+        self.locale = locale
+    }
+
+    ///
+    /// Formats a runtime, given in minutes, into a human-readable string.
+    ///
+    /// Negative values are treated as zero.
+    ///
+    /// - Parameter value: The runtime, in minutes.
+    ///
+    /// - Returns: A localized, human-readable runtime string.
+    ///
+    public func format(_ value: Int) -> String {
+        let totalMinutes = max(0, value)
+
+        switch displayUnit {
+        case .minutesOnly:
+            return minuteLabel(totalMinutes)
+
+        case .hourMinute:
+            return hourMinuteString(totalMinutes)
+        }
+    }
+
+    ///
+    /// Returns a copy of this format style using the given locale.
+    ///
+    /// - Parameter locale: The locale to apply.
+    ///
+    /// - Returns: A copy of the format style with the given locale.
+    ///
+    public func locale(_ locale: Locale) -> RuntimeFormatStyle {
+        RuntimeFormatStyle(style: style, displayUnit: displayUnit, locale: locale)
+    }
+
+}
+
+extension RuntimeFormatStyle {
+
+    private func hourMinuteString(_ totalMinutes: Int) -> String {
+        let hours = totalMinutes / 60
+        let minutes = totalMinutes % 60
+
+        guard hours > 0 else {
+            return minuteLabel(minutes)
+        }
+
+        guard minutes > 0 else {
+            return hourLabel(hours)
+        }
+
+        return "\(hourLabel(hours))\(separator)\(minuteLabel(minutes))"
+    }
+
+    private var separator: String {
+        switch style {
+        case .abbreviated:
+            " "
+        case .full:
+            ", "
+        }
+    }
+
+    private func hourLabel(_ hours: Int) -> String {
+        let number = hours.formatted(.number.locale(locale))
+        switch style {
+        case .abbreviated:
+            return "\(number)h"
+        case .full:
+            return "\(number) \(hours == 1 ? "hour" : "hours")"
+        }
+    }
+
+    private func minuteLabel(_ minutes: Int) -> String {
+        let number = minutes.formatted(.number.locale(locale))
+        switch style {
+        case .abbreviated where displayUnit == .minutesOnly:
+            return "\(number) min"
+        case .abbreviated:
+            return "\(number)m"
+        case .full:
+            return "\(number) \(minutes == 1 ? "minute" : "minutes")"
+        }
+    }
+
+}
+
+public extension FormatStyle where Self == RuntimeFormatStyle {
+
+    ///
+    /// A runtime format style for use with `Int.formatted(_:)`.
+    ///
+    /// ```swift
+    /// movie.runtime?.formatted(.runtimeStyle(.full, displayUnit: .hourMinute))
+    /// // "2 hours, 15 minutes"
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - style: The level of abbreviation applied to the formatted units.
+    ///     Defaults to ``RuntimeFormatStyle/Style/abbreviated``.
+    ///   - displayUnit: The units used to express the runtime. Defaults to
+    ///     ``RuntimeFormatStyle/DisplayUnit/hourMinute``.
+    ///
+    /// - Returns: A configured ``RuntimeFormatStyle``.
+    ///
+    static func runtimeStyle(
+        _ style: RuntimeFormatStyle.Style = .abbreviated,
+        displayUnit: RuntimeFormatStyle.DisplayUnit = .hourMinute
+    ) -> RuntimeFormatStyle {
+        RuntimeFormatStyle(style: style, displayUnit: displayUnit)
+    }
+
+}

--- a/Sources/TMDb/Domain/Formatting/RuntimeFormatStyle.swift
+++ b/Sources/TMDb/Domain/Formatting/RuntimeFormatStyle.swift
@@ -13,7 +13,9 @@ import Foundation
 ///
 /// TMDb exposes movie and television episode runtimes as an integer number of
 /// minutes (for example ``Movie/runtime`` and ``TVEpisode/runtime``). This
-/// format style turns that integer into a localized, display-ready string.
+/// format style turns that integer into a display-ready string. Numeric
+/// components are formatted using the provided `locale`, while the unit labels
+/// (such as `"h"`, `"m"`, `"min"`, `"hour"`, and `"minute"`) are in English.
 ///
 /// Use it directly:
 ///
@@ -23,17 +25,19 @@ import Foundation
 /// // "2h 15m"
 /// ```
 ///
-/// Or via the ``Foundation/FormatStyle`` convenience on `Int`:
+/// Or via the `FormatStyle` convenience on `Int`:
 ///
 /// ```swift
-/// movie.runtime?.formatted(.runtimeStyle(.full, displayUnit: .hourMinute))
+/// let runtime = 135
+///
+/// runtime.formatted(.runtimeStyle(.full, displayUnit: .hourMinute))
 /// // "2 hours, 15 minutes"
 ///
-/// movie.runtime?.formatted(.runtimeStyle(.abbreviated, displayUnit: .minutesOnly))
-/// // "139 min"
+/// runtime.formatted(.runtimeStyle(.abbreviated, displayUnit: .minutesOnly))
+/// // "135 min"
 /// ```
 ///
-public struct RuntimeFormatStyle: FormatStyle {
+public struct RuntimeFormatStyle: FormatStyle, Sendable {
 
     ///
     /// The runtime, in minutes, to be formatted.
@@ -92,7 +96,8 @@ public struct RuntimeFormatStyle: FormatStyle {
     public let displayUnit: DisplayUnit
 
     ///
-    /// The locale used when formatting numbers and unit labels.
+    /// The locale used when formatting the numeric components. Unit labels are
+    /// always in English.
     ///
     public var locale: Locale
 
@@ -124,7 +129,8 @@ public struct RuntimeFormatStyle: FormatStyle {
     ///
     /// - Parameter value: The runtime, in minutes.
     ///
-    /// - Returns: A localized, human-readable runtime string.
+    /// - Returns: A human-readable runtime string. Numeric components use the
+    ///   format style's `locale`; unit labels are in English.
     ///
     public func format(_ value: Int) -> String {
         let totalMinutes = max(0, value)

--- a/Sources/TMDb/Domain/Formatting/RuntimeFormatStyle.swift
+++ b/Sources/TMDb/Domain/Formatting/RuntimeFormatStyle.swift
@@ -37,7 +37,7 @@ import Foundation
 /// // "135 min"
 /// ```
 ///
-public struct RuntimeFormatStyle: FormatStyle, Sendable {
+public struct RuntimeFormatStyle: FormatStyle, Codable, Equatable, Hashable, Sendable {
 
     ///
     /// The runtime, in minutes, to be formatted.

--- a/Sources/TMDb/Domain/Formatting/VoteAverageFormatStyle.swift
+++ b/Sources/TMDb/Domain/Formatting/VoteAverageFormatStyle.swift
@@ -12,24 +12,26 @@ import Foundation
 ///
 /// TMDb expresses vote averages as a `Double` on a scale from `0` to `10` (for
 /// example ``Movie/voteAverage``). This format style converts that score into a
-/// rounded, localized percentage string.
+/// rounded percentage string. The percent symbol and its placement are
+/// determined by the provided `locale` via `.percent`, so the exact output
+/// varies by locale (for example `"85%"` in English locales).
 ///
 /// Use it directly:
 ///
 /// ```swift
 /// let style = VoteAverageFormatStyle()
 /// style.format(8.5)
-/// // "85%"
+/// // "85%" in English locales
 /// ```
 ///
-/// Or via the ``Foundation/FormatStyle`` convenience on `Double`:
+/// Or via the `FormatStyle` convenience on `Double`:
 ///
 /// ```swift
 /// movie.voteAverage?.formatted(.voteAveragePercentage)
-/// // "85%"
+/// // "85%" in English locales
 /// ```
 ///
-public struct VoteAverageFormatStyle: FormatStyle {
+public struct VoteAverageFormatStyle: FormatStyle, Sendable {
 
     ///
     /// The vote average, on a scale from `0` to `10`, to be formatted.
@@ -60,14 +62,17 @@ public struct VoteAverageFormatStyle: FormatStyle {
     /// Formats a vote average as a rounded percentage string.
     ///
     /// The score is clamped to the range `0...10` before conversion, and the
-    /// resulting percentage is rounded to the nearest whole number.
+    /// resulting percentage is rounded to the nearest whole number. Non-finite
+    /// values are handled gracefully: `nan` is treated as zero, while positive
+    /// and negative infinity clamp to the upper and lower bounds respectively.
     ///
     /// - Parameter value: The vote average, on a scale from `0` to `10`.
     ///
-    /// - Returns: A localized percentage string, for example `"85%"`.
+    /// - Returns: A percentage string, for example `"85%"` in English locales.
     ///
     public func format(_ value: Double) -> String {
-        let clamped = min(max(value, 0), 10)
+        let sanitised = value.isNaN ? 0 : value
+        let clamped = min(max(sanitised, 0), 10)
         let percent = Int((clamped * 10).rounded())
         return percent.formatted(.percent.scale(1).locale(locale))
     }
@@ -92,7 +97,7 @@ public extension FormatStyle where Self == VoteAverageFormatStyle {
     ///
     /// ```swift
     /// movie.voteAverage?.formatted(.voteAveragePercentage)
-    /// // "85%"
+    /// // "85%" in English locales
     /// ```
     ///
     static var voteAveragePercentage: VoteAverageFormatStyle {

--- a/Sources/TMDb/Domain/Formatting/VoteAverageFormatStyle.swift
+++ b/Sources/TMDb/Domain/Formatting/VoteAverageFormatStyle.swift
@@ -1,0 +1,102 @@
+//
+//  VoteAverageFormatStyle.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A format style that renders a TMDb vote average as a percentage.
+///
+/// TMDb expresses vote averages as a `Double` on a scale from `0` to `10` (for
+/// example ``Movie/voteAverage``). This format style converts that score into a
+/// rounded, localized percentage string.
+///
+/// Use it directly:
+///
+/// ```swift
+/// let style = VoteAverageFormatStyle()
+/// style.format(8.5)
+/// // "85%"
+/// ```
+///
+/// Or via the ``Foundation/FormatStyle`` convenience on `Double`:
+///
+/// ```swift
+/// movie.voteAverage?.formatted(.voteAveragePercentage)
+/// // "85%"
+/// ```
+///
+public struct VoteAverageFormatStyle: FormatStyle {
+
+    ///
+    /// The vote average, on a scale from `0` to `10`, to be formatted.
+    ///
+    public typealias FormatInput = Double
+
+    ///
+    /// The formatted percentage string.
+    ///
+    public typealias FormatOutput = String
+
+    ///
+    /// The locale used when formatting the percentage.
+    ///
+    public var locale: Locale
+
+    ///
+    /// Creates a vote average format style.
+    ///
+    /// - Parameter locale: The locale used when formatting. Defaults to
+    ///   `.autoupdatingCurrent`.
+    ///
+    public init(locale: Locale = .autoupdatingCurrent) {
+        self.locale = locale
+    }
+
+    ///
+    /// Formats a vote average as a rounded percentage string.
+    ///
+    /// The score is clamped to the range `0...10` before conversion, and the
+    /// resulting percentage is rounded to the nearest whole number.
+    ///
+    /// - Parameter value: The vote average, on a scale from `0` to `10`.
+    ///
+    /// - Returns: A localized percentage string, for example `"85%"`.
+    ///
+    public func format(_ value: Double) -> String {
+        let clamped = min(max(value, 0), 10)
+        let percent = Int((clamped * 10).rounded())
+        return percent.formatted(.percent.scale(1).locale(locale))
+    }
+
+    ///
+    /// Returns a copy of this format style using the given locale.
+    ///
+    /// - Parameter locale: The locale to apply.
+    ///
+    /// - Returns: A copy of the format style with the given locale.
+    ///
+    public func locale(_ locale: Locale) -> VoteAverageFormatStyle {
+        VoteAverageFormatStyle(locale: locale)
+    }
+
+}
+
+public extension FormatStyle where Self == VoteAverageFormatStyle {
+
+    ///
+    /// A vote average format style for use with `Double.formatted(_:)`.
+    ///
+    /// ```swift
+    /// movie.voteAverage?.formatted(.voteAveragePercentage)
+    /// // "85%"
+    /// ```
+    ///
+    static var voteAveragePercentage: VoteAverageFormatStyle {
+        VoteAverageFormatStyle()
+    }
+
+}

--- a/Sources/TMDb/Domain/Formatting/VoteAverageFormatStyle.swift
+++ b/Sources/TMDb/Domain/Formatting/VoteAverageFormatStyle.swift
@@ -31,7 +31,7 @@ import Foundation
 /// // "85%" in English locales
 /// ```
 ///
-public struct VoteAverageFormatStyle: FormatStyle, Sendable {
+public struct VoteAverageFormatStyle: FormatStyle, Codable, Equatable, Hashable, Sendable {
 
     ///
     /// The vote average, on a scale from `0` to `10`, to be formatted.
@@ -74,7 +74,7 @@ public struct VoteAverageFormatStyle: FormatStyle, Sendable {
         let sanitised = value.isNaN ? 0 : value
         let clamped = min(max(sanitised, 0), 10)
         let percent = Int((clamped * 10).rounded())
-        return percent.formatted(.percent.scale(1).locale(locale))
+        return percent.formatted(.percent.locale(locale))
     }
 
     ///

--- a/Sources/TMDb/TMDb.docc/TMDb.md
+++ b/Sources/TMDb/TMDb.docc/TMDb.md
@@ -464,3 +464,8 @@ Watch providers provided by [JustWatch](https://www.justwatch.com).
 ### Cache Configuration
 
 - ``CacheConfiguration``
+
+### Formatting
+
+- ``RuntimeFormatStyle``
+- ``VoteAverageFormatStyle``

--- a/Tests/TMDbTests/Domain/Formatting/RuntimeFormatStyleTests.swift
+++ b/Tests/TMDbTests/Domain/Formatting/RuntimeFormatStyleTests.swift
@@ -48,6 +48,11 @@ struct RuntimeFormatStyleTests {
             #expect(style.format(0) == "0m")
         }
 
+        @Test("exact single hour omits minutes")
+        func formatsSingleHour() {
+            #expect(style.format(60) == "1h")
+        }
+
         @Test("large value")
         func formatsLargeValue() {
             #expect(style.format(605) == "10h 5m")
@@ -103,6 +108,11 @@ struct RuntimeFormatStyleTests {
             #expect(style.format(61) == "1 hour, 1 minute")
         }
 
+        @Test("exact single hour uses singular hour and omits minutes")
+        func formatsSingleHour() {
+            #expect(style.format(60) == "1 hour")
+        }
+
         @Test("exact hours omits minutes")
         func formatsExactHours() {
             #expect(style.format(120) == "2 hours")
@@ -143,6 +153,12 @@ struct RuntimeFormatStyleTests {
     func defaultInitialiser() {
         let style = RuntimeFormatStyle(locale: locale)
         #expect(style.format(135) == "2h 15m")
+    }
+
+    @Test("defaulted runtimeStyle accessor uses abbreviated hour-minute")
+    func defaultedRuntimeStyleAccessor() {
+        let result = 135.formatted(.runtimeStyle().locale(locale))
+        #expect(result == "2h 15m")
     }
 
     @Test("Int convenience formatted accessor")

--- a/Tests/TMDbTests/Domain/Formatting/RuntimeFormatStyleTests.swift
+++ b/Tests/TMDbTests/Domain/Formatting/RuntimeFormatStyleTests.swift
@@ -147,6 +147,11 @@ struct RuntimeFormatStyleTests {
         func formatsSingularMinute() {
             #expect(style.format(1) == "1 minute")
         }
+
+        @Test("zero minutes")
+        func formatsZero() {
+            #expect(style.format(0) == "0 minutes")
+        }
     }
 
     @Test("default initialiser uses abbreviated hour-minute")

--- a/Tests/TMDbTests/Domain/Formatting/RuntimeFormatStyleTests.swift
+++ b/Tests/TMDbTests/Domain/Formatting/RuntimeFormatStyleTests.swift
@@ -1,0 +1,178 @@
+//
+//  RuntimeFormatStyleTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite("RuntimeFormatStyle", .tags(.formatting))
+struct RuntimeFormatStyleTests {
+
+    private let locale = Locale(identifier: "en_US_POSIX")
+
+    @Suite("abbreviated style, hour-minute display")
+    struct AbbreviatedHourMinute {
+
+        private let style = RuntimeFormatStyle(
+            style: .abbreviated,
+            displayUnit: .hourMinute,
+            locale: Locale(identifier: "en_US_POSIX")
+        )
+
+        @Test("more than one hour")
+        func formatsHoursAndMinutes() {
+            #expect(style.format(135) == "2h 15m")
+        }
+
+        @Test("exact hours omits minutes")
+        func formatsExactHours() {
+            #expect(style.format(120) == "2h")
+        }
+
+        @Test("less than one hour omits hours")
+        func formatsMinutesOnly() {
+            #expect(style.format(45) == "45m")
+        }
+
+        @Test("single hour and minute")
+        func formatsSingleHourAndMinute() {
+            #expect(style.format(61) == "1h 1m")
+        }
+
+        @Test("zero minutes")
+        func formatsZero() {
+            #expect(style.format(0) == "0m")
+        }
+
+        @Test("large value")
+        func formatsLargeValue() {
+            #expect(style.format(605) == "10h 5m")
+        }
+
+        @Test("negative input is treated as zero")
+        func formatsNegativeAsZero() {
+            #expect(style.format(-10) == "0m")
+        }
+    }
+
+    @Suite("abbreviated style, minutes-only display")
+    struct AbbreviatedMinutesOnly {
+
+        private let style = RuntimeFormatStyle(
+            style: .abbreviated,
+            displayUnit: .minutesOnly,
+            locale: Locale(identifier: "en_US_POSIX")
+        )
+
+        @Test("renders total minutes")
+        func formatsTotalMinutes() {
+            #expect(style.format(139) == "139 min")
+        }
+
+        @Test("under an hour")
+        func formatsUnderAnHour() {
+            #expect(style.format(45) == "45 min")
+        }
+
+        @Test("zero minutes")
+        func formatsZero() {
+            #expect(style.format(0) == "0 min")
+        }
+    }
+
+    @Suite("full style, hour-minute display")
+    struct FullHourMinute {
+
+        private let style = RuntimeFormatStyle(
+            style: .full,
+            displayUnit: .hourMinute,
+            locale: Locale(identifier: "en_US_POSIX")
+        )
+
+        @Test("more than one hour")
+        func formatsHoursAndMinutes() {
+            #expect(style.format(135) == "2 hours, 15 minutes")
+        }
+
+        @Test("singular hour and minute")
+        func formatsSingular() {
+            #expect(style.format(61) == "1 hour, 1 minute")
+        }
+
+        @Test("exact hours omits minutes")
+        func formatsExactHours() {
+            #expect(style.format(120) == "2 hours")
+        }
+
+        @Test("less than one hour omits hours")
+        func formatsMinutesOnly() {
+            #expect(style.format(45) == "45 minutes")
+        }
+
+        @Test("zero minutes")
+        func formatsZero() {
+            #expect(style.format(0) == "0 minutes")
+        }
+    }
+
+    @Suite("full style, minutes-only display")
+    struct FullMinutesOnly {
+
+        private let style = RuntimeFormatStyle(
+            style: .full,
+            displayUnit: .minutesOnly,
+            locale: Locale(identifier: "en_US_POSIX")
+        )
+
+        @Test("renders total minutes")
+        func formatsTotalMinutes() {
+            #expect(style.format(139) == "139 minutes")
+        }
+
+        @Test("singular minute")
+        func formatsSingularMinute() {
+            #expect(style.format(1) == "1 minute")
+        }
+    }
+
+    @Test("default initialiser uses abbreviated hour-minute")
+    func defaultInitialiser() {
+        let style = RuntimeFormatStyle(locale: locale)
+        #expect(style.format(135) == "2h 15m")
+    }
+
+    @Test("Int convenience formatted accessor")
+    func intConvenience() {
+        let runtime = 139
+        let result = runtime.formatted(.runtimeStyle(.abbreviated, displayUnit: .minutesOnly)
+            .locale(locale))
+        #expect(result == "139 min")
+    }
+
+    @Test("locale modifier returns a copy with the new locale")
+    func localeModifier() {
+        let style = RuntimeFormatStyle(style: .abbreviated, displayUnit: .hourMinute)
+            .locale(locale)
+        #expect(style.format(135) == "2h 15m")
+    }
+
+    @Test("conforms to Codable")
+    func codableRoundTrip() throws {
+        let style = RuntimeFormatStyle(style: .full, displayUnit: .hourMinute, locale: locale)
+        let data = try JSONEncoder().encode(style)
+        let decoded = try JSONDecoder().decode(RuntimeFormatStyle.self, from: data)
+        #expect(decoded == style)
+    }
+
+    @Test("equal styles are equal and hashable")
+    func equatableAndHashable() {
+        let lhs = RuntimeFormatStyle(style: .full, displayUnit: .minutesOnly, locale: locale)
+        let rhs = RuntimeFormatStyle(style: .full, displayUnit: .minutesOnly, locale: locale)
+        #expect(lhs == rhs)
+        #expect(lhs.hashValue == rhs.hashValue)
+    }
+}

--- a/Tests/TMDbTests/Domain/Formatting/VoteAverageFormatStyleTests.swift
+++ b/Tests/TMDbTests/Domain/Formatting/VoteAverageFormatStyleTests.swift
@@ -46,6 +46,24 @@ struct VoteAverageFormatStyleTests {
         #expect(style.format(0) == "0%")
     }
 
+    @Test("treats NaN as zero")
+    func formatsNaNAsZero() {
+        let style = VoteAverageFormatStyle(locale: locale)
+        #expect(style.format(.nan) == "0%")
+    }
+
+    @Test("clamps positive infinity to one hundred")
+    func formatsPositiveInfinity() {
+        let style = VoteAverageFormatStyle(locale: locale)
+        #expect(style.format(.infinity) == "100%")
+    }
+
+    @Test("clamps negative infinity to zero")
+    func formatsNegativeInfinity() {
+        let style = VoteAverageFormatStyle(locale: locale)
+        #expect(style.format(-.infinity) == "0%")
+    }
+
     @Test("Double convenience formatted accessor")
     func doubleConvenience() {
         let voteAverage = 8.5

--- a/Tests/TMDbTests/Domain/Formatting/VoteAverageFormatStyleTests.swift
+++ b/Tests/TMDbTests/Domain/Formatting/VoteAverageFormatStyleTests.swift
@@ -1,0 +1,77 @@
+//
+//  VoteAverageFormatStyleTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite("VoteAverageFormatStyle", .tags(.formatting))
+struct VoteAverageFormatStyleTests {
+
+    private let locale = Locale(identifier: "en_US_POSIX")
+
+    @Test("formats a vote average as a rounded percentage")
+    func formatsPercentage() {
+        let style = VoteAverageFormatStyle(locale: locale)
+        #expect(style.format(8.5) == "85%")
+    }
+
+    @Test("rounds to the nearest percent")
+    func roundsToNearestPercent() {
+        let style = VoteAverageFormatStyle(locale: locale)
+        #expect(style.format(7.26) == "73%")
+        #expect(style.format(7.24) == "72%")
+    }
+
+    @Test("clamps the lower bound to zero")
+    func clampsLowerBound() {
+        let style = VoteAverageFormatStyle(locale: locale)
+        #expect(style.format(-1) == "0%")
+    }
+
+    @Test("clamps the upper bound to one hundred")
+    func clampsUpperBound() {
+        let style = VoteAverageFormatStyle(locale: locale)
+        #expect(style.format(11) == "100%")
+        #expect(style.format(10) == "100%")
+    }
+
+    @Test("formats zero")
+    func formatsZero() {
+        let style = VoteAverageFormatStyle(locale: locale)
+        #expect(style.format(0) == "0%")
+    }
+
+    @Test("Double convenience formatted accessor")
+    func doubleConvenience() {
+        let voteAverage = 8.5
+        let result = voteAverage.formatted(.voteAveragePercentage.locale(locale))
+        #expect(result == "85%")
+    }
+
+    @Test("locale modifier returns a copy with the new locale")
+    func localeModifier() {
+        let style = VoteAverageFormatStyle().locale(locale)
+        #expect(style.format(8.5) == "85%")
+    }
+
+    @Test("conforms to Codable")
+    func codableRoundTrip() throws {
+        let style = VoteAverageFormatStyle(locale: locale)
+        let data = try JSONEncoder().encode(style)
+        let decoded = try JSONDecoder().decode(VoteAverageFormatStyle.self, from: data)
+        #expect(decoded == style)
+    }
+
+    @Test("equal styles are equal and hashable")
+    func equatableAndHashable() {
+        let lhs = VoteAverageFormatStyle(locale: locale)
+        let rhs = VoteAverageFormatStyle(locale: locale)
+        #expect(lhs == rhs)
+        #expect(lhs.hashValue == rhs.hashValue)
+    }
+}

--- a/Tests/TMDbTests/TestUtils/Tags.swift
+++ b/Tests/TMDbTests/TestUtils/Tags.swift
@@ -17,6 +17,7 @@ extension Tag {
     @Tag static var services: Self
     @Tag static var apiClient: Self
     @Tag static var filters: Self
+    @Tag static var formatting: Self
 
     @Tag static var decoding: Self
     @Tag static var encoding: Self


### PR DESCRIPTION
## Summary

Adds Foundation `FormatStyle` conformances for displaying TMDb data — a capability the package previously lacked entirely. Foundation-only, no UI frameworks. Concept inspired by `brettohland/swift-tmdb` (clean-room reimplemented in this package's style).

## Changes

**New (`Sources/TMDb/Domain/Formatting/`):**
- ✨ `RuntimeFormatStyle` — renders a runtime in minutes (`Int`) as "2h 15m" / "139 min" (abbreviated) or "2 hours, 15 minutes" (full), with `style`/`displayUnit`/`locale` options.
- ✨ `VoteAverageFormatStyle` — renders a vote average (`Double`, 0…10) as a percentage, e.g. "85%".
- Non-polluting static accessors via `FormatStyle where Self == …` (`.runtimeStyle(…)`, `.voteAveragePercentage`) — generic `Int.formatted()` / `Double.formatted()` are unaffected.

**Docs:** new "Formatting" topic in `TMDb.docc/TMDb.md`; README feature bullet.

## Tests

- ✅ ~37 Swift Testing cases (deterministic via `en_US_POSIX`): all style/displayUnit combinations, edge cases (0, sub-hour, exact hours, singular vs plural, large values, negative→0), percentage rounding/clamping, **NaN/±infinity** safety, Codable/Equatable/Hashable, `.locale()` modifier.

## Review & verification

- 🔎 Two adversarial reviews. Fixed: a **NaN crash** in `format(_:)` (`Int(nan)` trap), a **DocC `Foundation/FormatStyle` link** that broke `make build-docs`, over-claimed "localized" docs (unit labels are English; numerals use the locale — an intentional cross-platform choice), inconsistent doc examples, explicit `Sendable`.
- ✅ `make lint` + `make build-docs` pass.

## Benefits

- **Display-ready output** for runtimes and ratings without consumers hand-rolling formatters.
- **Cross-platform & deterministic** (no `Date.ComponentsFormatStyle`, which is inconsistent on Linux/Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)