### PR TITLE
✨ Add Claude tooling: failure-diagnosis skills, a Canon TDD skill, and a scheduled-Integration alert workflow

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -133,6 +133,12 @@ Use the `swift-concurrency` skill for detailed guidance. Key checks:
 - `make lint` — Check lint compliance
 - `make build-docs` — Build DocC with warnings-as-errors
 
+> Outside a subagent, the main agent runs these via the `/build`,
+> `/build-for-testing`, `/test`, `/integration-test`, `/lint`, and `/format`
+> skills (which delegate to a Haiku subagent and keep logs out of context). As a
+> reviewer subagent you normally just read; if you must build or test, the `make`
+> commands above are fine.
+
 **Never read or touch** `.swiftpm/` or `.build/` directories.
 
 ## Code Change Protocol

--- a/.claude/agents/documentation-writer.md
+++ b/.claude/agents/documentation-writer.md
@@ -53,7 +53,7 @@ Use `///` comment style. Never use `/** */`. Every `public` declaration must hav
 ///
 /// Provides an interface for obtaining movies from TMDb.
 ///
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
 public protocol MovieService: Sendable {
 ```
 

--- a/.claude/skills/canon-tdd/SKILL.md
+++ b/.claude/skills/canon-tdd/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: canon-tdd
+description: Implement features and fix bugs test-first, the Canon TDD way (test list → one test → make it pass → refactor → repeat). Use when implementing any new feature, endpoint, model, or method, fixing a bug, or executing a plan — write the test list and a failing test BEFORE production code.
+---
+
+# Canon TDD
+
+Test-driven development the way Kent Beck describes as "Canon TDD", per
+<https://adam-young.co.uk/blog/canon-tdd/>. CLAUDE.md mandates a TDD approach for
+this package; this skill is the detailed how.
+
+> **Red-Green-Refactor is the engine. The Test List is the steering wheel.**
+
+## Agent behaviour contract
+
+The point of this skill: do these by default, without being reminded.
+
+1. **Start with a test list, and show it.** Before touching production code,
+   enumerate the behaviours and edge cases as a checklist and confirm it with the
+   user (or state it explicitly). This is the steering wheel — it defines "done".
+2. **No production code before a failing test.** Write exactly **one** test,
+   run it, and watch it fail for the right reason. Never write the implementation
+   first and back-fill tests.
+3. **One test at a time.** Do not convert the whole test list into code up front
+   — the first passing test often forces a design change that affects the rest.
+4. **Refactor only on green**, and keep refactoring out of the make-it-pass step.
+5. **Repeat until the test list is empty**, adding newly-discovered cases to the
+   list as you go.
+
+## The five steps
+
+1. **Write a test list** — every behavioural variant and edge case you can think
+   of, as a plain checklist. Not code yet. It's a living list: add to it whenever
+   implementation reveals a new case.
+2. **Write a test** — pick the next item and write one real, automated test:
+   setup, invocation, and **assertions**. Define *what* the system does and *how
+   it's invoked* — not how it works inside. Run it; confirm it fails.
+3. **Make it pass** — change the system to satisfy that test with the simplest
+   thing that works. Nothing more; resist solving items still on the list.
+4. **Optionally refactor** — improve names, structure, and duplication while every
+   test stays green. Skip if there's nothing to improve.
+5. **Repeat** — next item, until the list is empty.
+
+## Separate interface from implementation
+
+A test fixes a *decision* about the interface (the call shape, inputs, outputs)
+and should be silent about the internals. Tests that assert on private mechanics
+break under refactoring and defeat step 4.
+
+## Anti-patterns (don't)
+
+- **Tests without assertions** — a test that invokes but asserts nothing proves
+  nothing.
+- **Pre-converting the whole list to code** — write one test, learn, then the
+  next. Batching tests locks in design decisions before you've learned anything.
+- **Mixing refactor into make-it-pass** — keep "make it work" and "make it clean"
+  as separate steps on either side of green.
+- **Premature abstraction from duplication** — a little duplication across two
+  green tests is fine; abstract when the shape is clear, not at the first repeat.
+
+## In this codebase (TMDb)
+
+Apply the loop with the project's tooling and conventions:
+
+- **Framework:** Swift Testing — `@Suite`, `@Test`, `#expect`, `#require`. Never
+  force-unwrap in tests; unwrap optionals with `try #require(...)`.
+- **Run tests via the delegated skills**, not `make` directly, so output stays
+  out of context: `/test` (unit) and `/integration-test` (live API). Re-run after
+  each red→green and after refactoring.
+- **Both layers are required for new behaviour.** Unit tests with JSON fixtures
+  AND integration tests against the live API — put both kinds of items on the
+  test list from the start.
+- **Models / new endpoints:** when the test list involves decoding, the fixture
+  must exercise **every** decode branch (all N optional appended properties, plus
+  a paired "without appended data" test that asserts they're `nil`). Use the TMDb
+  MCP server (`mcp__tmdb__*`) to fetch **real** API responses for fixtures rather
+  than inventing JSON — see CLAUDE.md → "Workflow for New Endpoints".
+- **Bug fixes:** the first item on the list is a test that **reproduces the bug**
+  (red), then the fix (green) — never fix first.
+- **New public API:** the test list should include the doc/DocC and README
+  updates as completion items, even though they aren't tests (CLAUDE.md
+  consistency checklist).
+
+## When NOT to use it
+
+Pure refactors with existing coverage, formatting, config/CI edits, and docs-only
+changes don't start from a new failing test — keep the existing tests green
+instead. TDD is for *new behaviour* and *bug fixes*.

--- a/.claude/skills/diagnose-ci-failure/SKILL.md
+++ b/.claude/skills/diagnose-ci-failure/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: diagnose-ci-failure
+description: Diagnose a failing CI workflow run (lint, markdown lint, build, or unit tests) — identify which job failed, the cause, and a concrete fix
+---
+
+# Diagnose a CI workflow failure
+
+## Overview
+
+The **CI** workflow (`.github/workflows/ci.yml`) gates every PR and the merge to
+`main`. Unlike the live-API integration suite, a CI failure is **almost always
+caused by the change under review** — a lint violation, a compile warning/error,
+a broken unit test, or a Linux-portability gap. Start from the diff, not from
+"maybe it's flaky".
+
+CI fans out into four real jobs (plus a `ci` gate job that only aggregates
+results). The diagnosis differs per job, so this skill is a **router**: identify
+the failing job, then follow the matching reference file for that job's causes,
+fixes, and local-reproduction command.
+
+> **Wrong suite?** If the **Integration** workflow (the live-API suite from
+> `integration.yml`) failed — not a CI job — use `/diagnose-integration-failure`
+> instead. It leads with the opposite assumption: a scheduled/live-API failure
+> is usually backend or data drift, not your change.
+
+## Agent Behaviour Contract
+
+1. **Identify the failing job first** — `Lint`, `Lint Markdown`, `Build and Test`
+   (macOS), or `Build and Test (Linux)`. Don't guess the cause before you know
+   the job.
+2. **Assume the change caused it.** CI gates the PR; read the diff and tie the
+   failure to a changed file. Don't open with "transient" or "flaky".
+3. **Treat warnings as errors.** Build steps use `-warnings-as-errors` / `--Werror`
+   — a deprecation or unused-binding warning is a real failure.
+4. **Reproduce locally before declaring a fix** using the matching tool (`/lint`,
+   `/build-for-testing`, `/test`, `make lint-markdown`, `make build-linux`).
+5. **Output the three sections** (Summary / Cause / Fix) defined below — concise,
+   tied to `file:line`.
+
+## Locate the failing run
+
+Use the first that applies:
+
+- A path or run id the caller handed you.
+- The current branch's run via the `gh` CLI:
+  `gh run list --workflow CI --branch "$(git branch --show-current)" --limit 1`,
+  then `gh run view <id> --log-failed`. (`gh pr checks` also shows which job is
+  red.)
+- CI pipes build/test output through **xcsift** in `github-actions` format, so
+  the failing lines are GitHub `::error::` annotations carrying `file:line` —
+  read those first.
+
+## Quick decision tree
+
+Once you know which job failed:
+
+- **Lint** (`swiftlint --strict` / `swiftformat --lint`)?
+  └─ `references/lint.md` — style/format violations + the version-drift gotcha
+- **Lint Markdown** (`markdownlint`)?
+  └─ `references/markdown.md` — README / DocC markdown rules
+- **Build and Test** — the **build** step failed?
+  └─ `references/build.md` — compile errors and `--Werror` warnings
+- **Build and Test** — the **test** step failed?
+  └─ `references/unit-tests.md` — failing `Suite/test`, fixture/model mismatch
+- **Build and Test (Linux)** — fails on Linux but passes on macOS?
+  └─ `references/linux.md` — Apple-only API gating, Foundation differences
+
+## Triage-first playbook
+
+Symptom → next move:
+
+- **`error: … is unavailable` / `cannot find … in scope`, Linux job only** → `references/linux.md`
+- **`warning: … treated as error`** → `references/build.md`
+- **`error:` from `swiftc` on macOS build** → `references/build.md`
+- **A `Suite/test` recorded a failure / `#expect` failed** → `references/unit-tests.md`
+- **Test fails to decode a fixture (`keyNotFound`, `valueNotFound`)** → `references/unit-tests.md`
+- **SwiftLint rule violation (`error: … (rule_id)`)** → `references/lint.md`
+- **`superfluous_disable_command` on unchanged code** → `references/lint.md` (suspect version drift)
+- **SwiftFormat would reformat a file (`--lint` non-zero)** → `references/lint.md`
+- **markdownlint `MD0xx` violation** → `references/markdown.md`
+
+## Output format
+
+Produce exactly these three sections (keep it under ~150 words; if the caller
+asked for a file, write the markdown there and nothing else, otherwise reply
+directly):
+
+**Summary:** which job and step failed, and the specific error (rule /
+`file:line` / failing `Suite/test`).
+
+**Cause:** the root cause, tied to a changed file where possible.
+
+**Fix:** the concrete next step from the relevant reference file.
+
+## Reference files
+
+| File | Failing job | Covers |
+|------|-------------|--------|
+| `references/_index.md` | — | Navigation index by symptom |
+| `references/lint.md` | Lint | SwiftLint `--strict`, SwiftFormat `--lint`, pinned versions, drift |
+| `references/markdown.md` | Lint Markdown | markdownlint on README + DocC `.md` |
+| `references/build.md` | Build and Test (build step) | compile errors, `--Werror` warnings, release build |
+| `references/unit-tests.md` | Build and Test (test step) | Swift Testing failures, JSON fixture/model mismatch |
+| `references/linux.md` | Build and Test (Linux) | Apple-only API gating, Foundation portability |

--- a/.claude/skills/diagnose-ci-failure/references/_index.md
+++ b/.claude/skills/diagnose-ci-failure/references/_index.md
@@ -1,0 +1,27 @@
+# CI failure diagnosis — reference index
+
+Each CI job has its own failure signature and reference file. Identify the
+failing job (`gh pr checks`, or `gh run view <id> --log-failed`), then open the
+matching file.
+
+| Failing job (`name:` in ci.yml) | Reference | When to use |
+|---|---|---|
+| **Lint** | [lint.md](lint.md) | `swiftlint --strict .` or `swiftformat --lint .` failed |
+| **Lint Markdown** | [markdown.md](markdown.md) | `markdownlint` failed on README or a DocC `.md` |
+| **Build and Test** (build step) | [build.md](build.md) | `swift build … -warnings-as-errors` failed (error or warning) |
+| **Build and Test** (test step) | [unit-tests.md](unit-tests.md) | `swift test --filter TMDbTests` failed |
+| **Build and Test (Linux)** | [linux.md](linux.md) | Fails in the `swift:6.1-jammy` container but passes on macOS |
+
+## By symptom
+
+- `error: … is unavailable` / `cannot find … in scope`, **Linux only** → [linux.md](linux.md)
+- `warning: … treated as error` → [build.md](build.md)
+- `swiftc` `error:` on the macOS build → [build.md](build.md)
+- `#expect`/`#require` failure, recorded `Suite/test` → [unit-tests.md](unit-tests.md)
+- `keyNotFound` / `valueNotFound` / `typeMismatch` while decoding a fixture → [unit-tests.md](unit-tests.md)
+- SwiftLint `(rule_id)` violation → [lint.md](lint.md)
+- `superfluous_disable_command` on **unchanged** code → [lint.md](lint.md) (version drift)
+- SwiftFormat `--lint` reports a file would change → [lint.md](lint.md)
+- markdownlint `MD0xx` → [markdown.md](markdown.md)
+
+All paths share the [output format](../SKILL.md#output-format): **Summary / Cause / Fix**.

--- a/.claude/skills/diagnose-ci-failure/references/build.md
+++ b/.claude/skills/diagnose-ci-failure/references/build.md
@@ -1,0 +1,52 @@
+# Build failure (Build and Test — build step)
+
+The **Build and Test** job (macOS) has two build steps, both with
+**warnings-as-errors**:
+
+```
+swift build --build-tests -Xswiftc -warnings-as-errors   # build + test targets
+swift build -c release      -Xswiftc -warnings-as-errors   # release build
+```
+
+Output is piped through `xcsift -f github-actions --Werror`, so diagnostics
+surface as GitHub `::error::` annotations with `file:line`.
+
+> A **warning is a failure here.** Code that compiles cleanly in a normal local
+> build can still fail CI if it emits any warning. Local `make build` /
+> `/build-for-testing` use `--Werror` too, so reproduce with those, not a plain
+> `swift build`.
+
+## Reading the failure
+
+- `file:line: error: <message>` — a genuine compile error.
+- `file:line: warning: <message>` promoted to an error by `--Werror`. Common
+  ones:
+  - **Deprecation** — using an API the project (or a newer SDK) deprecated.
+  - **Unused** — unused variable, unused result, unreachable code.
+  - **Unhandled `Sendable` / concurrency** warnings (strict concurrency is on).
+  - **Missing/incorrect availability** annotations.
+
+## Common causes & fixes
+
+1. **Compile error in changed code** — fix the type/signature/import at the
+   reported `file:line`.
+2. **Warning under `--Werror`** — resolve it properly rather than silencing:
+   replace the deprecated call, remove the unused binding, add the missing
+   `@available`/`Sendable` conformance. Only suppress with a documented reason if
+   the warning is genuinely unavoidable.
+3. **Release-only failure** (the `-c release` step) — usually an
+   optimisation-sensitive or `#if DEBUG`-gated issue: code that only compiles in
+   debug, or a `debug`-only symbol referenced from release paths.
+
+## Reproduce locally
+
+- `/build-for-testing` — builds the package + all test targets with `--Werror`
+  (Haiku subagent, logs to `.build/last-build-for-testing.log`). This is the
+  closest match to the failing CI step.
+- For the release step specifically: `make build-release`.
+
+## Output
+
+**Summary:** Build and Test — build step — `error`/`warning` at `file:line`.
+**Cause:** the compile error or `--Werror` warning, tied to a changed file.
+**Fix:** resolve it at `file:line`; reproduce with `/build-for-testing`.

--- a/.claude/skills/diagnose-ci-failure/references/lint.md
+++ b/.claude/skills/diagnose-ci-failure/references/lint.md
@@ -1,0 +1,51 @@
+# Lint job failure (SwiftLint / SwiftFormat)
+
+The **Lint** job runs on macOS with **pinned** tool versions so CI matches local
+`make lint` exactly:
+
+- `swiftlint --strict .` — every warning is an error.
+- `swiftformat --lint .` — fails if any file is not already formatted.
+
+CI pins **SwiftLint `0.63.2`** and **SwiftFormat `0.61.1`** (downloaded as exact
+release binaries). Local versions must match (the local pin lives at
+`~/.local/bin/swiftlint`) or you get spurious failures on unchanged code.
+
+## Reading the failure
+
+- SwiftLint emits `file:line:col: error: <message> (rule_id)`. The `rule_id` in
+  parentheses is the lever — look it up in `.swiftlint.yml`.
+- SwiftFormat `--lint` lists files it *would* change; it doesn't always say which
+  rule. Run `swiftformat --lint --verbose .` locally to see the rules, or just
+  format and diff.
+
+## Common causes & fixes
+
+1. **A real style/format violation in changed Swift.**
+   - Fix: run `/format` (auto-applies SwiftFormat + SwiftLint autocorrect),
+     commit the result, then `/lint` to confirm clean. Most format failures need
+     nothing more.
+   - For SwiftLint rules that can't autocorrect (e.g. line length, cyclomatic
+     complexity, force-unwrap), fix the flagged `file:line` by hand per the
+     project's style (line length 100, no force-unwrap/try, guard for early
+     exits).
+
+2. **Version drift — `superfluous_disable_command` on *unchanged* code.** A
+   rule's behaviour changed between SwiftLint releases, so a
+   `// swiftlint:disable` that was needed before is now flagged as superfluous.
+   This is almost never a real violation:
+   - Check `swiftlint version` against the pinned **0.63.2** (and
+     `swiftformat --version` against **0.61.1**). If local is newer, that's the
+     cause — match the pin (`~/.local/bin/swiftlint`) rather than editing the
+     flagged `// swiftlint:disable`.
+
+## Reproduce locally
+
+- `/lint` — checks SwiftLint + SwiftFormat compliance (Haiku subagent, logs to
+  `.build/last-*.log`).
+- `/format` — auto-fixes, then re-run `/lint`.
+
+## Output
+
+**Summary:** Lint job — SwiftLint/SwiftFormat — `rule_id` at `file:line`.
+**Cause:** the violation (or version drift) tied to a changed file.
+**Fix:** `/format` then `/lint`; or match the pinned tool version for drift.

