### PR TITLE
🔧 Use xcode-tools MCP (native) instead of mcp__xcode__ in Xcode

### DIFF
--- a/.claude/skills/build-for-testing/SKILL.md
+++ b/.claude/skills/build-for-testing/SKILL.md
@@ -5,8 +5,13 @@ description: Build the project for testing
 
 # Build for testing
 
+Use the `xcode-tools` MCP server when running inside Xcode, otherwise fall back to Make.
+
+## xcode-tools (preferred inside Xcode)
+
+1. Run `mcp__xcode-tools__BuildProject` with `buildForTesting: true` to build the package and all test targets.
+2. If the build fails, run `mcp__xcode-tools__GetBuildLog` with `severity: "error"` to see errors.
+
+## Fallback
+
 Run `make build-tests` from the project root.
-
-This differs from `/build` (`make build`) in that it also compiles all test targets, ensuring they build cleanly before running tests. Both use warnings-as-errors.
-
-If the build fails, review the output for error details.

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -5,13 +5,12 @@ description: Build the project
 
 # Build project
 
-Use the Xcode MCP if available, otherwise fall back to Make.
+Use the `xcode-tools` MCP server when running inside Xcode, otherwise fall back to Make.
 
-## Xcode MCP (preferred)
+## xcode-tools (preferred inside Xcode)
 
-1. Run `mcp__xcode__XcodeListWindows` to get the `tabIdentifier` for the TMDb package.
-2. Run `mcp__xcode__BuildProject` with the `tabIdentifier`.
-3. If the build fails, run `mcp__xcode__GetBuildLog` with `severity: "error"` to see errors.
+1. Run `mcp__xcode-tools__BuildProject` to build.
+2. If the build fails, run `mcp__xcode-tools__GetBuildLog` with `severity: "error"` to see errors.
 
 ## Fallback
 

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -5,13 +5,12 @@ description: Run all unit tests
 
 # Run tests
 
-Use the Xcode MCP if available, otherwise fall back to Make.
+Use the `xcode-tools` MCP server when running inside Xcode, otherwise fall back to Make.
 
-## Xcode MCP (preferred)
+## xcode-tools (preferred inside Xcode)
 
-1. Run `mcp__xcode__XcodeListWindows` to get the `tabIdentifier` for the TMDb package.
-2. Run `mcp__xcode__RunAllTests` with the `tabIdentifier` and the **TMDb** test plan.
-3. If tests fail, review the output for failure details. Use `mcp__xcode__GetBuildLog` with `severity: "error"` if build errors caused the failure.
+1. Run `mcp__xcode-tools__RunAllTests` with the **TMDb** test plan.
+2. If tests fail, review the output for failure details. Use `mcp__xcode-tools__GetBuildLog` with `severity: "error"` if build errors caused the failure.
 
 ## Fallback
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,21 +118,27 @@ for:
 
 ## Build and Test Tooling
 
-### When Xcode MCP is Available
+### When Running Inside Xcode (via Claude Agent)
 
-**ALWAYS prefer Xcode MCP tools** (`mcp__xcode__*`) when available:
+Use **`xcode-tools` MCP server tools** — the native Xcode–Claude Agent
+integration. Do **NOT** use `mcp__xcode__*` tools; those are a separate
+server and are redundant here.
 
-- `mcp__xcode__BuildProject` for building
-- `mcp__xcode__RunAllTests` for running tests
-- `mcp__xcode__XcodeRead`, `mcp__xcode__XcodeWrite`,
-  `mcp__xcode__XcodeUpdate` for file operations
+- `mcp__xcode-tools__BuildProject` for building
+- `mcp__xcode-tools__RunAllTests` / `mcp__xcode-tools__RunSomeTests` for tests
+- `mcp__xcode-tools__XcodeRead`, `mcp__xcode-tools__XcodeWrite`,
+  `mcp__xcode-tools__XcodeUpdate` for file operations
+- `mcp__xcode-tools__XcodeGrep`, `mcp__xcode-tools__XcodeGlob`,
+  `mcp__xcode-tools__XcodeLS` for searching
+- `mcp__xcode-tools__XcodeRefreshCodeIssuesInFile` for fast diagnostics
+- `mcp__xcode-tools__RunCodeSnippet` for lightweight code evaluation
 
 **Test Plan Selection:**
 
 - **Unit tests**: Use the **TMDb** test plan (default)
 - **Integration tests**: Use the **Integration** test plan
 
-### When Xcode MCP is Not Available
+### When Not Running Inside Xcode
 
 Fall back to `make` commands:
 


### PR DESCRIPTION
## Summary

Switches Claude Agent in Xcode from the redundant `mcp__xcode__*` MCP server to the native `xcode-tools` MCP server, which is the standard Xcode–Claude Agent integration. Also fixes a stale workflow step that referenced `XcodeListWindows`, a tool that no longer exists in either server.

## Changes

**`CLAUDE.md`:**
- Replaces "When Xcode MCP is Available" section with explicit guidance to use `mcp__xcode-tools__*` tools
- Adds a `DO NOT use mcp__xcode__*` directive to prevent the redundant server being picked up
- Expands the tool list to include search, diagnostics, and code evaluation tools

**Skills:**
- ♻️ `build/SKILL.md` — migrates to `mcp__xcode-tools__BuildProject`, removes stale `XcodeListWindows` step
- ♻️ `test/SKILL.md` — migrates to `mcp__xcode-tools__RunAllTests`, removes stale `XcodeListWindows` step
- ♻️ `build-for-testing/SKILL.md` — adds xcode-tools path (was make-only before); uses `buildForTesting: true` to compile all test targets

## Benefits

- **Correct tooling**: Uses the native Xcode integration rather than a separate redundant server
- **Terminal compatibility**: `make` fallbacks preserved for Claude Code in the terminal
- **Removes broken step**: `XcodeListWindows` no longer exists; old skills were referencing a dead tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)