### PR TITLE
👷 Pin SwiftLint and SwiftFormat versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,10 @@ jobs:
       }}
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.5.app/Contents/Developer
+      # Pin lint tool versions so CI matches local `make lint` exactly and does
+      # not drift when Homebrew publishes a new release.
+      SWIFTLINT_VERSION: 0.63.2
+      SWIFTFORMAT_VERSION: 0.61.1
     steps:
       - name: No changes detected
         if: needs.changes.outputs.swift != 'true' && github.event_name != 'workflow_dispatch'
@@ -71,7 +75,21 @@ jobs:
 
       - name: Install SwiftLint and SwiftFormat
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
-        run: brew install swiftlint swiftformat
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/lint-bin"
+
+          curl -fsSL "https://github.com/realm/SwiftLint/releases/download/${SWIFTLINT_VERSION}/portable_swiftlint.zip" -o "${RUNNER_TEMP}/swiftlint.zip"
+          unzip -oq "${RUNNER_TEMP}/swiftlint.zip" -d "${RUNNER_TEMP}/swiftlint"
+          install "$(find "${RUNNER_TEMP}/swiftlint" -name swiftlint -type f | head -1)" "${RUNNER_TEMP}/lint-bin/swiftlint"
+
+          curl -fsSL "https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat.zip" -o "${RUNNER_TEMP}/swiftformat.zip"
+          unzip -oq "${RUNNER_TEMP}/swiftformat.zip" -d "${RUNNER_TEMP}/swiftformat"
+          install "$(find "${RUNNER_TEMP}/swiftformat" -name swiftformat -type f | head -1)" "${RUNNER_TEMP}/lint-bin/swiftformat"
+
+          echo "${RUNNER_TEMP}/lint-bin" >> "${GITHUB_PATH}"
+          "${RUNNER_TEMP}/lint-bin/swiftlint" version
+          "${RUNNER_TEMP}/lint-bin/swiftformat" --version
 
       - name: SwiftLint
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary

The CI lint job installed SwiftLint and SwiftFormat with an unpinned
`brew install swiftlint swiftformat`, so a new Homebrew release could
silently change linting behaviour in CI and diverge from a local
`make lint`. SwiftLint **0.63.3**, for instance, stopped treating
`URL(string:)!` as a `force_unwrapping` violation, which turns the
existing `// swiftlint:disable[:next] force_unwrapping` directives into
`superfluous_disable_command` errors under `--strict`.

This pins the tools to fixed versions installed from their official
GitHub release artifacts, so CI is deterministic and matches a pinned
local toolchain.

## Changes

**CI:**
- 👷 Install **SwiftLint 0.63.2** (`portable_swiftlint.zip`) and
  **SwiftFormat 0.61.1** (`swiftformat.zip`) from GitHub Releases
  instead of unpinned `brew install`.
- 👷 Surface the pinned versions as `SWIFTLINT_VERSION` /
  `SWIFTFORMAT_VERSION` job-level env vars for easy future bumps.

## Benefits

- **Deterministic CI**: lint results no longer change underneath the
  repo when Homebrew ships a new SwiftLint/SwiftFormat.
- **Local ↔ CI parity**: contributors can pin the same versions
  locally and trust that `make lint` matches CI.

## Notes

- Pinning to 0.63.2 intentionally preserves the current
  `// swiftlint:disable force_unwrapping` directives. The alternative
  is to bump to 0.63.3 and delete the now-superfluous directives — a
  separate change if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)