--- a/.claude/skills/diagnose-ci-failure/references/linux.md
+++ b/.claude/skills/diagnose-ci-failure/references/linux.md
@@ -1,0 +1,63 @@
+# Linux build/test failure (Build and Test (Linux))
+
+The **Build and Test (Linux)** job runs in the `swift:6.1-jammy` container:
+
+```
+swift build --build-tests -Xswiftc -warnings-as-errors
+swift test  --skip-build  --filter TMDbTests
+swift build -c release    -Xswiftc -warnings-as-errors
+```
+
+The telltale signature: **it fails on Linux but the macOS `Build and Test` job
+passes.** That is almost always a **platform-portability** problem, not a logic
+bug — the package targets Linux and Windows alongside the Apple platforms.
+
+## Reading the failure
+
+- `error: '<API>' is unavailable` / `cannot find '<symbol>' in scope` that only
+  appears in the Linux job → an Apple-only API reached Linux compilation.
+- A test failure present only on Linux → behaviour that differs across Foundation
+  implementations (date formatting, URL handling, locale, etc.).
+
+## Common causes & fixes
+
+1. **Apple-only framework used without gating.** This package deliberately gates
+   Apple-only services:
+   - `naturalLanguageSearch` is behind `#if canImport(NaturalLanguage)`.
+   - `TMDbToolbox` / `LanguageModelTools` are behind
+     `#if canImport(FoundationModels) && !os(tvOS)` with
+     `@available(iOS 26, macOS 26, …)`.
+   If new code calls `NaturalLanguage`, `FoundationModels`, `CoreML`, etc.
+   without the same `#if canImport(...)` guard (and an `@available` where
+   needed), Linux can't compile it.
+   - Fix: wrap the Apple-only code path in `#if canImport(<Framework>)` and
+     provide a Linux fallback (or exclude the feature on Linux, matching how
+     `naturalLanguageSearch` degrades).
+
+2. **Foundation API differences.** Some Foundation APIs behave differently or are
+   missing on swift-corelibs-foundation. Recent work in this repo moved off
+   `DateFormatter` to `Date.ParseStrategy` / `Date.ISO8601FormatStyle` partly for
+   cross-platform consistency — keep to those portable APIs.
+   - Fix: use the portable API; if a value differs, assert on the parsed value
+     (`try #require(...)`) rather than a locale-dependent string.
+
+3. **`#if os(...)` / availability mismatch** — code compiled into the Linux
+   target that references symbols only present on Apple platforms.
+
+## Reproduce locally
+
+Run the Linux toolchain in Docker (matches CI):
+
+```
+make build-linux     # swift build in a Swift Docker container
+make test-linux       # swift test in a Swift Docker container
+```
+
+These surface failures the macOS build never will.
+
+## Output
+
+**Summary:** Build and Test (Linux) — `error` at `file:line`, Linux-only.
+**Cause:** Apple-only API/Foundation difference reaching the Linux target.
+**Fix:** gate behind `#if canImport(...)` / use a portable API; verify with
+`make build-linux` / `make test-linux`.

