### PR TITLE
✨ Self-healing weekly Integration run + lint Claude markdown

### DIFF
--- a/.claude/skills/diagnose-ci-failure/references/build.md
+++ b/.claude/skills/diagnose-ci-failure/references/build.md
@@ -3,7 +3,7 @@
 The **Build and Test** job (macOS) has two build steps, both with
 **warnings-as-errors**:
 
-```
+```bash
 swift build --build-tests -Xswiftc -warnings-as-errors   # build + test targets
 swift build -c release      -Xswiftc -warnings-as-errors   # release build
 ```

--- a/.claude/skills/diagnose-ci-failure/references/linux.md
+++ b/.claude/skills/diagnose-ci-failure/references/linux.md
@@ -2,7 +2,7 @@
 
 The **Build and Test (Linux)** job runs in the `swift:6.1-jammy` container:
 
-```
+```bash
 swift build --build-tests -Xswiftc -warnings-as-errors
 swift test  --skip-build  --filter TMDbTests
 swift build -c release    -Xswiftc -warnings-as-errors
@@ -48,7 +48,7 @@ bug — the package targets Linux and Windows alongside the Apple platforms.
 
 Run the Linux toolchain in Docker (matches CI):
 
-```
+```bash
 make build-linux     # swift build in a Swift Docker container
 make test-linux       # swift test in a Swift Docker container
 ```

--- a/.claude/skills/diagnose-ci-failure/references/markdown.md
+++ b/.claude/skills/diagnose-ci-failure/references/markdown.md
@@ -3,7 +3,7 @@
 The **Lint Markdown** job runs in the
 `ghcr.io/igorshubovych/markdownlint-cli:v0.41.0` container and lints:
 
-```
+```bash
 markdownlint "README.md" "**/*.docc/**/*.md"
 ```
 
@@ -36,7 +36,7 @@ check it before assuming the default limits.
 
 ## Reproduce locally
 
-```
+```bash
 make lint-markdown
 ```
 

--- a/.claude/skills/diagnose-ci-failure/references/unit-tests.md
+++ b/.claude/skills/diagnose-ci-failure/references/unit-tests.md
@@ -2,7 +2,7 @@
 
 The **Build and Test** job runs the unit suite:
 
-```
+```bash
 swift test --filter TMDbTests --enable-code-coverage --xunit-output junit.xml
 ```
 

--- a/.claude/skills/document-swift/SKILL.md
+++ b/.claude/skills/document-swift/SKILL.md
@@ -53,8 +53,8 @@ Returns**. No trailing whitespace on blank `///` lines.
   `/// [TMDb API - <Category>: <Endpoint>](https://developer.themoviedb.org/reference/<slug>)`
 - **Parameters** — `- Parameter name:` (singular) for exactly one parameter;
   `- Parameters:` with an indented list for two or more.
-- **Precondition** — methods with a `page` parameter add:
-  `/// - Precondition: `page` can be between `1` and `1000`.`
+- **Precondition** — methods with a `page` parameter add a
+  `/// - Precondition:` line — e.g. `page` can be between `1` and `1000`.
 - **Throws** — service methods use `/// - Throws: TMDb error ``TMDbError``.`; for
   `Decodable` inits, list the specific `DecodingError` cases.
 - **Returns** — describe what comes back, e.g. "Matching review."

