### PR TITLE
🔧 Refresh Claude tooling: guidance docs, worktree builds, Haiku-delegated skills, /watch-pr

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -40,7 +40,7 @@ Present me with the final report where both the review and the adversarial revie
 
 ## Architecture
 
-**Service-Based Design (25 services):**
+**Service-Based Design (26 services — 25 cross-platform + 1 Apple-only):**
 ```
 TMDbClient (main public facade)
 ├── AccountService        ├── ListService
@@ -55,17 +55,21 @@ TMDbClient (main public facade)
 ├── FindService           ├── TVSeasonService
 ├── GenreService          ├── TVSeriesService
 ├── GuestSessionService   ├── WatchProviderService
-└── KeywordService
+├── KeywordService
+└── NaturalLanguageSearchService  (Apple-only; #if canImport(NaturalLanguage))
 ```
 
 **Pattern:** Each service = public protocol + internal `TMDb`-prefixed implementation. Clean separation of concerns between layers.
 
 **Networking Layer:**
 ```
-Service → APIRequest (DecodableAPIRequest/CodableAPIRequest)
-       → APIClient (TMDbAPIClient)
-       → HTTPClient protocol (URLSessionHTTPClientAdapter)
-       → URLSession
+Service (e.g. TMDbMovieService)
+└── ErrorMappingAPIClient        (maps TMDbAPIError → public TMDbError; 18.0.0)
+    └── TMDbAPIClient            (adds api_key, validates status, decodes)
+        └── HTTPClient (protocol)
+            └── CacheHTTPClient          (opt-in; cache hits short-circuit)
+                └── RetryHTTPClient      (opt-in; exponential backoff)
+                    └── URLSessionHTTPClientAdapter  (or user-supplied client)
 ```
 
 **Dependency Injection:** `TMDbFactory` creates all services and wires dependencies.
@@ -74,8 +78,10 @@ Service → APIRequest (DecodableAPIRequest/CodableAPIRequest)
 - `Sources/TMDb/TMDbClient.swift` — Main public API entry point
 - `Sources/TMDb/TMDbFactory.swift` — DI factory
 - `Sources/TMDb/Domain/Services/` — Service protocols and implementations
-- `Sources/TMDb/Domain/Models/` — ~140 Codable data models
+- `Sources/TMDb/Domain/Models/` — ~170 Codable data models
 - `Sources/TMDb/Domain/APIClient/` — API abstraction layer
+- `Sources/TMDb/Domain/LanguageModelTools/` — `TMDbToolbox` FoundationModels
+  tools (Apple-only)
 - `Sources/TMDb/Networking/` — HTTP client, serializers
 
 ## Swift Rules
@@ -114,10 +120,10 @@ Use the `swift-concurrency` skill for detailed guidance. Key checks:
 
 ## Build/Tooling
 
-**Preferred (when Xcode MCP available):**
-- `mcp__xcode__BuildProject` for building
-- `mcp__xcode__RunAllTests` with **TMDb** test plan for unit tests
-- `mcp__xcode__RunAllTests` with **Integration** test plan for integration tests
+**Preferred (inside Xcode — use the `xcode-tools` MCP, NOT `mcp__xcode__*`):**
+- `mcp__xcode-tools__BuildProject` for building
+- `mcp__xcode-tools__RunAllTests` with **TMDb** test plan for unit tests
+- `mcp__xcode-tools__RunAllTests` with **Integration** test plan for integration tests
 
 **Fallback (command line):**
 - `make build` — Build with warnings-as-errors
@@ -137,6 +143,7 @@ Use the `swift-concurrency` skill for detailed guidance. Key checks:
 - Verify new public API is exposed through `TMDbClient` and registered in `TMDbFactory`.
 - Check that DocC catalog is updated when public API changes (see DocC Catalog Sync below).
 - When reviewing model changes or fixture accuracy, verify properties against the live TMDb API (see Model Verification below).
+- For changes under `Sources/TMDb/Domain/LanguageModelTools/` (the FoundationModels-based `TMDbToolbox`), verify the `#if canImport(FoundationModels) && !os(tvOS)` gating and `@available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)` annotations are present and correct.
 - When needing to verify Apple APIs (concurrency safety, availability, behavior), use `mcp__sosumi__searchAppleDocumentation` and `mcp__sosumi__fetchAppleDocumentation` to check official documentation.
 - For deep Swift Concurrency analysis (async/await patterns, actor isolation, Sendable conformance, data races), invoke the `swift-concurrency` skill.
 - For Swift Testing review (test structure, macros, traits, parameterized tests), invoke the `swift-testing-expert` skill.

--- a/.claude/agents/documentation-writer.md
+++ b/.claude/agents/documentation-writer.md
@@ -40,7 +40,7 @@ You are a Swift DocC documentation specialist for the TMDb Swift Package — a c
 
 **Key Documentation Touchpoints:**
 - `Sources/TMDb/Domain/Services/` — service protocols (documentation here defines the public API)
-- `Sources/TMDb/Domain/Models/` — ~140 Codable data models
+- `Sources/TMDb/Domain/Models/` — ~170 Codable data models
 - `Sources/TMDb/TMDb.docc/` — DocC catalog (extension files, topic sections, guides)
 
 ## Documentation Format
@@ -277,6 +277,7 @@ Sources/TMDb/TMDb.docc/
 │   ├── TMDbClient.md            # TMDbClient service property listings
 │   ├── MovieService.md          # Method groupings by category
 │   ├── TVSeriesService.md