--- a/.claude/skills/diagnose-ci-failure/references/markdown.md
+++ b/.claude/skills/diagnose-ci-failure/references/markdown.md
@@ -1,7 +1,7 @@
 # Lint Markdown job failure (markdownlint)
 
-The **Lint Markdown** job runs in the `markdownlint-cli:v0.41.0` container and
-lints:
+The **Lint Markdown** job runs in the
+`ghcr.io/igorshubovych/markdownlint-cli:v0.41.0` container and lints:
 
 ```
 markdownlint "README.md" "**/*.docc/**/*.md"
@@ -40,8 +40,8 @@ check it before assuming the default limits.
 make lint-markdown
 ```
 
-(uses the same `markdownlint-cli2`/`markdownlint` ruleset). Fix, re-run until
-clean.
+(runs the same `markdownlint` invocations as CI — `markdownlint "README.md"` and
+`markdownlint "**/*.docc/**/*.md"`). Fix, re-run until clean.
 
 ## Output
 

--- a/.claude/skills/diagnose-ci-failure/references/markdown.md
+++ b/.claude/skills/diagnose-ci-failure/references/markdown.md
@@ -1,0 +1,50 @@
+# Lint Markdown job failure (markdownlint)
+
+The **Lint Markdown** job runs in the `markdownlint-cli:v0.41.0` container and
+lints:
+
+```
+markdownlint "README.md" "**/*.docc/**/*.md"
+```
+
+So only `README.md` and DocC catalog markdown (`Sources/TMDb/TMDb.docc/**/*.md`)
+are checked — not arbitrary repo markdown. It only runs when the `markdown`
+paths filter matched (README or a DocC `.md` changed), or on
+`workflow_dispatch`.
+
+## Reading the failure
+
+markdownlint emits `file:line[:col] MD0xx/rule-name <message>`. The `MD0xx`
+code maps to a rule; common ones in this repo:
+
+- **MD013** line-length — a prose line exceeds the configured limit.
+- **MD024** duplicate heading — two headings with the same text in one file.
+- **MD031 / MD032** — fenced code blocks / lists need surrounding blank lines.
+- **MD040** — fenced code block missing a language (` ``` ` → ` ```swift `/` ```text `).
+- **MD041** — first line in the file should be a top-level heading.
+
+Configuration, if present, lives in a `.markdownlint*` file at the repo root —
+check it before assuming the default limits.
+
+## Common causes & fixes
+
+- **A DocC `.md` you edited** (service extension file, `TMDb.md`, `TMDbClient.md`)
+  introduced a long line, a missing code-fence language, or a duplicate heading.
+  Fix the flagged `file:line` to satisfy the rule.
+- **README edits** — same rules; watch MD013 line length and MD040 fence
+  languages in examples.
+
+## Reproduce locally
+
+```
+make lint-markdown
+```
+
+(uses the same `markdownlint-cli2`/`markdownlint` ruleset). Fix, re-run until
+clean.
+
+## Output
+
+**Summary:** Lint Markdown — `MD0xx` at `file:line`.
+**Cause:** the rule violation in the changed README/DocC file.
+**Fix:** correct the flagged line; re-run `make lint-markdown`.

--- a/.claude/skills/diagnose-ci-failure/references/unit-tests.md
+++ b/.claude/skills/diagnose-ci-failure/references/unit-tests.md
@@ -1,0 +1,54 @@
+# Unit-test failure (Build and Test — test step)
+
+The **Build and Test** job runs the unit suite:
+
+```
+swift test --filter TMDbTests --enable-code-coverage --xunit-output junit.xml
+```
+
+Tests use the **Swift Testing** framework (`@Suite`, `@Test`, `#expect`,
+`#require`) — not XCTest. Output is piped through `xcsift`, so failures appear as
+annotations with the failing `Suite/test` and `file:line`.
+
+## Reading the failure
+
+- A recorded `#expect(...)` failure prints the expression and the actual vs
+  expected values at `file:line`.
+- A `#require(...)` failure throws and aborts that test (used to unwrap
+  optionals) — the message names what couldn't be unwrapped.
+- A thrown `DecodingError` (`keyNotFound`, `valueNotFound`, `typeMismatch`) means
+  a JSON fixture no longer matches the model that decodes it.
+
+## Common causes & fixes
+
+1. **Assertion failure from changed logic.** The test encodes the old behaviour;
+   either the change is wrong, or the test needs updating to the new expected
+   value. Decide which — don't blindly "fix" the test to match a bug.
+
+2. **Fixture ↔ model mismatch** (most common for model changes). A model gained,
+   renamed, or re-typed a property but its JSON fixture in
+   `Tests/TMDbTests/Resources/json/` wasn't updated (or vice versa):
+   - `keyNotFound "x"` → the model requires `x` (non-optional) but the fixture
+     omits it. Add it to the fixture, or make the property optional if the API
+     can omit it.
+   - `valueNotFound` / `typeMismatch` → the fixture's value is `null` or the
+     wrong JSON type for the model's property type.
+   - Per CLAUDE.md, fixtures must exercise **every** decode branch: if a custom
+     `init(from:)` decodes N optional appended properties, the fixture must
+     include all N, paired with a "without appended data" test.
+
+3. **Missing `#require` unwrap** — a new test force-unwrapped (`!`) instead of
+   `try #require(...)`; if it crashed rather than recorded a failure, switch to
+   `#require`.
+
+## Reproduce locally
+
+- `/test` — runs the full unit suite (Haiku subagent, logs to
+  `.build/last-test.log`).
+- Single test: `swift test --filter "SuiteName/testName"`.
+
+## Output
+
+**Summary:** Build and Test — test step — `Suite/test` at `file:line`.
+**Cause:** the assertion or fixture/model mismatch (name the fixture + model).
+**Fix:** update fixture `X.json` / model `Y` (or the assertion); re-run `/test`.

