### PR TITLE
✨ Add fluent, composable Discover filters with AND/OR joins

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -29,6 +29,7 @@ identifier_name:
     - 'id'
     - 'l'
     - 'on'
+    - 'or'
     - 'r'
     - 'tv'
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ let movies = try await tmdbClient.discover.movies(
 ```
 
 Multi-valued parameters such as genres and keywords can be joined with
-logical `AND` (the default) or `OR` using ``DiscoverFilterJoin``:
+logical `AND` (the default) or `OR` using `DiscoverFilterJoin`:
 
 ```swift
 // Match movies tagged with genre 28 OR genre 12

--- a/README.md
+++ b/README.md
@@ -261,12 +261,28 @@ let images = try await tmdbClient.movies.images(forMovie: movieId)
 
 ### Building a Discover/Browse Interface
 
+Compose filters fluently with copy-returning builder methods. Each method
+returns a new filter, so filters can be built up incrementally without
+mutating shared state:
+
 ```swift
+let filter = DiscoverMovieFilter()
+    .withGenres([28, 12]) // Action AND Adventure
+    .voteAverage(in: 7...10)
+    .primaryReleaseYear(.on(2024))
+
 let movies = try await tmdbClient.discover.movies(
-    sortedBy: .popularity(descending: true),
-    withGenres: [28, 12], // Action & Adventure
-    releaseDateGTE: Date().addingTimeInterval(-365*24*60*60) // Last year
+    filter: filter,
+    sortedBy: .popularity(descending: true)
 )
+```
+
+Multi-valued parameters such as genres and keywords can be joined with
+logical `AND` (the default) or `OR` using ``DiscoverFilterJoin``:
+
+```swift
+// Match movies tagged with genre 28 OR genre 12
+let filter = DiscoverMovieFilter().withGenres([28, 12], joinedBy: .or)
 ```
 
 ### Getting Watch Providers (Streaming Availability)

--- a/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverFilterJoin.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverFilterJoin.swift
@@ -1,0 +1,55 @@
+//
+//  DiscoverFilterJoin.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A logical operator describing how multiple values of a discover filter
+/// parameter are combined.
+///
+/// The TMDb API joins multi-valued parameters such as genres and keywords
+/// using either a comma (logical AND — results must match **all** values) or
+/// a pipe (logical OR — results must match **any** value).
+///
+public enum DiscoverFilterJoin: Equatable, Hashable, Sendable {
+
+    ///
+    /// Match results that satisfy **all** of the supplied values.
+    ///
+    /// Values are joined with a comma (`,`) in the request.
+    ///
+    case and
+
+    ///
+    /// Match results that satisfy **any** of the supplied values.
+    ///
+    /// Values are joined with a pipe (`|`) in the request.
+    ///
+    case or
+
+    ///
+    /// The separator used to join values in the request query.
+    ///
+    public var separator: String {
+        switch self {
+        case .and: ","
+        case .or: "|"
+        }
+    }
+
+    ///
+    /// Joins a list of identifiers into a query value using this operator.
+    ///
+    /// - Parameter ids: The identifiers to join.
+    ///
+    /// - Returns: The identifiers joined with this operator's separator.
+    ///
+    public func queryValue(for ids: [Int]) -> String {
+        ids.map(\.description).joined(separator: separator)
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverFilterJoin.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverFilterJoin.swift
@@ -5,8 +5,6 @@
 //  Copyright © 2026 Adam Young.
 //
 
-import Foundation
-
 ///
 /// A logical operator describing how multiple values of a discover filter
 /// parameter are combined.

--- a/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverMovieFilter+Fluent.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverMovieFilter+Fluent.swift
@@ -5,8 +5,6 @@
 //  Copyright © 2026 Adam Young.
 //
 
-import Foundation
-
 public extension DiscoverMovieFilter {
 
     ///

--- a/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverMovieFilter+Fluent.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverMovieFilter+Fluent.swift
@@ -1,0 +1,243 @@
+//
+//  DiscoverMovieFilter+Fluent.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+public extension DiscoverMovieFilter {
+
+    ///
+    /// Returns a copy of the filter restricted to the given genres.
+    ///
+    /// - Parameters:
+    ///   - genres: A list of genre identifiers to match.
+    ///   - join: The logical operator used to combine the genres. Defaults to
+    ///     ``DiscoverFilterJoin/and``.
+    ///
+    /// - Returns: A new filter with the genres applied.
+    ///
+    func withGenres(
+        _ genres: [Genre.ID],
+        joinedBy join: DiscoverFilterJoin = .and
+    ) -> Self {
+        copy(genres: genres, genresJoin: join)
+    }
+
+    ///
+    /// Returns a copy of the filter excluding the given genres.
+    ///
+    /// - Parameter genres: A list of genre identifiers to exclude.
+    ///
+    /// - Returns: A new filter with the excluded genres applied.
+    ///
+    func withoutGenres(_ genres: [Genre.ID]) -> Self {
+        copy(withoutGenres: genres)
+    }
+
+    ///
+    /// Returns a copy of the filter restricted to the given keywords.
+    ///
+    /// - Parameters:
+    ///   - keywords: A list of keyword identifiers to match.
+    ///   - join: The logical operator used to combine the keywords. Defaults
+    ///     to ``DiscoverFilterJoin/and``.
+    ///
+    /// - Returns: A new filter with the keywords applied.
+    ///
+    func withKeywords(
+        _ keywords: [Keyword.ID],
+        joinedBy join: DiscoverFilterJoin = .and
+    ) -> Self {
+        copy(keywords: keywords, keywordsJoin: join)
+    }
+
+    ///
+    /// Returns a copy of the filter excluding the given keywords.
+    ///
+    /// - Parameter keywords: A list of keyword identifiers to exclude.
+    ///
+    /// - Returns: A new filter with the excluded keywords applied.
+    ///
+    func withoutKeywords(_ keywords: [Keyword.ID]) -> Self {
+        copy(withoutKeywords: keywords)
+    }
+
+    ///
+    /// Returns a copy of the filter restricted to the given people.
+    ///
+    /// - Parameter people: A list of Person identifiers to match.
+    ///
+    /// - Returns: A new filter with the people applied.
+    ///
+    func withPeople(_ people: [Person.ID]) -> Self {
+        copy(people: people)
+    }
+
+    ///
+    /// Returns a copy of the filter restricted to the given companies.
+    ///
+    /// - Parameter companies: A list of production company identifiers.
+    ///
+    /// - Returns: A new filter with the companies applied.
+    ///
+    func withCompanies(_ companies: [Company.ID]) -> Self {
+        copy(companies: companies)
+    }
+
+    ///
+    /// Returns a copy of the filter restricted to the given original language.
+    ///
+    /// - Parameter language: An ISO-639-1 language code.
+    ///
+    /// - Returns: A new filter with the original language applied.
+    ///
+    func originalLanguage(_ language: String) -> Self {
+        copy(originalLanguage: language)
+    }
+
+    ///
+    /// Returns a copy of the filter restricted to the given release year.
+    ///
+    /// - Parameter year: The primary release year filter.
+    ///
+    /// - Returns: A new filter with the release year applied.
+    ///
+    func primaryReleaseYear(_ year: PrimaryReleaseYearFilter) -> Self {
+        copy(primaryReleaseYear: year)
+    }
+
+    ///
+    /// Returns a copy of the filter restricted to the given vote average range.
+    ///
+    /// - Parameter range: The inclusive vote average range.
+    ///
+    /// - Returns: A new filter with the vote average range applied.
+    ///
+    func voteAverage(in range: ClosedRange<Double>) -> Self {
+        copy(voteAverageMin: range.lowerBound, voteAverageMax: range.upperBound)
+    }
+
+    ///
+    /// Returns a copy of the filter restricted to the given vote count range.
+    ///
+    /// - Parameter range: The inclusive vote count range.
+    ///
+    /// - Returns: A new filter with the vote count range applied.
+    ///
+    func voteCount(in range: ClosedRange<Int>) -> Self {
+        copy(voteCountMin: range.lowerBound, voteCountMax: range.upperBound)
+    }
+
+    ///
+    /// Returns a copy of the filter restricted to the given runtime range.
+    ///
+    /// - Parameter range: The inclusive runtime range, in minutes.
+    ///
+    /// - Returns: A new filter with the runtime range applied.
+    ///
+    func runtime(in range: ClosedRange<Int>) -> Self {
+        copy(runtimeMin: range.lowerBound, runtimeMax: range.upperBound)
+    }
+
+    ///
+    /// Returns a copy of the filter with the adult content preference set.
+    ///
+    /// - Parameter include: Whether to include adult content.
+    ///
+    /// - Returns: A new filter with the adult content preference applied.
+    ///
+    func includeAdult(_ include: Bool) -> Self {
+        copy(includeAdult: include)
+    }
+
+    ///
+    /// Returns a copy of the filter with the video content preference set.
+    ///
+    /// - Parameter include: Whether to include video content.
+    ///
+    /// - Returns: A new filter with the video content preference applied.
+    ///
+    func includeVideo(_ include: Bool) -> Self {
+        copy(includeVideo: include)
+    }
+
+    ///
+    /// Returns a copy of the filter restricted to the given watch providers.
+    ///
+    /// - Parameters:
+    ///   - providers: A list of watch provider identifiers.
+    ///   - region: An ISO-3166-1 watch region code.
+    ///
+    /// - Returns: A new filter with the watch providers applied.
+    ///
+    func watchProviders(
+        _ providers: [WatchProvider.ID],
+        region: String? = nil
+    ) -> Self {
+        copy(watchProviders: providers, watchRegion: region ?? watchRegion)
+    }
+
+}
+
+extension DiscoverMovieFilter {
+
+    private func copy(
+        people: [Person.ID]? = nil,
+        originalLanguage: String? = nil,
+        genres: [Genre.ID]? = nil,
+        withoutGenres: [Genre.ID]? = nil,
+        primaryReleaseYear: PrimaryReleaseYearFilter? = nil,
+        voteAverageMin: Double? = nil,
+        voteAverageMax: Double? = nil,
+        voteCountMin: Int? = nil,
+        voteCountMax: Int? = nil,
+        companies: [Company.ID]? = nil,
+        keywords: [Keyword.ID]? = nil,
+        withoutKeywords: [Keyword.ID]? = nil,
+        runtimeMin: Int? = nil,
+        runtimeMax: Int? = nil,
+        includeAdult: Bool? = nil,
+        includeVideo: Bool? = nil,
+        watchProviders: [WatchProvider.ID]? = nil,
+        watchRegion: String? = nil,
+        genresJoin: DiscoverFilterJoin? = nil,
+        keywordsJoin: DiscoverFilterJoin? = nil
+    ) -> Self {
+        DiscoverMovieFilter(
+            people: people ?? self.people,
+            originalLanguage: originalLanguage ?? self.originalLanguage,
+            genres: genres ?? self.genres,
+            withoutGenres: withoutGenres ?? self.withoutGenres,
+            primaryReleaseYear: primaryReleaseYear ?? self.primaryReleaseYear,
+            voteAverageMin: voteAverageMin ?? self.voteAverageMin,
+            voteAverageMax: voteAverageMax ?? self.voteAverageMax,
+            voteCountMin: voteCountMin ?? self.voteCountMin,
+            voteCountMax: voteCountMax ?? self.voteCountMax,
+            companies: companies ?? self.companies,
+            keywords: keywords ?? self.keywords,
+            withoutKeywords: withoutKeywords ?? self.withoutKeywords,
+            runtimeMin: runtimeMin ?? self.runtimeMin,
+            runtimeMax: runtimeMax ?? self.runtimeMax,
+            includeAdult: includeAdult ?? self.includeAdult,
+            includeVideo: includeVideo ?? self.includeVideo,
+            watchProviders: watchProviders ?? self.watchProviders,
+            watchRegion: watchRegion ?? self.watchRegion,
+            certification: certification,
+            certificationMin: certificationMin,
+            certificationMax: certificationMax,
+            certificationCountry: certificationCountry,
+            releaseTypes: releaseTypes,
+            withCast: withCast,
+            withCrew: withCrew,
+            withOriginCountry: withOriginCountry,
+            withoutCompanies: withoutCompanies,
+            watchMonetizationTypes: watchMonetizationTypes,
+            genresJoin: genresJoin ?? self.genresJoin,
+            keywordsJoin: keywordsJoin ?? self.keywordsJoin
+        )
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverMovieFilter.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverMovieFilter.swift
@@ -10,7 +10,7 @@ import Foundation
 ///
 /// A filter for discovering movies.
 ///
-public struct DiscoverMovieFilter: Sendable {
+public struct DiscoverMovieFilter: Equatable, Hashable, Sendable {
 
     ///
     /// A list of Person identifiers who have appeared in the movie.
@@ -153,6 +153,22 @@ public struct DiscoverMovieFilter: Sendable {
     public let watchMonetizationTypes: [WatchMonetizationType]?
 
     ///
+    /// The logical operator used to join ``genres``.
+    ///
+    /// When `nil`, genres are combined using a logical AND (comma), matching
+    /// the default TMDb behaviour.
+    ///
+    public let genresJoin: DiscoverFilterJoin?
+
+    ///
+    /// The logical operator used to join ``keywords``.
+    ///
+    /// When `nil`, keywords are combined using a logical AND (comma), matching
+    /// the default TMDb behaviour.
+    ///
+    public let keywordsJoin: DiscoverFilterJoin?
+
+    ///
     /// Creates a discover movies filter.
     ///
     /// - Parameters:
@@ -186,6 +202,8 @@ public struct DiscoverMovieFilter: Sendable {
     ///   - withOriginCountry: Filter by origin country.
     ///   - withoutCompanies: Production company identifiers to exclude.
     ///   - watchMonetizationTypes: Filter by monetization type.
+    ///   - genresJoin: The logical operator used to join ``genres``.
+    ///   - keywordsJoin: The logical operator used to join ``keywords``.
     ///
     public init(
         people: [Person.ID]? = nil,
@@ -215,7 +233,9 @@ public struct DiscoverMovieFilter: Sendable {
         withCrew: [Person.ID]? = nil,
         withOriginCountry: String? = nil,
         withoutCompanies: [Company.ID]? = nil,
-        watchMonetizationTypes: [WatchMonetizationType]? = nil
+        watchMonetizationTypes: [WatchMonetizationType]? = nil,
+        genresJoin: DiscoverFilterJoin? = nil,
+        keywordsJoin: DiscoverFilterJoin? = nil
     ) {
         self.people = people
         self.originalLanguage = originalLanguage
@@ -245,6 +265,8 @@ public struct DiscoverMovieFilter: Sendable {
         self.withOriginCountry = withOriginCountry
         self.withoutCompanies = withoutCompanies
         self.watchMonetizationTypes = watchMonetizationTypes
+        self.genresJoin = genresJoin
+        self.keywordsJoin = keywordsJoin
     }
 
 }
@@ -254,7 +276,7 @@ public extension DiscoverMovieFilter {
     ///
     /// A release year filter.
     ///
-    enum PrimaryReleaseYearFilter: Equatable, Sendable {
+    enum PrimaryReleaseYearFilter: Equatable, Hashable, Sendable {
 
         ///
         /// On a specific year.

--- a/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverTVSeriesFilter+Fluent.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverTVSeriesFilter+Fluent.swift
@@ -1,0 +1,232 @@
+//
+//  DiscoverTVSeriesFilter+Fluent.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+public extension DiscoverTVSeriesFilter {
+
+    ///
+    /// Returns a copy of the filter restricted to the given genres.
+    ///
+    /// - Parameters:
+    ///   - genres: A list of genre identifiers to match.
+    ///   - join: The logical operator used to combine the genres. Defaults to
+    ///     ``DiscoverFilterJoin/and``.
+    ///
+    /// - Returns: A new filter with the genres applied.
+    ///
+    func withGenres(
+        _ genres: [Genre.ID],
+        joinedBy join: DiscoverFilterJoin = .and
+    ) -> Self {
+        copy(genres: genres, genresJoin: join)
+    }
+
+    ///
+    /// Returns a copy of the filter excluding the given genres.
+    ///
+    /// - Parameter genres: A list of genre identifiers to exclude.
+    ///
+    /// - Returns: A new filter with the excluded genres applied.
+    ///
+    func withoutGenres(_ genres: [Genre.ID]) -> Self {
+        copy(withoutGenres: genres)
+    }
+
+    ///
+    /// Returns a copy of the filter restricted to the given keywords.
+    ///
+    /// - Parameters:
+    ///   - keywords: A list of keyword identifiers to match.
+    ///   - join: The logical operator used to combine the keywords. Defaults
+    ///     to ``DiscoverFilterJoin/and``.
+    ///
+    /// - Returns: A new filter with the keywords applied.
+    ///
+    func withKeywords(
+        _ keywords: [Keyword.ID],
+        joinedBy join: DiscoverFilterJoin = .and
+    ) -> Self {
+        copy(keywords: keywords, keywordsJoin: join)
+    }
+
+    ///
+    /// Returns a copy of the filter excluding the given keywords.
+    ///
+    /// - Parameter keywords: A list of keyword identifiers to exclude.
+    ///
+    /// - Returns: A new filter with the excluded keywords applied.
+    ///
+    func withoutKeywords(_ keywords: [Keyword.ID]) -> Self {
+        copy(withoutKeywords: keywords)
+    }
+
+    ///
+    /// Returns a copy of the filter restricted to the given networks.
+    ///
+    /// - Parameter networks: A list of network identifiers.
+    ///
+    /// - Returns: A new filter with the networks applied.
+    ///
+    func withNetworks(_ networks: [Network.ID]) -> Self {
+        copy(networks: networks)
+    }
+
+    ///
+    /// Returns a copy of the filter restricted to the given companies.
+    ///
+    /// - Parameter companies: A list of production company identifiers.
+    ///
+    /// - Returns: A new filter with the companies applied.
+    ///
+    func withCompanies(_ companies: [Company.ID]) -> Self {
+        copy(companies: companies)
+    }
+
+    ///
+    /// Returns a copy of the filter restricted to the given original language.
+    ///
+    /// - Parameter language: An ISO-639-1 language code.
+    ///
+    /// - Returns: A new filter with the original language applied.
+    ///
+    func originalLanguage(_ language: String) -> Self {
+        copy(originalLanguage: language)
+    }
+
+    ///
+    /// Returns a copy of the filter restricted to the given first air date
+    /// year.
+    ///
+    /// - Parameter year: The first air date year.
+    ///
+    /// - Returns: A new filter with the first air date year applied.
+    ///
+    func firstAirDateYear(_ year: Int) -> Self {
+        copy(firstAirDateYear: year)
+    }
+
+    ///
+    /// Returns a copy of the filter restricted to the given vote average range.
+    ///
+    /// - Parameter range: The inclusive vote average range.
+    ///
+    /// - Returns: A new filter with the vote average range applied.
+    ///
+    func voteAverage(in range: ClosedRange<Double>) -> Self {
+        copy(voteAverageMin: range.lowerBound, voteAverageMax: range.upperBound)
+    }
+
+    ///
+    /// Returns a copy of the filter restricted to the given vote count range.
+    ///
+    /// - Parameter range: The inclusive vote count range.
+    ///
+    /// - Returns: A new filter with the vote count range applied.
+    ///
+    func voteCount(in range: ClosedRange<Int>) -> Self {
+        copy(voteCountMin: range.lowerBound, voteCountMax: range.upperBound)
+    }
+
+    ///
+    /// Returns a copy of the filter restricted to the given runtime range.
+    ///
+    /// - Parameter range: The inclusive runtime range, in minutes.
+    ///
+    /// - Returns: A new filter with the runtime range applied.
+    ///
+    func runtime(in range: ClosedRange<Int>) -> Self {
+        copy(runtimeMin: range.lowerBound, runtimeMax: range.upperBound)
+    }
+
+    ///
+    /// Returns a copy of the filter with the adult content preference set.
+    ///
+    /// - Parameter include: Whether to include adult content.
+    ///
+    /// - Returns: A new filter with the adult content preference applied.
+    ///
+    func includeAdult(_ include: Bool) -> Self {
+        copy(includeAdult: include)
+    }
+
+    ///
+    /// Returns a copy of the filter restricted to the given watch providers.
+    ///
+    /// - Parameters:
+    ///   - providers: A list of watch provider identifiers.
+    ///   - region: An ISO-3166-1 watch region code.
+    ///
+    /// - Returns: A new filter with the watch providers applied.
+    ///
+    func watchProviders(
+        _ providers: [WatchProvider.ID],
+        region: String? = nil
+    ) -> Self {
+        copy(watchProviders: providers, watchRegion: region ?? watchRegion)
+    }
+
+}
+
+extension DiscoverTVSeriesFilter {
+
+    private func copy(
+        originalLanguage: String? = nil,
+        genres: [Genre.ID]? = nil,
+        withoutGenres: [Genre.ID]? = nil,
+        firstAirDateYear: Int? = nil,
+        voteAverageMin: Double? = nil,
+        voteAverageMax: Double? = nil,
+        voteCountMin: Int? = nil,
+        voteCountMax: Int? = nil,
+        networks: [Network.ID]? = nil,
+        companies: [Company.ID]? = nil,
+        keywords: [Keyword.ID]? = nil,
+        withoutKeywords: [Keyword.ID]? = nil,
+        runtimeMin: Int? = nil,
+        runtimeMax: Int? = nil,
+        includeAdult: Bool? = nil,
+        watchProviders: [WatchProvider.ID]? = nil,
+        watchRegion: String? = nil,
+        genresJoin: DiscoverFilterJoin? = nil,
+        keywordsJoin: DiscoverFilterJoin? = nil
+    ) -> Self {
+        DiscoverTVSeriesFilter(
+            originalLanguage: originalLanguage ?? self.originalLanguage,
+            genres: genres ?? self.genres,
+            withoutGenres: withoutGenres ?? self.withoutGenres,
+            firstAirDateYear: firstAirDateYear ?? self.firstAirDateYear,
+            firstAirDateMin: firstAirDateMin,
+            firstAirDateMax: firstAirDateMax,
+            airDateMin: airDateMin,
+            airDateMax: airDateMax,
+            voteAverageMin: voteAverageMin ?? self.voteAverageMin,
+            voteAverageMax: voteAverageMax ?? self.voteAverageMax,
+            voteCountMin: voteCountMin ?? self.voteCountMin,
+            voteCountMax: voteCountMax ?? self.voteCountMax,
+            networks: networks ?? self.networks,
+            companies: companies ?? self.companies,
+            keywords: keywords ?? self.keywords,
+            withoutKeywords: withoutKeywords ?? self.withoutKeywords,
+            runtimeMin: runtimeMin ?? self.runtimeMin,
+            runtimeMax: runtimeMax ?? self.runtimeMax,
+            includeAdult: includeAdult ?? self.includeAdult,
+            watchProviders: watchProviders ?? self.watchProviders,
+            watchRegion: watchRegion ?? self.watchRegion,
+            withOriginCountry: withOriginCountry,
+            withStatus: withStatus,
+            withType: withType,
+            withoutCompanies: withoutCompanies,
+            watchMonetizationTypes: watchMonetizationTypes,
+            screenedTheatrically: screenedTheatrically,
+            withPeople: withPeople,
+            genresJoin: genresJoin ?? self.genresJoin,
+            keywordsJoin: keywordsJoin ?? self.keywordsJoin
+        )
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverTVSeriesFilter.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverTVSeriesFilter.swift
@@ -10,7 +10,7 @@ import Foundation
 ///
 /// A filter for discovering TV series.
 ///
-public struct DiscoverTVSeriesFilter: Sendable {
+public struct DiscoverTVSeriesFilter: Equatable, Hashable, Sendable {
 
     ///
     /// The original language of the TV series.
@@ -153,6 +153,22 @@ public struct DiscoverTVSeriesFilter: Sendable {
     public let withPeople: [Person.ID]?
 
     ///
+    /// The logical operator used to join ``genres``.
+    ///
+    /// When `nil`, genres are combined using a logical AND (comma), matching
+    /// the default TMDb behaviour.
+    ///
+    public let genresJoin: DiscoverFilterJoin?
+
+    ///
+    /// The logical operator used to join ``keywords``.
+    ///
+    /// When `nil`, keywords are combined using a logical AND (comma), matching
+    /// the default TMDb behaviour.
+    ///
+    public let keywordsJoin: DiscoverFilterJoin?
+
+    ///
     /// Creates a discover TV series filter.
     ///
     /// - Parameters:
@@ -186,6 +202,8 @@ public struct DiscoverTVSeriesFilter: Sendable {
     ///   - screenedTheatrically: Filter for theatrically screened
     ///     series.
     ///   - withPeople: A list of Person identifiers to filter by.
+    ///   - genresJoin: The logical operator used to join ``genres``.
+    ///   - keywordsJoin: The logical operator used to join ``keywords``.
     ///
     public init(
         originalLanguage: String? = nil,
@@ -215,7 +233,9 @@ public struct DiscoverTVSeriesFilter: Sendable {
         withoutCompanies: [Company.ID]? = nil,
         watchMonetizationTypes: [WatchMonetizationType]? = nil,
         screenedTheatrically: Bool? = nil,
-        withPeople: [Person.ID]? = nil
+        withPeople: [Person.ID]? = nil,
+        genresJoin: DiscoverFilterJoin? = nil,
+        keywordsJoin: DiscoverFilterJoin? = nil
     ) {
         self.originalLanguage = originalLanguage
         self.genres = genres
@@ -245,6 +265,8 @@ public struct DiscoverTVSeriesFilter: Sendable {
         self.watchMonetizationTypes = watchMonetizationTypes
         self.screenedTheatrically = screenedTheatrically
         self.withPeople = withPeople
+        self.genresJoin = genresJoin
+        self.keywordsJoin = keywordsJoin
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Discover/Requests/DiscoverMoviesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Requests/DiscoverMoviesRequest.swift
@@ -51,7 +51,8 @@ private extension APIRequestQueryItems {
         }
 
         if let genres = filter.genres {
-            self[.withGenres] = Self.idsQueryItemValue(for: genres)
+            self[.withGenres] = (filter.genresJoin ?? .and)
+                .queryValue(for: genres)
         }
 
         if let withoutGenres = filter.withoutGenres {
@@ -98,7 +99,8 @@ private extension APIRequestQueryItems {
         }
 
         if let keywords = filter.keywords {
-            self[.withKeywords] = Self.idsQueryItemValue(for: keywords)
+            self[.withKeywords] = (filter.keywordsJoin ?? .and)
+                .queryValue(for: keywords)
         }
 
         if let withoutKeywords = filter.withoutKeywords {

--- a/Sources/TMDb/Domain/Services/Discover/Requests/DiscoverTVSeriesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Requests/DiscoverTVSeriesRequest.swift
@@ -47,7 +47,8 @@ private extension APIRequestQueryItems {
         }
 
         if let genres = filter.genres {
-            self[.withGenres] = Self.idsQueryItemValue(for: genres)
+            self[.withGenres] = (filter.genresJoin ?? .and)
+                .queryValue(for: genres)
         }
 
         if let withoutGenres = filter.withoutGenres {
@@ -113,7 +114,8 @@ private extension APIRequestQueryItems {
         }
 
         if let keywords = filter.keywords {
-            self[.withKeywords] = Self.idsQueryItemValue(for: keywords)
+            self[.withKeywords] = (filter.keywordsJoin ?? .and)
+                .queryValue(for: keywords)
         }
 
         if let withoutKeywords = filter.withoutKeywords {

--- a/Sources/TMDb/TMDb.docc/HowTos/DiscoveringMoviesAndTVSeries.md
+++ b/Sources/TMDb/TMDb.docc/HowTos/DiscoveringMoviesAndTVSeries.md
@@ -51,6 +51,35 @@ let actionMovies = try await tmdbClient.discover.movies(
 )
 ```
 
+### Composing Filters Fluently
+
+Filters also expose copy-returning builder methods so they can be composed
+incrementally. Each method returns a new filter, leaving the original
+unchanged.
+
+```swift
+let filter = DiscoverMovieFilter()
+    .withGenres([28, 12])
+    .voteAverage(in: 7...10)
+    .primaryReleaseYear(.on(2024))
+```
+
+Range-typed conveniences map a `ClosedRange` onto the underlying minimum and
+maximum fields for ``DiscoverMovieFilter/voteAverage(in:)``,
+``DiscoverMovieFilter/voteCount(in:)`` and
+``DiscoverMovieFilter/runtime(in:)``.
+
+### Combining Values with AND or OR
+
+Multi-valued parameters such as genres and keywords are joined with a
+logical `AND` by default, meaning a result must match **every** value. Use
+``DiscoverFilterJoin/or`` to match **any** value instead.
+
+```swift
+// Movies tagged with genre 28 OR genre 12
+let filter = DiscoverMovieFilter().withGenres([28, 12], joinedBy: .or)
+```
+
 ## Discovering TV Series
 
 Use ``DiscoverService/tvSeries(filter:sortedBy:page:language:)`` to

--- a/Sources/TMDb/TMDb.docc/TMDb.md
+++ b/Sources/TMDb/TMDb.docc/TMDb.md
@@ -229,6 +229,7 @@ Watch providers provided by [JustWatch](https://www.justwatch.com).
 - ``TVSeries``
 - ``TVSeriesSort``
 - ``DiscoverTVSeriesFilter``
+- ``DiscoverFilterJoin``
 - ``MovieReleaseType``
 - ``TVSeriesStatus``
 - ``TVSeriesType``

--- a/Tests/TMDbIntegrationTests/DiscoverIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/DiscoverIntegrationTests.swift
@@ -42,6 +42,44 @@ struct DiscoverIntegrationTests {
         #expect(!movieList.results.isEmpty)
     }
 
+    @Test("movies with genres joined by OR")
+    func moviesWithGenresJoinedByOr() async throws {
+        let filter = DiscoverMovieFilter()
+            .withGenres([28, 12], joinedBy: .or)
+
+        let movieList = try await discoverService.movies(filter: filter)
+
+        #expect(!movieList.results.isEmpty)
+    }
+
+    @Test("movies with genres joined by AND")
+    func moviesWithGenresJoinedByAnd() async throws {
+        let filter = DiscoverMovieFilter()
+            .withGenres([28, 12], joinedBy: .and)
+
+        let movieList = try await discoverService.movies(filter: filter)
+
+        #expect(!movieList.results.isEmpty)
+    }
+
+    @Test("movies AND join is at least as restrictive as OR join")
+    func moviesAndJoinIsAtLeastAsRestrictiveAsOrJoin() async throws {
+        let orFilter = DiscoverMovieFilter()
+            .withGenres([28, 12], joinedBy: .or)
+        let andFilter = DiscoverMovieFilter()
+            .withGenres([28, 12], joinedBy: .and)
+
+        let orList = try await discoverService.movies(filter: orFilter)
+        let andList = try await discoverService.movies(filter: andFilter)
+
+        let orTotal = try #require(orList.totalResults)
+        let andTotal = try #require(andList.totalResults)
+
+        // Matching ANY of the genres can never yield fewer results than
+        // matching ALL of them.
+        #expect(orTotal >= andTotal)
+    }
+
     @Test("TV series")
     func tvSeries() async throws {
         let tvSeriesList = try await discoverService.tvSeries()
@@ -58,6 +96,44 @@ struct DiscoverIntegrationTests {
         )
 
         #expect(!tvSeriesList.results.isEmpty)
+    }
+
+    @Test("TV series with genres joined by OR")
+    func tvSeriesWithGenresJoinedByOr() async throws {
+        let filter = DiscoverTVSeriesFilter()
+            .withGenres([18, 10765], joinedBy: .or)
+
+        let tvSeriesList = try await discoverService.tvSeries(filter: filter)
+
+        #expect(!tvSeriesList.results.isEmpty)
+    }
+
+    @Test("TV series with genres joined by AND")
+    func tvSeriesWithGenresJoinedByAnd() async throws {
+        let filter = DiscoverTVSeriesFilter()
+            .withGenres([18, 10765], joinedBy: .and)
+
+        let tvSeriesList = try await discoverService.tvSeries(filter: filter)
+
+        #expect(!tvSeriesList.results.isEmpty)
+    }
+
+    @Test("TV series AND join is at least as restrictive as OR join")
+    func tvSeriesAndJoinIsAtLeastAsRestrictiveAsOrJoin() async throws {
+        let orFilter = DiscoverTVSeriesFilter()
+            .withGenres([18, 10765], joinedBy: .or)
+        let andFilter = DiscoverTVSeriesFilter()
+            .withGenres([18, 10765], joinedBy: .and)
+
+        let orList = try await discoverService.tvSeries(filter: orFilter)
+        let andList = try await discoverService.tvSeries(filter: andFilter)
+
+        let orTotal = try #require(orList.totalResults)
+        let andTotal = try #require(andList.totalResults)
+
+        // Matching ANY of the genres can never yield fewer results than
+        // matching ALL of them.
+        #expect(orTotal >= andTotal)
     }
 
 }

--- a/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverFilterJoinTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverFilterJoinTests.swift
@@ -1,0 +1,39 @@
+//
+//  DiscoverFilterJoinTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.filters, .discover))
+struct DiscoverFilterJoinTests {
+
+    @Test("and separator is comma")
+    func andSeparatorIsComma() {
+        #expect(DiscoverFilterJoin.and.separator == ",")
+    }
+
+    @Test("or separator is pipe")
+    func orSeparatorIsPipe() {
+        #expect(DiscoverFilterJoin.or.separator == "|")
+    }
+
+    @Test("and joins identifiers with comma")
+    func andJoinsIdentifiersWithComma() {
+        let value = DiscoverFilterJoin.and.queryValue(for: [1, 2, 3])
+
+        #expect(value == "1,2,3")
+    }
+
+    @Test("or joins identifiers with pipe")
+    func orJoinsIdentifiersWithPipe() {
+        let value = DiscoverFilterJoin.or.queryValue(for: [1, 2, 3])
+
+        #expect(value == "1|2|3")
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverMovieFilterFluentTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverMovieFilterFluentTests.swift
@@ -1,0 +1,119 @@
+//
+//  DiscoverMovieFilterFluentTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.filters, .discover))
+struct DiscoverMovieFilterFluentTests {
+
+    @Test("withGenres sets genres and defaults to AND join")
+    func withGenresSetsGenresAndDefaultsToAndJoin() {
+        let filter = DiscoverMovieFilter().withGenres([28, 12])
+
+        #expect(filter.genres == [28, 12])
+        #expect(filter.genresJoin == .and)
+    }
+
+    @Test("withGenres with explicit OR join sets join operator")
+    func withGenresWithExplicitOrJoinSetsJoinOperator() {
+        let filter = DiscoverMovieFilter().withGenres([28, 12], joinedBy: .or)
+
+        #expect(filter.genres == [28, 12])
+        #expect(filter.genresJoin == .or)
+    }
+
+    @Test("withoutGenres sets without genres")
+    func withoutGenresSetsWithoutGenres() {
+        let filter = DiscoverMovieFilter().withoutGenres([27, 53])
+
+        #expect(filter.withoutGenres == [27, 53])
+    }
+
+    @Test("withKeywords sets keywords and join operator")
+    func withKeywordsSetsKeywordsAndJoinOperator() {
+        let filter = DiscoverMovieFilter().withKeywords([10, 20], joinedBy: .or)
+
+        #expect(filter.keywords == [10, 20])
+        #expect(filter.keywordsJoin == .or)
+    }
+
+    @Test("withPeople sets people")
+    func withPeopleSetsPeople() {
+        let filter = DiscoverMovieFilter().withPeople([1, 2, 3])
+
+        #expect(filter.people == [1, 2, 3])
+    }
+
+    @Test("primaryReleaseYear sets release year filter")
+    func primaryReleaseYearSetsReleaseYearFilter() {
+        let filter = DiscoverMovieFilter().primaryReleaseYear(.on(2024))
+
+        #expect(filter.primaryReleaseYear == .on(2024))
+    }
+
+    @Test("voteAverage with closed range maps to min and max")
+    func voteAverageWithClosedRangeMapsToMinAndMax() {
+        let filter = DiscoverMovieFilter().voteAverage(in: 7.0 ... 10.0)
+
+        #expect(filter.voteAverageMin == 7.0)
+        #expect(filter.voteAverageMax == 10.0)
+    }
+
+    @Test("voteCount with closed range maps to min and max")
+    func voteCountWithClosedRangeMapsToMinAndMax() {
+        let filter = DiscoverMovieFilter().voteCount(in: 100 ... 1000)
+
+        #expect(filter.voteCountMin == 100)
+        #expect(filter.voteCountMax == 1000)
+    }
+
+    @Test("runtime with closed range maps to min and max")
+    func runtimeWithClosedRangeMapsToMinAndMax() {
+        let filter = DiscoverMovieFilter().runtime(in: 90 ... 180)
+
+        #expect(filter.runtimeMin == 90)
+        #expect(filter.runtimeMax == 180)
+    }
+
+    @Test("includeAdult sets include adult")
+    func includeAdultSetsIncludeAdult() {
+        let filter = DiscoverMovieFilter().includeAdult(true)
+
+        #expect(filter.includeAdult == true)
+    }
+
+    @Test("chaining composes multiple fields without mutating the base")
+    func chainingComposesMultipleFieldsWithoutMutatingTheBase() {
+        let base = DiscoverMovieFilter()
+
+        let filter = base
+            .withGenres([28, 12])
+            .voteAverage(in: 7.0 ... 10.0)
+            .primaryReleaseYear(.on(2024))
+
+        #expect(filter.genres == [28, 12])
+        #expect(filter.voteAverageMin == 7.0)
+        #expect(filter.voteAverageMax == 10.0)
+        #expect(filter.primaryReleaseYear == .on(2024))
+
+        // Base instance is unchanged (value semantics preserved).
+        #expect(base.genres == nil)
+        #expect(base.voteAverageMin == nil)
+        #expect(base.primaryReleaseYear == nil)
+    }
+
+    @Test("filters are equatable")
+    func filtersAreEquatable() {
+        let lhs = DiscoverMovieFilter().withGenres([28, 12])
+        let rhs = DiscoverMovieFilter().withGenres([28, 12])
+
+        #expect(lhs == rhs)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverMovieFilterFluentTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverMovieFilterFluentTests.swift
@@ -51,6 +51,13 @@ struct DiscoverMovieFilterFluentTests {
         #expect(filter.keywordsJoin == .or)
     }
 
+    @Test("withoutKeywords sets without keywords")
+    func withoutKeywordsSetsWithoutKeywords() {
+        let filter = DiscoverMovieFilter().withoutKeywords([11, 12])
+
+        #expect(filter.withoutKeywords == [11, 12])
+    }
+
     @Test("withCompanies sets companies")
     func withCompaniesSetsCompanies() {
         let filter = DiscoverMovieFilter().withCompanies([5, 6, 7])

--- a/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverMovieFilterFluentTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverMovieFilterFluentTests.swift
@@ -35,12 +35,50 @@ struct DiscoverMovieFilterFluentTests {
         #expect(filter.withoutGenres == [27, 53])
     }
 
+    @Test("withKeywords sets keywords and defaults to AND join")
+    func withKeywordsSetsKeywordsAndDefaultsToAndJoin() {
+        let filter = DiscoverMovieFilter().withKeywords([10, 20])
+
+        #expect(filter.keywords == [10, 20])
+        #expect(filter.keywordsJoin == .and)
+    }
+
     @Test("withKeywords sets keywords and join operator")
     func withKeywordsSetsKeywordsAndJoinOperator() {
         let filter = DiscoverMovieFilter().withKeywords([10, 20], joinedBy: .or)
 
         #expect(filter.keywords == [10, 20])
         #expect(filter.keywordsJoin == .or)
+    }
+
+    @Test("withCompanies sets companies")
+    func withCompaniesSetsCompanies() {
+        let filter = DiscoverMovieFilter().withCompanies([5, 6, 7])
+
+        #expect(filter.companies == [5, 6, 7])
+    }
+
+    @Test("originalLanguage sets original language")
+    func originalLanguageSetsOriginalLanguage() {
+        let filter = DiscoverMovieFilter().originalLanguage("en")
+
+        #expect(filter.originalLanguage == "en")
+    }
+
+    @Test("includeVideo sets include video")
+    func includeVideoSetsIncludeVideo() {
+        let filter = DiscoverMovieFilter().includeVideo(true)
+
+        #expect(filter.includeVideo == true)
+    }
+
+    @Test("watchProviders sets providers and region")
+    func watchProvidersSetsProvidersAndRegion() {
+        let filter = DiscoverMovieFilter()
+            .watchProviders([8, 9], region: "US")
+
+        #expect(filter.watchProviders == [8, 9])
+        #expect(filter.watchRegion == "US")
     }
 
     @Test("withPeople sets people")
@@ -114,6 +152,55 @@ struct DiscoverMovieFilterFluentTests {
         let rhs = DiscoverMovieFilter().withGenres([28, 12])
 
         #expect(lhs == rhs)
+    }
+
+    @Test("no-op mutation preserves every other populated field")
+    func noOpMutationPreservesEveryOtherPopulatedField() {
+        // A single no-op-style mutation: re-applying includeAdult must leave
+        // every other field untouched. This guards the ~31-parameter `copy`
+        // helper against a future field being silently dropped to nil.
+        let base = Self.fullyPopulatedFilter(includeAdult: false)
+        let mutated = base.includeAdult(true)
+        let expected = Self.fullyPopulatedFilter(includeAdult: true)
+
+        #expect(mutated == expected)
+    }
+
+    private static func fullyPopulatedFilter(
+        includeAdult: Bool
+    ) -> DiscoverMovieFilter {
+        DiscoverMovieFilter(
+            people: [1],
+            originalLanguage: "en",
+            genres: [28],
+            withoutGenres: [27],
+            primaryReleaseYear: .on(2024),
+            voteAverageMin: 7.0,
+            voteAverageMax: 9.0,
+            voteCountMin: 100,
+            voteCountMax: 1000,
+            companies: [5],
+            keywords: [10],
+            withoutKeywords: [11],
+            runtimeMin: 90,
+            runtimeMax: 180,
+            includeAdult: includeAdult,
+            includeVideo: true,
+            watchProviders: [8],
+            watchRegion: "US",
+            certification: "PG-13",
+            certificationMin: "G",
+            certificationMax: "R",
+            certificationCountry: "US",
+            releaseTypes: [.theatrical],
+            withCast: [2],
+            withCrew: [3],
+            withOriginCountry: "GB",
+            withoutCompanies: [6],
+            watchMonetizationTypes: [.flatrate],
+            genresJoin: .or,
+            keywordsJoin: .or
+        )
     }
 
 }

--- a/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverTVSeriesFilterFluentTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverTVSeriesFilterFluentTests.swift
@@ -1,0 +1,98 @@
+//
+//  DiscoverTVSeriesFilterFluentTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.filters, .discover))
+struct DiscoverTVSeriesFilterFluentTests {
+
+    @Test("withGenres sets genres and defaults to AND join")
+    func withGenresSetsGenresAndDefaultsToAndJoin() {
+        let filter = DiscoverTVSeriesFilter().withGenres([18, 10765])
+
+        #expect(filter.genres == [18, 10765])
+        #expect(filter.genresJoin == .and)
+    }
+
+    @Test("withGenres with explicit OR join sets join operator")
+    func withGenresWithExplicitOrJoinSetsJoinOperator() {
+        let filter = DiscoverTVSeriesFilter()
+            .withGenres([18, 10765], joinedBy: .or)
+
+        #expect(filter.genres == [18, 10765])
+        #expect(filter.genresJoin == .or)
+    }
+
+    @Test("withKeywords sets keywords and join operator")
+    func withKeywordsSetsKeywordsAndJoinOperator() {
+        let filter = DiscoverTVSeriesFilter()
+            .withKeywords([10, 20], joinedBy: .or)
+
+        #expect(filter.keywords == [10, 20])
+        #expect(filter.keywordsJoin == .or)
+    }
+
+    @Test("firstAirDateYear sets first air date year")
+    func firstAirDateYearSetsFirstAirDateYear() {
+        let filter = DiscoverTVSeriesFilter().firstAirDateYear(2024)
+
+        #expect(filter.firstAirDateYear == 2024)
+    }
+
+    @Test("voteAverage with closed range maps to min and max")
+    func voteAverageWithClosedRangeMapsToMinAndMax() {
+        let filter = DiscoverTVSeriesFilter().voteAverage(in: 7.0 ... 10.0)
+
+        #expect(filter.voteAverageMin == 7.0)
+        #expect(filter.voteAverageMax == 10.0)
+    }
+
+    @Test("voteCount with closed range maps to min and max")
+    func voteCountWithClosedRangeMapsToMinAndMax() {
+        let filter = DiscoverTVSeriesFilter().voteCount(in: 100 ... 1000)
+
+        #expect(filter.voteCountMin == 100)
+        #expect(filter.voteCountMax == 1000)
+    }
+
+    @Test("runtime with closed range maps to min and max")
+    func runtimeWithClosedRangeMapsToMinAndMax() {
+        let filter = DiscoverTVSeriesFilter().runtime(in: 30 ... 60)
+
+        #expect(filter.runtimeMin == 30)
+        #expect(filter.runtimeMax == 60)
+    }
+
+    @Test("chaining composes multiple fields without mutating the base")
+    func chainingComposesMultipleFieldsWithoutMutatingTheBase() {
+        let base = DiscoverTVSeriesFilter()
+
+        let filter = base
+            .withGenres([18])
+            .voteAverage(in: 8.0 ... 10.0)
+            .firstAirDateYear(2024)
+
+        #expect(filter.genres == [18])
+        #expect(filter.voteAverageMin == 8.0)
+        #expect(filter.firstAirDateYear == 2024)
+
+        #expect(base.genres == nil)
+        #expect(base.voteAverageMin == nil)
+        #expect(base.firstAirDateYear == nil)
+    }
+
+    @Test("filters are equatable")
+    func filtersAreEquatable() {
+        let lhs = DiscoverTVSeriesFilter().withGenres([18])
+        let rhs = DiscoverTVSeriesFilter().withGenres([18])
+
+        #expect(lhs == rhs)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverTVSeriesFilterFluentTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverTVSeriesFilterFluentTests.swift
@@ -38,6 +38,57 @@ struct DiscoverTVSeriesFilterFluentTests {
         #expect(filter.keywordsJoin == .or)
     }
 
+    @Test("withoutGenres sets without genres")
+    func withoutGenresSetsWithoutGenres() {
+        let filter = DiscoverTVSeriesFilter().withoutGenres([27, 53])
+
+        #expect(filter.withoutGenres == [27, 53])
+    }
+
+    @Test("withoutKeywords sets without keywords")
+    func withoutKeywordsSetsWithoutKeywords() {
+        let filter = DiscoverTVSeriesFilter().withoutKeywords([11, 12])
+
+        #expect(filter.withoutKeywords == [11, 12])
+    }
+
+    @Test("withNetworks sets networks")
+    func withNetworksSetsNetworks() {
+        let filter = DiscoverTVSeriesFilter().withNetworks([213, 49])
+
+        #expect(filter.networks == [213, 49])
+    }
+
+    @Test("withCompanies sets companies")
+    func withCompaniesSetsCompanies() {
+        let filter = DiscoverTVSeriesFilter().withCompanies([5, 6, 7])
+
+        #expect(filter.companies == [5, 6, 7])
+    }
+
+    @Test("originalLanguage sets original language")
+    func originalLanguageSetsOriginalLanguage() {
+        let filter = DiscoverTVSeriesFilter().originalLanguage("en")
+
+        #expect(filter.originalLanguage == "en")
+    }
+
+    @Test("includeAdult sets include adult")
+    func includeAdultSetsIncludeAdult() {
+        let filter = DiscoverTVSeriesFilter().includeAdult(true)
+
+        #expect(filter.includeAdult == true)
+    }
+
+    @Test("watchProviders sets providers and region")
+    func watchProvidersSetsProvidersAndRegion() {
+        let filter = DiscoverTVSeriesFilter()
+            .watchProviders([8, 9], region: "US")
+
+        #expect(filter.watchProviders == [8, 9])
+        #expect(filter.watchRegion == "US")
+    }
+
     @Test("firstAirDateYear sets first air date year")
     func firstAirDateYearSetsFirstAirDateYear() {
         let filter = DiscoverTVSeriesFilter().firstAirDateYear(2024)
@@ -93,6 +144,55 @@ struct DiscoverTVSeriesFilterFluentTests {
         let rhs = DiscoverTVSeriesFilter().withGenres([18])
 
         #expect(lhs == rhs)
+    }
+
+    @Test("no-op mutation preserves every other populated field")
+    func noOpMutationPreservesEveryOtherPopulatedField() {
+        // A single no-op-style mutation: re-applying includeAdult must leave
+        // every other field untouched. This guards the ~31-parameter `copy`
+        // helper against a future field being silently dropped to nil.
+        let base = Self.fullyPopulatedFilter(includeAdult: false)
+        let mutated = base.includeAdult(true)
+        let expected = Self.fullyPopulatedFilter(includeAdult: true)
+
+        #expect(mutated == expected)
+    }
+
+    private static func fullyPopulatedFilter(
+        includeAdult: Bool
+    ) -> DiscoverTVSeriesFilter {
+        DiscoverTVSeriesFilter(
+            originalLanguage: "en",
+            genres: [18],
+            withoutGenres: [27],
+            firstAirDateYear: 2024,
+            firstAirDateMin: Date(timeIntervalSince1970: 1_000_000),
+            firstAirDateMax: Date(timeIntervalSince1970: 2_000_000),
+            airDateMin: Date(timeIntervalSince1970: 3_000_000),
+            airDateMax: Date(timeIntervalSince1970: 4_000_000),
+            voteAverageMin: 7.0,
+            voteAverageMax: 9.0,
+            voteCountMin: 100,
+            voteCountMax: 1000,
+            networks: [213],
+            companies: [5],
+            keywords: [10],
+            withoutKeywords: [11],
+            runtimeMin: 30,
+            runtimeMax: 60,
+            includeAdult: includeAdult,
+            watchProviders: [8],
+            watchRegion: "US",
+            withOriginCountry: "GB",
+            withStatus: [.returning],
+            withType: [.scripted],
+            withoutCompanies: [6],
+            watchMonetizationTypes: [.flatrate],
+            screenedTheatrically: true,
+            withPeople: [2],
+            genresJoin: .or,
+            keywordsJoin: .or
+        )
     }
 
 }

--- a/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverTVSeriesFilterFluentTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverTVSeriesFilterFluentTests.swift
@@ -29,6 +29,14 @@ struct DiscoverTVSeriesFilterFluentTests {
         #expect(filter.genresJoin == .or)
     }
 
+    @Test("withKeywords sets keywords and defaults to AND join")
+    func withKeywordsSetsKeywordsAndDefaultsToAndJoin() {
+        let filter = DiscoverTVSeriesFilter().withKeywords([10, 20])
+
+        #expect(filter.keywords == [10, 20])
+        #expect(filter.keywordsJoin == .and)
+    }
+
     @Test("withKeywords sets keywords and join operator")
     func withKeywordsSetsKeywordsAndJoinOperator() {
         let filter = DiscoverTVSeriesFilter()

--- a/Tests/TMDbTests/Domain/Services/Discover/Requests/DiscoverMoviesRequestJoinTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Requests/DiscoverMoviesRequestJoinTests.swift
@@ -1,0 +1,58 @@
+//
+//  DiscoverMoviesRequestJoinTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.requests, .discover))
+struct DiscoverMoviesRequestJoinTests {
+
+    @Test("genres with AND join produces comma-separated value")
+    func genresWithAndJoinProducesCommaSeparatedValue() {
+        let filter = DiscoverMovieFilter().withGenres([28, 12], joinedBy: .and)
+        let request = DiscoverMoviesRequest(filter: filter)
+
+        #expect(request.queryItems == ["with_genres": "28,12"])
+    }
+
+    @Test("genres with OR join produces pipe-separated value")
+    func genresWithOrJoinProducesPipeSeparatedValue() {
+        let filter = DiscoverMovieFilter().withGenres([28, 12], joinedBy: .or)
+        let request = DiscoverMoviesRequest(filter: filter)
+
+        #expect(request.queryItems == ["with_genres": "28|12"])
+    }
+
+    @Test("keywords with OR join produces pipe-separated value")
+    func keywordsWithOrJoinProducesPipeSeparatedValue() {
+        let filter = DiscoverMovieFilter()
+            .withKeywords([10, 20], joinedBy: .or)
+        let request = DiscoverMoviesRequest(filter: filter)
+
+        #expect(request.queryItems == ["with_keywords": "10|20"])
+    }
+
+    @Test("memberwise init genres still produce comma-separated value")
+    func memberwiseInitGenresStillProduceCommaSeparatedValue() {
+        let filter = DiscoverMovieFilter(genres: [28, 12])
+        let request = DiscoverMoviesRequest(filter: filter)
+
+        // Regression: existing memberwise-init path defaults to AND (comma)
+        // exactly as before the fluent layer was added.
+        #expect(request.queryItems == ["with_genres": "28,12"])
+    }
+
+    @Test("memberwise init keywords still produce comma-separated value")
+    func memberwiseInitKeywordsStillProduceCommaSeparatedValue() {
+        let filter = DiscoverMovieFilter(keywords: [10, 20])
+        let request = DiscoverMoviesRequest(filter: filter)
+
+        #expect(request.queryItems == ["with_keywords": "10,20"])
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Discover/Requests/DiscoverMoviesRequestJoinTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Requests/DiscoverMoviesRequestJoinTests.swift
@@ -37,6 +37,15 @@ struct DiscoverMoviesRequestJoinTests {
         #expect(request.queryItems == ["with_keywords": "10|20"])
     }
 
+    @Test("keywords with explicit AND join via fluent API produces comma-separated value")
+    func keywordsWithExplicitAndJoinViaFluentAPIProducesCommaSeparatedValue() {
+        let filter = DiscoverMovieFilter()
+            .withKeywords([10, 20], joinedBy: .and)
+        let request = DiscoverMoviesRequest(filter: filter)
+
+        #expect(request.queryItems == ["with_keywords": "10,20"])
+    }
+
     @Test("memberwise init genres still produce comma-separated value")
     func memberwiseInitGenresStillProduceCommaSeparatedValue() {
         let filter = DiscoverMovieFilter(genres: [28, 12])

--- a/Tests/TMDbTests/Domain/Services/Discover/Requests/DiscoverTVSeriesRequestJoinTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Requests/DiscoverTVSeriesRequestJoinTests.swift
@@ -1,0 +1,58 @@
+//
+//  DiscoverTVSeriesRequestJoinTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.requests, .discover))
+struct DiscoverTVSeriesRequestJoinTests {
+
+    @Test("genres with AND join produces comma-separated value")
+    func genresWithAndJoinProducesCommaSeparatedValue() {
+        let filter = DiscoverTVSeriesFilter()
+            .withGenres([18, 10765], joinedBy: .and)
+        let request = DiscoverTVSeriesRequest(filter: filter)
+
+        #expect(request.queryItems == ["with_genres": "18,10765"])
+    }
+
+    @Test("genres with OR join produces pipe-separated value")
+    func genresWithOrJoinProducesPipeSeparatedValue() {
+        let filter = DiscoverTVSeriesFilter()
+            .withGenres([18, 10765], joinedBy: .or)
+        let request = DiscoverTVSeriesRequest(filter: filter)
+
+        #expect(request.queryItems == ["with_genres": "18|10765"])
+    }
+
+    @Test("keywords with OR join produces pipe-separated value")
+    func keywordsWithOrJoinProducesPipeSeparatedValue() {
+        let filter = DiscoverTVSeriesFilter()
+            .withKeywords([10, 20], joinedBy: .or)
+        let request = DiscoverTVSeriesRequest(filter: filter)
+
+        #expect(request.queryItems == ["with_keywords": "10|20"])
+    }
+
+    @Test("memberwise init genres still produce comma-separated value")
+    func memberwiseInitGenresStillProduceCommaSeparatedValue() {
+        let filter = DiscoverTVSeriesFilter(genres: [18, 10765])
+        let request = DiscoverTVSeriesRequest(filter: filter)
+
+        #expect(request.queryItems == ["with_genres": "18,10765"])
+    }
+
+    @Test("memberwise init keywords still produce comma-separated value")
+    func memberwiseInitKeywordsStillProduceCommaSeparatedValue() {
+        let filter = DiscoverTVSeriesFilter(keywords: [10, 20])
+        let request = DiscoverTVSeriesRequest(filter: filter)
+
+        #expect(request.queryItems == ["with_keywords": "10,20"])
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Discover/Requests/DiscoverTVSeriesRequestJoinTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Requests/DiscoverTVSeriesRequestJoinTests.swift
@@ -39,6 +39,15 @@ struct DiscoverTVSeriesRequestJoinTests {
         #expect(request.queryItems == ["with_keywords": "10|20"])
     }
 
+    @Test("keywords with explicit AND join via fluent API produces comma-separated value")
+    func keywordsWithExplicitAndJoinViaFluentAPIProducesCommaSeparatedValue() {
+        let filter = DiscoverTVSeriesFilter()
+            .withKeywords([10, 20], joinedBy: .and)
+        let request = DiscoverTVSeriesRequest(filter: filter)
+
+        #expect(request.queryItems == ["with_keywords": "10,20"])
+    }
+
     @Test("memberwise init genres still produce comma-separated value")
     func memberwiseInitGenresStillProduceCommaSeparatedValue() {
         let filter = DiscoverTVSeriesFilter(genres: [18, 10765])


### PR DESCRIPTION
## Summary

Adds a fluent/composable layer over the existing Discover filters, plus `ClosedRange` conveniences and caller-controlled AND/OR joins for genres/keywords. **Non-breaking** — existing memberwise initialisers and query output are unchanged. Concept inspired by `brettohland/swift-tmdb` (clean-room reimplemented).

## Changes

**New (`Sources/TMDb/Domain/Services/Discover/Filters/`):**
- ✨ `DiscoverFilterJoin` (`.and` → ",", `.or` → "|") — exposes TMDb's AND/OR join semantics for `with_genres` / `with_keywords`.
- ✨ Fluent builders on `DiscoverMovieFilter` / `DiscoverTVSeriesFilter` (`withGenres(_:joinedBy:)`, `voteAverage(in:)`, `primaryReleaseYear(_:)`, …) returning modified copies (value semantics preserved).
- ✨ `ClosedRange` conveniences for voteAverage / voteCount / runtime.

**Changed:** filters gain `Equatable, Hashable` + two `nil`-defaulted join properties (appended — no call site breaks); request mapping honours the join (`?? .and`, identical to prior comma output).

**Docs:** `TMDb.docc/TMDb.md`, `DiscoveringMoviesAndTVSeries.md`, README (also corrected a stale example).

## Tests

- ✅ Each builder method, chaining/value-semantics, range mapping, AND→"," vs OR→"|" asserted against produced query items, a **memberwise-init regression** locking the prior output, and a **full-field `copy()` drift-guard** for both filters.

## Review & verification

- 🔎 Two adversarial reviews found **no correctness/back-compat bugs**; AND/OR semantics verified against the live TMDb API (comma = AND). Added the drift-guard + missing per-method tests per feedback.
- **Deferred (intentional):** fluent setters cover common fields, not every struct field (full control remains via the memberwise init).
- ✅ `make lint` + `make build-docs` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)