+│   ├── TMDbToolbox.md           # FoundationModels tools (Apple-only)
 │   └── ...                      # One file per service
 ├── GettingStarted/
 ├── HowTos/

--- a/.claude/skills/build-for-testing/SKILL.md
+++ b/.claude/skills/build-for-testing/SKILL.md
@@ -5,13 +5,28 @@ description: Build the project for testing
 
 # Build for testing
 
-Use the `xcode-tools` MCP server when running inside Xcode, otherwise fall back to Make.
+Delegate this to a **Haiku subagent** so the build output stays out of your
+context. Use the Agent tool with `subagent_type: general-purpose` and
+`model: haiku`, give it the prompt below, then relay its report. Do **not** run
+the build yourself.
 
-## xcode-tools (preferred inside Xcode)
+Subagent prompt:
 
-1. Run `mcp__xcode-tools__BuildProject` with `buildForTesting: true` to build the package and all test targets.
-2. If the build fails, run `mcp__xcode-tools__GetBuildLog` with `severity: "error"` to see errors.
+```text
+Build the TMDb Swift package and all test targets, then report concisely.
 
-## Fallback
+- If the xcode-tools MCP is available (inside Xcode), run
+  `mcp__xcode-tools__BuildProject` with `buildForTesting: true`. On failure,
+  call `mcp__xcode-tools__GetBuildLog` with `severity: "error"` for details.
+- Otherwise run `make build-tests` from the project root.
 
-Run `make build-tests` from the project root.
+Report back ONLY:
+- Status: succeeded or failed
+- Error and warning counts
+- Each error/warning as `file:line — message` (omit this list if there are none)
+
+Do not paste raw build logs or successful-compilation output.
+```
+
+If the subagent reports failures, fix them in your own context, then re-invoke
+this skill to re-check (a fresh subagent will rebuild).

--- a/.claude/skills/build-for-testing/SKILL.md
+++ b/.claude/skills/build-for-testing/SKILL.md
@@ -18,15 +18,20 @@ Build the TMDb Swift package and all test targets, then report concisely.
 - If the xcode-tools MCP is available (inside Xcode), run
   `mcp__xcode-tools__BuildProject` with `buildForTesting: true`. On failure,
   call `mcp__xcode-tools__GetBuildLog` with `severity: "error"` for details.
-- Otherwise run `make build-tests` from the project root.
+- Otherwise run
+  `mkdir -p .build && make build-tests > .build/last-build-tests.log 2>&1`,
+  check the exit status for pass/fail, and summarise from that log file.
 
 Report back ONLY:
 - Status: succeeded or failed
 - Error and warning counts
 - Each error/warning as `file:line — message` (omit this list if there are none)
+- On failure, the full log path `.build/last-build-tests.log` (or, inside Xcode,
+  note that the full log is available via `mcp__xcode-tools__GetBuildLog`)
 
 Do not paste raw build logs or successful-compilation output.
 ```
 
-If the subagent reports failures, fix them in your own context, then re-invoke
-this skill to re-check (a fresh subagent will rebuild).
+If the report is unclear on a failure, read the log path it provides (or call
+`mcp__xcode-tools__GetBuildLog`) rather than re-running. After fixing the issues,
+re-invoke this skill to re-check (a fresh subagent will rebuild).

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -18,15 +18,19 @@ Build the TMDb Swift package and report the result concisely.
 - If the xcode-tools MCP is available (running inside Xcode), run
   `mcp__xcode-tools__BuildProject`. On failure, call
   `mcp__xcode-tools__GetBuildLog` with `severity: "error"` for details.
-- Otherwise run `make build` from the project root.
+- Otherwise run `mkdir -p .build && make build > .build/last-build.log 2>&1`,
+  check the exit status for pass/fail, and summarise from that log file.
 
 Report back ONLY:
 - Status: succeeded or failed
 - Error and warning counts
 - Each error/warning as `file:line — message` (omit this list if there are none)
+- On failure, the full log path `.build/last-build.log` (or, inside Xcode, note
+  that the full log is available via `mcp__xcode-tools__GetBuildLog`)
 
 Do not paste raw build logs or successful-compilation output.
 ```
 
-If the subagent reports failures, fix them in your own context, then re-invoke
-this skill to re-check (a fresh subagent will rebuild).
+If the report is unclear on a failure, read the log path it provides (or call
+`mcp__xcode-tools__GetBuildLog`) rather than re-running. After fixing the issues,
+re-invoke this skill to re-check (a fresh subagent will rebuild).

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -5,13 +5,28 @@ description: Build the project
 
 # Build project
 
-Use the `xcode-tools` MCP server when running inside Xcode, otherwise fall back to Make.
+Delegate the build to a **Haiku subagent** so the (potentially verbose) build
+output stays out of your context. Use the Agent tool with
+`subagent_type: general-purpose` and `model: haiku`, give it the prompt below,
+then relay its report. Do **not** run the build yourself.
 
-## xcode-tools (preferred inside Xcode)
+Subagent prompt:
 
-1. Run `mcp__xcode-tools__BuildProject` to build.
-2. If the build fails, run `mcp__xcode-tools__GetBuildLog` with `severity: "error"` to see errors.
+```text
+Build the TMDb Swift package and report the result concisely.
 
-## Fallback
+- If the xcode-tools MCP is available (running inside Xcode), run
+  `mcp__xcode-tools__BuildProject`. On failure, call
+  `mcp__xcode-tools__GetBuildLog` with `severity: "error"` for details.
+- Otherwise run `make build` from the project root.
 
-Run `make build` from the project root.
+Report back ONLY:
+- Status: succeeded or failed
+- Error and warning counts
+- Each error/warning as `file:line — message` (omit this list if there are none)
+
+Do not paste raw build logs or successful-compilation output.
+```
+
+If the subagent reports failures, fix them in your own context, then re-invoke
+this skill to re-check (a fresh subagent will rebuild).

