### PR TITLE
✨ Add auto-pagination to Account, GuestSession, Keyword & Changes services

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,11 +333,13 @@ for try await page in tmdbClient.movies.allPopularPages() {
 }
 ```
 
-Available for all paginated endpoints across 7 services: `MovieService`
+Available for all paginated endpoints across 11 services: `MovieService`
 (8 endpoints), `SearchService` (7 endpoints), `TrendingService` (4 endpoints),
 `TVSeriesService` (8 endpoints), `PersonService` (2 endpoints),
-`DiscoverService` (2 endpoints), and `ListService` (1 endpoint). Total: 32
-paginated endpoints with 64 auto-pagination methods.
+`DiscoverService` (2 endpoints), `ListService` (1 endpoint), `AccountService`
+(8 endpoints), `GuestSessionService` (3 endpoints), `KeywordService`
+(1 endpoint), and `ChangesService` (3 endpoints). Total: 47 paginated endpoints
+with 94 auto-pagination methods.
 
 ### User Account Features (Authentication Required)
 

--- a/Sources/TMDb/Domain/Models/Change.swift
+++ b/Sources/TMDb/Domain/Models/Change.swift
@@ -178,7 +178,7 @@ public struct ChangeCollection: Codable, Equatable, Hashable, Sendable {
 ///
 /// A model representing a media item that has changed.
 ///
-public struct ChangedID: Codable, Equatable, Hashable, Sendable {
+public struct ChangedID: Identifiable, Codable, Equatable, Hashable, Sendable {
 
     ///
     /// The media item identifier.

--- a/Sources/TMDb/Domain/Services/Account/AccountService+Pagination.swift
+++ b/Sources/TMDb/Domain/Services/Account/AccountService+Pagination.swift
@@ -1,0 +1,445 @@
+//
+//  AccountService+Pagination.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+// swiftlint:disable file_length
+
+import Foundation
+
+///
+/// Auto-pagination extensions for ``AccountService``.
+///
+/// These methods provide lazy `AsyncSequence`-based iteration over paginated account endpoints,
+/// eliminating the need for manual pagination logic.
+///
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+public extension AccountService {
+
+    // MARK: - Item-Level Iteration
+
+    ///
+    /// Returns an async sequence of all the user's favourited movies across all pages.
+    ///
+    /// Pages are fetched lazily as items are consumed from the sequence.
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - accountID: The user's account identifier.
+    ///    - session: The user's TMDb session.
+    ///
+    /// - Returns: An async sequence that yields individual ``MovieListItem`` objects.
+    ///
+    func allFavouriteMovies(
+        sortedBy: FavouriteSort? = nil,
+        accountID: Int,
+        session: Session
+    ) -> PagedAsyncSequence<MovieListItem> {
+        PagedAsyncSequence { [self] page in
+            try await favouriteMovies(
+                sortedBy: sortedBy,
+                page: page,
+                accountID: accountID,
+                session: session
+            )
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all the user's favourited TV series across all pages.
+    ///
+    /// Pages are fetched lazily as items are consumed from the sequence.
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - accountID: The user's account identifier.
+    ///    - session: The user's TMDb session.
+    ///
+    /// - Returns: An async sequence that yields individual ``TVSeriesListItem`` objects.
+    ///
+    func allFavouriteTVSeries(
+        sortedBy: FavouriteSort? = nil,
+        accountID: Int,
+        session: Session
+    ) -> PagedAsyncSequence<TVSeriesListItem> {
+        PagedAsyncSequence { [self] page in
+            try await favouriteTVSeries(
+                sortedBy: sortedBy,
+                page: page,
+                accountID: accountID,
+                session: session
+            )
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all movies in the user's watchlist across all pages.
+    ///
+    /// Pages are fetched lazily as items are consumed from the sequence.
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - accountID: The user's account identifier.
+    ///    - session: The user's TMDb session.
+    ///
+    /// - Returns: An async sequence that yields individual ``MovieListItem`` objects.
+    ///
+    func allWatchlistMovies(
+        sortedBy: WatchlistSort? = nil,
+        accountID: Int,
+        session: Session
+    ) -> PagedAsyncSequence<MovieListItem> {
+        PagedAsyncSequence { [self] page in
+            try await movieWatchlist(
+                sortedBy: sortedBy,
+                page: page,
+                accountID: accountID,
+                session: session
+            )
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all TV series in the user's watchlist across all pages.
+    ///
+    /// Pages are fetched lazily as items are consumed from the sequence.
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - accountID: The user's account identifier.
+    ///    - session: The user's TMDb session.
+    ///
+    /// - Returns: An async sequence that yields individual ``TVSeriesListItem`` objects.
+    ///
+    func allWatchlistTVSeries(
+        sortedBy: WatchlistSort? = nil,
+        accountID: Int,
+        session: Session
+    ) -> PagedAsyncSequence<TVSeriesListItem> {
+        PagedAsyncSequence { [self] page in
+            try await tvSeriesWatchlist(
+                sortedBy: sortedBy,
+                page: page,
+                accountID: accountID,
+                session: session
+            )
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all movies rated by the user across all pages.
+    ///
+    /// Pages are fetched lazily as items are consumed from the sequence.
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - accountID: The user's account identifier.
+    ///    - session: The user's TMDb session.
+    ///
+    /// - Returns: An async sequence that yields individual ``MovieListItem`` objects.
+    ///
+    func allRatedMovies(
+        sortedBy: RatedSort? = nil,
+        accountID: Int,
+        session: Session
+    ) -> PagedAsyncSequence<MovieListItem> {
+        PagedAsyncSequence { [self] page in
+            try await ratedMovies(
+                sortedBy: sortedBy,
+                page: page,
+                accountID: accountID,
+                session: session
+            )
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all TV series rated by the user across all pages.
+    ///
+    /// Pages are fetched lazily as items are consumed from the sequence.
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - accountID: The user's account identifier.
+    ///    - session: The user's TMDb session.
+    ///
+    /// - Returns: An async sequence that yields individual ``TVSeriesListItem`` objects.
+    ///
+    func allRatedTVSeries(
+        sortedBy: RatedSort? = nil,
+        accountID: Int,
+        session: Session
+    ) -> PagedAsyncSequence<TVSeriesListItem> {
+        PagedAsyncSequence { [self] page in
+            try await ratedTVSeries(
+                sortedBy: sortedBy,
+                page: page,
+                accountID: accountID,
+                session: session
+            )
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all TV episodes rated by the user across all pages.
+    ///
+    /// Pages are fetched lazily as items are consumed from the sequence.
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - accountID: The user's account identifier.
+    ///    - session: The user's TMDb session.
+    ///
+    /// - Returns: An async sequence that yields individual ``TVEpisode`` objects.
+    ///
+    func allRatedTVEpisodes(
+        sortedBy: RatedSort? = nil,
+        accountID: Int,
+        session: Session
+    ) -> PagedAsyncSequence<TVEpisode> {
+        PagedAsyncSequence { [self] page in
+            try await ratedTVEpisodes(
+                sortedBy: sortedBy,
+                page: page,
+                accountID: accountID,
+                session: session
+            )
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all the user's custom lists across all pages.
+    ///
+    /// Pages are fetched lazily as items are consumed from the sequence.
+    ///
+    /// - Parameters:
+    ///    - accountID: The user's account identifier.
+    ///    - session: The user's TMDb session.
+    ///
+    /// - Returns: An async sequence that yields individual ``MediaListSummary`` objects.
+    ///
+    func allLists(
+        accountID: Int,
+        session: Session
+    ) -> PagedAsyncSequence<MediaListSummary> {
+        PagedAsyncSequence { [self] page in
+            try await lists(page: page, accountID: accountID, session: session)
+        }
+    }
+
+    // MARK: - Page-Level Iteration
+
+    ///
+    /// Returns an async sequence of all the user's favourited movie pages.
+    ///
+    /// Pages are fetched lazily as they are consumed from the sequence.
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - accountID: The user's account identifier.
+    ///    - session: The user's TMDb session.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages containing ``MovieListItem`` objects.
+    ///
+    func allFavouriteMoviesPages(
+        sortedBy: FavouriteSort? = nil,
+        accountID: Int,
+        session: Session
+    ) -> PagedPagesAsyncSequence<MovieListItem> {
+        PagedPagesAsyncSequence { [self] page in
+            try await favouriteMovies(
+                sortedBy: sortedBy,
+                page: page,
+                accountID: accountID,
+                session: session
+            )
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all the user's favourited TV series pages.
+    ///
+    /// Pages are fetched lazily as they are consumed from the sequence.
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - accountID: The user's account identifier.
+    ///    - session: The user's TMDb session.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages containing ``TVSeriesListItem`` objects.
+    ///
+    func allFavouriteTVSeriesPages(
+        sortedBy: FavouriteSort? = nil,
+        accountID: Int,
+        session: Session
+    ) -> PagedPagesAsyncSequence<TVSeriesListItem> {
+        PagedPagesAsyncSequence { [self] page in
+            try await favouriteTVSeries(
+                sortedBy: sortedBy,
+                page: page,
+                accountID: accountID,
+                session: session
+            )
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all the user's movie watchlist pages.
+    ///
+    /// Pages are fetched lazily as they are consumed from the sequence.
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - accountID: The user's account identifier.
+    ///    - session: The user's TMDb session.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages containing ``MovieListItem`` objects.
+    ///
+    func allWatchlistMoviesPages(
+        sortedBy: WatchlistSort? = nil,
+        accountID: Int,
+        session: Session
+    ) -> PagedPagesAsyncSequence<MovieListItem> {
+        PagedPagesAsyncSequence { [self] page in
+            try await movieWatchlist(
+                sortedBy: sortedBy,
+                page: page,
+                accountID: accountID,
+                session: session
+            )
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all the user's TV series watchlist pages.
+    ///
+    /// Pages are fetched lazily as they are consumed from the sequence.
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - accountID: The user's account identifier.
+    ///    - session: The user's TMDb session.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages containing ``TVSeriesListItem`` objects.
+    ///
+    func allWatchlistTVSeriesPages(
+        sortedBy: WatchlistSort? = nil,
+        accountID: Int,
+        session: Session
+    ) -> PagedPagesAsyncSequence<TVSeriesListItem> {
+        PagedPagesAsyncSequence { [self] page in
+            try await tvSeriesWatchlist(
+                sortedBy: sortedBy,
+                page: page,
+                accountID: accountID,
+                session: session
+            )
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all the user's rated movie pages.
+    ///
+    /// Pages are fetched lazily as they are consumed from the sequence.
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - accountID: The user's account identifier.
+    ///    - session: The user's TMDb session.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages containing ``MovieListItem`` objects.
+    ///
+    func allRatedMoviesPages(
+        sortedBy: RatedSort? = nil,
+        accountID: Int,
+        session: Session
+    ) -> PagedPagesAsyncSequence<MovieListItem> {
+        PagedPagesAsyncSequence { [self] page in
+            try await ratedMovies(
+                sortedBy: sortedBy,
+                page: page,
+                accountID: accountID,
+                session: session
+            )
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all the user's rated TV series pages.
+    ///
+    /// Pages are fetched lazily as they are consumed from the sequence.
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - accountID: The user's account identifier.
+    ///    - session: The user's TMDb session.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages containing ``TVSeriesListItem`` objects.
+    ///
+    func allRatedTVSeriesPages(
+        sortedBy: RatedSort? = nil,
+        accountID: Int,
+        session: Session
+    ) -> PagedPagesAsyncSequence<TVSeriesListItem> {
+        PagedPagesAsyncSequence { [self] page in
+            try await ratedTVSeries(
+                sortedBy: sortedBy,
+                page: page,
+                accountID: accountID,
+                session: session
+            )
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all the user's rated TV episode pages.
+    ///
+    /// Pages are fetched lazily as they are consumed from the sequence.
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - accountID: The user's account identifier.
+    ///    - session: The user's TMDb session.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages containing ``TVEpisode`` objects.
+    ///
+    func allRatedTVEpisodesPages(
+        sortedBy: RatedSort? = nil,
+        accountID: Int,
+        session: Session
+    ) -> PagedPagesAsyncSequence<TVEpisode> {
+        PagedPagesAsyncSequence { [self] page in
+            try await ratedTVEpisodes(
+                sortedBy: sortedBy,
+                page: page,
+                accountID: accountID,
+                session: session
+            )
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all the user's custom list pages.
+    ///
+    /// Pages are fetched lazily as they are consumed from the sequence.
+    ///
+    /// - Parameters:
+    ///    - accountID: The user's account identifier.
+    ///    - session: The user's TMDb session.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages containing ``MediaListSummary`` objects.
+    ///
+    func allListsPages(
+        accountID: Int,
+        session: Session
+    ) -> PagedPagesAsyncSequence<MediaListSummary> {
+        PagedPagesAsyncSequence { [self] page in
+            try await lists(page: page, accountID: accountID, session: session)
+        }
+    }
+
+}
+
+// swiftlint:enable file_length

--- a/Sources/TMDb/Domain/Services/Account/Sorts/FavouriteSort.swift
+++ b/Sources/TMDb/Domain/Services/Account/Sorts/FavouriteSort.swift
@@ -10,7 +10,7 @@ import Foundation
 ///
 /// A sort specifier when fetching movies.
 ///
-public enum FavouriteSort: CustomStringConvertible {
+public enum FavouriteSort: CustomStringConvertible, Sendable {
 
     ///
     /// By created at.

--- a/Sources/TMDb/Domain/Services/Account/Sorts/RatedSort.swift
+++ b/Sources/TMDb/Domain/Services/Account/Sorts/RatedSort.swift
@@ -10,7 +10,7 @@ import Foundation
 ///
 /// A sort specifier when fetching rated content.
 ///
-public enum RatedSort: CustomStringConvertible {
+public enum RatedSort: CustomStringConvertible, Sendable {
 
     ///
     /// By created at.

--- a/Sources/TMDb/Domain/Services/Account/Sorts/WatchlistSort.swift
+++ b/Sources/TMDb/Domain/Services/Account/Sorts/WatchlistSort.swift
@@ -10,7 +10,7 @@ import Foundation
 ///
 /// A sort specifier when fetching movies.
 ///
-public enum WatchlistSort: CustomStringConvertible {
+public enum WatchlistSort: CustomStringConvertible, Sendable {
 
     ///
     /// By created at.

--- a/Sources/TMDb/Domain/Services/Changes/ChangesService+Pagination.swift
+++ b/Sources/TMDb/Domain/Services/Changes/ChangesService+Pagination.swift
@@ -1,0 +1,178 @@
+//
+//  ChangesService+Pagination.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// Auto-pagination extensions for ``ChangesService``.
+///
+/// These methods provide lazy `AsyncSequence`-based iteration over the paginated change-list
+/// endpoints, eliminating the need for manual pagination logic.
+///
+/// The underlying endpoints return a ``ChangedIDCollection``; these sequences surface its page
+/// metadata as ``PageableListResult`` pages of ``ChangedID`` so they can reuse the shared
+/// pagination primitives.
+///
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+public extension ChangesService {
+
+    // MARK: - Item-Level Iteration
+
+    ///
+    /// Returns an async sequence of all movie IDs changed in the given date range across all pages.
+    ///
+    /// Pages are fetched lazily as items are consumed from the sequence.
+    ///
+    /// [TMDb API - Changes: Movie List](https://developer.themoviedb.org/reference/changes-movie-list)
+    ///
+    /// - Parameters:
+    ///    - startDate: Filter from this date.
+    ///    - endDate: Filter to this date.
+    ///
+    /// - Returns: An async sequence that yields individual ``ChangedID`` objects.
+    ///
+    func allMovieChanges(
+        startDate: Date? = nil,
+        endDate: Date? = nil
+    ) -> PagedAsyncSequence<ChangedID> {
+        PagedAsyncSequence { [self] page in
+            let collection = try await movieChanges(startDate: startDate, endDate: endDate, page: page)
+            return PageableListResult(changedIDCollection: collection)
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all TV series IDs changed in the given date range across all pages.
+    ///
+    /// Pages are fetched lazily as items are consumed from the sequence.
+    ///
+    /// [TMDb API - Changes: TV List](https://developer.themoviedb.org/reference/changes-tv-list)
+    ///
+    /// - Parameters:
+    ///    - startDate: Filter from this date.
+    ///    - endDate: Filter to this date.
+    ///
+    /// - Returns: An async sequence that yields individual ``ChangedID`` objects.
+    ///
+    func allTVSeriesChanges(
+        startDate: Date? = nil,
+        endDate: Date? = nil
+    ) -> PagedAsyncSequence<ChangedID> {
+        PagedAsyncSequence { [self] page in
+            let collection = try await tvSeriesChanges(startDate: startDate, endDate: endDate, page: page)
+            return PageableListResult(changedIDCollection: collection)
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all person IDs changed in the given date range across all pages.
+    ///
+    /// Pages are fetched lazily as items are consumed from the sequence.
+    ///
+    /// [TMDb API - Changes: Person List](https://developer.themoviedb.org/reference/changes-people-list)
+    ///
+    /// - Parameters:
+    ///    - startDate: Filter from this date.
+    ///    - endDate: Filter to this date.
+    ///
+    /// - Returns: An async sequence that yields individual ``ChangedID`` objects.
+    ///
+    func allPersonChanges(
+        startDate: Date? = nil,
+        endDate: Date? = nil
+    ) -> PagedAsyncSequence<ChangedID> {
+        PagedAsyncSequence { [self] page in
+            let collection = try await personChanges(startDate: startDate, endDate: endDate, page: page)
+            return PageableListResult(changedIDCollection: collection)
+        }
+    }
+
+    // MARK: - Page-Level Iteration
+
+    ///
+    /// Returns an async sequence of all changed-movie-ID pages for the given date range.
+    ///
+    /// Pages are fetched lazily as they are consumed from the sequence.
+    ///
+    /// [TMDb API - Changes: Movie List](https://developer.themoviedb.org/reference/changes-movie-list)
+    ///
+    /// - Parameters:
+    ///    - startDate: Filter from this date.
+    ///    - endDate: Filter to this date.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages containing ``ChangedID`` objects.
+    ///
+    func allMovieChangesPages(
+        startDate: Date? = nil,
+        endDate: Date? = nil
+    ) -> PagedPagesAsyncSequence<ChangedID> {
+        PagedPagesAsyncSequence { [self] page in
+            let collection = try await movieChanges(startDate: startDate, endDate: endDate, page: page)
+            return PageableListResult(changedIDCollection: collection)
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all changed-TV-series-ID pages for the given date range.
+    ///
+    /// Pages are fetched lazily as they are consumed from the sequence.
+    ///
+    /// [TMDb API - Changes: TV List](https://developer.themoviedb.org/reference/changes-tv-list)
+    ///
+    /// - Parameters:
+    ///    - startDate: Filter from this date.
+    ///    - endDate: Filter to this date.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages containing ``ChangedID`` objects.
+    ///
+    func allTVSeriesChangesPages(
+        startDate: Date? = nil,
+        endDate: Date? = nil
+    ) -> PagedPagesAsyncSequence<ChangedID> {
+        PagedPagesAsyncSequence { [self] page in
+            let collection = try await tvSeriesChanges(startDate: startDate, endDate: endDate, page: page)
+            return PageableListResult(changedIDCollection: collection)
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all changed-person-ID pages for the given date range.
+    ///
+    /// Pages are fetched lazily as they are consumed from the sequence.
+    ///
+    /// [TMDb API - Changes: Person List](https://developer.themoviedb.org/reference/changes-people-list)
+    ///
+    /// - Parameters:
+    ///    - startDate: Filter from this date.
+    ///    - endDate: Filter to this date.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages containing ``ChangedID`` objects.
+    ///
+    func allPersonChangesPages(
+        startDate: Date? = nil,
+        endDate: Date? = nil
+    ) -> PagedPagesAsyncSequence<ChangedID> {
+        PagedPagesAsyncSequence { [self] page in
+            let collection = try await personChanges(startDate: startDate, endDate: endDate, page: page)
+            return PageableListResult(changedIDCollection: collection)
+        }
+    }
+
+}
+
+private extension PageableListResult where Result == ChangedID {
+
+    init(changedIDCollection collection: ChangedIDCollection) {
+        self.init(
+            page: collection.page,
+            results: collection.results,
+            totalResults: collection.totalResults,
+            totalPages: collection.totalPages
+        )
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/GuestSessions/GuestSessionService+Pagination.swift
+++ b/Sources/TMDb/Domain/Services/GuestSessions/GuestSessionService+Pagination.swift
@@ -1,0 +1,157 @@
+//
+//  GuestSessionService+Pagination.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// Auto-pagination extensions for ``GuestSessionService``.
+///
+/// These methods provide lazy `AsyncSequence`-based iteration over paginated guest session endpoints,
+/// eliminating the need for manual pagination logic.
+///
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+public extension GuestSessionService {
+
+    // MARK: - Item-Level Iteration
+
+    ///
+    /// Returns an async sequence of all movies rated by a guest session across all pages.
+    ///
+    /// Pages are fetched lazily as items are consumed from the sequence.
+    ///
+    /// [TMDb API - Guest Sessions: Rated Movies](https://developer.themoviedb.org/reference/guest-session-rated-movies)
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - guestSessionID: The guest session identifier.
+    ///
+    /// - Returns: An async sequence that yields individual ``MovieListItem`` objects.
+    ///
+    func allRatedMovies(
+        sortedBy: RatedSort? = nil,
+        guestSessionID: String
+    ) -> PagedAsyncSequence<MovieListItem> {
+        PagedAsyncSequence { [self] page in
+            try await ratedMovies(sortedBy: sortedBy, page: page, guestSessionID: guestSessionID)
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all TV series rated by a guest session across all pages.
+    ///
+    /// Pages are fetched lazily as items are consumed from the sequence.
+    ///
+    /// [TMDb API - Guest Sessions: Rated TV](https://developer.themoviedb.org/reference/guest-session-rated-tv)
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - guestSessionID: The guest session identifier.
+    ///
+    /// - Returns: An async sequence that yields individual ``TVSeriesListItem`` objects.
+    ///
+    func allRatedTVSeries(
+        sortedBy: RatedSort? = nil,
+        guestSessionID: String
+    ) -> PagedAsyncSequence<TVSeriesListItem> {
+        PagedAsyncSequence { [self] page in
+            try await ratedTVSeries(sortedBy: sortedBy, page: page, guestSessionID: guestSessionID)
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all TV episodes rated by a guest session across all pages.
+    ///
+    /// Pages are fetched lazily as items are consumed from the sequence.
+    ///
+    /// [TMDb API - Guest Sessions: Rated TV
+    /// Episodes](https://developer.themoviedb.org/reference/guest-session-rated-tv-episodes)
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - guestSessionID: The guest session identifier.
+    ///
+    /// - Returns: An async sequence that yields individual ``TVEpisode`` objects.
+    ///
+    func allRatedTVEpisodes(
+        sortedBy: RatedSort? = nil,
+        guestSessionID: String
+    ) -> PagedAsyncSequence<TVEpisode> {
+        PagedAsyncSequence { [self] page in
+            try await ratedTVEpisodes(sortedBy: sortedBy, page: page, guestSessionID: guestSessionID)
+        }
+    }
+
+    // MARK: - Page-Level Iteration
+
+    ///
+    /// Returns an async sequence of all movie pages rated by a guest session.
+    ///
+    /// Pages are fetched lazily as they are consumed from the sequence.
+    ///
+    /// [TMDb API - Guest Sessions: Rated Movies](https://developer.themoviedb.org/reference/guest-session-rated-movies)
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - guestSessionID: The guest session identifier.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages containing ``MovieListItem`` objects.
+    ///
+    func allRatedMoviesPages(
+        sortedBy: RatedSort? = nil,
+        guestSessionID: String
+    ) -> PagedPagesAsyncSequence<MovieListItem> {
+        PagedPagesAsyncSequence { [self] page in
+            try await ratedMovies(sortedBy: sortedBy, page: page, guestSessionID: guestSessionID)
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all TV series pages rated by a guest session.
+    ///
+    /// Pages are fetched lazily as they are consumed from the sequence.
+    ///
+    /// [TMDb API - Guest Sessions: Rated TV](https://developer.themoviedb.org/reference/guest-session-rated-tv)
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - guestSessionID: The guest session identifier.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages containing ``TVSeriesListItem`` objects.
+    ///
+    func allRatedTVSeriesPages(
+        sortedBy: RatedSort? = nil,
+        guestSessionID: String
+    ) -> PagedPagesAsyncSequence<TVSeriesListItem> {
+        PagedPagesAsyncSequence { [self] page in
+            try await ratedTVSeries(sortedBy: sortedBy, page: page, guestSessionID: guestSessionID)
+        }
+    }
+
+    ///
+    /// Returns an async sequence of all TV episode pages rated by a guest session.
+    ///
+    /// Pages are fetched lazily as they are consumed from the sequence.
+    ///
+    /// [TMDb API - Guest Sessions: Rated TV
+    /// Episodes](https://developer.themoviedb.org/reference/guest-session-rated-tv-episodes)
+    ///
+    /// - Parameters:
+    ///    - sortedBy: How results should be sorted.
+    ///    - guestSessionID: The guest session identifier.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages containing ``TVEpisode`` objects.
+    ///
+    func allRatedTVEpisodesPages(
+        sortedBy: RatedSort? = nil,
+        guestSessionID: String
+    ) -> PagedPagesAsyncSequence<TVEpisode> {
+        PagedPagesAsyncSequence { [self] page in
+            try await ratedTVEpisodes(sortedBy: sortedBy, page: page, guestSessionID: guestSessionID)
+        }
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/Keywords/KeywordService+Pagination.swift
+++ b/Sources/TMDb/Domain/Services/Keywords/KeywordService+Pagination.swift
@@ -1,0 +1,69 @@
+//
+//  KeywordService+Pagination.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// Auto-pagination extensions for ``KeywordService``.
+///
+/// These methods provide lazy `AsyncSequence`-based iteration over paginated keyword endpoints,
+/// eliminating the need for manual pagination logic.
+///
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+public extension KeywordService {
+
+    // MARK: - Item-Level Iteration
+
+    ///
+    /// Returns an async sequence of all movies for a keyword across all pages.
+    ///
+    /// Pages are fetched lazily as items are consumed from the sequence.
+    ///
+    /// [TMDb API - Keywords: Movies](https://developer.themoviedb.org/reference/keyword-movies)
+    ///
+    /// - Parameters:
+    ///    - keywordID: The identifier of the keyword.
+    ///    - language: ISO 639-1 language code to display results in. Defaults to the client's configured default
+    /// language.
+    ///
+    /// - Returns: An async sequence that yields individual ``MovieListItem`` objects.
+    ///
+    func allMovies(
+        forKeyword keywordID: Keyword.ID,
+        language: String? = nil
+    ) -> PagedAsyncSequence<MovieListItem> {
+        PagedAsyncSequence { [self] page in
+            try await movies(forKeyword: keywordID, page: page, language: language)
+        }
+    }
+
+    // MARK: - Page-Level Iteration
+
+    ///
+    /// Returns an async sequence of all movie pages for a keyword.
+    ///
+    /// Pages are fetched lazily as they are consumed from the sequence.
+    ///
+    /// [TMDb API - Keywords: Movies](https://developer.themoviedb.org/reference/keyword-movies)
+    ///
+    /// - Parameters:
+    ///    - keywordID: The identifier of the keyword.
+    ///    - language: ISO 639-1 language code to display results in. Defaults to the client's configured default
+    /// language.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages containing ``MovieListItem`` objects.
+    ///
+    func allMoviesPages(
+        forKeyword keywordID: Keyword.ID,
+        language: String? = nil
+    ) -> PagedPagesAsyncSequence<MovieListItem> {
+        PagedPagesAsyncSequence { [self] page in
+            try await movies(forKeyword: keywordID, page: page, language: language)
+        }
+    }
+
+}

--- a/Sources/TMDb/TMDb.docc/Extensions/AccountService.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/AccountService.md
@@ -45,3 +45,22 @@
 ### Custom Lists
 
 - ``lists(page:accountID:session:)``
+
+### Auto-Pagination
+
+- ``allFavouriteMovies(sortedBy:accountID:session:)``
+- ``allFavouriteTVSeries(sortedBy:accountID:session:)``
+- ``allWatchlistMovies(sortedBy:accountID:session:)``
+- ``allWatchlistTVSeries(sortedBy:accountID:session:)``
+- ``allRatedMovies(sortedBy:accountID:session:)``
+- ``allRatedTVSeries(sortedBy:accountID:session:)``
+- ``allRatedTVEpisodes(sortedBy:accountID:session:)``
+- ``allLists(accountID:session:)``
+- ``allFavouriteMoviesPages(sortedBy:accountID:session:)``
+- ``allFavouriteTVSeriesPages(sortedBy:accountID:session:)``
+- ``allWatchlistMoviesPages(sortedBy:accountID:session:)``
+- ``allWatchlistTVSeriesPages(sortedBy:accountID:session:)``
+- ``allRatedMoviesPages(sortedBy:accountID:session:)``
+- ``allRatedTVSeriesPages(sortedBy:accountID:session:)``
+- ``allRatedTVEpisodesPages(sortedBy:accountID:session:)``
+- ``allListsPages(accountID:session:)``

--- a/Sources/TMDb/TMDb.docc/Extensions/ChangesService.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/ChangesService.md
@@ -15,3 +15,12 @@
 - ``personDetails(forPerson:startDate:endDate:page:)``
 - ``tvSeasonDetails(forSeason:startDate:endDate:page:)``
 - ``tvEpisodeDetails(forEpisode:startDate:endDate:page:)``
+
+### Auto-Pagination
+
+- ``allMovieChanges(startDate:endDate:)``
+- ``allTVSeriesChanges(startDate:endDate:)``
+- ``allPersonChanges(startDate:endDate:)``
+- ``allMovieChangesPages(startDate:endDate:)``
+- ``allTVSeriesChangesPages(startDate:endDate:)``
+- ``allPersonChangesPages(startDate:endDate:)``

--- a/Sources/TMDb/TMDb.docc/Extensions/GuestSessionService.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/GuestSessionService.md
@@ -16,3 +16,12 @@
 
 - ``ratedTVEpisodes(sortedBy:page:guestSessionID:)``
 - ``ratedTVEpisodes(guestSessionID:)``
+
+### Auto-Pagination
+
+- ``allRatedMovies(sortedBy:guestSessionID:)``
+- ``allRatedTVSeries(sortedBy:guestSessionID:)``
+- ``allRatedTVEpisodes(sortedBy:guestSessionID:)``
+- ``allRatedMoviesPages(sortedBy:guestSessionID:)``
+- ``allRatedTVSeriesPages(sortedBy:guestSessionID:)``
+- ``allRatedTVEpisodesPages(sortedBy:guestSessionID:)``

--- a/Sources/TMDb/TMDb.docc/Extensions/KeywordService.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/KeywordService.md
@@ -10,3 +10,8 @@
 
 - ``movies(forKeyword:page:language:)``
 - ``movies(forKeyword:)``
+
+### Auto-Pagination
+
+- ``allMovies(forKeyword:language:)``
+- ``allMoviesPages(forKeyword:language:)``

--- a/Tests/TMDbIntegrationTests/ChangesIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/ChangesIntegrationTests.swift
@@ -102,4 +102,26 @@ struct ChangesIntegrationTests {
         _ = result.changes
     }
 
+    @Test("allMovieChanges paginates across pages")
+    func allMovieChanges() async throws {
+        var items: [ChangedID] = []
+        for try await item in changesService.allMovieChanges().prefix(25) {
+            items.append(item)
+        }
+
+        #expect(items.isEmpty == false)
+    }
+
+    @Test("allMovieChangesPages yields pages")
+    func allMovieChangesPages() async throws {
+        var pages: [PageableListResult<ChangedID>] = []
+        for try await page in changesService.allMovieChangesPages().prefix(1) {
+            pages.append(page)
+        }
+
+        let firstPage = try #require(pages.first)
+        #expect(firstPage.page >= 1)
+        #expect(firstPage.results.isEmpty == false)
+    }
+
 }

--- a/Tests/TMDbIntegrationTests/KeywordIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/KeywordIntegrationTests.swift
@@ -58,4 +58,16 @@ struct KeywordIntegrationTests {
         #expect(movieList.page == 1)
     }
 
+    @Test("allMovies paginates across pages")
+    func allMovies() async throws {
+        let keywordID = 378
+
+        var items: [MovieListItem] = []
+        for try await item in keywordService.allMovies(forKeyword: keywordID).prefix(25) {
+            items.append(item)
+        }
+
+        #expect(items.isEmpty == false)
+    }
+
 }

--- a/Tests/TMDbTests/Domain/Services/Account/TMDbAccountServicePaginationTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Account/TMDbAccountServicePaginationTests.swift
@@ -1,0 +1,267 @@
+//
+//  TMDbAccountServicePaginationTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.services, .account))
+struct TMDbAccountServicePaginationTests {
+
+    var service: TMDbAccountService!
+    var apiClient: MockAPIClient!
+
+    let accountID = 11
+    let session = Session.mock()
+
+    init() {
+        self.apiClient = MockAPIClient()
+        self.service = TMDbAccountService(apiClient: apiClient)
+    }
+
+    // MARK: - allFavouriteMovies
+
+    @Test("allFavouriteMovies yields items from multiple pages")
+    func allFavouriteMoviesYieldsItemsFromMultiplePages() async throws {
+        let page1 = MoviePageableList.mock(page: 1, totalPages: 2)
+        let page2 = MoviePageableList.mock(page: 2, totalPages: 2)
+        apiClient.addResponse(.success(page1))
+        apiClient.addResponse(.success(page2))
+
+        var items: [MovieListItem] = []
+        for try await item in service.allFavouriteMovies(accountID: accountID, session: session) {
+            items.append(item)
+        }
+
+        #expect(items.count == page1.results.count + page2.results.count)
+        #expect(apiClient.requests.count == 2)
+        #expect(apiClient.lastRequest is FavouriteMoviesRequest)
+    }
+
+    @Test("allFavouriteMoviesPages yields page objects")
+    func allFavouriteMoviesPagesYieldsPageObjects() async throws {
+        apiClient.addResponse(.success(MoviePageableList.mock(page: 1, totalPages: 1)))
+
+        var pages: [MoviePageableList] = []
+        for try await page in service.allFavouriteMoviesPages(accountID: accountID, session: session) {
+            pages.append(page)
+        }
+
+        #expect(pages.count == 1)
+    }
+
+    // MARK: - allFavouriteTVSeries
+
+    @Test("allFavouriteTVSeries yields items from multiple pages")
+    func allFavouriteTVSeriesYieldsItemsFromMultiplePages() async throws {
+        let page1 = TVSeriesPageableList.mock(page: 1, totalPages: 2)
+        let page2 = TVSeriesPageableList.mock(page: 2, totalPages: 2)
+        apiClient.addResponse(.success(page1))
+        apiClient.addResponse(.success(page2))
+
+        var items: [TVSeriesListItem] = []
+        for try await item in service.allFavouriteTVSeries(accountID: accountID, session: session) {
+            items.append(item)
+        }
+
+        #expect(items.count == page1.results.count + page2.results.count)
+        #expect(apiClient.lastRequest is FavouriteTVSeriesRequest)
+    }
+
+    @Test("allFavouriteTVSeriesPages yields page objects")
+    func allFavouriteTVSeriesPagesYieldsPageObjects() async throws {
+        apiClient.addResponse(.success(TVSeriesPageableList.mock(page: 1, totalPages: 1)))
+
+        var pages: [TVSeriesPageableList] = []
+        for try await page in service.allFavouriteTVSeriesPages(accountID: accountID, session: session) {
+            pages.append(page)
+        }
+
+        #expect(pages.count == 1)
+    }
+
+    // MARK: - allWatchlistMovies
+
+    @Test("allWatchlistMovies yields items from multiple pages")
+    func allWatchlistMoviesYieldsItemsFromMultiplePages() async throws {
+        let page1 = MoviePageableList.mock(page: 1, totalPages: 2)
+        let page2 = MoviePageableList.mock(page: 2, totalPages: 2)
+        apiClient.addResponse(.success(page1))
+        apiClient.addResponse(.success(page2))
+
+        var items: [MovieListItem] = []
+        for try await item in service.allWatchlistMovies(accountID: accountID, session: session) {
+            items.append(item)
+        }
+
+        #expect(items.count == page1.results.count + page2.results.count)
+        #expect(apiClient.lastRequest is MovieWatchlistRequest)
+    }
+
+    @Test("allWatchlistMoviesPages yields page objects")
+    func allWatchlistMoviesPagesYieldsPageObjects() async throws {
+        apiClient.addResponse(.success(MoviePageableList.mock(page: 1, totalPages: 1)))
+
+        var pages: [MoviePageableList] = []
+        for try await page in service.allWatchlistMoviesPages(accountID: accountID, session: session) {
+            pages.append(page)
+        }
+
+        #expect(pages.count == 1)
+    }
+
+    // MARK: - allWatchlistTVSeries
+
+    @Test("allWatchlistTVSeries yields items from multiple pages")
+    func allWatchlistTVSeriesYieldsItemsFromMultiplePages() async throws {
+        let page1 = TVSeriesPageableList.mock(page: 1, totalPages: 2)
+        let page2 = TVSeriesPageableList.mock(page: 2, totalPages: 2)
+        apiClient.addResponse(.success(page1))
+        apiClient.addResponse(.success(page2))
+
+        var items: [TVSeriesListItem] = []
+        for try await item in service.allWatchlistTVSeries(accountID: accountID, session: session) {
+            items.append(item)
+        }
+
+        #expect(items.count == page1.results.count + page2.results.count)
+        #expect(apiClient.lastRequest is TVSeriesWatchlistRequest)
+    }
+
+    @Test("allWatchlistTVSeriesPages yields page objects")
+    func allWatchlistTVSeriesPagesYieldsPageObjects() async throws {
+        apiClient.addResponse(.success(TVSeriesPageableList.mock(page: 1, totalPages: 1)))
+
+        var pages: [TVSeriesPageableList] = []
+        for try await page in service.allWatchlistTVSeriesPages(accountID: accountID, session: session) {
+            pages.append(page)
+        }
+
+        #expect(pages.count == 1)
+    }
+
+    // MARK: - allRatedMovies
+
+    @Test("allRatedMovies yields items from multiple pages")
+    func allRatedMoviesYieldsItemsFromMultiplePages() async throws {
+        let page1 = MoviePageableList.mock(page: 1, totalPages: 2)
+        let page2 = MoviePageableList.mock(page: 2, totalPages: 2)
+        apiClient.addResponse(.success(page1))
+        apiClient.addResponse(.success(page2))
+
+        var items: [MovieListItem] = []
+        for try await item in service.allRatedMovies(accountID: accountID, session: session) {
+            items.append(item)
+        }
+
+        #expect(items.count == page1.results.count + page2.results.count)
+        #expect(apiClient.lastRequest is RatedMoviesRequest)
+    }
+
+    @Test("allRatedMoviesPages yields page objects")
+    func allRatedMoviesPagesYieldsPageObjects() async throws {
+        apiClient.addResponse(.success(MoviePageableList.mock(page: 1, totalPages: 1)))
+
+        var pages: [MoviePageableList] = []
+        for try await page in service.allRatedMoviesPages(accountID: accountID, session: session) {
+            pages.append(page)
+        }
+
+        #expect(pages.count == 1)
+    }
+
+    // MARK: - allRatedTVSeries
+
+    @Test("allRatedTVSeries yields items from multiple pages")
+    func allRatedTVSeriesYieldsItemsFromMultiplePages() async throws {
+        let page1 = TVSeriesPageableList.mock(page: 1, totalPages: 2)
+        let page2 = TVSeriesPageableList.mock(page: 2, totalPages: 2)
+        apiClient.addResponse(.success(page1))
+        apiClient.addResponse(.success(page2))
+
+        var items: [TVSeriesListItem] = []
+        for try await item in service.allRatedTVSeries(accountID: accountID, session: session) {
+            items.append(item)
+        }
+
+        #expect(items.count == page1.results.count + page2.results.count)
+        #expect(apiClient.lastRequest is RatedTVSeriesRequest)
+    }
+
+    @Test("allRatedTVSeriesPages yields page objects")
+    func allRatedTVSeriesPagesYieldsPageObjects() async throws {
+        apiClient.addResponse(.success(TVSeriesPageableList.mock(page: 1, totalPages: 1)))
+
+        var pages: [TVSeriesPageableList] = []
+        for try await page in service.allRatedTVSeriesPages(accountID: accountID, session: session) {
+            pages.append(page)
+        }
+
+        #expect(pages.count == 1)
+    }
+
+    // MARK: - allRatedTVEpisodes
+
+    @Test("allRatedTVEpisodes yields items from multiple pages")
+    func allRatedTVEpisodesYieldsItemsFromMultiplePages() async throws {
+        let page1 = TVEpisodePageableList.mock(page: 1, totalPages: 2)
+        let page2 = TVEpisodePageableList.mock(page: 2, totalPages: 2)
+        apiClient.addResponse(.success(page1))
+        apiClient.addResponse(.success(page2))
+
+        var items: [TVEpisode] = []
+        for try await item in service.allRatedTVEpisodes(accountID: accountID, session: session) {
+            items.append(item)
+        }
+
+        #expect(items.count == page1.results.count + page2.results.count)
+        #expect(apiClient.lastRequest is RatedTVEpisodesRequest)
+    }
+
+    @Test("allRatedTVEpisodesPages yields page objects")
+    func allRatedTVEpisodesPagesYieldsPageObjects() async throws {
+        apiClient.addResponse(.success(TVEpisodePageableList.mock(page: 1, totalPages: 1)))
+
+        var pages: [TVEpisodePageableList] = []
+        for try await page in service.allRatedTVEpisodesPages(accountID: accountID, session: session) {
+            pages.append(page)
+        }
+
+        #expect(pages.count == 1)
+    }
+
+    // MARK: - allLists
+
+    @Test("allLists yields items from multiple pages")
+    func allListsYieldsItemsFromMultiplePages() async throws {
+        let page1 = MediaListSummaryPageableList.mock(page: 1, totalPages: 2)
+        let page2 = MediaListSummaryPageableList.mock(page: 2, totalPages: 2)
+        apiClient.addResponse(.success(page1))
+        apiClient.addResponse(.success(page2))
+
+        var items: [MediaListSummary] = []
+        for try await item in service.allLists(accountID: accountID, session: session) {
+            items.append(item)
+        }
+
+        #expect(items.count == page1.results.count + page2.results.count)
+        #expect(apiClient.lastRequest is AccountListsRequest)
+    }
+
+    @Test("allListsPages yields page objects")
+    func allListsPagesYieldsPageObjects() async throws {
+        apiClient.addResponse(.success(MediaListSummaryPageableList.mock(page: 1, totalPages: 1)))
+
+        var pages: [MediaListSummaryPageableList] = []
+        for try await page in service.allListsPages(accountID: accountID, session: session) {
+            pages.append(page)
+        }
+
+        #expect(pages.count == 1)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Changes/TMDbChangesServicePaginationTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Changes/TMDbChangesServicePaginationTests.swift
@@ -1,0 +1,127 @@
+//
+//  TMDbChangesServicePaginationTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.services, .changes))
+struct TMDbChangesServicePaginationTests {
+
+    var service: TMDbChangesService!
+    var apiClient: MockAPIClient!
+
+    init() {
+        self.apiClient = MockAPIClient()
+        self.service = TMDbChangesService(apiClient: apiClient)
+    }
+
+    // MARK: - allMovieChanges
+
+    @Test("allMovieChanges yields items from multiple pages and caps at totalPages")
+    func allMovieChangesYieldsItemsFromMultiplePages() async throws {
+        let page1 = ChangedIDCollection.mock(page: 1, totalPages: 2)
+        let page2 = ChangedIDCollection.mock(page: 2, totalPages: 2)
+        apiClient.addResponse(.success(page1))
+        apiClient.addResponse(.success(page2))
+
+        var items: [ChangedID] = []
+        for try await item in service.allMovieChanges() {
+            items.append(item)
+        }
+
+        #expect(items.count == page1.results.count + page2.results.count)
+        #expect(apiClient.requests.count == 2)
+        #expect(apiClient.lastRequest is MovieChangesListRequest)
+    }
+
+    @Test("allMovieChangesPages yields page objects")
+    func allMovieChangesPagesYieldsPageObjects() async throws {
+        apiClient.addResponse(.success(ChangedIDCollection.mock(page: 1, totalPages: 2)))
+        apiClient.addResponse(.success(ChangedIDCollection.mock(page: 2, totalPages: 2)))
+
+        var pages: [PageableListResult<ChangedID>] = []
+        for try await page in service.allMovieChangesPages() {
+            pages.append(page)
+        }
+
+        #expect(pages.count == 2)
+        let firstPage = try #require(pages.first)
+        #expect(firstPage.page == 1)
+        #expect(firstPage.totalPages == 2)
+    }
+
+    // MARK: - allTVSeriesChanges
+
+    @Test("allTVSeriesChanges yields items from multiple pages")
+    func allTVSeriesChangesYieldsItemsFromMultiplePages() async throws {
+        let page1 = ChangedIDCollection.mock(page: 1, totalPages: 2)
+        let page2 = ChangedIDCollection.mock(page: 2, totalPages: 2)
+        apiClient.addResponse(.success(page1))
+        apiClient.addResponse(.success(page2))
+
+        var items: [ChangedID] = []
+        for try await item in service.allTVSeriesChanges() {
+            items.append(item)
+        }
+
+        #expect(items.count == page1.results.count + page2.results.count)
+        #expect(apiClient.lastRequest is TVSeriesChangesListRequest)
+    }
+
+    @Test("allTVSeriesChangesPages yields page objects")
+    func allTVSeriesChangesPagesYieldsPageObjects() async throws {
+        apiClient.addResponse(.success(ChangedIDCollection.mock(page: 1, totalPages: 1)))
+
+        var pages: [PageableListResult<ChangedID>] = []
+        for try await page in service.allTVSeriesChangesPages() {
+            pages.append(page)
+        }
+
+        #expect(pages.count == 1)
+    }
+
+    // MARK: - allPersonChanges
+
+    @Test("allPersonChanges yields items from multiple pages")
+    func allPersonChangesYieldsItemsFromMultiplePages() async throws {
+        let page1 = ChangedIDCollection.mock(page: 1, totalPages: 2)
+        let page2 = ChangedIDCollection.mock(page: 2, totalPages: 2)
+        apiClient.addResponse(.success(page1))
+        apiClient.addResponse(.success(page2))
+
+        var items: [ChangedID] = []
+        for try await item in service.allPersonChanges() {
+            items.append(item)
+        }
+
+        #expect(items.count == page1.results.count + page2.results.count)
+        #expect(apiClient.lastRequest is PersonChangesListRequest)
+    }
+
+    @Test("allPersonChangesPages yields page objects")
+    func allPersonChangesPagesYieldsPageObjects() async throws {
+        apiClient.addResponse(.success(ChangedIDCollection.mock(page: 1, totalPages: 1)))
+
+        var pages: [PageableListResult<ChangedID>] = []
+        for try await page in service.allPersonChangesPages() {
+            pages.append(page)
+        }
+
+        #expect(pages.count == 1)
+    }
+
+    // MARK: - ChangedID Identifiable
+
+    @Test("ChangedID id is the changed media identifier")
+    func changedIDIdentifiableIDIsMediaID() {
+        let changedID = ChangedID(id: 42, adult: false)
+
+        #expect(changedID.id == 42)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Changes/TMDbChangesServicePaginationTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Changes/TMDbChangesServicePaginationTests.swift
@@ -39,9 +39,14 @@ struct TMDbChangesServicePaginationTests {
         #expect(apiClient.lastRequest is MovieChangesListRequest)
     }
 
-    @Test("allMovieChangesPages yields page objects")
+    @Test("allMovieChangesPages yields page objects mapping every field")
     func allMovieChangesPagesYieldsPageObjects() async throws {
-        apiClient.addResponse(.success(ChangedIDCollection.mock(page: 1, totalPages: 2)))
+        // Distinct page/totalPages/totalResults so a field-swap in the
+        // ChangedIDCollection -> PageableListResult adapter can't pass.
+        let firstResult = ChangedID(id: 99, adult: false)
+        apiClient.addResponse(.success(
+            ChangedIDCollection.mock(results: [firstResult], page: 1, totalPages: 2, totalResults: 7)
+        ))
         apiClient.addResponse(.success(ChangedIDCollection.mock(page: 2, totalPages: 2)))
 
         var pages: [PageableListResult<ChangedID>] = []
@@ -53,6 +58,8 @@ struct TMDbChangesServicePaginationTests {
         let firstPage = try #require(pages.first)
         #expect(firstPage.page == 1)
         #expect(firstPage.totalPages == 2)
+        #expect(firstPage.totalResults == 7)
+        #expect(firstPage.results.first?.id == 99)
     }
 
     // MARK: - allTVSeriesChanges

--- a/Tests/TMDbTests/Domain/Services/GuestSessions/TMDbGuestSessionServicePaginationTests.swift
+++ b/Tests/TMDbTests/Domain/Services/GuestSessions/TMDbGuestSessionServicePaginationTests.swift
@@ -1,0 +1,118 @@
+//
+//  TMDbGuestSessionServicePaginationTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.services, .guestSession))
+struct TMDbGuestSessionServicePaginationTests {
+
+    var service: TMDbGuestSessionService!
+    var apiClient: MockAPIClient!
+
+    let guestSessionID = "abc123"
+
+    init() {
+        self.apiClient = MockAPIClient()
+        self.service = TMDbGuestSessionService(apiClient: apiClient)
+    }
+
+    // MARK: - allRatedMovies
+
+    @Test("allRatedMovies yields items from multiple pages")
+    func allRatedMoviesYieldsItemsFromMultiplePages() async throws {
+        let page1 = MoviePageableList.mock(page: 1, totalPages: 2)
+        let page2 = MoviePageableList.mock(page: 2, totalPages: 2)
+        apiClient.addResponse(.success(page1))
+        apiClient.addResponse(.success(page2))
+
+        var items: [MovieListItem] = []
+        for try await item in service.allRatedMovies(guestSessionID: guestSessionID) {
+            items.append(item)
+        }
+
+        #expect(items.count == page1.results.count + page2.results.count)
+        #expect(apiClient.requests.count == 2)
+        #expect(apiClient.lastRequest is GuestSessionRatedMoviesRequest)
+    }
+
+    @Test("allRatedMoviesPages yields page objects")
+    func allRatedMoviesPagesYieldsPageObjects() async throws {
+        apiClient.addResponse(.success(MoviePageableList.mock(page: 1, totalPages: 1)))
+
+        var pages: [MoviePageableList] = []
+        for try await page in service.allRatedMoviesPages(guestSessionID: guestSessionID) {
+            pages.append(page)
+        }
+
+        #expect(pages.count == 1)
+    }
+
+    // MARK: - allRatedTVSeries
+
+    @Test("allRatedTVSeries yields items from multiple pages")
+    func allRatedTVSeriesYieldsItemsFromMultiplePages() async throws {
+        let page1 = TVSeriesPageableList.mock(page: 1, totalPages: 2)
+        let page2 = TVSeriesPageableList.mock(page: 2, totalPages: 2)
+        apiClient.addResponse(.success(page1))
+        apiClient.addResponse(.success(page2))
+
+        var items: [TVSeriesListItem] = []
+        for try await item in service.allRatedTVSeries(guestSessionID: guestSessionID) {
+            items.append(item)
+        }
+
+        #expect(items.count == page1.results.count + page2.results.count)
+        #expect(apiClient.requests.count == 2)
+        #expect(apiClient.lastRequest is GuestSessionRatedTVSeriesRequest)
+    }
+
+    @Test("allRatedTVSeriesPages yields page objects")
+    func allRatedTVSeriesPagesYieldsPageObjects() async throws {
+        apiClient.addResponse(.success(TVSeriesPageableList.mock(page: 1, totalPages: 1)))
+
+        var pages: [TVSeriesPageableList] = []
+        for try await page in service.allRatedTVSeriesPages(guestSessionID: guestSessionID) {
+            pages.append(page)
+        }
+
+        #expect(pages.count == 1)
+    }
+
+    // MARK: - allRatedTVEpisodes
+
+    @Test("allRatedTVEpisodes yields items from multiple pages")
+    func allRatedTVEpisodesYieldsItemsFromMultiplePages() async throws {
+        let page1 = TVEpisodePageableList.mock(page: 1, totalPages: 2)
+        let page2 = TVEpisodePageableList.mock(page: 2, totalPages: 2)
+        apiClient.addResponse(.success(page1))
+        apiClient.addResponse(.success(page2))
+
+        var items: [TVEpisode] = []
+        for try await item in service.allRatedTVEpisodes(guestSessionID: guestSessionID) {
+            items.append(item)
+        }
+
+        #expect(items.count == page1.results.count + page2.results.count)
+        #expect(apiClient.requests.count == 2)
+        #expect(apiClient.lastRequest is GuestSessionRatedTVEpisodesRequest)
+    }
+
+    @Test("allRatedTVEpisodesPages yields page objects")
+    func allRatedTVEpisodesPagesYieldsPageObjects() async throws {
+        apiClient.addResponse(.success(TVEpisodePageableList.mock(page: 1, totalPages: 1)))
+
+        var pages: [TVEpisodePageableList] = []
+        for try await page in service.allRatedTVEpisodesPages(guestSessionID: guestSessionID) {
+            pages.append(page)
+        }
+
+        #expect(pages.count == 1)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Keywords/TMDbKeywordServicePaginationTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Keywords/TMDbKeywordServicePaginationTests.swift
@@ -1,0 +1,58 @@
+//
+//  TMDbKeywordServicePaginationTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.services, .keyword))
+struct TMDbKeywordServicePaginationTests {
+
+    var service: TMDbKeywordService!
+    var apiClient: MockAPIClient!
+
+    init() {
+        self.apiClient = MockAPIClient()
+        self.service = TMDbKeywordService(apiClient: apiClient)
+    }
+
+    // MARK: - allMovies
+
+    @Test("allMovies yields items from multiple pages")
+    func allMoviesYieldsItemsFromMultiplePages() async throws {
+        let page1 = MoviePageableList.mock(page: 1, totalPages: 2)
+        let page2 = MoviePageableList.mock(page: 2, totalPages: 2)
+        apiClient.addResponse(.success(page1))
+        apiClient.addResponse(.success(page2))
+
+        var items: [MovieListItem] = []
+        for try await item in service.allMovies(forKeyword: 1, language: "en") {
+            items.append(item)
+        }
+
+        #expect(items.count == page1.results.count + page2.results.count)
+        #expect(apiClient.requests.count == 2)
+        #expect(apiClient.lastRequest is KeywordMoviesRequest)
+    }
+
+    @Test("allMoviesPages yields page objects")
+    func allMoviesPagesYieldsPageObjects() async throws {
+        apiClient.addResponse(.success(MoviePageableList.mock(page: 1, totalPages: 2)))
+        apiClient.addResponse(.success(MoviePageableList.mock(page: 2, totalPages: 2)))
+
+        var pages: [MoviePageableList] = []
+        for try await page in service.allMoviesPages(forKeyword: 1) {
+            pages.append(page)
+        }
+
+        #expect(pages.count == 2)
+        let firstPage = try #require(pages.first)
+        #expect(firstPage.page == 1)
+        #expect(firstPage.totalPages == 2)
+    }
+
+}

--- a/knowledge/decisions/0002-changes-auto-pagination-adapter.md
+++ b/knowledge/decisions/0002-changes-auto-pagination-adapter.md
@@ -1,0 +1,53 @@
+# ADR-0002: Auto-pagination for Changes adapts `ChangedIDCollection`, excludes detail endpoints
+
+- **Status:** Accepted
+- **Date:** 2026-06-18
+- **Deciders:** Adam Young
+
+## Context
+
+Auto-pagination (`all*` / `all*Pages` over `PagedAsyncSequence` /
+`PagedPagesAsyncSequence`) was extended to the remaining paged services. Both
+pagination primitives are driven by a page fetcher returning
+`PageableListResult<Element>`, whose generic constraint requires
+`Element: Codable & Identifiable & Equatable & Hashable & Sendable`.
+
+`ChangesService` has eight `page:`-accepting methods, but in two shapes:
+
+- The three **list** endpoints (`movieChanges` / `tvSeriesChanges` /
+  `personChanges`) return `ChangedIDCollection` — which *does* carry
+  `page` / `totalPages` / `totalResults`, but is a distinct type from
+  `PageableListResult`, and its element `ChangedID` was not `Identifiable`.
+- The five **detail** endpoints (`movieDetails` / `tvSeriesDetails` /
+  `personDetails` / `tvSeasonDetails` / `tvEpisodeDetails`) return
+  `ChangeCollection`, which is just `{ changes: [Change] }` — no page metadata,
+  and `Change` is not `Identifiable`.
+
+## Decision
+
+We will add auto-pagination only to the three Changes **list** endpoints. Each
+`all*` wrapper adapts the returned `ChangedIDCollection` into a
+`PageableListResult<ChangedID>` via a private `init(changedIDCollection:)`, and
+`ChangedID` gains an additive `Identifiable` conformance (it already exposes
+`id: Int`). The five detail endpoints are **excluded**.
+
+## Consequences
+
+- The three change-list endpoints get the same lazy `AsyncSequence` ergonomics as
+  every other paged endpoint, reusing the existing primitives unchanged.
+- `ChangedID: Identifiable` is now public API; the only reason for the conformance
+  is the pagination element constraint (`id` is the changed media identifier).
+- The detail endpoints stay non-paginated. Honest "complete coverage" means *all
+  paginable* endpoints — not literally every method that takes a `page:` argument.
+- A small hand-written field mapping (`page`/`results`/`totalResults`/
+  `totalPages`) now exists and must stay correct; a unit test asserts all four
+  fields with distinct values to guard against a field swap.
+
+## Alternatives considered
+
+- **Make `ChangeCollection` paginate too** — rejected: it carries no page
+  metadata, so the sequence could only terminate on an empty page, and `Change`
+  isn't `Identifiable`. It is genuinely not a paginated resource.
+- **A separate non-`PageableListResult` pagination primitive for `ChangedIDCollection`**
+  — rejected as over-engineering; the adapter is a few lines and reuses the
+  battle-tested primitives.

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -29,6 +29,24 @@ out of it.
 - There is **no `GetBuildLog` tool** — for build-error detail inside Xcode use
   `mcp__xcode-tools__XcodeRefreshCodeIssuesInFile` on the flagged file(s).
 
+## Swift concurrency
+
+### Public enums are not implicitly `Sendable` — explicit conformance needed for `@Sendable` capture
+
+*2026-06-18.* Adding auto-pagination over a service method captures that method's
+non-page arguments into `PagedAsyncSequence`'s `@Sendable (Int) async throws -> …`
+page-fetcher closure. The sort enums `FavouriteSort` / `WatchlistSort` /
+`RatedSort` conformed only to `CustomStringConvertible`, so they were **not**
+`Sendable` — implicit `Sendable` is only inferred for non-`public` types. The
+build failed with *"capture of 'sortedBy' with non-Sendable type 'FavouriteSort?'
+in a '@Sendable' closure"*.
+
+- **Fix:** add explicit `: Sendable` to the enum (additive, non-breaking — their
+  associated values, e.g. `Bool`, were already `Sendable`).
+- **Lesson:** before wrapping a service method in any `@Sendable` closure
+  (auto-pagination, `Task {}`, etc.), check that every captured **public** type is
+  `Sendable`; don't assume a simple value enum already is.
+
 ## Testing
 
 ### Integration tests need live-API env vars, and can fail transiently

--- a/knowledge/tmdb-api-notes.md
+++ b/knowledge/tmdb-api-notes.md
@@ -37,3 +37,21 @@ Newest at the top; cite the endpoint and the date observed.
   it. Confirm against a live response via `mcp__tmdb__*` and the OpenAPI schema
   before deciding — the docs aren't always accurate about which fields are
   guaranteed.
+
+## Changes endpoints
+
+### `changes/movie|tv|person` list responses are large and carry an unmodelled `softcore` field
+
+*2026-06-18, `/3/movie/changes` (and the tv/person equivalents).*
+
+- These list endpoints return many pages — `total_pages` was ~76 for the default
+  24-hour movie window — so iterate them with a bounded `.prefix(n)` rather than
+  draining the whole sequence.
+- Each result object is `{ id, adult, softcore }`. `ChangedID` models only `id`
+  and `adult`; the extra `softcore` key is silently absorbed by
+  `PageableListResult`'s tolerant `FailableDecodable` decoder, so decoding never
+  fails — but the model is incomplete if `softcore` is ever needed.
+- The change **list** endpoints return a paged shape (`page`/`total_pages`/
+  `total_results`, modelled as `ChangedIDCollection`), but the per-entity change
+  **detail** endpoints (`/movie/{id}/changes` etc.) return an unpaged
+  `{ changes: [...] }` (`ChangeCollection`) — see [ADR-0002](decisions/0002-changes-auto-pagination-adapter.md).


### PR DESCRIPTION
## Summary

Completes the package's auto-pagination feature by extending the existing
`PagedAsyncSequence` / `PagedPagesAsyncSequence` primitives to the four
remaining paged services. Apps can now iterate every paginated endpoint with
`AsyncSequence` instead of hand-rolling page loops:

```swift
for try await movie in tmdbClient.keywords.allMovies(forKeyword: 378) { … }
for try await change in tmdbClient.changes.allMovieChanges().prefix(50) { … }
```

This brings auto-pagination from **7 → 11 services**, **32 → 47 paginated
endpoints**, **64 → 94 methods**.

## Changes

**New auto-pagination (`all*` items + `all*Pages` pages), 15 endpoints → 30 methods:**
- ✨ **AccountService** (8): favourites, watchlist, rated (movies/TV/episodes), lists
- ✨ **GuestSessionService** (3): rated movies/TV/episodes
- ✨ **KeywordService** (1): movies(forKeyword:)
- ✨ **ChangesService** (3): movie/TV/person change lists

**Supporting:**
- ♻️ `ChangesService` adapts `ChangedIDCollection` → `PageableListResult<ChangedID>`;
  adds additive `ChangedID: Identifiable`. The 5 `*Details` change endpoints are
  intentionally excluded (`ChangeCollection` has no page metadata) — see ADR-0002.
- ♻️ `FavouriteSort` / `WatchlistSort` / `RatedSort` made `Sendable` so they can be
  captured in the `@Sendable` page-fetcher closures.

**Tests:**
- ✅ Unit tests for all 30 methods (concrete service + `MockAPIClient`, asserting
  multi-page iteration, page metadata, request type, and the Changes field mapping)
- ✅ Live integration tests for Keyword + Changes (Account/GuestSession are
  unit-only — their live endpoints are unavailable/disabled)

**Documentation:**
- 📝 Auto-Pagination DocC sections for the four services; README service/endpoint/method counts updated
- 📝 Knowledge base: Sendable gotcha, Changes API notes, ADR-0002

## Benefits

- **Less boilerplate**: no manual `page` / `totalPages` loops for these services
- **Consistent API**: same `all*` / `all*Pages` shape as the existing 7 services
- **No breaking changes**: purely additive; Linux/Windows-safe; Swift 6 strict-concurrency clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)