--- a/.claude/skills/fix-integration-failures/SKILL.md
+++ b/.claude/skills/fix-integration-failures/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: fix-integration-failures
+description: Diagnose and fix a failing scheduled (or standalone) TMDb Integration workflow run — re-run transients, or fix real drift on a branch off main, then PR and (optionally) merge. Use for the weekly Sunday Integration cron failure, or any red Integration run not tied to an open PR.
+---
+
+# Fix Integration workflow failures
+
+The **`Integration`** workflow (`.github/workflows/integration.yml`) runs the
+live-API integration suite on a **weekly schedule** (`cron: '0 0 * * 0'` — Sunday
+00:00 UTC), as well as on PRs/pushes. The scheduled run is a **live-API canary**:
+nothing in the code changed, so a failure means the live TMDb API drifted, a test's
+assumed data went stale, or a transient error/rate-limit hit. This skill takes such
+a failure from **red run → green main**: diagnose it, then either re-run a transient
+or fix the real cause on its own branch and open (and optionally merge) a PR.
+
+> **Scope.** This is for an Integration failure **not attached to an open feature
+> PR** — the scheduled canary, a `workflow_dispatch`, or a failure on `main`. When a
+> failing Integration check belongs to an **open PR**, `/watch-pr` and
+> `/fix-pr-checks` own that; they delegate the *pre-existing/unrelated* case back
+> here (fix on a branch off `main`), which is exactly this skill's job.
+
+**Mode** — check the arguments passed to this skill (shown at the end). If they
+include `merge` (e.g. `/fix-integration-failures merge`), **auto-merge** the fix PR
+once green. Otherwise stop at **ready-to-merge** and hand off (default).
+
+## Agent behaviour contract
+
+1. **Never edit `main` directly** (`CLAUDE.md`). Any fix lands on a `fix/<slug>`
+   branch off `main`, via a PR.
+2. **Diagnose before fixing.** Always run `/diagnose-integration-failure` first;
+   let its ranked cause drive the fix. Don't guess.
+3. **Distinguish transient from real.** A re-run is the cheap test. Only open a PR
+   for a cause that survives a re-run (or is clearly a data/shape drift).
+4. **Test-first for real fixes.** A model/decoder fix follows `canon-tdd` (failing
+   unit test + fixture, then the fix). A drifted-assertion fix updates the
+   integration test to assert **behaviour, not a brittle exact value**.
+5. **The gate is `make ci`.** Never open the PR until it passes locally.
+6. **Don't paper over a real regression.** If the cause is a genuine library bug
+   (not drift/transient), fix it properly or stop and report — never just relax a
+   test to hide it.
+
+## 0. Find the failing run
+
+```bash
+gh run list --workflow Integration --status failure --limit 5 \
+  --json databaseId,event,headBranch,conclusion,createdAt,displayTitle
+```
+
+- Prefer the most recent **`schedule`** (or `workflow_dispatch`) run on `main`.
+- Note its `databaseId` (the run id) and `event` (sets the cause ranking).
+- No failing run → report "Integration is green, nothing to fix" and stop.
+
+## 1. Diagnose
+
+Invoke **`/diagnose-integration-failure`**, handing it the run id (it will
+`gh run view <id> --log-failed`). It returns the three-section analysis — Summary,
+Likely cause (ranked; for a scheduled run it leads with backend/data drift, **not**
+a code regression), and Suggested fix. Use that ranking to choose the path below.
+
+## 2. Transient? Re-run first
+
+If the diagnosis points to **case 3** (HTTP 429 / rate-limit, a timeout near the
+30-min cap, or a truncated log with no assertion failure):
+
+```bash
+gh run rerun <run-id> --failed
+gh run watch <run-id>
+```
+
+- **Green on re-run** → it was transient. Report and stop; no PR needed.
+- **Fails the same way again** → treat as deterministic; go to §3.
+
+(The integration client already retries 429/5xx with backoff, so a true transient
+that survives a re-run is uncommon — a repeat failure is usually real drift.)
+
+## 3. Fix the real cause on a branch off `main`
+
+Reproduce locally first to confirm and to get a fast edit loop:
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b fix/<slug>          # e.g. fix/<service>-integration-drift
+```
+
+Run the failing suite locally to reproduce — `/integration-test` (or
+`swift test --filter <Suite>/<test>`). Then fix per the diagnosis:
+
+- **TMDb backend / response-shape change** (a field added, removed, renamed, or now
+  nullable) → fix the Swift model / `CodingKeys` / fixture **test-first**
+  (`canon-tdd`): add a failing unit test + a JSON fixture matching the *current*
+  live shape (confirm via the OpenAPI spec / `mcp__tmdb__*`), then the model fix.
+- **Stale assumed data** (a test asserts a specific live title, count, id, date, or
+  ordering that drifted) → relax the integration assertion to verify **behaviour,
+  not a brittle exact value** (e.g. assert non-empty / a stable property / `>= 1`
+  rather than an exact count). Match the robust pattern already used by sibling
+  tests in the same suite.
+- **A genuine library regression** → fix it properly, test-first. If it is not a
+  quick, confident fix, **stop and report** — don't merge a workaround.
+
+Verify: `/integration-test` green for the touched suite, then **`make ci`**
+(mandatory full gate). If `make ci` is red, fix and re-run — never PR on red.
+
+## 4. Open the PR (and optionally merge)
+
+Run **`/pr`** to commit (gitmoji), push, and open the PR (`🐛`/`✅`/`♻️` as fits;
+`make ci` runs again inside `/pr`). Then run **`/watch-pr`** to drive it to ready:
+
+- **Default (no `merge`)** → `/watch-pr` watch-only: report the ready PR URL and
+  **stop** for the user to merge.
+- **`merge`** → `/watch-pr merge`: squash-merge once green, then report.
+
+`/watch-pr` handles any further transient flakes on the PR's own checks (re-run),
+so a live-API hiccup during CI won't strand the fix.
+
+## 5. Report
+
+Close with: the run id that failed, the diagnosis verdict (transient vs real), what
+you changed (file + one line) or that a re-run cleared it, the PR URL and whether it
+merged, and anything left for the user (e.g. a real regression you chose not to
+auto-fix).
+
+## Running headless (from `integration-failure.yml`)
+
+When the **Integration Failure Alert** workflow invokes this skill on a scheduled
+failure, it runs non-interactively, so adapt:
+
+- A failing-step log is already at **`failure-log.txt`** in the workspace — diagnose
+  from it (pass it to `/diagnose-integration-failure`); don't re-download logs.
+- **Verify with the targeted suite + a build** — `swift build --build-tests` and
+  `swift test --filter <Suite>/<test>` — **not** the full `make ci`. The **opened
+  PR's own CI** (`ci.yml` + `integration.yml`) is the authoritative gate; the alert
+  job need not replicate the whole pinned-lint/xcsift toolchain.
+- **Open the PR with `git`/`gh` directly** (`git checkout -b` → commit → push →
+  `gh pr create`), **not** `/pr` — `/pr` runs the full `make ci`, which the
+  lightweight alert job can't satisfy. The format/lint hooks still reshape files on
+  edit, so the diff stays clean.
+- **Then STOP** — do **not** run `/watch-pr` and do **not** merge (a human reviews
+  it). Write the diagnosis to `claude-analysis.md` and, if you open a PR, its URL on
+  one line to `pr-url.txt`.
+- If the cause is **transient** (re-run territory) or a **genuine regression you
+  should not auto-fix**, open **no** PR — explain in `claude-analysis.md` so the
+  alert issue carries it.
+
+## Guardrails
+
+- Never edit `.github/workflows/*` to force a check green, and never force-push,
+  without surfacing to the user first.
+- One failing run can surface several drifted assertions — fix them together in one
+  PR, but keep each change minimal and behaviour-preserving.
+- If the live API is broadly down/throttled (many unrelated suites failing fast),
+  that's an outage, not a fix target — report and wait it out.
+- Capture anything durable you learned (a new live-API shape, a recurring drift)
+  with `/capture-knowledge` before the PR, so the fixture/notes land with it.
+
+Arguments: $ARGUMENTS

--- a/.claude/skills/format/SKILL.md
+++ b/.claude/skills/format/SKILL.md
@@ -5,8 +5,8 @@ description: Format code with swiftlint and swiftformat
 
 # Format code
 
-Run `make format` from the project root to fix code style issues (swiftlint --fix
-+ swiftformat).
+Run `make format` from the project root to fix code style issues
+(`swiftlint --fix` then `swiftformat`).
 
 Run this directly — it is fast and low-output, so delegating to a subagent would
 cost more (subagent overhead) than it saves.

--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -58,6 +58,30 @@ ledger; if it pushed, the next pass re-checks.
 rather than polling, then loop. If `/fix-pr-checks` reports a check **exhausted**,
 stop and report it per the Loop Guard.
 
+### 1c. Failing checks not caused by this PR (usually a flaky integration test)
+
+`/fix-pr-checks` assumes the fix belongs on **this** branch. That is wrong when
+the failing check — most often a **live integration test** — is broken or flaky
+**independently of this PR's diff**. Patching it onto the feature branch would
+muddy the PR's scope and leave the test broken for everyone else. Triage before
+fixing here:
+
+1. **Is the failing test in this PR's diff?**
+   `gh pr diff <number> --name-only` — if the failing test's file is **not** in
+   that list, this PR did not cause it.
+
+2. **Transient or deterministic?** Re-run the failed jobs once
+   (`gh run rerun <run-id> --failed`) and watch. Passes on re-run → a transient
+   live-API flake; note it and continue. Fails again **and** not in this PR's diff
+   → a **pre-existing** problem (e.g. a brittle live-data assertion).
+
+3. **A pre-existing failure is a `main` problem — hand it to
+   `/fix-integration-failures`**, which fixes it on its own branch off `main`,
+   runs `make ci`, and opens/merges a PR (never on this feature branch). Tell the
+   user you're opening a **second** PR to unblock this one; if they'd rather you
+   stop, report and stop. Once that fix is on `main`, bring this PR's branch up to
+   date (`gh pr update-branch <number>`) and re-watch — the check now passes.
+
 ## 2. Loop guard (do not get stuck)
 
 - **Thread dedup is `/review-pr-threads`' job** — it shares this ledger, so it

--- a/.github/workflows/integration-failure.yml
+++ b/.github/workflows/integration-failure.yml
@@ -1,9 +1,11 @@
 name: Integration Failure Alert
 
-# Watches the "Integration" workflow. When a *scheduled* run of it fails,
-# Claude analyses the failing logs, then we open a GitHub issue (or comment
-# on the existing one) with that analysis and notify Adam. Does nothing on
-# PR / push runs.
+# Watches the "Integration" workflow. When a *scheduled* run of it fails, Claude
+# diagnoses the failing logs and — when the cause is a fixable drift (a TMDb
+# backend/shape change or a stale test assumption) — fixes it on a branch off
+# main, verifies the targeted suite, and opens a PR **for review** (it never
+# merges). Either way we open/refresh a tracking issue that pings Adam and links
+# the fix PR. Does nothing on PR / push runs.
 on:
   workflow_run:
     workflows: ["Integration"]
@@ -11,31 +13,49 @@ on:
       - completed
 
 permissions:
-  contents: read         # checkout, so Claude can inspect tests/fixtures
-  issues: write          # to create / update the alert issue
-  actions: read          # to read the triggering run's logs
+  contents: write        # branch off main + push the fix
+  pull-requests: write   # open the fix PR
+  issues: write          # create / update the alert issue
+  actions: read          # read the triggering run's logs
   id-token: write        # for claude-code-action
 
 jobs:
-  alert:
-    name: Open issue on scheduled failure
-    runs-on: ubuntu-latest
+  autofix:
+    name: Diagnose & fix scheduled failure
+    # macOS: the fix verifies with `swift build` / `swift test` (needs Xcode).
+    runs-on: macos-26
 
-    # Only react to the *scheduled* run, and only when it actually failed.
-    # This is what stops contributor PR failures from creating issues.
+    # Only react to the *scheduled* run, and only when it actually failed — this
+    # is what stops contributor PR failures from triggering an auto-fix.
     #
     # NOTE: `event == 'schedule'` matches ANY cron trigger on the Integration
-    # workflow. This is only equivalent to "the Sunday night run" while
-    # integration.yml has a single cron ('0 0 * * 0'). If you ever add another
-    # cron there, this will also fire for that one — revisit this guard then.
+    # workflow. Equivalent to "the Sunday night run" only while integration.yml
+    # has a single cron ('0 0 * * 0'). If you add another cron there, revisit.
     if: >-
       github.event.workflow_run.conclusion == 'failure'
       && github.event.workflow_run.event == 'schedule'
 
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.5.app/Contents/Developer
+      # A PR opened with the default GITHUB_TOKEN does NOT trigger downstream
+      # workflows (GitHub blocks token→workflow recursion), so the fix PR's own
+      # CI/Integration checks wouldn't run. Add a fine-grained PAT with
+      # `contents: write` + `pull-requests: write` as the repo secret
+      # INTEGRATION_FIX_PR_TOKEN to get those checks. Without it we fall back to
+      # GITHUB_TOKEN: the PR still opens, but you must kick its checks manually.
+      PR_TOKEN: ${{ secrets.INTEGRATION_FIX_PR_TOKEN || secrets.GITHUB_TOKEN }}
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0          # full history: branch off main and push
+          token: ${{ secrets.INTEGRATION_FIX_PR_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Download failing logs
         env:
@@ -60,23 +80,39 @@ jobs:
           tail -c 60000 failure-log-full.txt > failure-log.txt || true
           echo "Captured $(wc -l < failure-log.txt) lines of failing log"
 
-      - name: Analyse failure with Claude
+      - name: Diagnose & fix with Claude
         uses: anthropics/claude-code-action@v1
+        env:
+          # Live-API creds for the targeted-suite verification.
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+          TMDB_USERNAME: ${{ secrets.TMDB_USERNAME }}
+          TMDB_PASSWORD: ${{ secrets.TMDB_PASSWORD }}
+          # git push + `gh pr create` use this token (PAT so the PR triggers CI).
+          GH_TOKEN: ${{ secrets.INTEGRATION_FIX_PR_TOKEN || secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model claude-opus-4-8 --allowedTools "Read,Write,Glob,Grep,Bash(jq:*),Bash(curl:*)"'
-          # Invoke the repo skill by passing `/skill-name` as the prompt (the
-          # checkout step above is the prerequisite). Trailing text is passed to
-          # the skill as context.
+          # Broad Bash is intentional: the fix path drives git/gh/swift via the
+          # repo's own skills on an ephemeral runner — trusted first-party
+          # automation with no access beyond the repo and the TMDb API.
+          claude_args: '--model claude-opus-4-8 --allowedTools "Read,Write,Edit,Glob,Grep,Bash"'
+          # Invoke the repo skill by passing `/skill-name` as the prompt; trailing
+          # text is context. The skill's "Running headless" section governs this.
           prompt: |
-            /diagnose-integration-failure The scheduled Integration workflow
-            failed and its failing-step log is already at `failure-log.txt` in
-            the workspace root — use it directly; do not run the tests or call
-            `gh`. Write your three-section markdown result to
-            `claude-analysis.md` and nothing else — do not create issues,
-            comments, or branches.
+            /fix-integration-failures The scheduled Integration workflow run
+            ${{ github.event.workflow_run.id }} failed. You are running HEADLESS
+            in CI — follow the skill's "Running headless" section: the failing-step
+            log is already at `failure-log.txt` in the workspace root (diagnose
+            from it; don't re-download logs), verify a fix with the targeted suite
+            (`swift build --build-tests` + `swift test --filter <Suite>/<test>`,
+            NOT the full `make ci`), and open a PR off `main` for review using
+            `git`/`gh` directly (not `/pr`). Do NOT run `/watch-pr` and do NOT
+            merge. Write your three-section diagnosis to `claude-analysis.md`, and
+            if you open a PR write its URL on a single line to `pr-url.txt`. If the
+            cause is transient (re-run territory) or a genuine regression you
+            should not auto-fix, open no PR and explain in `claude-analysis.md`.
 
       - name: Create or update failure issue
+        if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_PAGER: cat
@@ -98,6 +134,13 @@ jobs:
             ANALYSIS="_Automated analysis unavailable — see the run logs._"
           fi
 
+          # Link the fix PR if Claude opened one.
+          if [ -s pr-url.txt ]; then
+            PR_LINE="🔧 Claude opened a proposed fix for review: $(head -n1 pr-url.txt)"
+          else
+            PR_LINE="ℹ️ No automated fix PR — likely transient (re-run) or needs a human; see the analysis."
+          fi
+
           # Make sure the label exists (ignore error if it already does).
           gh label create "$LABEL" \
             --repo "$REPO" \
@@ -105,8 +148,8 @@ jobs:
             --description "Scheduled integration run failed" \
             2>/dev/null || true
 
-          # Is there already an OPEN issue for this? If so, just comment on it
-          # rather than opening a duplicate every week it stays broken.
+          # Is there already an OPEN issue for this? If so, comment rather than
+          # opening a duplicate every week it stays broken.
           EXISTING=$(gh issue list \
             --repo "$REPO" \
             --label "$LABEL" \
@@ -115,12 +158,12 @@ jobs:
             --jq '.[0].number // empty')
 
           if [ -n "$EXISTING" ]; then
-            # Build the comment body with printf so no leading YAML indentation
-            # leaks into the markdown (indented lines render as a code block).
             COMMENT_BODY=$(printf '%s\n' \
               "🔁 The scheduled Integration run failed again on ${RUN_DATE}." \
               "" \
               "Latest failing run: ${RUN_URL}" \
+              "" \
+              "${PR_LINE}" \
               "" \
               "### 🤖 Claude's analysis" \
               "" \
@@ -134,6 +177,8 @@ jobs:
               "- **Run:** ${RUN_URL}" \
               "- **When:** ${RUN_DATE}" \
               "" \
+              "${PR_LINE}" \
+              "" \
               "### 🤖 Claude's analysis" \
               "" \
               "${ANALYSIS}" \
@@ -142,7 +187,7 @@ jobs:
               "" \
               "This same integration suite gates every PR and the merge to main, so this is unlikely to be a code regression. The usual culprits are a **TMDb backend change** (a response field added, removed, renamed, or made nullable) or **stale assumed data** in an integration test (a hard-coded title, count, id, or date the live API now returns differently) — with transient errors, rate limiting, or a run that hit its 30-minute job timeout (a cancelled run still surfaces as a failure) a distant third." \
               "" \
-              "A re-run clears the transient case. If it persists, the analysis above points at the model, fixture, or assertion to update.")
+              "A re-run clears the transient case. If it persists, the analysis above points at the model, fixture, or assertion to update — and Claude may already have opened a fix PR (linked above).")
             gh issue create \
               --repo "$REPO" \
               --label "$LABEL" \

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,13 +1,11 @@
 {
+  "comment": "Shared by README, DocC, and the .claude/ skills (see `make lint-markdown`).",
   "default": true,
-  "MD013": {
-    "line_length": 80,
-    "code_blocks": false,
-    "tables": false
-  },
+  "MD013": false,
   "MD024": {
     "siblings_only": true
   },
   "MD033": false,
-  "MD041": false
+  "MD041": false,
+  "MD060": false
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,18 @@ Key skills (the README's *Claude Code Skills* tables list them all):
 - **`/pr`**, **`/watch-pr`**, **`/review-pr-threads`**, **`/fix-pr-checks`** —
   open and shepherd the pull request.
 - **`/document-swift`** — the canonical DocC conventions for public API.
+- **`/fix-integration-failures`** — diagnose **and** fix a failing scheduled (or
+  standalone) `Integration` run: re-run a transient, or fix real drift on a branch
+  off `main` and open a PR. `/watch-pr` delegates the *pre-existing/unrelated*
+  integration failure (one not in the PR's diff) here, since it's a `main` problem.
+
+**Self-healing integration** — the weekly scheduled `Integration` run (Sunday
+00:00 UTC) is watched by [`.github/workflows/integration-failure.yml`](.github/workflows/integration-failure.yml),
+which runs `/fix-integration-failures` headless on a failure: it diagnoses, fixes
+real drift on a branch off `main`, and opens a **PR for review** (never
+auto-merges), then files/updates a tracking issue. Running headless, the skill
+verifies with the targeted suite (not full `make ci`) and opens the PR via
+`git`/`gh` (not `/pr`) — the PR's own CI is the gate.
 
 **Code review** — both the local `/review-changes` and the GitHub Actions reviewer
 follow one shared spec, [`.github/CODE_REVIEW.md`](.github/CODE_REVIEW.md), and

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,9 @@ lint:
 
 .PHONY: lint-markdown
 lint-markdown:
-	markdownlint "README.md"
+	markdownlint "README.md" "CLAUDE.md"
 	markdownlint "**/*.docc/**/*.md"
