### PR TITLE
✨ Add TMDbToolbox: FoundationModels tools for a conversational movie assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
   Apple's Natural Language framework on every Apple platform, with
   Foundation Models handling fuzzier prompts on devices with Apple
   Intelligence
+* **Language Model Tools**: Drop-in Foundation Models `Tool`s for a
+  conversational movie assistant — add them to a `LanguageModelSession`
+  and the model searches, fetches details, and finds streaming
+  availability on its own (iOS/macOS/visionOS 26, watchOS 27)
 * **Modern Swift**: Async/await throughout, strongly-typed models,
   protocol-based architecture
 
@@ -76,6 +80,7 @@ A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
 | **tvEpisodeGroups** | TV episode group details and episode organization |
 | **guestSessions** | Guest session rated movies, TV series, and episodes |
 | **naturalLanguageSearch** | On-device natural-language search (all Apple platforms; enhanced by Foundation Models with Apple Intelligence) |
+| **languageModelTools** | Foundation Models tools for a `LanguageModelSession` movie assistant (iOS/macOS/visionOS 26, watchOS 27) |
 
 See the [full API documentation](https://adamayoung.github.io/TMDb/documentation/tmdb/)
 for detailed usage.

--- a/Sources/TMDb/Domain/LanguageModelTools/TMDbClient+LanguageModelTools.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/TMDbClient+LanguageModelTools.swift
@@ -1,0 +1,95 @@
+//
+//  TMDbClient+LanguageModelTools.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && !os(tvOS)
+    import FoundationModels
+
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
+    public extension TMDbClient {
+
+        ///
+        /// FoundationModels `Tool`s that expose TMDb to a `LanguageModelSession`,
+        /// for building a conversational movie assistant.
+        ///
+        /// ```swift
+        /// let session = LanguageModelSession(tools: tmdbClient.languageModelTools)
+        /// let reply = try await session.respond(to: "What's trending this week?")
+        /// ```
+        ///
+        /// Each tool returns compact text whose every line leads with the relevant
+        /// TMDb `id`, so the model can chain calls — searching for a title, then
+        /// fetching its details or watch providers.
+        ///
+        /// - Note: This is a shorthand for `TMDbToolbox(client:).all`. To pass a
+        ///   smaller, task-relevant subset of tools, combine the individual tool
+        ///   properties below — for example
+        ///   `[searchTool, watchProvidersTool]`. To apply a default language or
+        ///   region, construct a ``TMDbToolbox`` directly. Each access builds a new
+        ///   toolbox, so store the result in a local rather than accessing it twice.
+        ///
+        var languageModelTools: [any Tool] {
+            TMDbToolbox(client: self).all
+        }
+
+        ///
+        /// A FoundationModels tool that searches TMDb for movies, TV series, and
+        /// people by name.
+        ///
+        var searchTool: any Tool {
+            TMDbToolbox(client: self).search
+        }
+
+        ///
+        /// A FoundationModels tool that fetches full details for a movie by its
+        /// TMDb id.
+        ///
+        var movieDetailsTool: any Tool {
+            TMDbToolbox(client: self).movieDetails
+        }
+
+        ///
+        /// A FoundationModels tool that fetches full details for a TV series by its
+        /// TMDb id.
+        ///
+        var tvSeriesDetailsTool: any Tool {
+            TMDbToolbox(client: self).tvSeriesDetails
+        }
+
+        ///
+        /// A FoundationModels tool that fetches a person's profile and notable
+        /// credits by their TMDb id.
+        ///
+        var personFilmographyTool: any Tool {
+            TMDbToolbox(client: self).personFilmography
+        }
+
+        ///
+        /// A FoundationModels tool that lists currently trending movies, TV series,
+        /// or people.
+        ///
+        var trendingTool: any Tool {
+            TMDbToolbox(client: self).trending
+        }
+
+        ///
+        /// A FoundationModels tool that finds where a movie or TV series can be
+        /// streamed, rented, or bought.
+        ///
+        var watchProvidersTool: any Tool {
+            TMDbToolbox(client: self).watchProviders
+        }
+
+        ///
+        /// A FoundationModels tool that browses movies by genre, year, rating, and
+        /// streaming provider.
+        ///
+        var discoverMoviesTool: any Tool {
+            TMDbToolbox(client: self).discoverMovies
+        }
+
+    }
+#endif

--- a/Sources/TMDb/Domain/LanguageModelTools/TMDbToolbox.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/TMDbToolbox.swift
@@ -1,0 +1,168 @@
+//
+//  TMDbToolbox.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && !os(tvOS)
+    import Foundation
+    import FoundationModels
+
+    ///
+    /// A collection of FoundationModels `Tool`s that expose TMDb to a
+    /// `LanguageModelSession`, for building a conversational movie assistant.
+    ///
+    /// Pass ``all`` to a session to make every tool available, or compose a smaller,
+    /// task-relevant subset from the individual accessors — Apple recommends keeping
+    /// to three to five tools per request:
+    ///
+    /// ```swift
+    /// let toolbox = TMDbToolbox(client: tmdbClient, region: "GB")
+    /// let session = LanguageModelSession(tools: toolbox.all)
+    /// let reply = try await session.respond(to: "What's a good thriller on Netflix UK?")
+    /// ```
+    ///
+    /// Each tool returns compact text whose every line leads with the relevant TMDb
+    /// `id`, so the model can chain calls — searching for a title, then fetching its
+    /// details or watch providers.
+    ///
+    /// - Note: ``TMDbClient/languageModelTools`` is a shorthand for
+    ///   `TMDbToolbox(client:).all`.
+    ///
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
+    public struct TMDbToolbox: Sendable {
+
+        private let movieService: any MovieService
+        private let tvSeriesService: any TVSeriesService
+        private let personService: any PersonService
+        private let searchService: any SearchService
+        private let trendingService: any TrendingService
+        private let discoverService: any DiscoverService
+        private let watchProviderService: any WatchProviderService
+        private let language: String?
+        private let region: String?
+
+        ///
+        /// Creates a toolbox backed by a TMDb client.
+        ///
+        /// - Parameters:
+        ///   - client: The TMDb client whose services the tools call.
+        ///   - language: An optional ISO 639-1 language code applied to every tool's
+        ///     results. Defaults to the client's configured language when `nil`.
+        ///   - region: An optional ISO-3166-1 country code used for watch-provider
+        ///     and streaming-availability lookups. Defaults to `US` when `nil`.
+        ///
+        public init(client: TMDbClient, language: String? = nil, region: String? = nil) {
+            self.init(
+                movieService: client.movies,
+                tvSeriesService: client.tvSeries,
+                personService: client.people,
+                searchService: client.search,
+                trendingService: client.trending,
+                discoverService: client.discover,
+                watchProviderService: client.watchProviders,
+                language: language,
+                region: region
+            )
+        }
+
+        init(
+            movieService: any MovieService,
+            tvSeriesService: any TVSeriesService,
+            personService: any PersonService,
+            searchService: any SearchService,
+            trendingService: any TrendingService,
+            discoverService: any DiscoverService,
+            watchProviderService: any WatchProviderService,
+            language: String?,
+            region: String?
+        ) {
+            self.movieService = movieService
+            self.tvSeriesService = tvSeriesService
+            self.personService = personService
+            self.searchService = searchService
+            self.trendingService = trendingService
+            self.discoverService = discoverService
+            self.watchProviderService = watchProviderService
+            self.language = language
+            self.region = region
+        }
+
+        ///
+        /// Every tool in the toolbox, ready to pass to a `LanguageModelSession`.
+        ///
+        public var all: [any Tool] {
+            [
+                search,
+                movieDetails,
+                tvSeriesDetails,
+                personFilmography,
+                trending,
+                watchProviders,
+                discoverMovies
+            ]
+        }
+
+        ///
+        /// A tool that searches TMDb for movies, TV series, and people by name.
+        ///
+        public var search: any Tool {
+            SearchTMDbTool(searchService: searchService, language: language)
+        }
+
+        ///
+        /// A tool that fetches full details for a movie by its TMDb id.
+        ///
+        public var movieDetails: any Tool {
+            MovieDetailsTool(movieService: movieService, language: language)
+        }
+
+        ///
+        /// A tool that fetches full details for a TV series by its TMDb id.
+        ///
+        public var tvSeriesDetails: any Tool {
+            TVSeriesDetailsTool(tvSeriesService: tvSeriesService, language: language)
+        }
+
+        ///
+        /// A tool that fetches a person's profile and notable credits by their TMDb
+        /// id.
+        ///
+        public var personFilmography: any Tool {
+            PersonFilmographyTool(personService: personService, language: language)
+        }
+
+        ///
+        /// A tool that lists currently trending movies, TV series, or people.
+        ///
+        public var trending: any Tool {
+            TrendingTool(trendingService: trendingService, language: language)
+        }
+
+        ///
+        /// A tool that finds where a movie or TV series can be streamed, rented, or
+        /// bought.
+        ///
+        public var watchProviders: any Tool {
+            WatchProvidersTool(
+                movieService: movieService,
+                tvSeriesService: tvSeriesService,
+                region: region
+            )
+        }
+
+        ///
+        /// A tool that browses movies by genre, year, rating, and streaming provider.
+        ///
+        public var discoverMovies: any Tool {
+            DiscoverMoviesTool(
+                discoverService: discoverService,
+                watchProviderService: watchProviderService,
+                language: language,
+                region: region
+            )
+        }
+
+    }
+#endif

--- a/Sources/TMDb/Domain/LanguageModelTools/TMDbToolbox.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/TMDbToolbox.swift
@@ -92,6 +92,9 @@
         ///
         /// Every tool in the toolbox, ready to pass to a `LanguageModelSession`.
         ///
+        /// Each access builds a new set of tool instances; store the result in a
+        /// local if you need it more than once.
+        ///
         public var all: [any Tool] {
             [
                 search,

--- a/Sources/TMDb/Domain/LanguageModelTools/ToolArgumentEnums.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/ToolArgumentEnums.swift
@@ -1,0 +1,142 @@
+//
+//  ToolArgumentEnums.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && !os(tvOS)
+    import Foundation
+    import FoundationModels
+
+    ///
+    /// A media type a language model can request when searching.
+    ///
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
+    @Generable
+    enum SearchMediaType {
+        /// A movie.
+        case movie
+        /// A TV series.
+        case tvSeries
+        /// A person.
+        case person
+    }
+
+    ///
+    /// A media type a language model can request when fetching trending items.
+    ///
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
+    @Generable
+    enum TrendingMediaType {
+        /// Trending movies.
+        case movie
+        /// Trending TV series.
+        case tvSeries
+        /// Trending people.
+        case person
+    }
+
+    ///
+    /// The time window for a trending request.
+    ///
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
+    @Generable
+    enum TrendingWindow {
+        /// The trending items over the last day.
+        case day
+        /// The trending items over the last week.
+        case week
+
+        /// The matching domain time-window filter.
+        var filterType: TrendingTimeWindowFilterType {
+            switch self {
+            case .day: .day
+            case .week: .week
+            }
+        }
+    }
+
+    ///
+    /// A media type a language model can request when fetching watch providers.
+    ///
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
+    @Generable
+    enum WatchMediaType {
+        /// A movie.
+        case movie
+        /// A TV series.
+        case tvSeries
+    }
+
+    ///
+    /// A movie genre a language model can filter by when discovering movies.
+    ///
+    /// Each case maps to its stable TMDb genre identifier, so no network lookup is
+    /// needed to resolve a genre name.
+    ///
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
+    @Generable
+    enum MovieGenre {
+        /// Action.
+        case action
+        /// Adventure.
+        case adventure
+        /// Animation.
+        case animation
+        /// Comedy.
+        case comedy
+        /// Crime.
+        case crime
+        /// Documentary.
+        case documentary
+        /// Drama.
+        case drama
+        /// Family.
+        case family
+        /// Fantasy.
+        case fantasy
+        /// History.
+        case history
+        /// Horror.
+        case horror
+        /// Music.
+        case music
+        /// Mystery.
+        case mystery
+        /// Romance.
+        case romance
+        /// Science fiction.
+        case scienceFiction
+        /// Thriller.
+        case thriller
+        /// War.
+        case war
+        /// Western.
+        case western
+
+        /// The stable TMDb genre identifier for this genre.
+        var genreID: Genre.ID {
+            switch self {
+            case .action: 28
+            case .adventure: 12
+            case .animation: 16
+            case .comedy: 35
+            case .crime: 80
+            case .documentary: 99
+            case .drama: 18
+            case .family: 10751
+            case .fantasy: 14
+            case .history: 36
+            case .horror: 27
+            case .music: 10402
+            case .mystery: 9648
+            case .romance: 10749
+            case .scienceFiction: 878
+            case .thriller: 53
+            case .war: 10752
+            case .western: 37
+            }
+        }
+    }
+#endif

--- a/Sources/TMDb/Domain/LanguageModelTools/ToolErrorMapper.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/ToolErrorMapper.swift
@@ -1,0 +1,56 @@
+//
+//  ToolErrorMapper.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// Maps a ``TMDbError`` to a short, model-readable message for recoverable cases.
+///
+/// Language model tools favour recovery over failure: returning a readable string
+/// lets the model adjust (try a different id, broaden the query, ask the user)
+/// rather than aborting the turn. Genuine infrastructure failures return `nil` so
+/// the caller rethrows them and the host app sees the real error.
+///
+/// This type references only the public ``TMDbError`` and so compiles on every
+/// supported platform.
+///
+enum ToolErrorMapper {
+
+    ///
+    /// Returns a readable message for a recoverable error, or `nil` to rethrow.
+    ///
+    /// - Parameters:
+    ///   - error: The error thrown by a TMDb service.
+    ///   - entity: A noun for the looked-up resource, such as `"movie"`.
+    ///   - id: The identifier that was looked up, when applicable.
+    ///
+    /// - Returns: A message to return to the model, or `nil` when the error should
+    ///   propagate to the host app.
+    ///
+    static func message(for error: TMDbError, entity: String? = nil, id: Int? = nil) -> String? {
+        switch error {
+        case .notFound:
+            let suffix = id.map { " with id \($0)" } ?? ""
+            return "No TMDb \(entity ?? "result")\(suffix) found."
+
+        case .badRequest(let message):
+            return "Invalid request: \(message ?? "bad request"). Check the id or country code."
+
+        case .tooManyRequests:
+            return "TMDb is rate limiting requests right now; please retry shortly."
+
+        case .unauthorised, .forbidden:
+            return "TMDb access was denied (check the API key)."
+
+        case .network, .serverError, .decode, .invalidRating, .unknown:
+            // Infrastructure or programmer errors the model cannot recover from by
+            // re-prompting — rethrow so the host app handles them.
+            return nil
+        }
+    }
+
+}

--- a/Sources/TMDb/Domain/LanguageModelTools/ToolOutputFormatter.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/ToolOutputFormatter.swift
@@ -1,0 +1,375 @@
+//
+//  ToolOutputFormatter.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// Renders TMDb models into compact, token-efficient text lines for a language
+/// model to reason about.
+///
+/// Every list entry leads with a `kind` token and the TMDb `id` so the model can
+/// chain tool calls — for example, take an `id` from ``mediaList(_:limit:query:)``
+/// and pass it to a details or watch-providers tool. The output is plain text
+/// rather than JSON to keep within the on-device model's context window.
+///
+/// This type references only public, platform-agnostic models, so it compiles and
+/// is testable on every supported platform — including those without the
+/// FoundationModels framework.
+///
+enum ToolOutputFormatter {
+
+    /// The default maximum number of entries a list-producing tool returns.
+    ///
+    /// Deliberately small to bound the token cost of a tool result; this is not a
+    /// TMDb page-size limit.
+    static let defaultListLimit = 8
+
+    /// The maximum length of an overview shown on a single list line.
+    static let lineOverviewLimit = 140
+
+    /// The maximum length of an overview shown in a details block.
+    static let blockOverviewLimit = 300
+
+    private static let utcCalendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC") ?? .gmt
+        return calendar
+    }()
+
+}
+
+// MARK: - List lines
+
+extension ToolOutputFormatter {
+
+    ///
+    /// Formats a multi-search result list, one entity per line.
+    ///
+    /// Collection results are omitted: there is no tool that consumes a collection
+    /// id, so a collection line would not be chainable.
+    ///
+    /// - Parameters:
+    ///   - items: The media items to format.
+    ///   - limit: The maximum number of lines to include.
+    ///   - query: A description of the request, used in the empty-result message.
+    ///
+    /// - Returns: The formatted lines, or a "no results" message when empty.
+    ///
+    static func mediaList(_ items: [Media], limit: Int, query: String) -> String {
+        let lines = items.compactMap(line(for:)).prefix(limit)
+        guard !lines.isEmpty else {
+            return "No results found for '\(sanitize(query))'."
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    ///
+    /// Formats a single media item as a list line, or `nil` for a collection.
+    ///
+    /// - Parameter media: The media item to format.
+    ///
+    /// - Returns: The formatted line, or `nil` when the item is a collection.
+    ///
+    static func line(for media: Media) -> String? {
+        switch media {
+        case .movie(let movie): line(for: movie)
+        case .tvSeries(let tvSeries): line(for: tvSeries)
+        case .person(let person): line(for: person)
+        case .collection: nil
+        }
+    }
+
+    ///
+    /// Formats a movie list item as a single line.
+    ///
+    /// - Parameter movie: The movie list item to format.
+    ///
+    /// - Returns: The formatted line.
+    ///
+    static func line(for movie: MovieListItem) -> String {
+        var line = "movie | \(movie.id) | \(titleWithYear(movie.title, movie.releaseDate))"
+        if let rating = ratingToken(movie.voteAverage) {
+            line += " | \(rating)"
+        }
+        if let overview = overviewToken(movie.overview, limit: lineOverviewLimit) {
+            line += " | \(overview)"
+        }
+
+        return line
+    }
+
+    ///
+    /// Formats a TV series list item as a single line.
+    ///
+    /// - Parameter tvSeries: The TV series list item to format.
+    ///
+    /// - Returns: The formatted line.
+    ///
+    static func line(for tvSeries: TVSeriesListItem) -> String {
+        var line = "tv | \(tvSeries.id) | \(titleWithYear(tvSeries.name, tvSeries.firstAirDate))"
+        if let rating = ratingToken(tvSeries.voteAverage) {
+            line += " | \(rating)"
+        }
+        if let overview = overviewToken(tvSeries.overview, limit: lineOverviewLimit) {
+            line += " | \(overview)"
+        }
+
+        return line
+    }
+
+    ///
+    /// Formats a person list item as a single line.
+    ///
+    /// - Parameter person: The person list item to format.
+    ///
+    /// - Returns: The formatted line.
+    ///
+    static func line(for person: PersonListItem) -> String {
+        var line = "person | \(person.id) | \(sanitize(person.name))"
+        if let department = person.knownForDepartment, !department.isEmpty {
+            line += " | \(sanitize(department))"
+        }
+
+        return line
+    }
+
+    ///
+    /// Formats a person's credit (``Show``) as a single line.
+    ///
+    /// - Parameter show: The show to format.
+    ///
+    /// - Returns: The formatted line.
+    ///
+    static func line(for show: Show) -> String {
+        switch show {
+        case .movie(let movie): line(for: movie)
+        case .tvSeries(let tvSeries): line(for: tvSeries)
+        }
+    }
+
+}
+
+// MARK: - Detail blocks
+
+extension ToolOutputFormatter {
+
+    ///
+    /// Formats the full details of a movie as a compact block.
+    ///
+    /// - Parameter movie: The movie to format.
+    ///
+    /// - Returns: The formatted block.
+    ///
+    static func block(for movie: Movie) -> String {
+        var lines = ["movie | \(movie.id) | \(titleWithYear(movie.title, movie.releaseDate))"]
+
+        var facts: [String] = []
+        if let runtime = movie.runtime, runtime > 0 {
+            facts.append("\(runtime) min")
+        }
+        if let genres = genreNames(movie.genres) {
+            facts.append("genres: \(genres)")
+        }
+        if let rating = ratingToken(movie.voteAverage) {
+            facts.append(rating)
+        }
+        if let status = movie.status {
+            facts.append("status: \(status.rawValue)")
+        }
+        if !facts.isEmpty {
+            lines.append(facts.joined(separator: " | "))
+        }
+
+        if let tagline = movie.tagline, !tagline.isEmpty {
+            lines.append("tagline: \(sanitize(tagline))")
+        }
+        if let overview = overviewToken(movie.overview, limit: blockOverviewLimit) {
+            lines.append("overview: \(overview)")
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    ///
+    /// Formats the full details of a TV series as a compact block.
+    ///
+    /// - Parameter tvSeries: The TV series to format.
+    ///
+    /// - Returns: The formatted block.
+    ///
+    static func block(for tvSeries: TVSeries) -> String {
+        var lines = ["tv | \(tvSeries.id) | \(titleWithYear(tvSeries.name, tvSeries.firstAirDate))"]
+
+        var facts: [String] = []
+        if let seasons = tvSeries.numberOfSeasons, seasons > 0 {
+            facts.append("\(seasons) season\(seasons == 1 ? "" : "s")")
+        }
+        if let genres = genreNames(tvSeries.genres) {
+            facts.append("genres: \(genres)")
+        }
+        if let rating = ratingToken(tvSeries.voteAverage) {
+            facts.append(rating)
+        }
+        if let status = tvSeries.status, !status.isEmpty {
+            facts.append("status: \(sanitize(status))")
+        }
+        if !facts.isEmpty {
+            lines.append(facts.joined(separator: " | "))
+        }
+
+        if let tagline = tvSeries.tagline, !tagline.isEmpty {
+            lines.append("tagline: \(sanitize(tagline))")
+        }
+        if let overview = overviewToken(tvSeries.overview, limit: blockOverviewLimit) {
+            lines.append("overview: \(overview)")
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    ///
+    /// Formats a person header line for a filmography.
+    ///
+    /// - Parameter person: The person to format.
+    ///
+    /// - Returns: The formatted header line.
+    ///
+    static func header(for person: Person) -> String {
+        var line = "person | \(person.id) | \(sanitize(person.name))"
+        if let department = person.knownForDepartment, !department.isEmpty {
+            line += " | \(sanitize(department))"
+        }
+
+        return line
+    }
+
+}
+
+// MARK: - Watch providers
+
+extension ToolOutputFormatter {
+
+    ///
+    /// Formats the watch providers for a title in a single country.
+    ///
+    /// The `flatRate` group is labelled `stream` for readability. Empty groups are
+    /// omitted. Only provider names are shown — logos and links are dropped.
+    ///
+    /// - Parameters:
+    ///   - id: The TMDb id of the movie or TV series.
+    ///   - countryCode: The ISO-3166-1 country code.
+    ///   - providers: The watch providers for that country.
+    ///
+    /// - Returns: The formatted block, or a "none" message when no providers exist.
+    ///
+    static func watchProviders(
+        id: Int,
+        countryCode: String,
+        providers: ShowWatchProvider
+    ) -> String {
+        let groups: [(label: String, providers: [WatchProvider]?)] = [
+            ("stream", providers.flatRate),
+            ("free", providers.free),
+            ("ads", providers.ads),
+            ("rent", providers.rent),
+            ("buy", providers.buy)
+        ]
+
+        var lines = ["watchProviders | \(id) | \(countryCode)"]
+        for group in groups {
+            guard let names = providerNames(group.providers) else { continue }
+            lines.append("\(group.label): \(names)")
+        }
+
+        guard lines.count > 1 else {
+            return "No watch providers listed for id \(id) in \(countryCode)."
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+}
+
+// MARK: - Helpers
+
+extension ToolOutputFormatter {
+
+    /// Extracts the four-digit year from a date, in UTC, or `nil`.
+    static func year(from date: Date?) -> Int? {
+        date.map { utcCalendar.component(.year, from: $0) }
+    }
+
+    private static func titleWithYear(_ title: String, _ date: Date?) -> String {
+        guard let year = year(from: date) else {
+            return sanitize(title)
+        }
+
+        return "\(sanitize(title)) (\(year))"
+    }
+
+    private static func ratingToken(_ voteAverage: Double?) -> String? {
+        guard let voteAverage, voteAverage > 0 else {
+            return nil
+        }
+
+        return "⭐\(String(format: "%.1f", voteAverage))"
+    }
+
+    private static func overviewToken(_ overview: String?, limit: Int) -> String? {
+        guard let overview else {
+            return nil
+        }
+
+        let truncated = truncate(overview, limit: limit)
+        return truncated.isEmpty ? nil : truncated
+    }
+
+    private static func genreNames(_ genres: [Genre]?) -> String? {
+        guard let genres, !genres.isEmpty else {
+            return nil
+        }
+
+        return genres.map { sanitize($0.name) }.joined(separator: ", ")
+    }
+
+    private static func providerNames(_ providers: [WatchProvider]?) -> String? {
+        guard let providers, !providers.isEmpty else {
+            return nil
+        }
+
+        return providers.map { sanitize($0.name) }.joined(separator: ", ")
+    }
+
+    /// Replaces the field delimiter and newlines so they cannot corrupt a line's
+    /// `kind | id | …` structure, and collapses runs of whitespace.
+    private static func sanitize(_ text: String) -> String {
+        let replaced = text
+            .replacingOccurrences(of: "|", with: "/")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\t", with: " ")
+        let parts = replaced.split(whereSeparator: { $0 == " " })
+        return parts.joined(separator: " ")
+    }
+
+    private static func truncate(_ text: String, limit: Int) -> String {
+        let clean = sanitize(text)
+        guard clean.count > limit else {
+            return clean
+        }
+
+        let endIndex = clean.index(clean.startIndex, offsetBy: limit)
+        var prefix = String(clean[..<endIndex])
+        if let lastSpace = prefix.lastIndex(of: " ") {
+            prefix = String(prefix[..<lastSpace])
+        }
+
+        return "\(prefix)…"
+    }
+
+}

--- a/Sources/TMDb/Domain/LanguageModelTools/ToolOutputFormatter.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/ToolOutputFormatter.swift
@@ -359,6 +359,8 @@ extension ToolOutputFormatter {
 
     private static func truncate(_ text: String, limit: Int) -> String {
         let clean = sanitize(text)
+        // `count` and `index(_:offsetBy:)` both work in grapheme clusters, matching
+        // the user-visible character limit.
         guard clean.count > limit else {
             return clean
         }

--- a/Sources/TMDb/Domain/LanguageModelTools/Tools/DiscoverMoviesTool.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/Tools/DiscoverMoviesTool.swift
@@ -1,0 +1,201 @@
+//
+//  DiscoverMoviesTool.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && !os(tvOS)
+    import Foundation
+    import FoundationModels
+
+    ///
+    /// A language model tool that browses movies by attributes — genre, release
+    /// year, minimum rating, and streaming provider — when no specific title is
+    /// named.
+    ///
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
+    struct DiscoverMoviesTool: Tool {
+
+        let name = "discoverMovies"
+        let description = """
+        Browse movies by attributes such as genre, year range, minimum rating, or \
+        streaming provider, when no specific title is named.
+        """
+
+        private static let defaultWatchRegion = "US"
+
+        private let discoverService: any DiscoverService
+        private let watchProviderService: any WatchProviderService
+        private let language: String?
+        private let region: String?
+
+        init(
+            discoverService: any DiscoverService,
+            watchProviderService: any WatchProviderService,
+            language: String? = nil,
+            region: String? = nil
+        ) {
+            self.discoverService = discoverService
+            self.watchProviderService = watchProviderService
+            self.language = language
+            self.region = region
+        }
+
+        ///
+        /// The arguments for a movie discovery request.
+        ///
+        @Generable
+        struct Arguments {
+            /// A genre to filter by.
+            @Guide(description: "Genre to filter by")
+            var genre: MovieGenre?
+
+            /// The earliest release year.
+            @Guide(description: "Earliest release year, for example 1990")
+            var yearFrom: Int?
+
+            /// The latest release year.
+            @Guide(description: "Latest release year, for example 1999")
+            var yearTo: Int?
+
+            /// The minimum average rating, from 0 to 10.
+            @Guide(description: "Minimum average rating from 0 to 10")
+            var minRating: Double?
+
+            /// A streaming provider name to filter by.
+            @Guide(description: "Streaming provider name such as Netflix")
+            var watchProvider: String?
+
+            /// The ISO-3166-1 country code for the streaming provider.
+            @Guide(description: "Two-letter ISO country code for the provider, such as GB")
+            var watchRegion: String?
+        }
+
+        func call(arguments: Arguments) async throws -> String {
+            let watchRegion = resolvedRegion(arguments.watchRegion)
+            do {
+                let providerIDs = try await resolveProviderIDs(
+                    named: arguments.watchProvider,
+                    in: watchRegion
+                )
+                if case .failure(let message) = providerIDs {
+                    return message
+                }
+
+                let resolvedProviderIDs = providerIDs.value
+                let filter = DiscoverMovieFilter(
+                    genres: arguments.genre.map { [$0.genreID] },
+                    primaryReleaseYear: yearFilter(from: arguments.yearFrom, to: arguments.yearTo),
+                    voteAverageMin: arguments.minRating.map { min(max($0, 0), 10) },
+                    watchProviders: resolvedProviderIDs,
+                    watchRegion: resolvedProviderIDs == nil
+                        ? nil
+                        : (watchRegion ?? Self.defaultWatchRegion)
+                )
+
+                let list = try await discoverService.movies(
+                    filter: filter,
+                    sortedBy: .popularity(descending: true),
+                    page: 1,
+                    language: language
+                )
+
+                return ToolOutputFormatter.mediaList(
+                    list.results.map(Media.movie),
+                    limit: ToolOutputFormatter.defaultListLimit,
+                    query: "those filters"
+                )
+            } catch {
+                if let message = ToolErrorMapper.message(for: error) {
+                    return message
+                }
+                throw error
+            }
+        }
+
+        /// The outcome of resolving a provider name to its identifiers.
+        private enum ProviderResolution {
+            case none
+            case resolved([WatchProvider.ID])
+            case failure(String)
+
+            var value: [WatchProvider.ID]? {
+                switch self {
+                case .resolved(let ids): ids
+                case .none, .failure: nil
+                }
+            }
+        }
+
+        private func resolveProviderIDs(
+            named name: String?,
+            in watchRegion: String?
+        ) async throws(TMDbError) -> ProviderResolution {
+            guard let providerName = trimmedNonEmpty(name) else {
+                return .none
+            }
+
+            let providers = try await watchProviderService.movieWatchProviders(
+                filter: WatchProviderFilter(country: watchRegion ?? Self.defaultWatchRegion),
+                language: language
+            )
+            guard let match = providers.first(
+                where: { $0.name.localizedCaseInsensitiveContains(providerName) }
+            )
+            else {
+                return .failure(
+                    "Unknown streaming provider '\(providerName)'. Try a name like Netflix, "
+                        + "Disney Plus, or Amazon Prime Video."
+                )
+            }
+
+            return .resolved([match.id])
+        }
+
+        private func yearFilter(
+            from lower: Int?,
+            to upper: Int?
+        ) -> DiscoverMovieFilter.PrimaryReleaseYearFilter? {
+            switch (lower, upper) {
+            case (nil, nil):
+                return nil
+
+            case (let lower?, nil):
+                return .from(lower)
+
+            case (nil, let upper?):
+                return .upTo(upper)
+
+            case (let lower?, let upper?):
+                if lower == upper {
+                    return .on(lower)
+                }
+
+                return .between(start: lower, end: upper)
+            }
+        }
+
+        private func resolvedRegion(_ argument: String?) -> String? {
+            if let argument = trimmedNonEmpty(argument) {
+                return argument.uppercased()
+            }
+            if let region, !region.isEmpty {
+                return region.uppercased()
+            }
+
+            return nil
+        }
+
+        private func trimmedNonEmpty(_ value: String?) -> String? {
+            guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !trimmed.isEmpty
+            else {
+                return nil
+            }
+
+            return trimmed
+        }
+
+    }
+#endif

--- a/Sources/TMDb/Domain/LanguageModelTools/Tools/DiscoverMoviesTool.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/Tools/DiscoverMoviesTool.swift
@@ -172,7 +172,9 @@
                     return .on(lower)
                 }
 
-                return .between(start: lower, end: upper)
+                // Tolerate an inverted range from the model rather than submitting
+                // a bound that always returns zero results.
+                return .between(start: min(lower, upper), end: max(lower, upper))
             }
         }
 

--- a/Sources/TMDb/Domain/LanguageModelTools/Tools/MovieDetailsTool.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/Tools/MovieDetailsTool.swift
@@ -1,0 +1,62 @@
+//
+//  MovieDetailsTool.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && !os(tvOS)
+    import Foundation
+    import FoundationModels
+
+    ///
+    /// A language model tool that fetches full details for a movie by its TMDb id.
+    ///
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
+    struct MovieDetailsTool: Tool {
+
+        let name = "movieDetails"
+        let description = """
+        Get full details for a movie by its TMDb id, including overview, runtime, \
+        genres, rating, and release year. Get the id from search.
+        """
+
+        private let movieService: any MovieService
+        private let language: String?
+
+        init(movieService: any MovieService, language: String? = nil) {
+            self.movieService = movieService
+            self.language = language
+        }
+
+        ///
+        /// The arguments for a movie details lookup.
+        ///
+        @Generable
+        struct Arguments {
+            /// The TMDb movie id.
+            @Guide(description: "The TMDb movie id, for example from search", .minimum(1))
+            var movieID: Int
+        }
+
+        func call(arguments: Arguments) async throws -> String {
+            do {
+                let movie = try await movieService.details(
+                    forMovie: arguments.movieID,
+                    language: language
+                )
+                return ToolOutputFormatter.block(for: movie)
+            } catch {
+                if let message = ToolErrorMapper.message(
+                    for: error,
+                    entity: "movie",
+                    id: arguments.movieID
+                ) {
+                    return message
+                }
+                throw error
+            }
+        }
+
+    }
+#endif

--- a/Sources/TMDb/Domain/LanguageModelTools/Tools/PersonFilmographyTool.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/Tools/PersonFilmographyTool.swift
@@ -57,7 +57,9 @@
                     language: language
                 )
 
-                let limit = arguments.maxCredits ?? Self.defaultMaxCredits
+                // Clamp to a non-negative value: `prefix(_:)` traps on a negative
+                // length, and a language model could generate one.
+                let limit = max(0, arguments.maxCredits ?? Self.defaultMaxCredits)
                 let shows = credits.allShows
                     .sorted(by: isMoreNotable)
                     .prefix(limit)

--- a/Sources/TMDb/Domain/LanguageModelTools/Tools/PersonFilmographyTool.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/Tools/PersonFilmographyTool.swift
@@ -42,7 +42,7 @@
             var personID: Int
 
             /// The maximum number of credits to list.
-            @Guide(description: "Maximum number of credits to list, from 1 to 20")
+            @Guide(description: "Maximum number of credits to list, from 1 to 20", .minimum(1))
             var maxCredits: Int?
         }
 

--- a/Sources/TMDb/Domain/LanguageModelTools/Tools/PersonFilmographyTool.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/Tools/PersonFilmographyTool.swift
@@ -1,0 +1,103 @@
+//
+//  PersonFilmographyTool.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && !os(tvOS)
+    import Foundation
+    import FoundationModels
+
+    ///
+    /// A language model tool that fetches a person's profile and most notable
+    /// movie and TV credits by their TMDb id.
+    ///
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
+    struct PersonFilmographyTool: Tool {
+
+        let name = "personFilmography"
+        let description = """
+        Get a person's profile and notable movie and TV credits by their TMDb id. \
+        Get the id from search.
+        """
+
+        private static let defaultMaxCredits = 12
+
+        private let personService: any PersonService
+        private let language: String?
+
+        init(personService: any PersonService, language: String? = nil) {
+            self.personService = personService
+            self.language = language
+        }
+
+        ///
+        /// The arguments for a person filmography lookup.
+        ///
+        @Generable
+        struct Arguments {
+            /// The TMDb person id.
+            @Guide(description: "The TMDb person id, for example from search", .minimum(1))
+            var personID: Int
+
+            /// The maximum number of credits to list.
+            @Guide(description: "Maximum number of credits to list, from 1 to 20")
+            var maxCredits: Int?
+        }
+
+        func call(arguments: Arguments) async throws -> String {
+            do {
+                let person = try await personService.details(
+                    forPerson: arguments.personID,
+                    language: language
+                )
+                let credits = try await personService.combinedCredits(
+                    forPerson: arguments.personID,
+                    language: language
+                )
+
+                let limit = arguments.maxCredits ?? Self.defaultMaxCredits
+                let shows = credits.allShows
+                    .sorted(by: isMoreNotable)
+                    .prefix(limit)
+
+                var lines = [ToolOutputFormatter.header(for: person)]
+                if shows.isEmpty {
+                    lines.append("No notable credits found.")
+                } else {
+                    lines.append(contentsOf: shows.map(ToolOutputFormatter.line(for:)))
+                }
+
+                return lines.joined(separator: "\n")
+            } catch {
+                if let message = ToolErrorMapper.message(
+                    for: error,
+                    entity: "person",
+                    id: arguments.personID
+                ) {
+                    return message
+                }
+                throw error
+            }
+        }
+
+        private func isMoreNotable(_ lhs: Show, _ rhs: Show) -> Bool {
+            let lhsPopularity = popularity(of: lhs)
+            let rhsPopularity = popularity(of: rhs)
+            if lhsPopularity != rhsPopularity {
+                return lhsPopularity > rhsPopularity
+            }
+
+            return lhs.id < rhs.id
+        }
+
+        private func popularity(of show: Show) -> Double {
+            switch show {
+            case .movie(let movie): movie.popularity ?? 0
+            case .tvSeries(let tvSeries): tvSeries.popularity ?? 0
+            }
+        }
+
+    }
+#endif

--- a/Sources/TMDb/Domain/LanguageModelTools/Tools/SearchTMDbTool.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/Tools/SearchTMDbTool.swift
@@ -1,0 +1,83 @@
+//
+//  SearchTMDbTool.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && !os(tvOS)
+    import Foundation
+    import FoundationModels
+
+    ///
+    /// A language model tool that searches TMDb for movies, TV series, and people
+    /// by name, returning the ids other tools need.
+    ///
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
+    struct SearchTMDbTool: Tool {
+
+        let name = "search"
+        let description = """
+        Find a specific movie, TV show, or person by name. Do not use for browsing by \
+        genre, year, or rating (use discoverMovies) or for trending feeds (use trending).
+        """
+
+        private let searchService: any SearchService
+        private let language: String?
+
+        init(searchService: any SearchService, language: String? = nil) {
+            self.searchService = searchService
+            self.language = language
+        }
+
+        ///
+        /// The arguments for a TMDb search.
+        ///
+        @Generable
+        struct Arguments {
+            /// The movie, TV show, or person name to search for.
+            @Guide(description: "The movie, TV show, or person name to search for")
+            var query: String
+
+            /// An optional media type to limit results to.
+            @Guide(description: "Optionally limit results to movie, tvSeries, or person")
+            var mediaType: SearchMediaType?
+        }
+
+        func call(arguments: Arguments) async throws -> String {
+            let query = arguments.query.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !query.isEmpty else {
+                return "Provide a movie, TV show, or person name to search for."
+            }
+
+            do {
+                let list = try await searchService.searchAll(query: query, page: 1, language: language)
+                let filtered = list.results.filter { include($0, matching: arguments.mediaType) }
+                return ToolOutputFormatter.mediaList(
+                    filtered,
+                    limit: ToolOutputFormatter.defaultListLimit,
+                    query: query
+                )
+            } catch {
+                if let message = ToolErrorMapper.message(for: error) {
+                    return message
+                }
+                throw error
+            }
+        }
+
+        private func include(_ media: Media, matching type: SearchMediaType?) -> Bool {
+            switch (type, media) {
+            case (nil, _),
+                 (.movie?, .movie),
+                 (.tvSeries?, .tvSeries),
+                 (.person?, .person):
+                true
+
+            default:
+                false
+            }
+        }
+
+    }
+#endif

--- a/Sources/TMDb/Domain/LanguageModelTools/Tools/TVSeriesDetailsTool.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/Tools/TVSeriesDetailsTool.swift
@@ -1,0 +1,63 @@
+//
+//  TVSeriesDetailsTool.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && !os(tvOS)
+    import Foundation
+    import FoundationModels
+
+    ///
+    /// A language model tool that fetches full details for a TV series by its TMDb
+    /// id.
+    ///
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
+    struct TVSeriesDetailsTool: Tool {
+
+        let name = "tvSeriesDetails"
+        let description = """
+        Get full details for a TV series by its TMDb id, including overview, genres, \
+        rating, status, and first-air year. Get the id from search.
+        """
+
+        private let tvSeriesService: any TVSeriesService
+        private let language: String?
+
+        init(tvSeriesService: any TVSeriesService, language: String? = nil) {
+            self.tvSeriesService = tvSeriesService
+            self.language = language
+        }
+
+        ///
+        /// The arguments for a TV series details lookup.
+        ///
+        @Generable
+        struct Arguments {
+            /// The TMDb TV series id.
+            @Guide(description: "The TMDb TV series id, for example from search", .minimum(1))
+            var tvSeriesID: Int
+        }
+
+        func call(arguments: Arguments) async throws -> String {
+            do {
+                let tvSeries = try await tvSeriesService.details(
+                    forTVSeries: arguments.tvSeriesID,
+                    language: language
+                )
+                return ToolOutputFormatter.block(for: tvSeries)
+            } catch {
+                if let message = ToolErrorMapper.message(
+                    for: error,
+                    entity: "TV series",
+                    id: arguments.tvSeriesID
+                ) {
+                    return message
+                }
+                throw error
+            }
+        }
+
+    }
+#endif

--- a/Sources/TMDb/Domain/LanguageModelTools/Tools/TrendingTool.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/Tools/TrendingTool.swift
@@ -1,0 +1,104 @@
+//
+//  TrendingTool.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && !os(tvOS)
+    import Foundation
+    import FoundationModels
+
+    ///
+    /// A language model tool that lists currently trending movies, TV series, or
+    /// people on TMDb.
+    ///
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
+    struct TrendingTool: Tool {
+
+        let name = "trending"
+        let description = """
+        List what is currently trending or popular on TMDb (daily or weekly). Only \
+        for trending feeds, not for searching or browsing by attribute.
+        """
+
+        private let trendingService: any TrendingService
+        private let language: String?
+
+        init(trendingService: any TrendingService, language: String? = nil) {
+            self.trendingService = trendingService
+            self.language = language
+        }
+
+        ///
+        /// The arguments for a trending request.
+        ///
+        @Generable
+        struct Arguments {
+            /// The media type to list.
+            @Guide(description: "Which media type to list: movie, tvSeries, or person")
+            var mediaType: TrendingMediaType
+
+            /// The trending time window.
+            @Guide(description: "Trending window: day or week")
+            var timeWindow: TrendingWindow
+        }
+
+        func call(arguments: Arguments) async throws -> String {
+            let window = arguments.timeWindow.filterType
+            do {
+                let media = try await fetch(arguments.mediaType, inTimeWindow: window)
+                return ToolOutputFormatter.mediaList(
+                    media,
+                    limit: ToolOutputFormatter.defaultListLimit,
+                    query: label(for: arguments.mediaType)
+                )
+            } catch {
+                if let message = ToolErrorMapper.message(for: error) {
+                    return message
+                }
+                throw error
+            }
+        }
+
+        private func fetch(
+            _ mediaType: TrendingMediaType,
+            inTimeWindow window: TrendingTimeWindowFilterType
+        ) async throws(TMDbError) -> [Media] {
+            switch mediaType {
+            case .movie:
+                let list = try await trendingService.movies(
+                    inTimeWindow: window,
+                    page: 1,
+                    language: language
+                )
+                return list.results.map(Media.movie)
+
+            case .tvSeries:
+                let list = try await trendingService.tvSeries(
+                    inTimeWindow: window,
+                    page: 1,
+                    language: language
+                )
+                return list.results.map(Media.tvSeries)
+
+            case .person:
+                let list = try await trendingService.people(
+                    inTimeWindow: window,
+                    page: 1,
+                    language: language
+                )
+                return list.results.map(Media.person)
+            }
+        }
+
+        private func label(for mediaType: TrendingMediaType) -> String {
+            switch mediaType {
+            case .movie: "trending movies"
+            case .tvSeries: "trending TV series"
+            case .person: "trending people"
+            }
+        }
+
+    }
+#endif

--- a/Sources/TMDb/Domain/LanguageModelTools/Tools/WatchProvidersTool.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/Tools/WatchProvidersTool.swift
@@ -1,0 +1,120 @@
+//
+//  WatchProvidersTool.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && !os(tvOS)
+    import Foundation
+    import FoundationModels
+
+    ///
+    /// A language model tool that finds where a specific movie or TV series can be
+    /// streamed, rented, or bought in a country.
+    ///
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
+    struct WatchProvidersTool: Tool {
+
+        let name = "watchProviders"
+        let description = """
+        Find where a specific movie or TV series can be streamed, rented, or bought \
+        in a country, by its TMDb id. To browse what is on a provider, use \
+        discoverMovies instead.
+        """
+
+        private static let defaultCountryCode = "US"
+
+        private let movieService: any MovieService
+        private let tvSeriesService: any TVSeriesService
+        private let region: String?
+
+        init(
+            movieService: any MovieService,
+            tvSeriesService: any TVSeriesService,
+            region: String? = nil
+        ) {
+            self.movieService = movieService
+            self.tvSeriesService = tvSeriesService
+            self.region = region
+        }
+
+        ///
+        /// The arguments for a watch providers lookup.
+        ///
+        @Generable
+        struct Arguments {
+            /// Whether the id is a movie or TV series.
+            @Guide(description: "Whether the id is for a movie or tvSeries")
+            var mediaType: WatchMediaType
+
+            /// The TMDb id of the movie or TV series.
+            @Guide(description: "The TMDb id of the movie or TV series", .minimum(1))
+            var id: Int
+
+            /// The ISO-3166-1 country code to look up providers for.
+            @Guide(description: "Two-letter ISO country code such as GB or US")
+            var countryCode: String?
+        }
+
+        func call(arguments: Arguments) async throws -> String {
+            let country = resolvedCountryCode(arguments.countryCode)
+            do {
+                let byCountry = try await fetch(arguments.mediaType, id: arguments.id)
+                guard let match = byCountry.first(
+                    where: { $0.countryCode.caseInsensitiveCompare(country) == .orderedSame }
+                )
+                else {
+                    return "No watch providers found for id \(arguments.id) in \(country)."
+                }
+
+                return ToolOutputFormatter.watchProviders(
+                    id: arguments.id,
+                    countryCode: country,
+                    providers: match.watchProviders
+                )
+            } catch {
+                if let message = ToolErrorMapper.message(
+                    for: error,
+                    entity: entity(for: arguments.mediaType),
+                    id: arguments.id
+                ) {
+                    return message
+                }
+                throw error
+            }
+        }
+
+        private func fetch(
+            _ mediaType: WatchMediaType,
+            id: Int
+        ) async throws(TMDbError) -> [ShowWatchProvidersByCountry] {
+            switch mediaType {
+            case .movie:
+                try await movieService.watchProviders(forMovie: id)
+            case .tvSeries:
+                try await tvSeriesService.watchProviders(forTVSeries: id)
+            }
+        }
+
+        private func resolvedCountryCode(_ argument: String?) -> String {
+            let candidate = argument?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let candidate, !candidate.isEmpty {
+                return candidate.uppercased()
+            }
+            if let region, !region.isEmpty {
+                return region.uppercased()
+            }
+
+            return Self.defaultCountryCode
+        }
+
+        private func entity(for mediaType: WatchMediaType) -> String {
+            switch mediaType {
+            case .movie: "movie"
+            case .tvSeries: "TV series"
+            }
+        }
+
+    }
+#endif

--- a/Sources/TMDb/TMDb.docc/Extensions/TMDbClient.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/TMDbClient.md
@@ -23,7 +23,6 @@
 - ``trending``
 - ``search``
 - ``naturalLanguageSearch``
-- ``languageModelTools``
 - ``find``
 - ``credits``
 - ``reviews``
@@ -40,3 +39,14 @@
 - ``authentication``
 - ``changes``
 - ``guestSessions``
+
+### Language Model Tools
+
+- ``languageModelTools``
+- ``searchTool``
+- ``movieDetailsTool``
+- ``tvSeriesDetailsTool``
+- ``personFilmographyTool``
+- ``trendingTool``
+- ``watchProvidersTool``
+- ``discoverMoviesTool``

--- a/Sources/TMDb/TMDb.docc/Extensions/TMDbClient.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/TMDbClient.md
@@ -23,6 +23,7 @@
 - ``trending``
 - ``search``
 - ``naturalLanguageSearch``
+- ``languageModelTools``
 - ``find``
 - ``credits``
 - ``reviews``

--- a/Sources/TMDb/TMDb.docc/Extensions/TMDbToolbox.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/TMDbToolbox.md
@@ -1,0 +1,21 @@
+# ``TMDbToolbox``
+
+## Topics
+
+### Creating a Toolbox
+
+- ``init(client:language:region:)``
+
+### All Tools
+
+- ``all``
+
+### Individual Tools
+
+- ``search``
+- ``movieDetails``
+- ``tvSeriesDetails``
+- ``personFilmography``
+- ``trending``
+- ``watchProviders``
+- ``discoverMovies``

--- a/Sources/TMDb/TMDb.docc/HowTos/UsingLanguageModelTools.md
+++ b/Sources/TMDb/TMDb.docc/HowTos/UsingLanguageModelTools.md
@@ -1,0 +1,67 @@
+# Using Language Model Tools
+
+Build a conversational movie assistant with Apple's Foundation Models framework.
+
+## Overview
+
+``TMDbToolbox`` exposes TMDb as a set of Foundation Models `Tool`s, so a
+`LanguageModelSession` can answer movie and TV questions by calling TMDb on your
+behalf. The model decides which tools to call; the tools fetch and format the data.
+
+The toolbox is available on devices with the Foundation Models framework — iOS 26,
+macOS 26, visionOS 26, and watchOS 27. It is unavailable on tvOS, Linux, and
+Windows.
+
+## Adding the Tools to a Session
+
+Pass ``TMDbClient/languageModelTools`` to a session to make every tool available:
+
+```swift
+import FoundationModels
+import TMDb
+
+let tmdbClient = TMDbClient(apiKey: "<your-tmdb-api-key>")
+
+let session = LanguageModelSession(tools: tmdbClient.languageModelTools)
+let reply = try await session.respond(to: "What's trending?")
+print(reply.content)
+```
+
+Each tool returns compact text whose every line leads with the relevant TMDb
+`id`, so the model can chain calls — searching for a title, then fetching its
+details or watch providers.
+
+## Choosing a Subset of Tools
+
+Apple recommends keeping to three to five tools per request. Construct a
+``TMDbToolbox`` and pass only the tools a task needs:
+
+```swift
+let toolbox = TMDbToolbox(client: tmdbClient, region: "GB")
+
+let session = LanguageModelSession(
+    tools: [toolbox.search, toolbox.discoverMovies, toolbox.watchProviders]
+)
+let reply = try await session.respond(to: "A thriller on Netflix?")
+```
+
+The `language` and `region` you pass to ``TMDbToolbox/init(client:language:region:)``
+are applied to every tool's results — `region` drives watch-provider and
+streaming-availability lookups.
+
+## Checking Availability
+
+The tools run wherever the framework is present, but the model you attach to a
+session may not be ready. Check the availability of the model you intend to
+use — for example the on-device model — before starting a session:
+
+```swift
+switch SystemLanguageModel.default.availability {
+case .available:
+    let session = LanguageModelSession(tools: tmdbClient.languageModelTools)
+    // ...
+
+case .unavailable(let reason):
+    print("Foundation model unavailable: \(reason)")
+}
+```

--- a/Sources/TMDb/TMDb.docc/HowTos/UsingLanguageModelTools.md
+++ b/Sources/TMDb/TMDb.docc/HowTos/UsingLanguageModelTools.md
@@ -49,6 +49,16 @@ The `language` and `region` you pass to ``TMDbToolbox/init(client:language:regio
 are applied to every tool's results — `region` drives watch-provider and
 streaming-availability lookups.
 
+Each tool is also available directly on the client when you don't need a default
+language or region — for example ``TMDbClient/searchTool`` and
+``TMDbClient/watchProvidersTool``:
+
+```swift
+let session = LanguageModelSession(
+    tools: [tmdbClient.searchTool, tmdbClient.watchProvidersTool]
+)
+```
+
 ## Checking Availability
 
 The tools run wherever the framework is present, but the model you attach to a

--- a/Sources/TMDb/TMDb.docc/TMDb.md
+++ b/Sources/TMDb/TMDb.docc/TMDb.md
@@ -58,6 +58,7 @@ Watch providers provided by [JustWatch](https://www.justwatch.com).
 - <doc:/UsingAutoPagination>
 - <doc:/GeneratingImageURLs>
 - <doc:/ManagingUserAccounts>
+- <doc:/UsingLanguageModelTools>
 
 ### Movies
 
@@ -242,6 +243,10 @@ Watch providers provided by [JustWatch](https://www.justwatch.com).
 - ``SearchDegradation``
 - ``NaturalLanguageSearchAvailability``
 - ``NaturalLanguageSearchError``
+
+### Language Model Tools
+
+- ``TMDbToolbox``
 
 ### Trending
 

--- a/Sources/TMDb/TMDbClient.swift
+++ b/Sources/TMDb/TMDbClient.swift
@@ -319,34 +319,3 @@ public final class TMDbClient: Sendable {
 
     }
 #endif
-
-#if canImport(FoundationModels) && !os(tvOS)
-    import FoundationModels
-
-    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
-    public extension TMDbClient {
-
-        ///
-        /// FoundationModels `Tool`s that expose TMDb to a `LanguageModelSession`,
-        /// for building a conversational movie assistant.
-        ///
-        /// ```swift
-        /// let session = LanguageModelSession(tools: tmdbClient.languageModelTools)
-        /// let reply = try await session.respond(to: "What's trending this week?")
-        /// ```
-        ///
-        /// Each tool returns compact text whose every line leads with the relevant
-        /// TMDb `id`, so the model can chain calls — searching for a title, then
-        /// fetching its details or watch providers.
-        ///
-        /// - Note: This is a shorthand for `TMDbToolbox(client:).all`. For a smaller,
-        ///   task-relevant subset of tools, or to apply a default language or region,
-        ///   construct a ``TMDbToolbox`` directly. Each access builds a new toolbox,
-        ///   so store the result in a local rather than accessing the property twice.
-        ///
-        var languageModelTools: [any Tool] {
-            TMDbToolbox(client: self).all
-        }
-
-    }
-#endif

--- a/Sources/TMDb/TMDbClient.swift
+++ b/Sources/TMDb/TMDbClient.swift
@@ -319,3 +319,34 @@ public final class TMDbClient: Sendable {
 
     }
 #endif
+
+#if canImport(FoundationModels) && !os(tvOS)
+    import FoundationModels
+
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
+    public extension TMDbClient {
+
+        ///
+        /// FoundationModels `Tool`s that expose TMDb to a `LanguageModelSession`,
+        /// for building a conversational movie assistant.
+        ///
+        /// ```swift
+        /// let session = LanguageModelSession(tools: tmdbClient.languageModelTools)
+        /// let reply = try await session.respond(to: "What's trending this week?")
+        /// ```
+        ///
+        /// Each tool returns compact text whose every line leads with the relevant
+        /// TMDb `id`, so the model can chain calls — searching for a title, then
+        /// fetching its details or watch providers.
+        ///
+        /// - Note: This is a shorthand for `TMDbToolbox(client:).all`. For a smaller,
+        ///   task-relevant subset of tools, or to apply a default language or region,
+        ///   construct a ``TMDbToolbox`` directly. Each access builds a new toolbox,
+        ///   so store the result in a local rather than accessing the property twice.
+        ///
+        var languageModelTools: [any Tool] {
+            TMDbToolbox(client: self).all
+        }
+
+    }
+#endif

--- a/Tests/TMDbIntegrationTests/LanguageModelToolsIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/LanguageModelToolsIntegrationTests.swift
@@ -1,0 +1,119 @@
+//
+//  LanguageModelToolsIntegrationTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+// Compiles only against the macOS 26 / FoundationModels SDK; the tools validate
+// their formatting against live API data without invoking Apple Intelligence.
+#if canImport(FoundationModels) && os(macOS)
+    import Foundation
+    import Testing
+    @testable import TMDb
+
+    @Suite(
+        .integrationGate,
+        .serialized,
+        .tags(.languageModelTools),
+        .enabled(if: CredentialHelper.shared.hasAPIKey)
+    )
+    struct LanguageModelToolsIntegrationTests {
+
+        // Durable TMDb anchors used elsewhere in the integration suite.
+        private let fightClubID = 550
+        private let breakingBadID = 1396
+        private let bradPittID = 287
+
+        private var client: TMDbClient {
+            CredentialHelper.shared.makeClient()
+        }
+
+        @available(macOS 26, *)
+        @Test("search resolves a title to an id-bearing line")
+        func search() async throws {
+            let tool = SearchTMDbTool(searchService: client.search)
+            let output = try await tool.call(arguments: .init(query: "Fight Club", mediaType: .movie))
+
+            #expect(output.contains("\(fightClubID)"))
+            #expect(output.localizedCaseInsensitiveContains("Fight Club"))
+        }
+
+        @available(macOS 26, *)
+        @Test("movie details returns a block for a known movie")
+        func movieDetails() async throws {
+            let tool = MovieDetailsTool(movieService: client.movies)
+            let output = try await tool.call(arguments: .init(movieID: fightClubID))
+
+            #expect(output.hasPrefix("movie | \(fightClubID)"))
+            #expect(output.localizedCaseInsensitiveContains("Fight Club"))
+        }
+
+        @available(macOS 26, *)
+        @Test("tv series details returns a block for a known series")
+        func tvSeriesDetails() async throws {
+            let tool = TVSeriesDetailsTool(tvSeriesService: client.tvSeries)
+            let output = try await tool.call(arguments: .init(tvSeriesID: breakingBadID))
+
+            #expect(output.hasPrefix("tv | \(breakingBadID)"))
+            #expect(output.localizedCaseInsensitiveContains("Breaking Bad"))
+        }
+
+        @available(macOS 26, *)
+        @Test("person filmography returns a header and credits")
+        func personFilmography() async throws {
+            let tool = PersonFilmographyTool(personService: client.people)
+            let output = try await tool.call(arguments: .init(personID: bradPittID, maxCredits: 5))
+            let lines = output.components(separatedBy: "\n")
+
+            #expect(output.contains("person | \(bradPittID)"))
+            #expect(output.localizedCaseInsensitiveContains("Brad Pitt"))
+            #expect(lines.count > 1)
+        }
+
+        @available(macOS 26, *)
+        @Test("trending returns id-bearing movie lines")
+        func trending() async throws {
+            let tool = TrendingTool(trendingService: client.trending)
+            let output = try await tool.call(arguments: .init(mediaType: .movie, timeWindow: .week))
+
+            #expect(output.contains("movie | "))
+        }
+
+        @available(macOS 26, *)
+        @Test("watch providers returns a self-describing result")
+        func watchProviders() async throws {
+            let tool = WatchProvidersTool(
+                movieService: client.movies,
+                tvSeriesService: client.tvSeries
+            )
+            let output = try await tool.call(
+                arguments: .init(mediaType: .movie, id: fightClubID, countryCode: "US")
+            )
+
+            #expect(output.contains("\(fightClubID)"))
+        }
+
+        @available(macOS 26, *)
+        @Test("discover movies returns id-bearing movie lines for a genre")
+        func discoverMovies() async throws {
+            let tool = DiscoverMoviesTool(
+                discoverService: client.discover,
+                watchProviderService: client.watchProviders
+            )
+            let output = try await tool.call(
+                arguments: .init(
+                    genre: .thriller,
+                    yearFrom: 2010,
+                    yearTo: 2019,
+                    minRating: 7,
+                    watchProvider: nil,
+                    watchRegion: nil
+                )
+            )
+
+            #expect(output.contains("movie | "))
+        }
+
+    }
+#endif

--- a/Tests/TMDbIntegrationTests/LanguageModelToolsSessionIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/LanguageModelToolsSessionIntegrationTests.swift
@@ -1,0 +1,42 @@
+//
+//  LanguageModelToolsSessionIntegrationTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+// Opt-in end-to-end check that drives a real LanguageModelSession with the TMDb
+// tools. Requires Apple Intelligence and is gated behind the TMDB_FM_TOOLS_EVAL
+// environment variable so it never runs in ordinary CI.
+#if canImport(FoundationModels) && os(macOS)
+    import Foundation
+    import FoundationModels
+    import Testing
+    import TMDb
+
+    @Suite(
+        .serialized,
+        .tags(.languageModelTools),
+        .enabled(
+            if: CredentialHelper.shared.hasAPIKey
+                && ProcessInfo.processInfo.environment["TMDB_FM_TOOLS_EVAL"] != nil
+        )
+    )
+    struct LanguageModelToolsSessionIntegrationTests {
+
+        @available(macOS 26, *)
+        @Test("the assistant answers a movie question using the tools")
+        func answersAMovieQuestion() async throws {
+            guard SystemLanguageModel.default.availability == .available else {
+                return
+            }
+
+            let client = CredentialHelper.shared.makeClient()
+            let session = LanguageModelSession(tools: client.languageModelTools)
+            let response = try await session.respond(to: "Tell me about the movie Inception.")
+
+            #expect(!response.content.isEmpty)
+        }
+
+    }
+#endif

--- a/Tests/TMDbIntegrationTests/TestUtils/Tags.swift
+++ b/Tests/TMDbIntegrationTests/TestUtils/Tags.swift
@@ -37,5 +37,6 @@ extension Tag {
     @Tag static var retry: Self
     @Tag static var cache: Self
     @Tag static var naturalLanguageSearch: Self
+    @Tag static var languageModelTools: Self
 
 }

--- a/Tests/TMDbTests/Domain/LanguageModelTools/DiscoverMoviesToolTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/DiscoverMoviesToolTests.swift
@@ -1,0 +1,107 @@
+//
+//  DiscoverMoviesToolTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && os(macOS)
+    import Foundation
+    import Testing
+    @testable import TMDb
+
+    @Suite(.tags(.languageModelTools))
+    struct DiscoverMoviesToolTests {
+
+        private let apiClient = MockAPIClient()
+
+        @available(macOS 26, *)
+        private var tool: DiscoverMoviesTool {
+            DiscoverMoviesTool(
+                discoverService: TMDbDiscoverService(apiClient: apiClient),
+                watchProviderService: TMDbWatchProviderService(apiClient: apiClient)
+            )
+        }
+
+        @available(macOS 26, *)
+        @Test("returns movies matching genre, year and rating")
+        func discoversByAttributes() async throws {
+            let list = MoviePageableList.mock(results: [.mock(id: 27205, title: "Inception")])
+            apiClient.addResponse(.success(list))
+
+            let output = try await tool.call(
+                arguments: .init(
+                    genre: .thriller,
+                    yearFrom: 2010,
+                    yearTo: 2019,
+                    minRating: 7,
+                    watchProvider: nil,
+                    watchRegion: nil
+                )
+            )
+
+            #expect(output.contains("movie | 27205"))
+        }
+
+        @available(macOS 26, *)
+        @Test("resolves a provider name and returns matching movies")
+        func discoversByProvider() async throws {
+            apiClient.addResponse(.success(WatchProviderResult.mock))
+            apiClient.addResponse(
+                .success(MoviePageableList.mock(results: [.mock(id: 1, title: "A Thriller")]))
+            )
+
+            let output = try await tool.call(
+                arguments: .init(
+                    genre: .thriller,
+                    yearFrom: nil,
+                    yearTo: nil,
+                    minRating: nil,
+                    watchProvider: "Netflix",
+                    watchRegion: "GB"
+                )
+            )
+
+            #expect(output.contains("movie | 1"))
+        }
+
+        @available(macOS 26, *)
+        @Test("returns guidance for an unknown provider without discovering")
+        func unknownProvider() async throws {
+            apiClient.addResponse(.success(WatchProviderResult.mock))
+
+            let output = try await tool.call(
+                arguments: .init(
+                    genre: nil,
+                    yearFrom: nil,
+                    yearTo: nil,
+                    minRating: nil,
+                    watchProvider: "Nonexistent Service",
+                    watchRegion: "GB"
+                )
+            )
+
+            #expect(output.contains("Unknown streaming provider 'Nonexistent Service'"))
+        }
+
+        @available(macOS 26, *)
+        @Test("works with no filters")
+        func noFilters() async throws {
+            apiClient.addResponse(.success(MoviePageableList.mock(results: [.mock(id: 9, title: "X")])))
+
+            let output = try await tool.call(
+                arguments: .init(
+                    genre: nil,
+                    yearFrom: nil,
+                    yearTo: nil,
+                    minRating: nil,
+                    watchProvider: nil,
+                    watchRegion: nil
+                )
+            )
+
+            #expect(output.contains("movie | 9"))
+        }
+
+    }
+#endif

--- a/Tests/TMDbTests/Domain/LanguageModelTools/MovieDetailsToolTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/MovieDetailsToolTests.swift
@@ -1,0 +1,56 @@
+//
+//  MovieDetailsToolTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && os(macOS)
+    import Foundation
+    import Testing
+    @testable import TMDb
+
+    @Suite(.tags(.languageModelTools))
+    struct MovieDetailsToolTests {
+
+        private struct DummyError: Error {}
+
+        private let apiClient = MockAPIClient()
+
+        @available(macOS 26, *)
+        private var tool: MovieDetailsTool {
+            MovieDetailsTool(movieService: TMDbMovieService(apiClient: apiClient))
+        }
+
+        @available(macOS 26, *)
+        @Test("returns a details block carrying the id")
+        func returnsDetailsBlock() async throws {
+            apiClient.addResponse(.success(Movie.mock(id: 27205, title: "Inception")))
+
+            let output = try await tool.call(arguments: .init(movieID: 27205))
+
+            #expect(output.contains("movie | 27205 | Inception"))
+        }
+
+        @available(macOS 26, *)
+        @Test("recovers from not found with a readable message")
+        func recoversFromNotFound() async throws {
+            apiClient.addResponse(.failure(.notFound()))
+
+            let output = try await tool.call(arguments: .init(movieID: 999))
+
+            #expect(output == "No TMDb movie with id 999 found.")
+        }
+
+        @available(macOS 26, *)
+        @Test("rethrows infrastructure errors")
+        func rethrowsInfrastructureErrors() async {
+            apiClient.addResponse(.failure(.network(DummyError())))
+
+            await #expect(throws: TMDbError.self) {
+                _ = try await tool.call(arguments: .init(movieID: 1))
+            }
+        }
+
+    }
+#endif

--- a/Tests/TMDbTests/Domain/LanguageModelTools/MovieGenreTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/MovieGenreTests.swift
@@ -1,0 +1,52 @@
+//
+//  MovieGenreTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && os(macOS)
+    import Foundation
+    import Testing
+    @testable import TMDb
+
+    @Suite(.tags(.languageModelTools))
+    struct MovieGenreTests {
+
+        @available(macOS 26, *)
+        @Test(
+            "each genre maps to its stable TMDb identifier",
+            arguments: [
+                (MovieGenre.action, 28),
+                (.adventure, 12),
+                (.animation, 16),
+                (.comedy, 35),
+                (.crime, 80),
+                (.documentary, 99),
+                (.drama, 18),
+                (.family, 10751),
+                (.fantasy, 14),
+                (.history, 36),
+                (.horror, 27),
+                (.music, 10402),
+                (.mystery, 9648),
+                (.romance, 10749),
+                (.scienceFiction, 878),
+                (.thriller, 53),
+                (.war, 10752),
+                (.western, 37)
+            ]
+        )
+        func genreIDMapping(genre: MovieGenre, expectedID: Genre.ID) {
+            #expect(genre.genreID == expectedID)
+        }
+
+        @available(macOS 26, *)
+        @Test("trending window maps to the domain filter type")
+        func trendingWindowMapping() {
+            #expect(TrendingWindow.day.filterType == .day)
+            #expect(TrendingWindow.week.filterType == .week)
+        }
+
+    }
+#endif

--- a/Tests/TMDbTests/Domain/LanguageModelTools/PersonFilmographyToolTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/PersonFilmographyToolTests.swift
@@ -78,6 +78,22 @@
         }
 
         @available(macOS 26, *)
+        @Test("clamps a negative maxCredits without crashing")
+        func clampsNegativeMaxCredits() async throws {
+            let credits = PersonCombinedCredits(
+                id: 287,
+                cast: [.movie(.mock(id: 10, popularity: 5))],
+                crew: []
+            )
+            apiClient.addResponse(.success(Person.mock(id: 287, name: "Brad Pitt")))
+            apiClient.addResponse(.success(credits))
+
+            let output = try await tool.call(arguments: .init(personID: 287, maxCredits: -3))
+
+            #expect(output.contains("No notable credits found."))
+        }
+
+        @available(macOS 26, *)
         @Test("recovers from not found with a readable message")
         func recoversFromNotFound() async throws {
             apiClient.addResponse(.failure(.notFound()))

--- a/Tests/TMDbTests/Domain/LanguageModelTools/PersonFilmographyToolTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/PersonFilmographyToolTests.swift
@@ -1,0 +1,91 @@
+//
+//  PersonFilmographyToolTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && os(macOS)
+    import Foundation
+    import Testing
+    @testable import TMDb
+
+    @Suite(.tags(.languageModelTools))
+    struct PersonFilmographyToolTests {
+
+        private let apiClient = MockAPIClient()
+
+        @available(macOS 26, *)
+        private var tool: PersonFilmographyTool {
+            PersonFilmographyTool(personService: TMDbPersonService(apiClient: apiClient))
+        }
+
+        @available(macOS 26, *)
+        @Test("returns a person header followed by credit lines")
+        func returnsHeaderAndCredits() async throws {
+            apiClient.addResponse(
+                .success(Person.mock(id: 287, name: "Brad Pitt", knownForDepartment: "Acting"))
+            )
+            apiClient.addResponse(.success(PersonCombinedCredits.mock(id: 287)))
+
+            let output = try await tool.call(arguments: .init(personID: 287, maxCredits: nil))
+            let lines = output.components(separatedBy: "\n")
+
+            #expect(lines.first == "person | 287 | Brad Pitt | Acting")
+            #expect(lines.count > 1)
+        }
+
+        @available(macOS 26, *)
+        @Test("orders credits by popularity, most notable first")
+        func ordersByPopularity() async throws {
+            let credits = PersonCombinedCredits(
+                id: 287,
+                cast: [
+                    .movie(.mock(id: 10, title: "Less Popular", popularity: 5)),
+                    .movie(.mock(id: 20, title: "More Popular", popularity: 90))
+                ],
+                crew: []
+            )
+            apiClient.addResponse(.success(Person.mock(id: 287, name: "Brad Pitt")))
+            apiClient.addResponse(.success(credits))
+
+            let output = try await tool.call(arguments: .init(personID: 287, maxCredits: nil))
+            let morePopular = try #require(output.range(of: "movie | 20"))
+            let lessPopular = try #require(output.range(of: "movie | 10"))
+
+            #expect(morePopular.lowerBound < lessPopular.lowerBound)
+        }
+
+        @available(macOS 26, *)
+        @Test("limits the number of credits to maxCredits")
+        func limitsCredits() async throws {
+            let credits = PersonCombinedCredits(
+                id: 287,
+                cast: [
+                    .movie(.mock(id: 10, popularity: 5)),
+                    .movie(.mock(id: 20, popularity: 90)),
+                    .movie(.mock(id: 30, popularity: 50))
+                ],
+                crew: []
+            )
+            apiClient.addResponse(.success(Person.mock(id: 287, name: "Brad Pitt")))
+            apiClient.addResponse(.success(credits))
+
+            let output = try await tool.call(arguments: .init(personID: 287, maxCredits: 1))
+
+            // Header line + exactly one credit line.
+            #expect(output.components(separatedBy: "\n").count == 2)
+        }
+
+        @available(macOS 26, *)
+        @Test("recovers from not found with a readable message")
+        func recoversFromNotFound() async throws {
+            apiClient.addResponse(.failure(.notFound()))
+
+            let output = try await tool.call(arguments: .init(personID: 999, maxCredits: nil))
+
+            #expect(output == "No TMDb person with id 999 found.")
+        }
+
+    }
+#endif

--- a/Tests/TMDbTests/Domain/LanguageModelTools/SearchTMDbToolTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/SearchTMDbToolTests.swift
@@ -1,0 +1,89 @@
+//
+//  SearchTMDbToolTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && os(macOS)
+    import Foundation
+    import Testing
+    @testable import TMDb
+
+    @Suite(.tags(.languageModelTools))
+    struct SearchTMDbToolTests {
+
+        private struct DummyError: Error {}
+
+        private let apiClient = MockAPIClient()
+
+        @available(macOS 26, *)
+        private var tool: SearchTMDbTool {
+            SearchTMDbTool(searchService: TMDbSearchService(apiClient: apiClient))
+        }
+
+        @available(macOS 26, *)
+        @Test("returns formatted results carrying ids")
+        func returnsResultsWithIDs() async throws {
+            let list = MediaPageableList.mock(
+                results: [
+                    .movie(.mock(id: 27205, title: "Inception")),
+                    .person(.mock(id: 287, name: "Brad Pitt", originalName: "Brad Pitt"))
+                ]
+            )
+            apiClient.addResponse(.success(list))
+
+            let output = try await tool.call(arguments: .init(query: "Inception", mediaType: nil))
+
+            #expect(output.contains("movie | 27205"))
+            #expect(output.contains("person | 287"))
+        }
+
+        @available(macOS 26, *)
+        @Test("limits results to the requested media type")
+        func filtersByMediaType() async throws {
+            let list = MediaPageableList.mock(
+                results: [
+                    .movie(.mock(id: 1, title: "A Movie")),
+                    .person(.mock(id: 2, name: "A Person", originalName: "A Person"))
+                ]
+            )
+            apiClient.addResponse(.success(list))
+
+            let output = try await tool.call(arguments: .init(query: "A", mediaType: .person))
+
+            #expect(output.contains("person | 2"))
+            #expect(!output.contains("movie | 1"))
+        }
+
+        @available(macOS 26, *)
+        @Test("returns a no-results message when nothing matches")
+        func noResults() async throws {
+            apiClient.addResponse(.success(MediaPageableList.mock(results: [])))
+
+            let output = try await tool.call(arguments: .init(query: "zzz", mediaType: nil))
+
+            #expect(output == "No results found for 'zzz'.")
+        }
+
+        @available(macOS 26, *)
+        @Test("returns guidance for an empty query without calling the API")
+        func emptyQuery() async throws {
+            let output = try await tool.call(arguments: .init(query: "   ", mediaType: nil))
+
+            #expect(output.contains("Provide"))
+            #expect(apiClient.lastRequest == nil)
+        }
+
+        @available(macOS 26, *)
+        @Test("rethrows infrastructure errors")
+        func rethrowsInfrastructureErrors() async {
+            apiClient.addResponse(.failure(.network(DummyError())))
+
+            await #expect(throws: TMDbError.self) {
+                _ = try await tool.call(arguments: .init(query: "Inception", mediaType: nil))
+            }
+        }
+
+    }
+#endif

--- a/Tests/TMDbTests/Domain/LanguageModelTools/TMDbClientLanguageModelToolsTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/TMDbClientLanguageModelToolsTests.swift
@@ -1,0 +1,38 @@
+//
+//  TMDbClientLanguageModelToolsTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && os(macOS)
+    import Foundation
+    import FoundationModels
+    import Testing
+    @testable import TMDb
+
+    @Suite(.tags(.languageModelTools))
+    struct TMDbClientLanguageModelToolsTests {
+
+        private let client = TMDbClient(apiKey: "test-api-key")
+
+        @available(macOS 26, *)
+        @Test("languageModelTools exposes the seven tools")
+        func languageModelToolsCount() {
+            #expect(client.languageModelTools.count == 7)
+        }
+
+        @available(macOS 26, *)
+        @Test("each individual tool property returns the expected tool")
+        func individualToolProperties() {
+            #expect(client.searchTool.name == "search")
+            #expect(client.movieDetailsTool.name == "movieDetails")
+            #expect(client.tvSeriesDetailsTool.name == "tvSeriesDetails")
+            #expect(client.personFilmographyTool.name == "personFilmography")
+            #expect(client.trendingTool.name == "trending")
+            #expect(client.watchProvidersTool.name == "watchProviders")
+            #expect(client.discoverMoviesTool.name == "discoverMovies")
+        }
+
+    }
+#endif

--- a/Tests/TMDbTests/Domain/LanguageModelTools/TMDbToolboxTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/TMDbToolboxTests.swift
@@ -1,0 +1,87 @@
+//
+//  TMDbToolboxTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && os(macOS)
+    import Foundation
+    import FoundationModels
+    import Testing
+    @testable import TMDb
+
+    @Suite(.tags(.languageModelTools))
+    struct TMDbToolboxTests {
+
+        @available(macOS 26, *)
+        private func makeToolbox(language: String? = nil, region: String? = nil) -> TMDbToolbox {
+            let apiClient = MockAPIClient()
+            return TMDbToolbox(
+                movieService: TMDbMovieService(apiClient: apiClient),
+                tvSeriesService: TMDbTVSeriesService(apiClient: apiClient),
+                personService: TMDbPersonService(apiClient: apiClient),
+                searchService: TMDbSearchService(apiClient: apiClient),
+                trendingService: TMDbTrendingService(apiClient: apiClient),
+                discoverService: TMDbDiscoverService(apiClient: apiClient),
+                watchProviderService: TMDbWatchProviderService(apiClient: apiClient),
+                language: language,
+                region: region
+            )
+        }
+
+        @available(macOS 26, *)
+        @Test("all exposes the seven tools")
+        func allHasSevenTools() {
+            #expect(makeToolbox().all.count == 7)
+        }
+
+        @available(macOS 26, *)
+        @Test("tools expose stable, frozen names")
+        func toolNames() {
+            let names = makeToolbox().all.map(\.name).sorted()
+            #expect(
+                names == [
+                    "discoverMovies",
+                    "movieDetails",
+                    "personFilmography",
+                    "search",
+                    "trending",
+                    "tvSeriesDetails",
+                    "watchProviders"
+                ]
+            )
+        }
+
+        @available(macOS 26, *)
+        @Test("every tool has a non-empty description")
+        func toolDescriptions() {
+            for tool in makeToolbox().all {
+                #expect(!tool.description.isEmpty)
+            }
+        }
+
+        @available(macOS 26, *)
+        @Test("the retrieval trio descriptions disambiguate one another")
+        func retrievalTrioDisambiguation() {
+            let toolbox = makeToolbox()
+            #expect(toolbox.search.description.contains("discoverMovies"))
+            #expect(toolbox.search.description.contains("trending"))
+            #expect(toolbox.discoverMovies.description.contains("Browse"))
+        }
+
+        @available(macOS 26, *)
+        @Test("each accessor returns the expected tool")
+        func accessorsWireToTheRightTools() {
+            let toolbox = makeToolbox()
+            #expect(toolbox.search.name == "search")
+            #expect(toolbox.movieDetails.name == "movieDetails")
+            #expect(toolbox.tvSeriesDetails.name == "tvSeriesDetails")
+            #expect(toolbox.personFilmography.name == "personFilmography")
+            #expect(toolbox.trending.name == "trending")
+            #expect(toolbox.watchProviders.name == "watchProviders")
+            #expect(toolbox.discoverMovies.name == "discoverMovies")
+        }
+
+    }
+#endif

--- a/Tests/TMDbTests/Domain/LanguageModelTools/TVSeriesDetailsToolTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/TVSeriesDetailsToolTests.swift
@@ -1,0 +1,44 @@
+//
+//  TVSeriesDetailsToolTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && os(macOS)
+    import Foundation
+    import Testing
+    @testable import TMDb
+
+    @Suite(.tags(.languageModelTools))
+    struct TVSeriesDetailsToolTests {
+
+        private let apiClient = MockAPIClient()
+
+        @available(macOS 26, *)
+        private var tool: TVSeriesDetailsTool {
+            TVSeriesDetailsTool(tvSeriesService: TMDbTVSeriesService(apiClient: apiClient))
+        }
+
+        @available(macOS 26, *)
+        @Test("returns a details block carrying the id")
+        func returnsDetailsBlock() async throws {
+            apiClient.addResponse(.success(TVSeries.mock(id: 1396, name: "Breaking Bad")))
+
+            let output = try await tool.call(arguments: .init(tvSeriesID: 1396))
+
+            #expect(output.contains("tv | 1396 | Breaking Bad"))
+        }
+
+        @available(macOS 26, *)
+        @Test("recovers from not found with a readable message")
+        func recoversFromNotFound() async throws {
+            apiClient.addResponse(.failure(.notFound()))
+
+            let output = try await tool.call(arguments: .init(tvSeriesID: 999))
+
+            #expect(output == "No TMDb TV series with id 999 found.")
+        }
+
+    }
+#endif

--- a/Tests/TMDbTests/Domain/LanguageModelTools/TVSeriesDetailsToolTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/TVSeriesDetailsToolTests.swift
@@ -13,6 +13,8 @@
     @Suite(.tags(.languageModelTools))
     struct TVSeriesDetailsToolTests {
 
+        private struct DummyError: Error {}
+
         private let apiClient = MockAPIClient()
 
         @available(macOS 26, *)
@@ -38,6 +40,16 @@
             let output = try await tool.call(arguments: .init(tvSeriesID: 999))
 
             #expect(output == "No TMDb TV series with id 999 found.")
+        }
+
+        @available(macOS 26, *)
+        @Test("rethrows infrastructure errors")
+        func rethrowsInfrastructureErrors() async {
+            apiClient.addResponse(.failure(.network(DummyError())))
+
+            await #expect(throws: TMDbError.self) {
+                _ = try await tool.call(arguments: .init(tvSeriesID: 1))
+            }
         }
 
     }

--- a/Tests/TMDbTests/Domain/LanguageModelTools/ToolErrorMapperTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/ToolErrorMapperTests.swift
@@ -1,0 +1,56 @@
+//
+//  ToolErrorMapperTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.languageModelTools))
+struct ToolErrorMapperTests {
+
+    private struct DummyError: Error {}
+
+    @Test("not found maps to a message naming the entity and id")
+    func notFoundWithEntityAndID() {
+        let message = ToolErrorMapper.message(for: .notFound(), entity: "movie", id: 5)
+        #expect(message == "No TMDb movie with id 5 found.")
+    }
+
+    @Test("not found without context maps to a generic message")
+    func notFoundWithoutContext() {
+        let message = ToolErrorMapper.message(for: .notFound())
+        #expect(message == "No TMDb result found.")
+    }
+
+    @Test("bad request maps to a message including the underlying detail")
+    func badRequest() {
+        let message = ToolErrorMapper.message(for: .badRequest("invalid country"))
+        #expect(message?.contains("Invalid request: invalid country") == true)
+    }
+
+    @Test("too many requests maps to a rate-limit message")
+    func tooManyRequests() {
+        let message = ToolErrorMapper.message(for: .tooManyRequests())
+        #expect(message?.contains("rate limiting") == true)
+    }
+
+    @Test("unauthorised and forbidden map to an access-denied message")
+    func accessDenied() {
+        #expect(ToolErrorMapper.message(for: .unauthorised()) == "TMDb access was denied (check the API key).")
+        #expect(ToolErrorMapper.message(for: .forbidden()) == "TMDb access was denied (check the API key).")
+    }
+
+    @Test("infrastructure errors return nil so they are rethrown")
+    func infrastructureErrorsAreRethrown() {
+        #expect(ToolErrorMapper.message(for: .network(DummyError())) == nil)
+        #expect(ToolErrorMapper.message(for: .serverError()) == nil)
+        #expect(ToolErrorMapper.message(for: .decode(DummyError())) == nil)
+        #expect(ToolErrorMapper.message(for: .invalidRating) == nil)
+        #expect(ToolErrorMapper.message(for: .unknown) == nil)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/LanguageModelTools/ToolOutputFormatterTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/ToolOutputFormatterTests.swift
@@ -1,0 +1,297 @@
+//
+//  ToolOutputFormatterTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.languageModelTools))
+struct ToolOutputFormatterTests {
+
+    // MARK: - List lines
+
+    @Test("movie line leads with kind and id, and includes year, rating, overview")
+    func movieLineStructure() throws {
+        let movie = MovieListItem.mock(
+            id: 27205,
+            title: "Inception",
+            overview: "A thief who steals corporate secrets.",
+            releaseDate: Date(iso8601: "2010-07-16T00:00:00Z"),
+            voteAverage: 8.4
+        )
+
+        let line = try #require(ToolOutputFormatter.line(for: Media.movie(movie)))
+        let tokens = line.components(separatedBy: " | ")
+
+        #expect(tokens[0] == "movie")
+        #expect(tokens[1] == "27205")
+        #expect(line.contains("Inception (2010)"))
+        #expect(line.contains("⭐8.4"))
+        #expect(line.contains("A thief who steals corporate secrets."))
+    }
+
+    @Test("tv line uses tv kind and first-air year")
+    func tvLineStructure() throws {
+        let tvSeries = TVSeriesListItem.mock(
+            id: 1396,
+            name: "Breaking Bad",
+            firstAirDate: Date(iso8601: "2008-01-20T00:00:00Z"),
+            voteAverage: 8.9
+        )
+
+        let line = try #require(ToolOutputFormatter.line(for: Media.tvSeries(tvSeries)))
+        let tokens = line.components(separatedBy: " | ")
+
+        #expect(tokens[0] == "tv")
+        #expect(tokens[1] == "1396")
+        #expect(line.contains("Breaking Bad (2008)"))
+        #expect(line.contains("⭐8.9"))
+    }
+
+    @Test("person line uses person kind and known-for department, no rating")
+    func personLineStructure() throws {
+        let person = PersonListItem.mock(
+            id: 287,
+            name: "Brad Pitt",
+            originalName: "Brad Pitt",
+            knownForDepartment: "Acting"
+        )
+
+        let line = try #require(ToolOutputFormatter.line(for: Media.person(person)))
+        let tokens = line.components(separatedBy: " | ")
+
+        #expect(tokens[0] == "person")
+        #expect(tokens[1] == "287")
+        #expect(tokens[2] == "Brad Pitt")
+        #expect(tokens[3] == "Acting")
+        #expect(!line.contains("⭐"))
+    }
+
+    @Test("collection media is dropped from a line")
+    func collectionLineIsNil() {
+        let collection = CollectionListItem(
+            id: 99,
+            title: "Some Collection",
+            originalTitle: "Some Collection",
+            originalLanguage: "en",
+            overview: ""
+        )
+
+        #expect(ToolOutputFormatter.line(for: Media.collection(collection)) == nil)
+    }
+
+    @Test("mediaList drops collections and keeps movies, tv, and people")
+    func mediaListDropsCollections() {
+        let items: [Media] = [
+            .movie(.mock(id: 1, title: "A")),
+            .collection(
+                CollectionListItem(
+                    id: 2,
+                    title: "Coll",
+                    originalTitle: "Coll",
+                    originalLanguage: "en",
+                    overview: ""
+                )
+            ),
+            .person(.mock(id: 3, name: "P", originalName: "P"))
+        ]
+
+        let output = ToolOutputFormatter.mediaList(items, limit: 8, query: "a")
+        let lines = output.components(separatedBy: "\n")
+
+        #expect(lines.count == 2)
+        #expect(output.contains("movie | 1"))
+        #expect(output.contains("person | 3"))
+        #expect(!output.contains("Coll"))
+    }
+
+    @Test("mediaList returns a no-results message when empty")
+    func mediaListEmptyMessage() {
+        let output = ToolOutputFormatter.mediaList([], limit: 8, query: "nothing here")
+        #expect(output == "No results found for 'nothing here'.")
+    }
+
+    @Test("mediaList respects the limit")
+    func mediaListRespectsLimit() {
+        let items: [Media] = (1 ... 10).map { .movie(.mock(id: $0, title: "Movie \($0)")) }
+        let output = ToolOutputFormatter.mediaList(items, limit: 3, query: "movies")
+
+        #expect(output.components(separatedBy: "\n").count == 3)
+    }
+
+    @Test("rating is omitted when nil or zero")
+    func ratingOmittedWhenAbsent() throws {
+        let noRating = MovieListItem.mock(id: 1, title: "A", voteAverage: nil)
+        let zeroRating = MovieListItem.mock(id: 2, title: "B", voteAverage: 0)
+
+        let lineNoRating = try #require(ToolOutputFormatter.line(for: Media.movie(noRating)))
+        let lineZeroRating = try #require(ToolOutputFormatter.line(for: Media.movie(zeroRating)))
+
+        #expect(!lineNoRating.contains("⭐"))
+        #expect(!lineZeroRating.contains("⭐"))
+    }
+
+    @Test("year is omitted when the release date is nil")
+    func yearOmittedWhenDateAbsent() throws {
+        let movie = MovieListItem.mock(id: 1, title: "No Date Movie", releaseDate: nil)
+        let line = try #require(ToolOutputFormatter.line(for: Media.movie(movie)))
+
+        #expect(line.contains("No Date Movie"))
+        #expect(!line.contains("("))
+    }
+
+    @Test("pipe and newline characters in title and overview do not corrupt the line")
+    func sanitizesDelimitersInText() throws {
+        let movie = MovieListItem.mock(
+            id: 42,
+            title: "Crash | Boom",
+            overview: "Line one\nLine | two",
+            releaseDate: Date(iso8601: "2004-05-06T00:00:00Z"),
+            voteAverage: 7
+        )
+
+        let line = try #require(ToolOutputFormatter.line(for: Media.movie(movie)))
+        let tokens = line.components(separatedBy: " | ")
+
+        #expect(tokens[0] == "movie")
+        #expect(tokens[1] == "42")
+        #expect(!line.contains("Crash | Boom"))
+        #expect(!line.contains("\n"))
+    }
+
+    @Test("long overview is truncated with an ellipsis")
+    func truncatesLongOverview() throws {
+        let overview = String(repeating: "word ", count: 80)
+        let movie = MovieListItem.mock(id: 1, title: "A", overview: overview)
+
+        let line = try #require(ToolOutputFormatter.line(for: Media.movie(movie)))
+
+        #expect(line.contains("…"))
+        #expect(line.count < overview.count)
+    }
+
+    @Test("show line delegates to the underlying media kind")
+    func showLine() {
+        let movieShow = Show.movie(.mock(id: 11, title: "Film"))
+        let tvShow = Show.tvSeries(.mock(id: 22, name: "Series"))
+
+        #expect(ToolOutputFormatter.line(for: movieShow).hasPrefix("movie | 11"))
+        #expect(ToolOutputFormatter.line(for: tvShow).hasPrefix("tv | 22"))
+    }
+
+    // MARK: - Detail blocks
+
+    @Test("movie block includes id, genres, runtime, status and overview")
+    func movieBlock() {
+        let movie = Movie.mock(
+            id: 27205,
+            title: "Inception",
+            tagline: "Your mind is the scene of the crime.",
+            overview: "A thief enters dreams.",
+            runtime: 148,
+            genres: [Genre(id: 28, name: "Action"), Genre(id: 878, name: "Science Fiction")],
+            releaseDate: Date(iso8601: "2010-07-16T00:00:00Z"),
+            status: .released,
+            voteAverage: 8.4
+        )
+
+        let block = ToolOutputFormatter.block(for: movie)
+
+        #expect(block.hasPrefix("movie | 27205 | Inception (2010)"))
+        #expect(block.contains("148 min"))
+        #expect(block.contains("genres: Action, Science Fiction"))
+        #expect(block.contains("⭐8.4"))
+        #expect(block.contains("status: Released"))
+        #expect(block.contains("tagline: Your mind is the scene of the crime."))
+        #expect(block.contains("overview: A thief enters dreams."))
+    }
+
+    @Test("tv series block includes id, season count and status")
+    func tvSeriesBlock() {
+        let tvSeries = TVSeries.mock(
+            id: 1396,
+            name: "Breaking Bad",
+            overview: "A teacher turns to crime.",
+            numberOfSeasons: 5,
+            genres: [Genre(id: 18, name: "Drama")],
+            firstAirDate: Date(iso8601: "2008-01-20T00:00:00Z"),
+            status: "Ended",
+            voteAverage: 8.9
+        )
+
+        let block = ToolOutputFormatter.block(for: tvSeries)
+
+        #expect(block.hasPrefix("tv | 1396 | Breaking Bad (2008)"))
+        #expect(block.contains("5 seasons"))
+        #expect(block.contains("genres: Drama"))
+        #expect(block.contains("status: Ended"))
+        #expect(block.contains("overview: A teacher turns to crime."))
+    }
+
+    @Test("person header includes id, name and department")
+    func personHeader() {
+        let person = Person.mock(id: 287, name: "Brad Pitt", knownForDepartment: "Acting")
+        let header = ToolOutputFormatter.header(for: person)
+
+        #expect(header == "person | 287 | Brad Pitt | Acting")
+    }
+
+    // MARK: - Watch providers
+
+    @Test("watch providers groups flat-rate as stream and skips empty groups")
+    func watchProvidersGrouping() {
+        let providers = ShowWatchProvider.mock(
+            free: nil,
+            flatRate: [.netflix],
+            buy: nil,
+            rent: [WatchProvider.mock(id: 2, name: "Apple TV")],
+            ads: nil
+        )
+
+        let output = ToolOutputFormatter.watchProviders(
+            id: 27205,
+            countryCode: "GB",
+            providers: providers
+        )
+
+        #expect(output.hasPrefix("watchProviders | 27205 | GB"))
+        #expect(output.contains("stream: Netflix"))
+        #expect(output.contains("rent: Apple TV"))
+        #expect(!output.contains("free:"))
+        #expect(!output.contains("buy:"))
+        #expect(!output.contains("ads:"))
+    }
+
+    @Test("watch providers returns a none message when all groups are empty")
+    func watchProvidersNone() {
+        let providers = ShowWatchProvider.mock(
+            free: nil,
+            flatRate: nil,
+            buy: nil,
+            rent: nil,
+            ads: nil
+        )
+
+        let output = ToolOutputFormatter.watchProviders(
+            id: 99,
+            countryCode: "US",
+            providers: providers
+        )
+
+        #expect(output == "No watch providers listed for id 99 in US.")
+    }
+
+    // MARK: - Helpers
+
+    @Test("year is extracted in UTC")
+    func yearExtraction() {
+        let date = Date(iso8601: "1999-12-31T23:00:00Z")
+        #expect(ToolOutputFormatter.year(from: date) == 1999)
+        #expect(ToolOutputFormatter.year(from: nil) == nil)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/LanguageModelTools/TrendingToolTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/TrendingToolTests.swift
@@ -1,0 +1,59 @@
+//
+//  TrendingToolTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && os(macOS)
+    import Foundation
+    import Testing
+    @testable import TMDb
+
+    @Suite(.tags(.languageModelTools))
+    struct TrendingToolTests {
+
+        private let apiClient = MockAPIClient()
+
+        @available(macOS 26, *)
+        private var tool: TrendingTool {
+            TrendingTool(trendingService: TMDbTrendingService(apiClient: apiClient))
+        }
+
+        @available(macOS 26, *)
+        @Test("returns trending movies carrying ids")
+        func trendingMovies() async throws {
+            let list = MoviePageableList.mock(results: [.mock(id: 27205, title: "Inception")])
+            apiClient.addResponse(.success(list))
+
+            let output = try await tool.call(arguments: .init(mediaType: .movie, timeWindow: .week))
+
+            #expect(output.contains("movie | 27205"))
+        }
+
+        @available(macOS 26, *)
+        @Test("returns trending TV series carrying ids")
+        func trendingTVSeries() async throws {
+            let list = TVSeriesPageableList.mock(results: [.mock(id: 1396, name: "Breaking Bad")])
+            apiClient.addResponse(.success(list))
+
+            let output = try await tool.call(arguments: .init(mediaType: .tvSeries, timeWindow: .day))
+
+            #expect(output.contains("tv | 1396"))
+        }
+
+        @available(macOS 26, *)
+        @Test("returns trending people carrying ids")
+        func trendingPeople() async throws {
+            let list = PersonPageableList.mock(
+                results: [.mock(id: 287, name: "Brad Pitt", originalName: "Brad Pitt")]
+            )
+            apiClient.addResponse(.success(list))
+
+            let output = try await tool.call(arguments: .init(mediaType: .person, timeWindow: .day))
+
+            #expect(output.contains("person | 287"))
+        }
+
+    }
+#endif

--- a/Tests/TMDbTests/Domain/LanguageModelTools/WatchProvidersToolTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/WatchProvidersToolTests.swift
@@ -1,0 +1,76 @@
+//
+//  WatchProvidersToolTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && os(macOS)
+    import Foundation
+    import Testing
+    @testable import TMDb
+
+    @Suite(.tags(.languageModelTools))
+    struct WatchProvidersToolTests {
+
+        private let apiClient = MockAPIClient()
+
+        @available(macOS 26, *)
+        private var tool: WatchProvidersTool {
+            WatchProvidersTool(
+                movieService: TMDbMovieService(apiClient: apiClient),
+                tvSeriesService: TMDbTVSeriesService(apiClient: apiClient)
+            )
+        }
+
+        @available(macOS 26, *)
+        @Test("returns providers for the requested movie and country")
+        func returnsMovieProviders() async throws {
+            apiClient.addResponse(.success(ShowWatchProviderResult.mock(regionCode: "GB")))
+
+            let output = try await tool.call(
+                arguments: .init(mediaType: .movie, id: 27205, countryCode: "GB")
+            )
+
+            #expect(output.hasPrefix("watchProviders | 27205 | GB"))
+            #expect(output.contains("Netflix"))
+        }
+
+        @available(macOS 26, *)
+        @Test("returns a message when the country has no providers")
+        func noProvidersForCountry() async throws {
+            apiClient.addResponse(.success(ShowWatchProviderResult.mock(regionCode: "US")))
+
+            let output = try await tool.call(
+                arguments: .init(mediaType: .movie, id: 27205, countryCode: "FR")
+            )
+
+            #expect(output == "No watch providers found for id 27205 in FR.")
+        }
+
+        @available(macOS 26, *)
+        @Test("supports TV series")
+        func returnsTVSeriesProviders() async throws {
+            apiClient.addResponse(.success(ShowWatchProviderResult.mock(regionCode: "US")))
+
+            let output = try await tool.call(
+                arguments: .init(mediaType: .tvSeries, id: 1396, countryCode: "us")
+            )
+
+            #expect(output.hasPrefix("watchProviders | 1396 | US"))
+        }
+
+        @available(macOS 26, *)
+        @Test("recovers from not found with a readable message")
+        func recoversFromNotFound() async throws {
+            apiClient.addResponse(.failure(.notFound()))
+
+            let output = try await tool.call(
+                arguments: .init(mediaType: .movie, id: 999, countryCode: "US")
+            )
+
+            #expect(output == "No TMDb movie with id 999 found.")
+        }
+
+    }
+#endif

--- a/Tests/TMDbTests/TestUtils/Tags.swift
+++ b/Tests/TMDbTests/TestUtils/Tags.swift
@@ -48,5 +48,6 @@ extension Tag {
     @Tag static var tvSeries: Self
     @Tag static var watchProvider: Self
     @Tag static var changes: Self
+    @Tag static var languageModelTools: Self
 
 }


### PR DESCRIPTION
## Summary

Exposes TMDb as a set of Apple **FoundationModels `Tool`s** so an app can drop them into a `LanguageModelSession` and get a conversational movie assistant — the model searches, fetches details, and finds streaming availability on its own, while TMDb's typed services do the work.

```swift
let session = LanguageModelSession(tools: tmdbClient.languageModelTools)
let reply = try await session.respond(to: "What's a good thriller on Netflix UK tonight?")
```

This mirrors the package's existing on-device NaturalLanguageSearch integration, gated behind `#if canImport(FoundationModels) && !os(tvOS)` and `@available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)`.

## Changes

**New Feature:**
- ✨ `TMDbToolbox` — the sole public type: a public `all: [any Tool]` plus per-tool `any Tool` accessors so a host can compose a task-relevant subset (Apple recommends 3–5 tools per request). The seven concrete `Tool` structs and their `@Generable` arguments stay internal.
- ✨ `TMDbClient.languageModelTools` — convenience shorthand for `TMDbToolbox(client:).all`.
- ✨ Seven tools: `search`, `movieDetails`, `tvSeriesDetails`, `personFilmography`, `trending`, `watchProviders`, `discoverMovies`.

**Design details:**
- 🎨 Every output line leads with `kind | id | …` so the model can chain calls (search → details → watch providers).
- ⚡️ `discoverMovies` resolves genres via an on-device `@Generable` enum (no network round-trip, no unknown-genre retry) and resolves a streaming-provider name to an id, collapsing the headline "thriller on Netflix UK" case to a single discover hop.
- 🎨 Errors recover to a readable string where the model can adjust (not-found, empty, bad id/country, rate-limit); genuine infrastructure failures rethrow so the host app sees them.

**Tests:**
- ✅ 62 unit tests — pure formatter/error-mapper/genre-table coverage (runs everywhere) plus per-tool tests using real services backed by `MockAPIClient`.
- ✅ 7 live integration tests validating formatting against real TMDb data (API-key-gated), plus an opt-in end-to-end `LanguageModelSession` suite (`TMDB_FM_TOOLS_EVAL`).
- ✅ Full `make ci` passes: lint, markdown, 2563 unit tests, 275 integration tests, release build, docs.

**Documentation:**
- 📚 New `TMDbToolbox` DocC page, `UsingLanguageModelTools` How-To, and topic/section entries in `TMDb.md`, `TMDbClient.md`, and `README.md`.

## Benefits

- **Apple Intelligence-ready**: drop-in tools make TMDb usable from any `LanguageModelSession`, on-device or (via the new iOS 27 `LanguageModel` protocol) frontier cloud models.
- **Composable & token-aware**: pick a subset of tools; every result is compact and id-bearing for reliable multi-step reasoning.
- **Small, stable API surface**: only `TMDbToolbox` + `languageModelTools` are public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)