--- a/.claude/skills/diagnose-integration-failure/SKILL.md
+++ b/.claude/skills/diagnose-integration-failure/SKILL.md
@@ -10,6 +10,11 @@ every PR and the merge to `main`, so a failure is **unlikely to be a code
 regression** — a code bug would have been caught by the PR status check before
 reaching this point. Diagnose accordingly.
 
+> **Wrong suite?** If a **CI** check failed instead (lint, markdown, build, or
+> unit tests from `ci.yml`), use `/diagnose-ci-failure`. That one leads with the
+> opposite assumption: a CI failure is almost always caused by the change under
+> review.
+
 Produce a concise markdown analysis with exactly these three sections:
 
 **Summary:** one or two sentences on what failed — name the failing

--- a/.claude/skills/diagnose-integration-failure/SKILL.md
+++ b/.claude/skills/diagnose-integration-failure/SKILL.md
@@ -29,14 +29,18 @@ NOT lead with "a code bug". Rank these:
 2. **Stale assumed data in an integration test** — the test asserts a specific
    live value (a title, count, id, date, or ordering) that the API now returns
    differently. The code is fine; the test's baseline has drifted.
-3. **A transient API error or rate limiting (HTTP 429).**
+3. **A transient API error, rate limiting (HTTP 429), or a timeout** — the
+   Integration Test job has a 30-minute `timeout-minutes`, and a cancelled
+   (timed-out) run still surfaces as a workflow `failure`. A truncated log with
+   no assertion failure, or a run that ran the full 30 minutes, points here.
 
 Cite the specific HTTP status codes, error messages, or failing assertions from
 the log that point to your conclusion.
 
 **Suggested fix:** the concrete next step — which Swift model or JSON fixture to
 update for an API change, which integration-test assertion to relax or refresh