--- a/.claude/skills/format/SKILL.md
+++ b/.claude/skills/format/SKILL.md
@@ -5,4 +5,21 @@ description: Format code with swiftlint and swiftformat
 
 # Format code
 
-Run `make format` from the project root to fix code style issues.
+Delegate formatting to a **Haiku subagent** so the output stays out of your
+context. Use the Agent tool with `subagent_type: general-purpose` and
+`model: haiku`, give it the prompt below, then relay its report. The subagent
+runs in your working directory, so its formatting edits persist for you. Do
+**not** run format yourself.
+
+Subagent prompt:
+
+```text
+Run `make format` from the TMDb project root (swiftlint --fix + swiftformat),
+then run `git status --short` to see what changed. Report concisely.
+
+Report back ONLY:
+- Status: files reformatted or already clean
+- The list of modified files (from `git status --short`)
+
+Do not paste file diffs or the full formatter output.
+```

--- a/.claude/skills/format/SKILL.md
+++ b/.claude/skills/format/SKILL.md
@@ -5,21 +5,8 @@ description: Format code with swiftlint and swiftformat
 
 # Format code
 
-Delegate formatting to a **Haiku subagent** so the output stays out of your
-context. Use the Agent tool with `subagent_type: general-purpose` and
-`model: haiku`, give it the prompt below, then relay its report. The subagent
-runs in your working directory, so its formatting edits persist for you. Do
-**not** run format yourself.
+Run `make format` from the project root to fix code style issues (swiftlint --fix
++ swiftformat).
 
-Subagent prompt:
-
-```text
-Run `make format` from the TMDb project root (swiftlint --fix + swiftformat),
-then run `git status --short` to see what changed. Report concisely.
-
-Report back ONLY:
-- Status: files reformatted or already clean
-- The list of modified files (from `git status --short`)
-
-Do not paste file diffs or the full formatter output.
-```
+Run this directly — it is fast and low-output, so delegating to a subagent would
+cost more (subagent overhead) than it saves.

--- a/.claude/skills/integration-test/SKILL.md
+++ b/.claude/skills/integration-test/SKILL.md
@@ -17,7 +17,9 @@ Run the TMDb integration tests against the live API and report concisely.
 
 - If the xcode-tools MCP is available (inside Xcode), run
   `mcp__xcode-tools__RunAllTests` with the Integration test plan.
-- Otherwise run `make integration-test` from the project root.
+- Otherwise run
+  `mkdir -p .build && make integration-test > .build/last-integration-test.log 2>&1`,
+  check the exit status for pass/fail, and summarise from that log file.
 
 These require TMDB_API_KEY, TMDB_USERNAME, and TMDB_PASSWORD, which are injected
 via the env block in .claude/settings.local.json — no sourcing is needed.
@@ -27,9 +29,12 @@ Report back ONLY:
 - Counts: total / passed / failed
 - Each failing test as `SuiteName/testName` with its `file:line` and the
   failure message (omit this list if there are none)
+- On failure, the full log path `.build/last-integration-test.log` (or, inside
+  Xcode, note that the full log is available via `mcp__xcode-tools__GetBuildLog`)
 
 Do not paste passing-test output or raw logs.
 ```
 
-If the subagent reports failures, fix them in your own context, then re-invoke
-this skill to re-check (a fresh subagent will re-run the tests).
+If the report is unclear on a failure, read the log path it provides rather than
+re-running. After fixing the issues, re-invoke this skill to re-check (a fresh
+subagent will re-run the tests).

--- a/.claude/skills/integration-test/SKILL.md
+++ b/.claude/skills/integration-test/SKILL.md
@@ -5,6 +5,15 @@ description: Run integration tests against the live TMDb API
 
 # Run integration tests
 
+Use the `xcode-tools` MCP server when running inside Xcode, otherwise fall back to Make.
+
+## xcode-tools (preferred inside Xcode)
+
+1. Run `mcp__xcode-tools__RunAllTests` with the **Integration** test plan.
+2. If tests fail, review the output for failure details. Use `mcp__xcode-tools__GetBuildLog` with `severity: "error"` if build errors caused the failure.
+
+## Fallback
+
 Run `make integration-test` from the project root.
 
-This requires `TMDB_API_KEY`, `TMDB_USERNAME`, and `TMDB_PASSWORD` environment variables to be set. These are injected automatically via the `env` block in `.claude/settings.local.json`, so no sourcing is needed.
+Either way, this requires the `TMDB_API_KEY`, `TMDB_USERNAME`, and `TMDB_PASSWORD` environment variables. These are injected automatically via the `env` block in `.claude/settings.local.json`, so no sourcing is needed.

--- a/.claude/skills/integration-test/SKILL.md
+++ b/.claude/skills/integration-test/SKILL.md
@@ -5,15 +5,31 @@ description: Run integration tests against the live TMDb API
 
 # Run integration tests
 
-Use the `xcode-tools` MCP server when running inside Xcode, otherwise fall back to Make.
+Delegate the test run to a **Haiku subagent** so the output stays out of your
+context. Use the Agent tool with `subagent_type: general-purpose` and
+`model: haiku`, give it the prompt below, then relay its report. Do **not** run
+the tests yourself.
 
-## xcode-tools (preferred inside Xcode)
+Subagent prompt:
 
-1. Run `mcp__xcode-tools__RunAllTests` with the **Integration** test plan.
-2. If tests fail, review the output for failure details. Use `mcp__xcode-tools__GetBuildLog` with `severity: "error"` if build errors caused the failure.
+```text
+Run the TMDb integration tests against the live API and report concisely.
 