+	markdownlint ".claude/**/*.md"
 
 .PHONY: build
 build:

--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ These delegate to a Haiku subagent to keep the main context lean.
 | --- | --- |
 | `/diagnose-ci-failure` | Diagnose a failing CI job and propose a fix |
 | `/diagnose-integration-failure` | Diagnose a failing integration-test run and propose a fix |
+| `/fix-integration-failures` | Diagnose **and** fix a failing scheduled/standalone Integration run — re-run transients, or fix real drift on a branch off `main` and open a PR |
 | `/canon-tdd` | Drive test-first development (test list → failing test → pass → refactor) |
 | `/document-swift` | Write DocC documentation for public API per project conventions |
 
@@ -481,6 +482,19 @@ Two subagents back the review and documentation steps: `code-reviewer`
 (deep Swift/TMDb review) and `documentation-writer` (bulk DocC generation).
 The reviewer follows the shared spec in
 [`.github/CODE_REVIEW.md`](.github/CODE_REVIEW.md).
+
+#### Self-healing weekly integration run
+
+The live-API integration suite runs on a weekly schedule
+([`.github/workflows/integration.yml`](.github/workflows/integration.yml),
+Sunday 00:00 UTC). When that scheduled run fails,
+[`.github/workflows/integration-failure.yml`](.github/workflows/integration-failure.yml)
+invokes `/fix-integration-failures` headless: it diagnoses the failure,
+re-runs a transient, or fixes real drift (a TMDb backend/shape change or a
+stale assumption) on a branch off `main` and opens a **PR for review** (it
+never auto-merges), then files/updates a tracking issue linking the fix. See
+the skill for the headless contract and the `INTEGRATION_FIX_PR_TOKEN` secret
+it needs.
 
 ### Feature Workflow (`/plan` → `/deliver`)
 


