### PR TITLE
🐛 Retry transient transport errors in RetryHTTPClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,18 +213,20 @@ let movieInFrench = try await tmdbClient.movies.details(forMovie: 550, language:
 
 #### Automatic Retry
 
-Enable automatic retry with exponential backoff for transient errors:
+Enable automatic retry with exponential backoff for transient errors. By
+default this retries rate limits (HTTP 429), server errors (HTTP 5xx) and
+transient network failures (timeouts, dropped connections, DNS failures):
 
 ```swift
 // Use default retry (3 retries, exponential backoff)
 let configuration = TMDbConfiguration(retry: .default)
 let tmdbClient = TMDbClient(apiKey: "<your-api-key>", configuration: configuration)
 
-// Custom retry configuration
+// Custom retry configuration: retry rate limits and transient network errors
 let retryConfig = RetryConfiguration(
     maxRetries: 5,
     initialDelay: .seconds(2),
-    retryableErrors: .rateLimit  // Only retry rate limit errors
+    retryableErrors: [.rateLimit, .networkErrors]
 )
 let tmdbClient = TMDbClient(
     apiKey: "<your-api-key>",

--- a/Sources/TMDb/Domain/Models/RetryConfiguration.swift
+++ b/Sources/TMDb/Domain/Models/RetryConfiguration.swift
@@ -51,8 +51,8 @@ public struct RetryConfiguration: Hashable, Sendable {
     ///
     /// The categories of errors that should trigger a retry.
     ///
-    /// Defaults to both ``RetryableErrors/rateLimit`` and
-    /// ``RetryableErrors/serverErrors``.
+    /// Defaults to ``RetryableErrors/rateLimit``,
+    /// ``RetryableErrors/serverErrors`` and ``RetryableErrors/networkErrors``.
     ///
     public let retryableErrors: RetryableErrors
 
@@ -63,13 +63,14 @@ public struct RetryConfiguration: Hashable, Sendable {
     ///   - maxRetries: The maximum number of retry attempts. Defaults to `3`.
     ///   - initialDelay: The initial delay before the first retry. Defaults to 1 second.
     ///   - maxDelay: The maximum delay between retries. Defaults to 30 seconds.
-    ///   - retryableErrors: The error categories to retry. Defaults to rate limit and server errors.
+    ///   - retryableErrors: The error categories to retry. Defaults to rate
+    ///     limit, server errors and transient network errors.
     ///
     public init(
         maxRetries: Int = 3,
         initialDelay: Duration = .seconds(1),
         maxDelay: Duration = .seconds(30),
-        retryableErrors: RetryableErrors = [.rateLimit, .serverErrors]
+        retryableErrors: RetryableErrors = [.rateLimit, .serverErrors, .networkErrors]
     ) {
         self.maxRetries = max(0, maxRetries)
         self.initialDelay = initialDelay
@@ -81,7 +82,7 @@ public struct RetryConfiguration: Hashable, Sendable {
     /// The default retry configuration.
     ///
     /// Uses 3 retries, 1 second initial delay, 30 second max delay,
-    /// and retries both rate limit and server errors.
+    /// and retries rate limit, server errors and transient network errors.
     ///
     public static let `default` = RetryConfiguration()
 

--- a/Sources/TMDb/Domain/Models/RetryableErrors.swift
+++ b/Sources/TMDb/Domain/Models/RetryableErrors.swift
@@ -45,4 +45,11 @@ public struct RetryableErrors: OptionSet, Hashable, Sendable {
     /// (such as a proxy returning an error page with a 200 status).
     public static let serverErrors = RetryableErrors(rawValue: 1 << 1)
 
+    /// Transient network transport errors.
+    ///
+    /// Covers connection-level `URLError`s that are usually temporary, such as
+    /// a request timing out, a dropped connection, a DNS lookup failure, or a
+    /// failure to reach the host. Deliberate cancellations are never retried.
+    public static let networkErrors = RetryableErrors(rawValue: 1 << 2)
+
 }

--- a/Sources/TMDb/Networking/RetryHTTPClient.swift
+++ b/Sources/TMDb/Networking/RetryHTTPClient.swift
@@ -108,6 +108,10 @@ extension RetryHTTPClient {
             return false
         }
 
+        // TMDbAPIError is constructed above this layer (in TMDbAPIClient) and
+        // will never arrive here in the real decorator chain. Handle it
+        // defensively in case the chain is composed differently in tests or
+        // future configurations.
         if let apiError = error as? TMDbAPIError {
             return isRetryableAPIError(apiError)
         }

--- a/Sources/TMDb/Networking/RetryHTTPClient.swift
+++ b/Sources/TMDb/Networking/RetryHTTPClient.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
 final class RetryHTTPClient: HTTPClient, Sendable {
 
     private let httpClient: any HTTPClient
@@ -99,22 +103,63 @@ extension RetryHTTPClient {
     }
 
     private func isRetryableError(_ error: Error) -> Bool {
-        guard let apiError = error as? TMDbAPIError else {
+        // A deliberate cancellation must never be retried.
+        if error is CancellationError {
             return false
         }
 
+        if let apiError = error as? TMDbAPIError {
+            return isRetryableAPIError(apiError)
+        }
+
+        // At the retry layer the transport adapter throws raw `URLError`s for
+        // connection-level failures (timeouts, dropped connections, DNS
+        // failures). Retry the transient ones when network retries are enabled.
+        if let urlError = error as? URLError {
+            return isRetryableURLError(urlError)
+        }
+
+        return false
+    }
+
+    private func isRetryableAPIError(_ apiError: TMDbAPIError) -> Bool {
         switch apiError {
         case .tooManyRequests:
-            return configuration.retryableErrors.contains(.rateLimit)
+            configuration.retryableErrors.contains(.rateLimit)
 
         case .internalServerError, .notImplemented, .badGateway,
              .serviceUnavailable, .gatewayTimeout:
-            return configuration.retryableErrors.contains(.serverErrors)
+            configuration.retryableErrors.contains(.serverErrors)
 
         default:
-            return false
+            false
         }
     }
+
+    private func isRetryableURLError(_ urlError: URLError) -> Bool {
+        guard configuration.retryableErrors.contains(.networkErrors) else {
+            return false
+        }
+
+        // A URLError can wrap an explicit cancellation; never retry it.
+        guard urlError.code != .cancelled else {
+            return false
+        }
+
+        return Self.retryableURLErrorCodes.contains(urlError.code)
+    }
+
+    /// Transient `URLError` codes that warrant a retry.
+    private static let retryableURLErrorCodes: Set<URLError.Code> = [
+        .timedOut,
+        .cannotConnectToHost,
+        .cannotFindHost,
+        .networkConnectionLost,
+        .notConnectedToInternet,
+        .dnsLookupFailed,
+        .resourceUnavailable,
+        .badServerResponse
+    ]
 
     private func delay(forAttempt attempt: Int, retryAfter: Duration?) async throws {
         if let retryAfter {

--- a/Tests/TMDbTests/Domain/Models/RetryConfigurationTests.swift
+++ b/Tests/TMDbTests/Domain/Models/RetryConfigurationTests.swift
@@ -18,7 +18,7 @@ struct RetryConfigurationTests {
         #expect(config.maxRetries == 3)
         #expect(config.initialDelay == .seconds(1))
         #expect(config.maxDelay == .seconds(30))
-        #expect(config.retryableErrors == [.rateLimit, .serverErrors])
+        #expect(config.retryableErrors == [.rateLimit, .serverErrors, .networkErrors])
     }
 
     @Test("custom values are stored")
@@ -57,7 +57,7 @@ struct RetryConfigurationTests {
         #expect(config.maxRetries == 3)
         #expect(config.initialDelay == .seconds(1))
         #expect(config.maxDelay == .seconds(30))
-        #expect(config.retryableErrors == [.rateLimit, .serverErrors])
+        #expect(config.retryableErrors == [.rateLimit, .serverErrors, .networkErrors])
     }
 
     @Test("equatable returns true for equal configurations")

--- a/Tests/TMDbTests/Domain/Models/RetryableErrorsTests.swift
+++ b/Tests/TMDbTests/Domain/Models/RetryableErrorsTests.swift
@@ -68,6 +68,7 @@ struct RetryableErrorsTests {
 
         #expect(!errors.contains(.rateLimit))
         #expect(!errors.contains(.serverErrors))
+        #expect(!errors.contains(.networkErrors))
     }
 
 }

--- a/Tests/TMDbTests/Domain/Models/RetryableErrorsTests.swift
+++ b/Tests/TMDbTests/Domain/Models/RetryableErrorsTests.swift
@@ -21,6 +21,19 @@ struct RetryableErrorsTests {
         #expect(RetryableErrors.serverErrors.rawValue == 2)
     }
 
+    @Test("networkErrors has raw value 4")
+    func networkErrorsRawValue() {
+        #expect(RetryableErrors.networkErrors.rawValue == 4)
+    }
+
+    @Test("networkErrors only does not contain rateLimit or serverErrors")
+    func networkErrorsOnlyDoesNotContainOthers() {
+        let errors: RetryableErrors = .networkErrors
+
+        #expect(!errors.contains(.rateLimit))
+        #expect(!errors.contains(.serverErrors))
+    }
+
     @Test("contains rateLimit in combined set")
     func containsRateLimitInCombinedSet() {
         let errors: RetryableErrors = [.rateLimit, .serverErrors]

--- a/Tests/TMDbTests/Networking/RetryHTTPClientNetworkErrorTests.swift
+++ b/Tests/TMDbTests/Networking/RetryHTTPClientNetworkErrorTests.swift
@@ -1,0 +1,186 @@
+//
+//  RetryHTTPClientNetworkErrorTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+struct RetryHTTPClientNetworkErrorTests {
+
+    private static let networkConfig = RetryConfiguration(
+        maxRetries: 3,
+        initialDelay: .milliseconds(1),
+        maxDelay: .milliseconds(10),
+        retryableErrors: [.rateLimit, .serverErrors, .networkErrors]
+    )
+
+    @Test("transient URLError then success retries and succeeds")
+    func transientNetworkErrorThenSuccess() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.failure(URLError(.timedOut)))
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 200, data: Data())))
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.networkConfig
+        )
+        let request = try HTTPRequest(url: #require(URL(string: "https://example.com")))
+
+        let response = try await retryClient.perform(request: request)
+
+        #expect(response.statusCode == 200)
+        #expect(mockClient.performCount == 2)
+    }
+
+    @Test(
+        "transient URLError codes are retried",
+        arguments: [
+            URLError.Code.timedOut,
+            .networkConnectionLost,
+            .cannotConnectToHost,
+            .notConnectedToInternet,
+            .dnsLookupFailed,
+            .cannotFindHost,
+            .resourceUnavailable
+        ]
+    )
+    func transientNetworkErrorCodesAreRetried(code: URLError.Code) async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.failure(URLError(code)))
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 200, data: Data())))
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.networkConfig
+        )
+        let request = try HTTPRequest(url: #require(URL(string: "https://example.com")))
+
+        let response = try await retryClient.perform(request: request)
+
+        #expect(response.statusCode == 200)
+        #expect(mockClient.performCount == 2)
+    }
+
+    @Test("transient URLError exhausts retries then rethrows")
+    func transientNetworkErrorExhaustsRetries() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        for _ in 0 ... 3 {
+            mockClient.enqueue(.failure(URLError(.networkConnectionLost)))
+        }
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.networkConfig
+        )
+        let request = try HTTPRequest(url: #require(URL(string: "https://example.com")))
+
+        await #expect(throws: URLError.self) {
+            _ = try await retryClient.perform(request: request)
+        }
+
+        #expect(mockClient.performCount == 4)
+    }
+
+    @Test("non-transient URLError is not retried")
+    func nonTransientNetworkErrorNotRetried() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.failure(URLError(.badURL)))
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.networkConfig
+        )
+        let request = try HTTPRequest(url: #require(URL(string: "https://example.com")))
+
+        await #expect(throws: URLError.self) {
+            _ = try await retryClient.perform(request: request)
+        }
+
+        #expect(mockClient.performCount == 1)
+    }
+
+    @Test("cancelled URLError is never retried")
+    func cancelledURLErrorNotRetried() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.failure(URLError(.cancelled)))
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.networkConfig
+        )
+        let request = try HTTPRequest(url: #require(URL(string: "https://example.com")))
+
+        await #expect(throws: URLError.self) {
+            _ = try await retryClient.perform(request: request)
+        }
+
+        #expect(mockClient.performCount == 1)
+    }
+
+    @Test("CancellationError is never retried")
+    func cancellationErrorNotRetried() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.failure(CancellationError()))
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.networkConfig
+        )
+        let request = try HTTPRequest(url: #require(URL(string: "https://example.com")))
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await retryClient.perform(request: request)
+        }
+
+        #expect(mockClient.performCount == 1)
+    }
+
+    @Test("transient URLError not retried when networkErrors disabled")
+    func transientNetworkErrorNotRetriedWhenDisabled() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.failure(URLError(.timedOut)))
+
+        let config = RetryConfiguration(
+            maxRetries: 3,
+            initialDelay: .milliseconds(1),
+            maxDelay: .milliseconds(10),
+            retryableErrors: [.rateLimit, .serverErrors]
+        )
+        let retryClient = RetryHTTPClient(httpClient: mockClient, configuration: config)
+        let request = try HTTPRequest(url: #require(URL(string: "https://example.com")))
+
+        await #expect(throws: URLError.self) {
+            _ = try await retryClient.perform(request: request)
+        }
+
+        #expect(mockClient.performCount == 1)
+    }
+
+    @Test("POST with transient network error is not retried")
+    func postWithTransientNetworkErrorNotRetried() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.failure(URLError(.timedOut)))
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.networkConfig
+        )
+        let url = try #require(URL(string: "https://example.com"))
+        let request = HTTPRequest(url: url, method: .post)
+
+        await #expect(throws: URLError.self) {
+            _ = try await retryClient.perform(request: request)
+        }
+
+        #expect(mockClient.performCount == 1)
+    }
+
+}

--- a/Tests/TMDbTests/Networking/RetryHTTPClientNetworkErrorTests.swift
+++ b/Tests/TMDbTests/Networking/RetryHTTPClientNetworkErrorTests.swift
@@ -49,7 +49,8 @@ struct RetryHTTPClientNetworkErrorTests {
             .notConnectedToInternet,
             .dnsLookupFailed,
             .cannotFindHost,
-            .resourceUnavailable
+            .resourceUnavailable,
+            .badServerResponse
         ]
     )
     func transientNetworkErrorCodesAreRetried(code: URLError.Code) async throws {


### PR DESCRIPTION
## Summary

`RetryHTTPClient.isRetryableError` decided retryability with
`error as? TMDbAPIError`, but `TMDbAPIError` is only ever created in
`TMDbAPIClient`, which sits **above** the entire HTTPClient decorator chain. At
the retry layer the only errors that can arrive are the raw `URLError`/`NSError`
thrown by `URLSessionHTTPClientAdapter`. The cast therefore **always failed in
production**, making the catch → delay → retry branch dead code: a dropped
connection, DNS failure, or request timeout was thrown on the first attempt with
zero retries — exactly the failures retry exists for. Status-code retries
(429/5xx) kept working only because the adapter returns those as `HTTPResponse`s
rather than throwing, which masked the bug. The existing unit tests passed
because they enqueued `TMDbAPIError` failures directly — a path the real chain
never feeds.

Closes #322

## Changes

**Existing Files:**
- 🐛 `RetryHTTPClient.isRetryableError` now matches transient `URLError.Code`s
  (`.timedOut`, `.networkConnectionLost`, `.cannotConnectToHost`,
  `.cannotFindHost`, `.notConnectedToInternet`, `.dnsLookupFailed`,
  `.resourceUnavailable`, `.badServerResponse`) and explicitly excludes both
  `CancellationError` and `URLError.cancelled`
- ✨ Added `RetryableErrors.networkErrors` option and folded it into the default
  retry set so the advertised resilience is delivered out of the box
- 📝 Updated `RetryConfiguration` defaults and doc comments

**Tests:**
- ✅ New `RetryHTTPClientNetworkErrorTests` throwing raw `URLError`s — the path
  the real decorator chain feeds: retry-then-succeed, parameterised transient
  codes, retry exhaustion + rethrow, non-transient not retried, cancellation
  (both `CancellationError` and `URLError.cancelled`) never retried, gated off
  when `.networkErrors` is absent, and POST (non-idempotent) not retried
- ✅ Extended `RetryableErrorsTests` and updated `RetryConfigurationTests` for
  the new option and default

**Documentation:**
- 📚 README retry example and intro updated to describe network-error retries

## Benefits

- **Real resilience**: transient network failures are now actually retried, not
  silently dropped on the first attempt
- **Safe by construction**: deliberate cancellations are never retried, and
  non-idempotent requests remain single-shot
- **Honest tests**: coverage now exercises the errors the production chain
  genuinely throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)