-## Fallback
+- If the xcode-tools MCP is available (inside Xcode), run
+  `mcp__xcode-tools__RunAllTests` with the Integration test plan.
+- Otherwise run `make integration-test` from the project root.
 
-Run `make integration-test` from the project root.
+These require TMDB_API_KEY, TMDB_USERNAME, and TMDB_PASSWORD, which are injected
+via the env block in .claude/settings.local.json — no sourcing is needed.
 
-Either way, this requires the `TMDB_API_KEY`, `TMDB_USERNAME`, and `TMDB_PASSWORD` environment variables. These are injected automatically via the `env` block in `.claude/settings.local.json`, so no sourcing is needed.
+Report back ONLY:
+- Status: passed or failed
+- Counts: total / passed / failed
+- Each failing test as `SuiteName/testName` with its `file:line` and the
+  failure message (omit this list if there are none)
+
+Do not paste passing-test output or raw logs.
+```
+
+If the subagent reports failures, fix them in your own context, then re-invoke
+this skill to re-check (a fresh subagent will re-run the tests).

--- a/.claude/skills/lint/SKILL.md
+++ b/.claude/skills/lint/SKILL.md
@@ -5,28 +5,13 @@ description: Lint code with swiftlint and swiftformat
 
 # Lint code
 
-Delegate the lint check to a **Haiku subagent** so the output stays out of your
-context. Use the Agent tool with `subagent_type: general-purpose` and
-`model: haiku`, give it the prompt below, then relay its report. Do **not** run
-lint yourself.
+Run `make lint` from the project root to check code style (swiftlint --strict +
+swiftformat --lint).
 
-Subagent prompt:
+Run this directly — it is fast and low-output, so delegating to a subagent would
+cost more (subagent overhead) than it saves.
 
-```text
-Run `make lint` from the TMDb project root (swiftlint --strict + swiftformat
---lint) and report concisely.
-
-Report back ONLY:
-- Status: clean or violations found
-- Each violation as `file:line — rule: message` (omit this list if there are
-  none)
-
-If you see `superfluous_disable_command` errors on files that were not just
-changed, flag it — that is usually a swiftlint version-drift artifact (the pin
-is swiftlint 0.63.2 / swiftformat 0.61.1), not a real violation.
-
-Do not paste the full lint output.
-```
-
-If the subagent reports violations, fix them in your own context (or run
-`/format` for auto-fixable ones), then re-invoke this skill to re-check.
+If you see `superfluous_disable_command` errors on files you did not just change,
+it is usually a swiftlint version-drift artifact (the pin is swiftlint 0.63.2 /
+swiftformat 0.61.1), not a real violation. Run `/format` to auto-fix fixable
+violations.

--- a/.claude/skills/lint/SKILL.md
+++ b/.claude/skills/lint/SKILL.md
@@ -5,4 +5,28 @@ description: Lint code with swiftlint and swiftformat
 
 # Lint code
 
-Run `make lint` from the project root to check code style.
+Delegate the lint check to a **Haiku subagent** so the output stays out of your
+context. Use the Agent tool with `subagent_type: general-purpose` and
+`model: haiku`, give it the prompt below, then relay its report. Do **not** run
+lint yourself.
+
+Subagent prompt:
+
+```text
+Run `make lint` from the TMDb project root (swiftlint --strict + swiftformat
+--lint) and report concisely.
+
+Report back ONLY:
+- Status: clean or violations found
+- Each violation as `file:line — rule: message` (omit this list if there are
+  none)
+
+If you see `superfluous_disable_command` errors on files that were not just
+changed, flag it — that is usually a swiftlint version-drift artifact (the pin
+is swiftlint 0.63.2 / swiftformat 0.61.1), not a real violation.
+
+Do not paste the full lint output.
+```
+
+If the subagent reports violations, fix them in your own context (or run
+`/format` for auto-fixable ones), then re-invoke this skill to re-check.

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -19,16 +19,20 @@ Run the TMDb unit tests and report concisely.
   `mcp__xcode-tools__RunAllTests` with the TMDb test plan. If a build error
   caused the failure, call `mcp__xcode-tools__GetBuildLog` with
   `severity: "error"`.
-- Otherwise run `make test` from the project root.
+- Otherwise run `mkdir -p .build && make test > .build/last-test.log 2>&1`,
+  check the exit status for pass/fail, and summarise from that log file.
 
 Report back ONLY:
 - Status: passed or failed
 - Counts: total / passed / failed
 - Each failing test as `SuiteName/testName` with its `file:line` and the
   assertion message (omit this list if there are none)
+- On failure, the full log path `.build/last-test.log` (or, inside Xcode, note
+  that the full log is available via `mcp__xcode-tools__GetBuildLog`)
 
 Do not paste passing-test output or raw logs.
 ```
 
-If the subagent reports failures, fix them in your own context, then re-invoke
-this skill to re-check (a fresh subagent will re-run the tests).
+If the report is unclear on a failure, read the log path it provides rather than
+re-running. After fixing the issues, re-invoke this skill to re-check (a fresh
+subagent will re-run the tests).

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -5,13 +5,30 @@ description: Run all unit tests
 
 # Run tests
 
