### PR TITLE
🐛 Sort query items by name for a canonical cache key

### DIFF
--- a/Sources/TMDb/Networking/TMDbAPIClient.swift
+++ b/Sources/TMDb/Networking/TMDbAPIClient.swift
@@ -100,7 +100,12 @@ extension TMDbAPIClient {
         urlComponents.host = baseURL.host
         urlComponents.path = "\(baseURL.path)\(urlComponents.path)"
         var queryItems = urlComponents.queryItems ?? []
-        for requestQueryItem in requestQueryItems {
+        // Append query items in a deterministic, name-sorted order so the same
+        // logical request always serialises to an identical URL. The unordered
+        // `[String: String]` dictionary would otherwise iterate in an arbitrary
+        // order, producing a non-canonical URL and silent cache misses for
+        // identical requests in `CacheHTTPClient`.
+        for requestQueryItem in requestQueryItems.sorted(by: { $0.key < $1.key }) {
             queryItems.append(
                 URLQueryItem(name: requestQueryItem.key, value: requestQueryItem.value)
             )

--- a/Tests/TMDbTests/Networking/TMDbAPIClientTests.swift
+++ b/Tests/TMDbTests/Networking/TMDbAPIClientTests.swift
@@ -68,6 +68,48 @@ struct TMDbAPIClientTests {
         #expect(request.url.absoluteString.starts(with: expectedURL.absoluteString))
     }
 
+    @Test("perform builds query items sorted by name for a canonical URL")
+    @MainActor
+    func performBuildsQueryItemsSortedByNameForCanonicalURL() async throws {
+        let stubRequest = APIStubRequest<String, String>(
+            path: "/endpoint",
+            queryItems: ["zebra": "1", "alpha": "2", "mango": "3"]
+        )
+        httpClient.result = .success(HTTPResponse())
+
+        _ = try? await apiClient.perform(stubRequest)
+
+        let request = try #require(httpClient.lastRequest)
+        let components = try #require(
+            URLComponents(url: request.url, resolvingAgainstBaseURL: false)
+        )
+        let names = try #require(components.queryItems).map(\.name)
+
+        #expect(names == names.sorted())
+    }
+
+    @Test("perform builds the same URL regardless of query item insertion order")
+    @MainActor
+    func performBuildsSameURLRegardlessOfQueryItemInsertionOrder() async throws {
+        let firstRequest = APIStubRequest<String, String>(
+            path: "/endpoint",
+            queryItems: ["zebra": "1", "alpha": "2", "mango": "3"]
+        )
+        let secondRequest = APIStubRequest<String, String>(
+            path: "/endpoint",
+            queryItems: ["alpha": "2", "mango": "3", "zebra": "1"]
+        )
+        httpClient.result = .success(HTTPResponse())
+
+        _ = try? await apiClient.perform(firstRequest)
+        let firstURL = try #require(httpClient.lastRequest).url
+
+        _ = try? await apiClient.perform(secondRequest)
+        let secondURL = try #require(httpClient.lastRequest).url
+
+        #expect(firstURL.absoluteString == secondURL.absoluteString)
+    }
+
     @Test("perform when GET method")
     @MainActor
     func performWhenGetMethod() async throws {


### PR DESCRIPTION
## Summary

`CacheHTTPClient` keys cache entries on `request.url.absoluteString`, but
`TMDbAPIClient.urlFromPath` built the request URL by iterating an **unordered**
`[String: String]` query-item dictionary. The same logical request could
therefore serialise to different `absoluteString`s across calls, producing
**silent cache misses** for identical requests and unpredictably defeating the
cache. Functionally safe, but it negates the cache's purpose.

This fix sorts the appended query items by name before building the URL,
yielding a deterministic, canonical URL — and therefore a stable cache key —
for any given set of query items.

Closes #325

## Changes

**Existing Files:**
- 🐛 `TMDbAPIClient.urlFromPath` now appends `requestQueryItems` in
  name-sorted order (`requestQueryItems.sorted(by: { $0.key < $1.key })`),
  with an explanatory comment tying the canonicalisation to the cache key.

**Tests:**
- ✅ Added `performBuildsQueryItemsSortedByNameForCanonicalURL` — asserts the
  built URL's query items are name-sorted (fails on the unpatched code).
- ✅ Added `performBuildsSameURLRegardlessOfQueryItemInsertionOrder` — two
  logically identical requests built from differently-ordered dictionaries
  produce an identical `absoluteString`.
- ✅ All 2572 unit tests and 275 integration tests pass.

## Benefits

- **Reliable caching**: identical requests now always map to the same cache
  key, so `CacheHTTPClient` hits instead of silently missing.
- **Deterministic URLs**: request serialisation is stable and reproducible,
  which also aids debugging and testing.
- **No public API change**: purely an internal networking-layer fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)