### PR TITLE
🔧 Track project Claude Code and MCP config

### DIFF
--- a/.claude/hooks.json
+++ b/.claude/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hook_events": [
+    {
+      "event": "PreToolUse",
+      "matcher": "Bash\\(git commit.*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "make lint"
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "allow": []
+  },
+  "outputStyle": "default",
+  "enabledPlugins": {
+    "swift-testing-expert@swift-testing-agent-skill": true,
+    "swift-concurrency@swift-concurrency-agent-skill": true
+  },
+  "extraKnownMarketplaces": {
+    "swift-concurrency-agent-skill": {
+      "source": {
+        "source": "github",
+        "repo": "AvdLee/Swift-Concurrency-Agent-Skill"
+      }
+    },
+    "swift-testing-agent-skill": {
+      "source": {
+        "source": "github",
+        "repo": "AvdLee/Swift-Testing-Agent-Skill"
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -13,11 +13,8 @@ default.profraw
 junit-swift-testing.xml
 
 # Claude
-.claude/settings.json
 .claude/settings.local.json
-.claude/hooks.json
 .claude/scheduled_tasks.lock
-.mcp.json
 
 # Git worktrees
 .worktrees/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,26 @@
+{
+  "mcpServers": {
+    "xcode": {
+      "type": "stdio",
+      "command": "xcrun",
+      "args": [
+        "mcpbridge"
+      ],
+      "env": {}
+    },
+    "tmdb": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@adamayoung/mcp-server-tmdb"
+      ],
+      "env": {
+        "TMDB_API_KEY": "${TMDB_API_KEY}"
+      }
+    },
+    "sosumi": {
+      "type": "http",
+      "url": "https://sosumi.ai/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Re-adds the project-level Claude Code / MCP configuration that was intended to be committed, reverting the over-eager removal in #309.

## Changes

- 🔧 Track `.mcp.json` (MCP server definitions — env-var placeholders only, no secrets), `.claude/settings.json` (enabled plugins + marketplaces), and `.claude/hooks.json`.
- 🔧 Remove their `.gitignore` entries.

`.claude/settings.local.json` (API key / credentials env block) remains gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)