-Use the `xcode-tools` MCP server when running inside Xcode, otherwise fall back to Make.
+Delegate the test run to a **Haiku subagent** so the test output stays out of
+your context. Use the Agent tool with `subagent_type: general-purpose` and
+`model: haiku`, give it the prompt below, then relay its report. Do **not** run
+the tests yourself.
 
-## xcode-tools (preferred inside Xcode)
+Subagent prompt:
 
-1. Run `mcp__xcode-tools__RunAllTests` with the **TMDb** test plan.
-2. If tests fail, review the output for failure details. Use `mcp__xcode-tools__GetBuildLog` with `severity: "error"` if build errors caused the failure.
+```text
+Run the TMDb unit tests and report concisely.
 
-## Fallback
+- If the xcode-tools MCP is available (inside Xcode), run
+  `mcp__xcode-tools__RunAllTests` with the TMDb test plan. If a build error
+  caused the failure, call `mcp__xcode-tools__GetBuildLog` with
+  `severity: "error"`.
+- Otherwise run `make test` from the project root.
 
-Run `make test` from the project root.
+Report back ONLY:
+- Status: passed or failed
+- Counts: total / passed / failed
+- Each failing test as `SuiteName/testName` with its `file:line` and the
+  assertion message (omit this list if there are none)
+
+Do not paste passing-test output or raw logs.
+```
+
+If the subagent reports failures, fix them in your own context, then re-invoke
+this skill to re-check (a fresh subagent will re-run the tests).

--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: watch-pr
+description: Watch the current branch's PR — reply to and resolve review threads, fix failing checks, and optionally merge when ready
+---
+
+# Watch PR
+
+Watch the open pull request for the current branch: handle review conversations,
+fix failing status checks, and — when asked — merge once everything is green.
+Repo is `adamayoung/TMDb`; `gh` is authenticated.
+
+**Mode** — check the arguments passed to this skill (shown at the end). If they
+include `merge` (e.g. `/watch-pr merge` or "merge when ready"), enable
+**merge-when-ready**; otherwise run in **watch-only** mode.
+
+## 0. Find the PR
+
+```bash
+gh pr view --json number,url,state,headRefName,mergeStateStatus,statusCheckRollup,reviewDecision
+```
+
+- No PR for the current branch → stop and tell the user (suggest `/pr`).
+- State not `OPEN` → stop and report.
+
+Keep a **run ledger** in your working notes: resolved thread IDs, a topic
+signature per handled thread (`path:line` + short gist), and a fix-attempt
+counter per failing check. Use it to avoid repeating work (see Loop Guard).
+
+## 1. Watch loop
+
+Repeat the pass below until the PR is **ready** (§3) or **stuck** (§2).
+
+### 1a. Review threads
+
+Fetch unresolved threads (use the PR number from step 0):
+
+```bash
+gh api graphql -f query='
+query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$number){
+      reviewThreads(first:100){
+        nodes{
+          id isResolved isOutdated path line
+          comments(first:50){ nodes{ author{login} body createdAt } }
+        }
+      }
+    }
+  }
+}' -f owner=adamayoung -f name=TMDb -F number=<NUMBER>
+```
+
+For each thread where `isResolved` is `false` and whose `id` is not already in
+the ledger:
+
+1. Read the comment(s) and decide whether a code change is warranted.
+2. **Needs a fix** (clear and in scope): edit the code, then verify with the
+   delegated skills — `/lint`, `/build`, `/test` (and `/integration-test` if the
+   change could affect live-API behaviour). Those run in Haiku subagents, so
+   their output stays out of your context. Commit with a gitmoji message and
+   `git push`. Note the commit SHA.
+3. **No fix warranted** (you disagree, out of scope, it's a question, or already
+   done): make no code change — you'll explain in the reply.
+4. **Reply** on the thread with your feedback: what you assessed and whether you
+   fixed it (include the commit SHA when you did):
+
+   ```bash
+   gh api graphql -f query='mutation($id:ID!,$body:String!){
+     addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$id,body:$body}){ comment{ id } }
+   }' -f id=<THREAD_ID> -f body='<your feedback>'
+   ```
+
+5. **Resolve** the thread:
+
+   ```bash
+   gh api graphql -f query='mutation($id:ID!){
+     resolveReviewThread(input:{threadId:$id}){ thread{ isResolved } }
+   }' -f id=<THREAD_ID>
+   ```
+
+6. Record the thread ID and its topic signature in the ledger.
+
+### 1b. Status checks
+
+```bash
+gh pr checks --json name,state,bucket,link
+```
+
+Classify by `bucket`: `fail` = failing, `pending` = in progress, `pass` /
+`skipping` = fine. `claude-review` and other neutral checks are non-blocking.
+While anything is pending, block efficiently with `gh pr checks --watch` rather
+than polling in a tight loop.
+
+For each **failing** check, delegate log retrieval to a **Haiku subagent** so raw
+CI logs never enter your context. Use the Agent tool with
+`subagent_type: general-purpose` and `model: haiku` and this prompt:
+
+```text
+Find why the `<CHECK NAME>` check failed on the TMDb PR for branch `<branch>`
+and report concisely.
+
+1. Run `gh run list --branch <branch> --limit 5 --json databaseId,name,conclusion`
+   to find the failed run id.
+2. Run `gh run view <id> --log-failed`.
+
+Report back ONLY:
+- The failing job/step
+- The root cause
+- The offending `file:line` and message (if any)
+
+Do not paste raw logs.
+```
+
+Then fix the issue, verify locally with the matching delegated skill (`/lint`,
+`/build`, `/test`, `/integration-test`), commit (gitmoji), and `git push` — the
+push re-triggers CI. Increment that check's attempt counter.
+
+## 2. Loop guard (do not get stuck)
+
+- Never reprocess a thread already in the ledger.
+- If a **new** thread repeats a topic you already fixed this run, do **not**
+  re-edit — reply pointing to the earlier commit SHA and resolve it.
+- A failing check gets at most **3** fix→push attempts. If it still fails with
+  the same root cause, **stop** and report it to the user — never loop forever.
+- End the loop when a full pass resolves no new threads and has no actionable
+  check failures. Hard backstop: ~10 passes, then report and stop.
+- Waiting: use `gh pr checks --watch` for in-flight CI. When only waiting on a
+  human to review, pause and resume later with `ScheduleWakeup` (a few minutes
+  while CI is active; longer when idle). This skill also composes with `/loop`
+  if the user prefers harness-driven cadence.
+
+## 3. Ready / merge
+
+The PR is **ready** when every review thread is resolved AND no check is failing
+or pending.
+
+- **Watch-only**: report "PR is ready" with a short summary (threads handled,
+  checks green) and stop.
+- **Merge-when-ready**: on ready, merge and clean up, then report the result:
+
+  ```bash
+  gh pr merge --squash --delete-branch
+  ```
+
+## Guardrails
+
+- Never edit `.github/workflows/*` or other CI/config to force a check green, and
+  never force-push, without surfacing to the user first.
+- If a requested change is ambiguous or risky, reply on the thread with your
+  assessment and leave it for the user (note it in the final summary) rather than
+  guessing.
+- Every commit fires the pre-commit `make lint` hook; fix lint before retrying.
+
+Arguments: $ARGUMENTS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,16 @@ for:
 
 ## Build and Test Tooling
 