-for drifted data, or (only for case 3) re-run the job / wait out rate limiting.
+for drifted data, or (only for case 3) re-run the job / wait out rate limiting /
+investigate the slow run if it timed out.
 
 Keep it under ~150 words.
 

--- a/.claude/skills/diagnose-integration-failure/SKILL.md
+++ b/.claude/skills/diagnose-integration-failure/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: diagnose-integration-failure
+description: Diagnose a failing TMDb integration-test run — summarise the failure, rank the likely cause, and suggest a concrete fix
+---
+
+# Diagnose an integration-test failure
+
+The TMDb integration tests hit the **live** TMDb API. This same suite gates
+every PR and the merge to `main`, so a failure is **unlikely to be a code
+regression** — a code bug would have been caught by the PR status check before
+reaching this point. Diagnose accordingly.
+
+Produce a concise markdown analysis with exactly these three sections:
+
+**Summary:** one or two sentences on what failed — name the failing
+suite/test where visible.
+
+**Likely cause:** the most probable root cause, ranked most-likely first. DO
+NOT lead with "a code bug". Rank these:
+
+1. **A TMDb backend change** — a response field was added, removed, renamed, or
+   became nullable, breaking a model's `Decodable`. Confirm against the OpenAPI
+   spec (see step 3).
+2. **Stale assumed data in an integration test** — the test asserts a specific
+   live value (a title, count, id, date, or ordering) that the API now returns
+   differently. The code is fine; the test's baseline has drifted.
+3. **A transient API error or rate limiting (HTTP 429).**
+
+Cite the specific HTTP status codes, error messages, or failing assertions from
+the log that point to your conclusion.
+
+**Suggested fix:** the concrete next step — which Swift model or JSON fixture to
+update for an API change, which integration-test assertion to relax or refresh
+for drifted data, or (only for case 3) re-run the job / wait out rate limiting.
+
+Keep it under ~150 words.
+
+## Steps
+
+1. **Locate the failure log**, in this order — use the first that exists:
+   - A path the caller handed you (e.g. `failure-log.txt` in the working
+     directory, used by the CI alert workflow).
+   - `.build/last-integration-test.log` — written by the `/integration-test`
+     skill. If you (or the user) haven't run the tests yet locally, run
+     `/integration-test` first, then read this log.
+   - Otherwise, find the failing run with the `gh` CLI:
+     `gh run list --workflow Integration --status failure --limit 1` then
+     `gh run view <id> --log-failed`.
+
+2. **Read the failing portion** — focus on the assertion failures and error
+   messages, which surface near the end. Read the specific test, model, and
+   fixture files the log points to so your suggested fix names real symbols.
+
+3. **Check the OpenAPI spec when the failure looks like a decode/shape error.**
+   The live spec is the source of truth for the current response shape, but it
+   is **~3 MB of minified JSON on a single line** — NEVER `grep`, `cat`, or
+   `Read` it whole; that dumps the entire file into context. Extract only the
+   one endpoint you need with `jq` (requires `jq`, which is present in CI and
+   installable via Homebrew locally; if `jq` is unavailable, skip this step and
+   say so):
+   - Use `tmdb-openapi.json` in the working directory if present; otherwise
+     fetch it (best-effort):
+     `curl -fsSL --max-time 30 https://developer.themoviedb.org/openapi/tmdb-api.json -o tmdb-openapi.json`
+   - The spec is OpenAPI 3.1 with response schemas **inlined per endpoint**
+     (there is no reusable `components.schemas`). Find the endpoint, then pull
+     just its 200-response schema:
+     - List endpoints (cheap, ~5 KB): `jq -r '.paths | keys[]' tmdb-openapi.json`
+     - Pull one schema (~5 KB): `jq '.paths."/3/movie/{movie_id}".get.responses."200".content."application/json".schema' tmdb-openapi.json`
+       (swap in the path + HTTP method for the failing request)
+     - Even cheaper, just the field names:
+       `… .schema.properties | keys[]`
+   - Compare the live schema against the failing model/fixture to confirm
+     whether a field changed, became nullable, or was removed — then point at
+     the specific Swift model or JSON fixture that needs updating.
+   - If the spec can't be fetched or `jq` is unavailable, say so and proceed
+     without it.
+
+4. **Output the analysis.** If the caller asked you to write it to a file (e.g.
+   `claude-analysis.md`), write the three-section markdown there and nothing
+   else. Otherwise present it directly in your reply.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -9,27 +9,24 @@ I'll create a pull request for the current branch by following these steps. If a
 
 1. Run `/format` to format code
 2. Check for formatting changes and commit them if needed with message "🤖 apply code formatting"
