### PR TITLE
🐛 Decode missing genre_ids in search list items as empty array

### DIFF
--- a/Sources/TMDb/Domain/Models/MediaListItem.swift
+++ b/Sources/TMDb/Domain/Models/MediaListItem.swift
@@ -185,7 +185,9 @@ extension MediaListItem {
         self.originalTitle = try container.decode(String.self, forKey: .originalTitle)
         self.originalLanguage = try container.decode(String.self, forKey: .originalLanguage)
         self.overview = try container.decode(String.self, forKey: .overview)
-        self.genreIDs = try container.decode([Genre.ID].self, forKey: .genreIDs)
+        // Some results omit `genre_ids` entirely; default to an empty array
+        // rather than failing to decode.
+        self.genreIDs = try container.decodeIfPresent([Genre.ID].self, forKey: .genreIDs) ?? []
         self.posterPath = try container.decodeIfPresent(URL.self, forKey: .posterPath)
         self.backdropPath = try container.decodeIfPresent(URL.self, forKey: .backdropPath)
         self.popularity = try container.decodeIfPresent(Double.self, forKey: .popularity)

--- a/Sources/TMDb/Domain/Models/MovieListItem.swift
+++ b/Sources/TMDb/Domain/Models/MovieListItem.swift
@@ -192,7 +192,9 @@ extension MovieListItem {
             [String].self, forKey: .originCountry
         )
         self.overview = try container.decode(String.self, forKey: .overview)
-        self.genreIDs = try container.decode([Genre.ID].self, forKey: .genreIDs)
+        // Collection entries interleaved into `/search/movie` results omit
+        // `genre_ids` entirely; default to an empty array rather than failing.
+        self.genreIDs = try container.decodeIfPresent([Genre.ID].self, forKey: .genreIDs) ?? []
 
         // Need to deal with empty strings - date decoding will fail with an empty string
         let releaseDateString = try container.decodeIfPresent(String.self, forKey: .releaseDate)

--- a/Sources/TMDb/Domain/Models/TVSeriesListItem.swift
+++ b/Sources/TMDb/Domain/Models/TVSeriesListItem.swift
@@ -180,7 +180,9 @@ extension TVSeriesListItem {
         self.originalName = try container.decode(String.self, forKey: .originalName)
         self.originalLanguage = try container.decode(String.self, forKey: .originalLanguage)
         self.overview = try container.decode(String.self, forKey: .overview)
-        self.genreIDs = try container.decode([Genre.ID].self, forKey: .genreIDs)
+        // Some search results omit `genre_ids` entirely; default to an empty
+        // array rather than failing to decode the whole page.
+        self.genreIDs = try container.decodeIfPresent([Genre.ID].self, forKey: .genreIDs) ?? []
 
         // Need to deal with empty strings - date decoding will fail with an empty string
         let firstAirDateString = try container.decodeIfPresent(String.self, forKey: .firstAirDate)

--- a/Tests/TMDbTests/Domain/Models/MediaListItemTests.swift
+++ b/Tests/TMDbTests/Domain/Models/MediaListItemTests.swift
@@ -144,6 +144,26 @@ struct MediaListItemTests {
         #expect(result.releaseDate == nil)
     }
 
+    @Test("JSON decoding of MediaListItem with missing genre_ids", .tags(.decoding))
+    func decodeReturnsMediaListItemWithMissingGenreIDsAsEmpty() throws {
+        let json = """
+        {
+          "id": 654321,
+          "title": "No Genres Movie",
+          "original_title": "No Genres Movie Original",
+          "overview": "A movie without a genre_ids field.",
+          "media_type": "movie",
+          "original_language": "en"
+        }
+        """
+
+        let data = Data(json.utf8)
+        let result = try JSONDecoder.theMovieDatabase.decode(MediaListItem.self, from: data)
+
+        #expect(result.id == 654_321)
+        #expect(result.genreIDs == [])
+    }
+
     @Test("init sets all properties correctly")
     func initSetsAllProperties() throws {
         let releaseDate = Date(iso8601: "2024-06-15T00:00:00Z")

--- a/Tests/TMDbTests/Domain/Models/MovieListItemTests.swift
+++ b/Tests/TMDbTests/Domain/Models/MovieListItemTests.swift
@@ -30,6 +30,7 @@ struct MovieListItemTests {
             MovieListItem.self, fromResource: "movie-list-item-collection"
         )
 
+        #expect(result.id == 1_697_536)
         #expect(result.genreIDs == [])
     }
 

--- a/Tests/TMDbTests/Domain/Models/MovieListItemTests.swift
+++ b/Tests/TMDbTests/Domain/Models/MovieListItemTests.swift
@@ -21,6 +21,18 @@ struct MovieListItemTests {
         #expect(result == movie)
     }
 
+    @Test(
+        "JSON decoding of MovieListItem with missing genreIds defaults to empty",
+        .tags(.decoding)
+    )
+    func decodeWhenGenreIDsMissingReturnsEmptyGenreIDs() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            MovieListItem.self, fromResource: "movie-list-item-collection"
+        )
+
+        #expect(result.genreIDs == [])
+    }
+
 }
 
 extension MovieListItemTests {

--- a/Tests/TMDbTests/Domain/Models/TVSeriesListItemTests.swift
+++ b/Tests/TMDbTests/Domain/Models/TVSeriesListItemTests.swift
@@ -21,6 +21,18 @@ struct TVSeriesListItemTests {
         #expect(result == tvSeries)
     }
 
+    @Test(
+        "JSON decoding of TVSeriesListItem with missing genreIds defaults to empty",
+        .tags(.decoding)
+    )
+    func decodeWhenGenreIDsMissingReturnsEmptyGenreIDs() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            TVSeriesListItem.self, fromResource: "tv-series-list-item-no-genre-ids"
+        )
+
+        #expect(result.genreIDs == [])
+    }
+
 }
 
 extension TVSeriesListItemTests {

--- a/Tests/TMDbTests/Domain/Models/TVSeriesListItemTests.swift
+++ b/Tests/TMDbTests/Domain/Models/TVSeriesListItemTests.swift
@@ -30,6 +30,7 @@ struct TVSeriesListItemTests {
             TVSeriesListItem.self, fromResource: "tv-series-list-item-no-genre-ids"
         )
 
+        #expect(result.id == 11366)
         #expect(result.genreIDs == [])
     }
 