+### Prefer the Project Skills (Delegated to Haiku)
+
+For builds and test runs, invoke the project skills rather than calling `make`
+or the Xcode MCP directly: `/build`, `/build-for-testing`, `/test`, and
+`/integration-test`. Each delegates to a Haiku subagent that runs the command,
+writes the full output to a `.build/last-*.log` file, and returns only a
+concise summary (status, counts, failures as `file:line`) — keeping this
+context lean. `/lint` and `/format` run `make` directly (they are fast and
+low-output), and `make ci` is run directly before a PR.
+
 ### When Running Inside Xcode (via Claude Agent)
 
 Use **`xcode-tools` MCP server tools** — the native Xcode–Claude Agent
@@ -423,6 +433,10 @@ After public API changes, verify all of the following are in sync:
 6. **Lint markdown**: `make lint-markdown` — required if `.md` files
    changed
 7. **Run full CI**: `make ci` — **REQUIRED before creating any PR**
+
+Run steps 3-4 (and any builds) via the `/test` and `/integration-test`
+skills — they delegate to a Haiku subagent to keep this context lean.
+`/format`, `/lint`, and `make ci` run directly.
 
 Steps 3-4 must always pass. Steps 5-6 are conditional. Steps 1-2 can
 be skipped if formatting tools are not installed. Step 7 is mandatory

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,14 +48,20 @@ TMDbClient (main facade)
 
 The `naturalLanguageSearch` service is **Apple-platforms only** — it is
 defined in a `TMDbClient` extension gated by `#if canImport(NaturalLanguage)`,
-so it is unavailable on Linux and Windows.
+so it is unavailable on Linux and Windows. It interprets free-text queries
+on-device with a deterministic planner (a rule-based intent classifier plus
+`NLTagger` person-name extraction) and, on capable devices, an optional
+`FoundationModelsSearchPlanGenerator` fallback for fuzzier prompts — degrading
+to a plain multi-search where neither is available.
 
 **Key files:**
 
 - `Sources/TMDb/TMDbClient.swift` — main public API entry point
 - `Sources/TMDb/TMDbFactory.swift` — dependency injection factory
 - `Sources/TMDb/Domain/Services/` — service protocols and implementations
-- `Sources/TMDb/Domain/Models/` — Codable data models (~140 files)
+- `Sources/TMDb/Domain/Models/` — Codable data models (~170 files)
+- `Sources/TMDb/Domain/LanguageModelTools/` — FoundationModels `Tool`s
+  exposing TMDb to a conversational assistant (Apple-only)
 
 ### Networking Layer
 
@@ -79,6 +85,22 @@ Service (e.g. TMDbMovieService)
 
 In 18.0.0 an `ErrorMappingAPIClient` decorator wraps the `APIClient` to
 centralise mapping of `TMDbAPIError` into the public `TMDbError`.
+
+### Language Model Tools (Apple-only)
+
+`TMDbToolbox` (`Sources/TMDb/Domain/LanguageModelTools/`) wraps the services
+as FoundationModels `Tool`s so TMDb can back a conversational movie assistant
+through a `LanguageModelSession`. It is gated by
+`#if canImport(FoundationModels) && !os(tvOS)` and annotated
+`@available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)`.
+
+Seven tools are exposed: `search`, `movieDetails`, `tvSeriesDetails`,
+`personFilmography`, `trending`, `watchProviders`, and `discoverMovies`. They
+are reachable from `TMDbClient` via `languageModelTools` (shorthand for
+`TMDbToolbox(client:).all`) and individual `*Tool` accessors (`searchTool`,
+`movieDetailsTool`, …). Each tool returns compact text whose every line leads
+with the relevant TMDb `id`, letting the model chain calls — search a title,
+then fetch its details or watch providers.
 
 ### Test Organization
 