-3. Run `/lint` to verify code style and quality
-4. Run `/build-for-testing` to ensure project builds successfully with no warnings
-5. Run `/test` to verify all unit tests pass
-6. Run `/integration-test` to verify all integration tests pass
-7. Spawn the `code-reviewer` agent to perform a code review of all changes (pass the git diff output as context)
-8. Summarize the code review findings:
+3. Run `make ci` — **MANDATORY; it must pass before going further.** This is the full gate CLAUDE.md requires before any PR: it runs lint, markdown lint, unit tests, integration tests, the release build, and the docs build. Run it directly (do not delegate). If it fails, stop and fix — never open a PR on a red gate.
+4. Spawn the `code-reviewer` agent to perform a code review of all changes (pass the git diff output as context)
+5. Summarize the code review findings:
     - List any critical or high-severity issues that should be addressed
     - List any medium-severity suggestions for improvement
     - Note any low-severity or stylistic recommendations
-9. If there are critical/high-severity issues:
+6. If there are critical/high-severity issues:
     - Recommend specific changes needed
     - Ask user for confirmation before proceeding (fix issues or continue anyway)
     - If user wants to fix issues, stop and let them address the feedback
-10. Check if branch is up-to-date with main (warn if behind)
-11. Run `git status` and `git diff origin/main...HEAD` to understand all changes
-12. Analyze the commits and changes to generate an appropriate title and summary
-13. Push the current branch to remote if not already pushed
-14. Create a PR using `gh pr create` with:
-    - **IMPORTANT: Title MUST start with a gitmoji prefix** (e.g., "✨ Add new feature", "🐛 Fix bug", "📚 Improve documentation")
+7. Check if branch is up-to-date with main (warn if behind)
+8. Run `git status` and `git diff origin/main...HEAD` to understand all changes
+9. Analyze the commits and changes to generate an appropriate title and summary
+10. Push the current branch to remote if not already pushed
+11. Create a PR using `gh pr create` with:
+    - **IMPORTANT: Title MUST start with a gitmoji prefix** (e.g., "✨ Add new feature", "🐛 Fix bug", "📝 Improve documentation")
         - Refer to <https://gitmoji.dev> to use the correct emoji
-        - Common: ✨ feature, 🐛 bugfix, ♻️ refactor, 🧪 tests, 📚 docs, 🔧 config, 🎨 style
+        - Common: ✨ feature, 🐛 bugfix, ♻️ refactor, ✅ tests, 📝 docs, 🔧 config, 🎨 style
     - A comprehensive summary with bullet points
     - Proper formatting with sections (Summary, Changes, Benefits, etc.)
 

--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -91,27 +91,28 @@ Classify by `bucket`: `fail` = failing, `pending` = in progress, `pass` /
 While anything is pending, block efficiently with `gh pr checks --watch` rather
 than polling in a tight loop.
 
-For each **failing** check, delegate log retrieval to a **Haiku subagent** so raw
-CI logs never enter your context. Use the Agent tool with
-`subagent_type: general-purpose` and `model: haiku` and this prompt:
+For each **failing** check, delegate diagnosis to a **Haiku subagent** so raw CI
+logs never enter your context. Pick the diagnosis skill by which check failed:
+
+- The **Integration** check (live-API suite from `integration.yml`) →
+  `/diagnose-integration-failure`
+- Any **CI** check — lint, markdown, build, or unit tests from `ci.yml` →
+  `/diagnose-ci-failure`
+
+Use the Agent tool with `subagent_type: general-purpose` and `model: haiku` and
+this prompt (substitute the check name and the chosen skill):
 
 ```text
-Find why the `<CHECK NAME>` check failed on the TMDb PR for branch `<branch>`
-and report concisely.
+The `<CHECK NAME>` check failed on the TMDb PR for branch `<branch>`.
 
-1. Run `gh run list --branch <branch> --limit 5 --json databaseId,name,conclusion`
-   to find the failed run id.
-2. Run `gh run view <id> --log-failed`.
+Use the `<SKILL>` skill to diagnose it. The skill locates the failing run,
+reads the log, and maps it to a cause and fix.
 
-Report back ONLY:
-- The failing job/step
-- The root cause
-- The offending `file:line` and message (if any)
-
-Do not paste raw logs.
+Report back ONLY the skill's three-section result — Summary, Cause, Fix —
+including the offending `file:line`. Do not paste raw logs.
 ```
 
