### PR TITLE
🐛 Guard review-plan workflow against stringified args

### DIFF
--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -68,6 +68,13 @@ contain arbitrary text). Call `Workflow` with `args: { plan: "<full plan text>",
 goal: "<one–two sentence restatement of the underlying task>" }` and the script
 below. The three lenses live in the script; only `args` changes per run.
 
+> **Args may arrive stringified.** The harness sometimes delivers `args` to the
+> script as a JSON **string** rather than an object, so reading `args.plan`
+> directly yields `undefined` and the critics silently review an empty plan. The
+> script below already guards against this (`typeof args === 'string' ?
+> JSON.parse(args) : args`) — keep that guard. If a critic ever reports the plan
+> or goal is literally `"undefined"`, this is the cause: the args weren't parsed.
+
 ```javascript
 export const meta = {
   name: 'review-plan-critics',
@@ -126,8 +133,12 @@ const VERDICT_SCHEMA = {
   required: ['lens', 'stance', 'findings'],
 }
 
-const plan = args.plan
-const goal = args.goal
+// `args` can arrive as a JSON string rather than an object (a known harness
+// gotcha), in which case `args.plan` / `args.goal` would be `undefined` and the
+// critics would review an empty plan. Parse it back to an object first.
+const input = typeof args === 'string' ? JSON.parse(args) : args
+const plan = input.plan
+const goal = input.goal
 
 phase('Review')
 const verdicts = await parallel(LENSES.map((lens) => () =>


### PR DESCRIPTION
## Summary

The `/review-plan` skill's embedded Workflow script read `args.plan` and
`args.goal` directly. The harness can deliver `args` to a workflow script as a
JSON **string** rather than an object, in which case both fields resolved to
`undefined` and all three critic subagents silently reviewed an **empty plan**
(reporting the literal token `"undefined"`).

## Changes

**`.claude/skills/review-plan/SKILL.md`:**
- 🐛 Parse `args` back to an object before reading fields
  (`typeof args === 'string' ? JSON.parse(args) : args`)
- 📝 Document the failure mode and its tell-tale sign (`"undefined"` plan/goal)
  in the skill prose so it's recognised if it ever recurs

## Notes

Skill-markdown change only — no Swift touched, so the Swift `make ci` /
code-review gates don't apply. The `markdownlint --fix` PostToolUse hook ran on
save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)