@@ -160,6 +182,19 @@ token-efficient output. Linux/Docker targets do not use xcsift.
 - `set -o pipefail` ensures failures propagate through the pipe
 - `2>&1` captures stderr (where compiler diagnostics are emitted)
 
+### Build Isolation and Sequential Builds
+
+The `make` targets build with SwiftPM (`swift build`/`swift test`), not
+`xcodebuild`, so there is no `-derivedDataPath`; the equivalent is the
+scratch directory. Every target accepts an overridable `SCRATCH_PATH`
+(default `.build`):
+
+- Run builds **sequentially** within a worktree — concurrent `swift build`s
+  fight over the same `.build` and cause SwiftPM lock contention and hangs.
+- When multiple agents build at once in **separate git worktrees**, give each
+  its own scratch dir, e.g. `make test SCRATCH_PATH=.build/agent-a`. Any path
+  under `.build` is already covered by the `/.build` `.gitignore` rule.
+
 ### Shell Environment
 
 Run shell commands directly — do not prefix them with
@@ -178,12 +213,14 @@ gh pr create ...
 ```bash
 # Build
 make build                    # Build for current platform
+make build-tests              # Build the package + all test targets
 make build-release            # Release build
+make build-linux              # Build in a Swift Docker container
 
 # Test
 make test                     # Unit tests (macOS)
-make test-ios                 # iOS simulator tests
 make integration-test         # Integration tests (requires env vars)
+make test-linux               # Unit tests in a Swift Docker container
 
 # Single test (Swift Testing framework)
 swift test --filter "TestClassName"
@@ -197,10 +234,16 @@ make lint-markdown            # Lint markdown files
 # Documentation
 make preview-docs             # Preview DocC locally
 make build-docs               # Build documentation (warnings-as-errors)
+make generate-docs            # Generate static DocC site into docs/
 
 # Full CI check (run before creating a PR)
-make ci                       # All checks: lint, test, build, docs
+make ci                       # lint, lint-markdown, test, integration-test,
+                              #   build-release, build-docs
 ```
+
+There is no `make test-ios` target. Run simulator tests
+(iOS/watchOS/tvOS/visionOS) from Xcode using the **TMDb** (unit) or
+**Integration** test plans.
 
 ## Code Style
 
@@ -215,8 +258,12 @@ Enforced via `swiftlint` and `swiftformat`:
   `OptionSet` values, nil/empty strings, and other degenerate inputs
   even if callers are unlikely to pass them
 