--- a/Tests/TMDbTests/Resources/json/movie-list-item-collection.json
+++ b/Tests/TMDbTests/Resources/json/movie-list-item-collection.json
@@ -1,0 +1,8 @@
+{
+    "id": 1697536,
+    "title": "Cloverfield collection",
+    "original_language": "en",
+    "original_title": "Cloverfield collection",
+    "overview": "Cloverfield is an American kaiju science fiction horror anthology film series and media franchise created and produced by J. J. Abrams",
+    "poster_path": "/bAmV18yndCkCbmVnz0BnbGV6FOn.jpg"
+}

--- a/Tests/TMDbTests/Resources/json/tv-series-list-item-no-genre-ids.json
+++ b/Tests/TMDbTests/Resources/json/tv-series-list-item-no-genre-ids.json
@@ -1,0 +1,10 @@
+{
+    "id": 11366,
+    "name": "Big Brother",
+    "original_name": "Big Brother",
+    "original_language": "en",
+    "overview": "A British reality television game show in which a number of contestants live in an isolated house for several weeks.",
+    "origin_country": [
+        "GB"
+    ]
+}


### PR DESCRIPTION
## Summary

Fixes a `DecodingError.keyNotFound("genreIds")` that fails entire
`/search/movie` result pages. TMDb has started interleaving `collection`
entries among movie search results, and those rows omit `genre_ids` (and
other movie-only fields). `MovieListItem` decoded `genreIDs` with a
non-optional `decode`, so a single collection row threw and the whole
page failed to decode.

Reproduced via the TMDb MCP: searching **Cloverfield** returns a
`"Cloverfield collection"` row at `results[3]` with no `genre_ids` —
exactly matching the `codingPath: [results, Index 3]` seen failing in the
[popcorn-epg](https://github.com/adamayoung/popcorn-epg) GitHub Action.

## Changes

**Existing Files:**
- 🐛 `MovieListItem`, `TVSeriesListItem`, `MediaListItem` now decode
  `genreIDs` with `decodeIfPresent(...) ?? []`. The property stays a
  non-optional `[Genre.ID]`, so this is source-compatible.

**Tests:**
- ✅ `MovieListItem` decodes a real "Cloverfield collection" fixture
  (missing `genre_ids`) to an empty array
- ✅ `TVSeriesListItem` decodes a fixture missing `genre_ids` to an empty
  array
- ✅ `MediaListItem` decodes JSON missing `genre_ids` to an empty array

## Benefits

- **Resilience**: a single malformed/atypical search row no longer fails
  the entire results page
- **Forward-compatible**: gracefully handles TMDb mixing collection
  entries into movie/TV search responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)