-Then fix the issue, verify locally with the matching delegated skill (`/lint`,
+Then apply the fix, verify locally with the matching delegated skill (`/lint`,
 `/build`, `/test`, `/integration-test`), commit (gitmoji), and `git push` — the
 push re-triggers CI. Increment that check's attempt counter.
 

--- a/.github/workflows/integration-failure.yml
+++ b/.github/workflows/integration-failure.yml
@@ -1,0 +1,89 @@
+name: Integration Failure Alert
+
+# Watches the "Integration" workflow. When a *scheduled* run of it fails,
+# opens a GitHub issue and notifies Adam. Does nothing on PR / push runs.
+on:
+  workflow_run:
+    workflows: ["Integration"]
+    types:
+      - completed
+
+permissions:
+  issues: write          # to create / update the alert issue
+  actions: read          # to read the triggering run's details
+
+jobs:
+  alert:
+    name: Open issue on scheduled failure
+    runs-on: ubuntu-latest
+
+    # Only react to the *scheduled* run, and only when it actually failed.
+    # This is what stops contributor PR failures from creating issues.
+    #
+    # NOTE: `event == 'schedule'` matches ANY cron trigger on the Integration
+    # workflow. This is only equivalent to "the Sunday night run" while
+    # integration.yml has a single cron ('0 0 * * 0'). If you ever add another
+    # cron there, this will also fire for that one — revisit this guard then.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure'
+      && github.event.workflow_run.event == 'schedule'
+
+    steps:
+      - name: Create or update failure issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAGER: cat
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+          RUN_DATE: ${{ github.event.workflow_run.created_at }}
+          # Who to ping. Change if you ever want to notify someone else.
+          NOTIFY: adamayoung
+        run: |
+          set -euo pipefail
+
+          LABEL="integration-failure"
+
+          # Make sure the label exists (ignore error if it already does).
+          gh label create "$LABEL" \
+            --repo "$REPO" \
+            --color B60205 \
+            --description "Scheduled integration run failed" \
+            2>/dev/null || true
+
+          # Is there already an OPEN issue for this? If so, just comment on it
+          # rather than opening a duplicate every week it stays broken.
+          EXISTING=$(gh issue list \
+            --repo "$REPO" \
+            --label "$LABEL" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            # Build the comment body with printf so no leading YAML indentation
+            # leaks into the markdown (indented lines render as a code block).
+            COMMENT_BODY=$(printf '%s\n' \
+              "🔁 The scheduled Integration run failed again on ${RUN_DATE}." \
+              "" \
+              "Latest failing run: ${RUN_URL}")
+            gh issue comment "$EXISTING" --repo "$REPO" --body "$COMMENT_BODY"
+            echo "Commented on existing issue #${EXISTING}"
+          else
+            ISSUE_BODY=$(printf '%s\n' \
+              "@${NOTIFY} the weekly scheduled **Integration** workflow failed." \
+              "" \
+              "- **Run:** ${RUN_URL}" \
+              "- **When:** ${RUN_DATE}" \
+              "" \
+              "Integration tests hit the live TMDb API, so the most likely causes are a transient API issue, rate limiting, or live data drift rather than a code change (code problems are caught by the PR status check before reaching main)." \
+              "" \
+              "A re-run often clears transient failures. If it persists, the logs above will show which suite failed.")
+            gh issue create \
+              --repo "$REPO" \
+              --label "$LABEL" \
+              --assignee "$NOTIFY" \
+              --title "Scheduled Integration run failed (#${RUN_NUMBER})" \
+              --body "$ISSUE_BODY"
+            echo "Opened new issue"
+          fi

--- a/.github/workflows/integration-failure.yml
+++ b/.github/workflows/integration-failure.yml
@@ -1,7 +1,9 @@
 name: Integration Failure Alert
 
 # Watches the "Integration" workflow. When a *scheduled* run of it fails,
-# opens a GitHub issue and notifies Adam. Does nothing on PR / push runs.
+# Claude analyses the failing logs, then we open a GitHub issue (or comment
+# on the existing one) with that analysis and notify Adam. Does nothing on
+# PR / push runs.
 on:
   workflow_run:
     workflows: ["Integration"]
@@ -9,8 +11,10 @@ on:
       - completed
 
 permissions:
+  contents: read         # checkout, so Claude can inspect tests/fixtures
   issues: write          # to create / update the alert issue
-  actions: read          # to read the triggering run's details
+  actions: read          # to read the triggering run's logs
+  id-token: write        # for claude-code-action
 
 jobs:
   alert:
@@ -29,6 +33,49 @@ jobs:
       && github.event.workflow_run.event == 'schedule'
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Download failing logs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+
+          # --log-failed prints only the failed steps' logs.
+          gh run view "$RUN_ID" --repo "$REPO" --log-failed \
+            > failure-log-full.txt 2>/dev/null || true
+
+          # Fall back to the full log if --log-failed yielded nothing.
+          if [ ! -s failure-log-full.txt ]; then
+            gh run view "$RUN_ID" --repo "$REPO" --log \
+              > failure-log-full.txt 2>/dev/null || true
+          fi
+
+          # Keep the last ~60k chars — failures surface at the end — so the
+          # analysis prompt stays within a sensible token budget.
+          tail -c 60000 failure-log-full.txt > failure-log.txt || true
+          echo "Captured $(wc -l < failure-log.txt) lines of failing log"
+
+      - name: Analyse failure with Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--model claude-opus-4-8 --allowedTools "Read,Write,Glob,Grep,Bash(jq:*),Bash(curl:*)"'
+          # Invoke the repo skill by passing `/skill-name` as the prompt (the
+          # checkout step above is the prerequisite). Trailing text is passed to
+          # the skill as context.
+          prompt: |
+            /diagnose-integration-failure The scheduled Integration workflow
+            failed and its failing-step log is already at `failure-log.txt` in
+            the workspace root — use it directly; do not run the tests or call
+            `gh`. Write your three-section markdown result to
+            `claude-analysis.md` and nothing else — do not create issues,
+            comments, or branches.
+
       - name: Create or update failure issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -43,6 +90,13 @@ jobs:
           set -euo pipefail
 
           LABEL="integration-failure"
+
+          # Pull in Claude's analysis if it produced one; otherwise fall back.
+          if [ -s claude-analysis.md ]; then
+            ANALYSIS=$(cat claude-analysis.md)
+          else
+            ANALYSIS="_Automated analysis unavailable — see the run logs._"
+          fi
 
           # Make sure the label exists (ignore error if it already does).
           gh label create "$LABEL" \
@@ -66,7 +120,11 @@ jobs:
             COMMENT_BODY=$(printf '%s\n' \
               "🔁 The scheduled Integration run failed again on ${RUN_DATE}." \
               "" \
-              "Latest failing run: ${RUN_URL}")
+              "Latest failing run: ${RUN_URL}" \
+              "" \
+              "### 🤖 Claude's analysis" \
+              "" \
+              "${ANALYSIS}")
             gh issue comment "$EXISTING" --repo "$REPO" --body "$COMMENT_BODY"
             echo "Commented on existing issue #${EXISTING}"
           else
@@ -76,9 +134,15 @@ jobs:
               "- **Run:** ${RUN_URL}" \
               "- **When:** ${RUN_DATE}" \
               "" \
-              "Integration tests hit the live TMDb API, so the most likely causes are a transient API issue, rate limiting, or live data drift rather than a code change (code problems are caught by the PR status check before reaching main)." \
+              "### 🤖 Claude's analysis" \
               "" \
-              "A re-run often clears transient failures. If it persists, the logs above will show which suite failed.")
+              "${ANALYSIS}" \
+              "" \
+              "---" \
+              "" \
+              "This same integration suite gates every PR and the merge to main, so this is unlikely to be a code regression. The usual culprits are a **TMDb backend change** (a response field added, removed, renamed, or made nullable) or **stale assumed data** in an integration test (a hard-coded title, count, id, or date the live API now returns differently) — with transient errors / rate limiting a distant third." \
+              "" \
+              "A re-run clears the transient case. If it persists, the analysis above points at the model, fixture, or assertion to update.")
             gh issue create \
               --repo "$REPO" \
               --label "$LABEL" \