-Tools are installed via Homebrew at `/opt/homebrew/bin/swiftlint` and
-`/opt/homebrew/bin/swiftformat`, which is already on `PATH`.
+`swiftlint` and `swiftformat` are on `PATH`. **Versions are pinned** —
+swiftlint `0.63.2` / swiftformat `0.61.1` — and CI downloads these exact
+binaries, so keep local versions matched. A `superfluous_disable_command`
+error on *unchanged* files is almost always a version-drift artifact (a
+rule's behaviour changed between versions), not a real violation — check
+`swiftlint version` against the pin before editing the flagged code.
 
 ## Testing
 

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,14 @@ VISIONOS_DESTINATION = 'platform=visionOS Simulator,name=Apple Vision Pro,OS=26.
 
 SWIFT_CONTAINER_IMAGE = swift:6.0.3-jammy
 
+# SwiftPM scratch (build) directory — the swift-build equivalent of Xcode's
+# DerivedData. Override to isolate concurrent builds across git worktrees, e.g.
+# `make test SCRATCH_PATH=.build/agent-a` (stays under the gitignored .build).
+SCRATCH_PATH ?= .build
+
 .PHONY: clean
 clean:
-	swift package clean
+	swift package --scratch-path $(SCRATCH_PATH) clean
 	rm -rf docs
 
 .PHONY: format
@@ -31,11 +36,11 @@ lint-markdown:
 
 .PHONY: build
 build:
-	set -o pipefail && swift build -Xswiftc -warnings-as-errors 2>&1 | xcsift -f toon --Werror
+	set -o pipefail && swift build --scratch-path $(SCRATCH_PATH) -Xswiftc -warnings-as-errors 2>&1 | xcsift -f toon --Werror
 
 .PHONY: build-tests
 build-tests:
-	set -o pipefail && swift build --build-tests -Xswiftc -warnings-as-errors 2>&1 | xcsift -f toon --Werror
+	set -o pipefail && swift build --build-tests --scratch-path $(SCRATCH_PATH) -Xswiftc -warnings-as-errors 2>&1 | xcsift -f toon --Werror
 
 .PHONY: build-linux
 build-linux:
@@ -43,7 +48,7 @@ build-linux:
 
 .PHONY: build-release
 build-release:
-	set -o pipefail && swift build -c release -Xswiftc -warnings-as-errors 2>&1 | xcsift -f toon --Werror
+	set -o pipefail && swift build -c release --scratch-path $(SCRATCH_PATH) -Xswiftc -warnings-as-errors 2>&1 | xcsift -f toon --Werror
 
 .PHONY: build-linux-release
 build-linux-release:
@@ -51,16 +56,16 @@ build-linux-release:
 
 .PHONY: build-docs
 build-docs:
-	SWIFTCI_DOCC=1 swift package generate-documentation --warnings-as-errors
-	swift package resolve
+	SWIFTCI_DOCC=1 swift package --scratch-path $(SCRATCH_PATH) generate-documentation --warnings-as-errors
+	swift package --scratch-path $(SCRATCH_PATH) resolve
 
 .PHONY: preview-docs
 preview-docs:
-	SWIFTCI_DOCC=1 swift package --disable-sandbox preview-documentation --target $(TARGET)
+	SWIFTCI_DOCC=1 swift package --scratch-path $(SCRATCH_PATH) --disable-sandbox preview-documentation --target $(TARGET)
 
 .PHONY: generate-docs
 generate-docs:
-	SWIFTCI_DOCC=1 swift package --allow-writing-to-directory docs \
+	SWIFTCI_DOCC=1 swift package --scratch-path $(SCRATCH_PATH) --allow-writing-to-directory docs \
 		generate-documentation --target $(TARGET) \
 		--disable-indexing \
 		--transform-for-static-hosting \
@@ -69,8 +74,8 @@ generate-docs:
 
 .PHONY: test
 test:
-	set -o pipefail && swift build --build-tests -Xswiftc -warnings-as-errors 2>&1 | xcsift -f toon --Werror
-	set -o pipefail && swift test --skip-build --filter $(TEST_TARGET) 2>&1 | xcsift -f toon
+	set -o pipefail && swift build --build-tests --scratch-path $(SCRATCH_PATH) -Xswiftc -warnings-as-errors 2>&1 | xcsift -f toon --Werror
+	set -o pipefail && swift test --skip-build --scratch-path $(SCRATCH_PATH) --filter $(TEST_TARGET) 2>&1 | xcsift -f toon
 
 .PHONY: test-linux
 test-linux:
@@ -78,8 +83,8 @@ test-linux:
 
 .PHONY: integration-test
 integration-test: .check-env-vars
-	set -o pipefail && swift build --build-tests 2>&1 | xcsift -f toon
-	set -o pipefail && swift test --skip-build --filter $(INTEGRATION_TEST_TARGET) 2>&1 | xcsift -f toon
+	set -o pipefail && swift build --build-tests --scratch-path $(SCRATCH_PATH) 2>&1 | xcsift -f toon
+	set -o pipefail && swift test --skip-build --scratch-path $(SCRATCH_PATH) --filter $(INTEGRATION_TEST_TARGET) 2>&1 | xcsift -f toon
 
 .PHONY: ci
 ci: .check-env-vars lint lint-markdown test integration-test build-release build-docs


### PR DESCRIPTION
## Summary

A round of Claude/dev-tooling maintenance: bring the guidance files back in sync
with the codebase, make SwiftPM builds isolatable per git worktree, delegate
verbose build/test work to a Haiku subagent, and add a new `/watch-pr` skill.
This PR touches only `.claude/` config, `CLAUDE.md`, and the `Makefile` — no
Swift source changes. `make ci` is green.

## Changes

**Guidance refresh (`CLAUDE.md`, `.claude/agents/*`):**
- 📝 Document the new Apple-only Language Model Tools (`TMDbToolbox`) and expand
  the natural-language-search note (deterministic + FoundationModels).
- 📝 Fix drift: model count (~140 → ~170), drop the non-existent `make test-ios`,
  list the real make targets, clarify `make ci`.
- 📝 Note the pinned swiftlint 0.63.2 / swiftformat 0.61.1 versions and the
  `superfluous_disable_command` version-drift gotcha.
- ♻️ `code-reviewer.md`: 25 → 26 services (+`NaturalLanguageSearchService`),
  refresh the networking decorator chain, switch `mcp__xcode__*` →
  `mcp__xcode-tools__*`, add a LanguageModelTools gating check.

**Worktree-isolated builds (`Makefile`):**
- 🔧 Add an overridable `SCRATCH_PATH ?= .build` and pass `--scratch-path` to
  every host `swift build`/`test`/`package` target (Docker targets unchanged).
  Concurrent agents can isolate with `make test SCRATCH_PATH=.build/agent-a`
  (already covered by the `/.build` gitignore rule).

**Haiku-delegated skills (`.claude/skills/*`):**
- 🔧 `build`, `build-for-testing`, `test`, `integration-test` now delegate to a
  Haiku subagent that runs the command, tees full output to `.build/last-*.log`,
  and returns only a concise summary — keeping the caller's context lean.
- 🔧 `lint` and `format` run `make` directly (fast/low-output; subagent overhead
  would cost more than it saves).
- 📝 `CLAUDE.md` points routine work at these skills.

**New skill (`.claude/skills/watch-pr/SKILL.md`):**
- ✨ `/watch-pr` watches the current branch's PR: assess + autonomously fix and
  resolve review threads (reply with feedback + commit SHA), fix failing status
  checks (Haiku subagent summarises `--log-failed`), with a loop guard (handled-
  thread ledger, repeated-topic short-circuit, 3-attempt cap per check).
- ✨ Optional `/watch-pr merge` squash-merges and deletes the branch once all
  threads are resolved and all checks pass.

## Verification

- ✅ `make ci` green (lint, lint-markdown, unit + integration tests, release
  build, docs) — all targets exercised with the new `--scratch-path`.
- ✅ `/watch-pr` GraphQL query/mutation shapes and `gh pr checks` JSON fields
  verified against a live PR.
- ✅ Smoke-tested the Haiku delegation pattern end-to-end.

## Benefits

- **Accurate guidance**: CLAUDE.md and the review/doc agents match the current code.
- **Parallel-friendly**: agents can build in separate worktrees without SwiftPM
  lock contention.
- **Leaner context / lower cost**: verbose build/test output stays in cheap Haiku
  contexts.
- **Less PR babysitting**: `/watch-pr` handles review threads and checks, and can
  merge when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)