### PR TITLE
🐛 Decode unknown Status and media_type values resiliently

### DIFF
--- a/Sources/TMDb/Domain/Models/Media.swift
+++ b/Sources/TMDb/Domain/Models/Media.swift
@@ -64,6 +64,13 @@ extension Media {
         case tvSeries = "tv"
         case person
         case collection
+        case unknown
+
+        init(from decoder: Decoder) throws {
+            self =
+                try MediaType(rawValue: decoder.singleValueContainer().decode(RawValue.self))
+                ?? .unknown
+        }
     }
 
     ///
@@ -95,6 +102,13 @@ extension Media {
 
         case .collection:
             self = try .collection(CollectionListItem(from: decoder))
+
+        case .unknown:
+            throw DecodingError.dataCorruptedError(
+                forKey: .mediaType,
+                in: container,
+                debugDescription: "Unknown media type"
+            )
         }
     }
 

--- a/Sources/TMDb/Domain/Models/PageableListResult.swift
+++ b/Sources/TMDb/Domain/Models/PageableListResult.swift
@@ -71,6 +71,10 @@ extension PageableListResult {
     /// Missing or `null` count fields fall back to sensible defaults: `page`
     /// defaults to `1`, while `totalResults` and `totalPages` default to `0`.
     ///
+    /// Individual result elements are decoded tolerantly: an element that fails
+    /// to decode — for example a list item with a `media_type` this library
+    /// does not yet model — is skipped rather than failing the whole page.
+    ///
     /// - Parameter decoder: The decoder to read data from.
     ///
     /// - Throws: An error if reading from the decoder fails, or if the data is
@@ -80,9 +84,32 @@ extension PageableListResult {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         self.page = try container.decodeIfPresent(Int.self, forKey: .page) ?? 1
-        self.results = try container.decode([Result].self, forKey: .results)
+        let wrapped = try container.decodeIfPresent(
+            [FailableDecodable<Result>].self,
+            forKey: .results
+        )
+        self.results = (wrapped ?? []).compactMap(\.value)
         self.totalResults = try container.decodeIfPresent(Int.self, forKey: .totalResults) ?? 0
         self.totalPages = try container.decodeIfPresent(Int.self, forKey: .totalPages) ?? 0
+    }
+
+}
+
+///
+/// A decoding wrapper that tolerates a failing element.
+///
+/// Decoding never throws: when the wrapped value cannot be decoded, ``value``
+/// is `nil` and the element is consumed so the surrounding array continues to
+/// decode. This lets a list skip an unrecognised element instead of dropping
+/// the whole page.
+///
+private struct FailableDecodable<Wrapped: Decodable>: Decodable {
+
+    let value: Wrapped?
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.value = try? container.decode(Wrapped.self)
     }
 
 }

--- a/Sources/TMDb/Domain/Models/Status.swift
+++ b/Sources/TMDb/Domain/Models/Status.swift
@@ -42,4 +42,30 @@ public enum Status: String, Codable, Equatable, Hashable, Sendable {
     ///
     case cancelled = "Canceled"
 
+    ///
+    /// Unknown.
+    ///
+    /// Used when TMDb returns a status value this library does not yet model,
+    /// so decoding a `Movie` or `TVSeries` does not fail on an unrecognised
+    /// status.
+    ///
+    case unknown
+
+    ///
+    /// Creates a new instance by decoding from the given decoder.
+    ///
+    /// An unrecognised raw value decodes to ``unknown`` rather than throwing.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    ///
+    /// - Throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to
+    /// the requested type.
+    /// - Throws: `DecodingError.valueNotFound` if self has a null entry.
+    ///
+    public init(from decoder: Decoder) throws {
+        self =
+            try Status(rawValue: decoder.singleValueContainer().decode(RawValue.self))
+            ?? .unknown
+    }
+
 }

--- a/Sources/TMDb/Domain/Models/TaggedImageMedia.swift
+++ b/Sources/TMDb/Domain/Models/TaggedImageMedia.swift
@@ -49,6 +49,13 @@ extension TaggedImageMedia {
     private enum MediaType: String, Codable, Equatable {
         case movie
         case tvEpisode = "tv_episode"
+        case unknown
+
+        init(from decoder: Decoder) throws {
+            self =
+                try MediaType(rawValue: decoder.singleValueContainer().decode(RawValue.self))
+                ?? .unknown
+        }
     }
 
     ///
@@ -69,6 +76,13 @@ extension TaggedImageMedia {
 
         case .tvEpisode:
             self = try .tvEpisode(TVEpisode(from: decoder))
+
+        case .unknown:
+            throw DecodingError.dataCorruptedError(
+                forKey: .mediaType,
+                in: container,
+                debugDescription: "Unknown media type"
+            )
         }
     }
 

--- a/Sources/TMDb/Domain/Models/TrendingItem.swift
+++ b/Sources/TMDb/Domain/Models/TrendingItem.swift
@@ -55,6 +55,13 @@ extension TrendingItem {
         case movie
         case tvSeries = "tv"
         case person
+        case unknown
+
+        init(from decoder: Decoder) throws {
+            self =
+                try MediaType(rawValue: decoder.singleValueContainer().decode(RawValue.self))
+                ?? .unknown
+        }
     }
 
     ///