### PR DESCRIPTION
## Summary

Two related dev-tooling improvements (no library code — Swift gates skip; the
expanded `make lint-markdown` runs in CI).

### 1. `/fix-integration-failures` skill + self-healing weekly run

The live-API integration suite runs weekly (`integration.yml`, Sunday 00:00 UTC).
When that scheduled run fails it's almost always live-API drift, not a regression.

- ✨ **New `/fix-integration-failures` skill** — find the failed `Integration`
  run → diagnose (via `/diagnose-integration-failure`) → re-run a transient, or
  fix real drift (a TMDb backend/shape change or a stale assertion) on a branch
  off `main`, `make ci`, and open a PR. Watch-only by default; `merge` to
  auto-merge interactively. Includes a "Running headless" contract.
- 🔧 **`integration-failure.yml` now self-heals** — on a *scheduled* failure it
  runs the skill headless (`macos-26`, write perms, TMDb secrets) to diagnose
  **and open a fix PR for review** (never auto-merges), then files/updates the
  tracking issue linking it.
- ♻️ **`watch-pr §1c`** delegates a pre-existing/unrelated integration failure on
  an open PR to this skill (fix on `main`, then update the PR branch).

> **Needs one secret for full effect:** a fine-grained PAT
> (`contents: write` + `pull-requests: write`) as `INTEGRATION_FIX_PR_TOKEN`, so
> the fix PR triggers its own CI (a PR opened with `GITHUB_TOKEN` does not).
> Without it the PR still opens; its checks must be kicked manually.

### 2. Lint Claude markdown

- 🔧 `make lint-markdown` now also covers `CLAUDE.md` and `.claude/**/*.md`.
- 🔧 `.markdownlintrc` relaxed to sensible rules: disable `MD013` (skill files
  legitimately have ~700-char lines, and the autofix hook can't fix line-length
  anyway) and `MD060` (pedantic table padding); keep `MD040` and fix the 6 bare
  fences; reword 2 lines that tripped genuine `MD032`/`MD038`.

## Docs

- 📝 README ("Self-healing weekly integration run" + skill row), CLAUDE.md
  (Key skills + Self-healing note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)