--- a/.github/workflows/integration-failure.yml
+++ b/.github/workflows/integration-failure.yml
@@ -140,7 +140,7 @@ jobs:
               "" \
               "---" \
               "" \
-              "This same integration suite gates every PR and the merge to main, so this is unlikely to be a code regression. The usual culprits are a **TMDb backend change** (a response field added, removed, renamed, or made nullable) or **stale assumed data** in an integration test (a hard-coded title, count, id, or date the live API now returns differently) — with transient errors / rate limiting a distant third." \
+              "This same integration suite gates every PR and the merge to main, so this is unlikely to be a code regression. The usual culprits are a **TMDb backend change** (a response field added, removed, renamed, or made nullable) or **stale assumed data** in an integration test (a hard-coded title, count, id, or date the live API now returns differently) — with transient errors, rate limiting, or a run that hit its 30-minute job timeout (a cancelled run still surfaces as a failure) a distant third." \
               "" \
               "A re-run clears the transient case. If it persists, the analysis above points at the model, fixture, or assertion to update.")
             gh issue create \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,12 +279,17 @@ rule's behaviour changed between versions), not a real violation — check
 
 ### Test-Driven Development
 
-Use a TDD approach when implementing changes or new features:
+Use a TDD approach when implementing changes or new features. **Follow the
+`canon-tdd` skill** — start every feature, endpoint, model, method, or bug
+fix by writing a test list and a failing test before any production code.
+The loop:
 
-1. **Write failing tests first** — define expected behaviour with unit
-   tests and integration tests before writing implementation code
-2. **Implement the minimum code** to make the tests pass
-3. **Refactor** while keeping tests green
+1. **Write a test list** — enumerate the behaviours and edge cases first
+2. **Write failing tests first** — define expected behaviour with unit
+   tests and integration tests before writing implementation code, one
+   test at a time
+3. **Implement the minimum code** to make the tests pass
+4. **Refactor** while keeping tests green
 
 For bug fixes, write a test that reproduces the bug before writing the
 fix.


### PR DESCRIPTION
## Summary

This started as a single GitHub Actions workflow to alert on **scheduled Integration** failures and grew into a small, cohesive set of Claude Code tooling for **diagnosing and preventing** CI/integration failures — plus a TDD skill the project kept needing.

## Changes

**New Workflow:**
- 👷 `.github/workflows/integration-failure.yml` — on a *scheduled* (cron) **Integration** failure only (PR/push runs ignored), downloads the failing log, runs Claude via the `diagnose-integration-failure` skill to produce a **Summary / Cause / Fix** analysis, and opens — or comments on, de-duplicated — a GitHub issue assigned to `@adamayoung`.

**New Skills:**
- ✨ `diagnose-integration-failure` — ranks the realistic causes of a live-API failure (**TMDb backend change > stale assumed test data > transient/429**), confirms decode/shape drift against the TMDb OpenAPI spec using targeted `jq` (the spec is ~3 MB minified — never grep/read whole), and outputs Summary/Cause/Fix. Used by the workflow and invocable locally.
- ✨ `diagnose-ci-failure` — a **router** (`SKILL.md`) plus one reference file per CI job (`lint`, `markdown`, `build`, `unit-tests`, `linux`). Leads with the opposite assumption: a CI failure is almost always caused by the change under review.
- ✨ `canon-tdd` — Canon TDD methodology (test list → one failing test → make it pass → optional refactor → repeat), grounded in the project's Swift Testing + JSON-fixture conventions. Based on <https://adam-young.co.uk/blog/canon-tdd/>.

**Updated Files:**
- ♻️ `watch-pr` skill now delegates a failing check's diagnosis to the right skill by check name (**Integration → diagnose-integration-failure, CI → diagnose-ci-failure**) inside its existing Haiku subagent, so raw logs stay out of context but the report gains job-specific causes/fixes.
- 📝 `CLAUDE.md` TDD section points at `canon-tdd` and adds the test-list step.
- 🔧 `pr` skill now gates on **`make ci`** (the mandatory pre-PR check) instead of a partial sequence that skipped `lint-markdown`/`build-release`/`build-docs`; gitmoji list aligned with CLAUDE.md.
- 🔧 `code-reviewer` / `documentation-writer` agents — small audit fixes (delegated-skills note; `visionOS` added to an `@available` example).
- 🔗 Reciprocal "wrong suite?" cross-pointers between the two diagnosis skills.

## Benefits

- **Visibility:** scheduled live-API failures surface as actionable, de-duplicated issues with an AI diagnosis attached — no silent weekend breakage.
- **No noise:** PR/push failures (already caught by status checks) never raise issues.
- **One source of truth:** the diagnosis methodology is reusable by you (`/diagnose-*`), the `watch-pr` loop, and the alert workflow.
- **TDD by default:** the detailed Canon TDD method is captured once and auto-triggered from CLAUDE.md.
- **Tighter PR gate:** `pr` now matches CLAUDE.md's hard `make ci` requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)