@@ -85,6 +92,13 @@ extension TrendingItem {
 
         case .person:
             self = try .person(PersonListItem(from: decoder))
+
+        case .unknown:
+            throw DecodingError.dataCorruptedError(
+                forKey: .mediaType,
+                in: container,
+                debugDescription: "Unknown media type"
+            )
         }
     }
 

--- a/Tests/TMDbTests/Domain/Models/MediaPageableListTests.swift
+++ b/Tests/TMDbTests/Domain/Models/MediaPageableListTests.swift
@@ -23,6 +23,54 @@ struct MediaPageableListTests {
         #expect(result.totalPages == list.totalPages)
     }
 
+    @Test(
+        "JSON decoding of a page containing an unknown media_type drops only that item",
+        .tags(.decoding)
+    )
+    func decodeWhenPageContainsUnknownMediaTypeDropsUnknownItem() throws {
+        let json = """
+        {
+            "page": 1,
+            "results": [
+                {
+                    "id": 1,
+                    "title": "A Movie",
+                    "original_title": "A Movie",
+                    "original_language": "en",
+                    "overview": "An overview.",
+                    "genre_ids": [],
+                    "media_type": "movie"
+                },
+                {
+                    "id": 2,
+                    "name": "A Future Thing",
+                    "media_type": "future_media"
+                },
+                {
+                    "id": 3,
+                    "name": "A TV Series",
+                    "original_name": "A TV Series",
+                    "original_language": "en",
+                    "overview": "An overview.",
+                    "genre_ids": [],
+                    "origin_country": [],
+                    "media_type": "tv"
+                }
+            ],
+            "total_results": 3,
+            "total_pages": 1
+        }
+        """
+        let data = Data(json.utf8)
+
+        let result = try JSONDecoder.theMovieDatabase.decode(MediaPageableList.self, from: data)
+
+        #expect(result.results.count == 2)
+        #expect(result.results.contains { $0.id == 1 })
+        #expect(result.results.contains { $0.id == 3 })
+        #expect(!result.results.contains { $0.id == 2 })
+    }
+
     private let list = MediaPageableList(
         page: 1,
         results: [

--- a/Tests/TMDbTests/Domain/Models/StatusTests.swift
+++ b/Tests/TMDbTests/Domain/Models/StatusTests.swift
@@ -42,4 +42,32 @@ struct StatusTests {
         #expect(Status.cancelled.rawValue == "Canceled")
     }
 
+    @Test("JSON decoding of a known status", .tags(.decoding))
+    func decodeWhenKnownValueReturnsStatus() throws {
+        let data = Data("{\"status\": \"Released\"}".utf8)
+        let decoder = JSONDecoder()
+
+        let result = try decoder.decode(MockObject.self, from: data).status
+
+        #expect(result == .released)
+    }
+
+    @Test("JSON decoding of an unknown status returns unknown", .tags(.decoding))
+    func decodeWhenInvalidValueReturnsUnknown() throws {
+        let data = Data("{\"status\": \"some-new-status\"}".utf8)
+        let decoder = JSONDecoder()
+
+        let result = try decoder.decode(MockObject.self, from: data).status
+
+        #expect(result == .unknown)
+    }
+
+}
+
+extension StatusTests {
+
+    private struct MockObject: Decodable {
+        let status: Status
+    }
+
 }


### PR DESCRIPTION
## Summary

`Gender`, `VideoType` and `ReleaseType` already decode unknown raw values to
`.unknown` instead of throwing, but two response-decoded enums missed the same
treatment. This PR hardens them so a future TMDb API change cannot fail an
entire response decode.

- **`Status`** used synthesized `RawRepresentable` decoding with no fallback. A
  new status string would throw and fail the whole `Movie` / `TVSeries` decode.
- **`media_type` discriminators** in `Media`, `TrendingItem` and
  `TaggedImageMedia` decoded strictly, so a single unrecognised value (most
  likely in `search/multi` or `trending`) failed the **whole page**, not one
  element.

## Changes

**Existing Files:**
- 🐛 `Status.swift` — add a `.unknown` case and a tolerant `init(from:)`,
  mirroring the existing `VideoType` pattern
- 🐛 `Media.swift`, `TrendingItem.swift`, `TaggedImageMedia.swift` — their
  private `MediaType` discriminator enums now decode unknown values to
  `.unknown` and throw a clear `DecodingError` for that element only
- 🐛 `PageableListResult.swift` — decode `results` tolerantly via a private
  `FailableDecodable` wrapper, so an un-decodable element is skipped rather than
  dropping the entire page

**Tests:**
- ✅ `StatusTests` — known value decodes correctly; unknown value decodes to
  `.unknown`
- ✅ `MediaPageableListTests` — a page containing one unknown `media_type`
  drops only that item and keeps the rest
- ✅ All 2573 unit tests and 275 integration tests pass; `make ci` green

## Benefits

- **Forward compatibility**: new TMDb status strings or media types no longer
  break decoding of an entire movie, series or results page
- **Resilient lists**: one unrecognised list item is dropped instead of failing
  the whole page
- **Consistency**: applies the established `.unknown` resilient-decode pattern
  to the remaining response enums

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)