### PR TITLE
🐛 Stop the Claude PR review cancelling itself via its progress comment

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,8 +18,15 @@ on:
 
 # A new push (synchronize) supersedes the in-flight review for the same PR —
 # cancel it so reviews don't stack up and double-post while watch-pr iterates.
+#
+# The group is keyed by event type as well as PR number. Without that, the
+# review's own `track_progress` tracking comment fires an `issue_comment` event
+# that lands in the same group and cancels the in-flight `claude-review` (a
+# self-inflicted cancel — the review never completes). Separating by event_name
+# keeps push-supersedes-push behaviour while stopping a comment from cancelling a
+# review (the comment-triggered run does nothing anyway — both jobs' `if` fail).
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

The automated `claude-review` job has been **cancelling itself** on every PR, so
no automated review is ever posted.

**Chain (repeats on every PR):**

1. PR opens → `claude-review` starts (it runs with `track_progress: true`).
2. ~15s in, the action posts a "Claude is working…" **tracking comment**.
3. That comment fires `issue_comment: created` → a new run of the same `Claude`
   workflow → the **same** concurrency group `claude-review-<PR#>` with
   `cancel-in-progress: true` → **cancels the in-flight review**.
4. The comment-triggered run then does nothing (both jobs' `if` fail — not a
   `pull_request`, no `@claude`), leaving only a cancelled review.

Evidence: every recent PR shows `pull_request → cancelled` followed ~15s later by
`issue_comment → skipped` (on `main`); the review is cancelled ~30s in, far too
short for a real review.

## Fix

Key the concurrency group by `github.event_name` as well as the PR number:

```yaml
group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
```

- A new **push** (`pull_request: synchronize`) still supersedes an in-flight
  review (same `event_name` → same group) — the intended behaviour.
- A **comment** (`issue_comment` / `pull_request_review_comment`) now lands in a
  separate group and can no longer cancel a review.

## Verification

This workflow-only change doesn't trigger `claude-review` (the `paths:
['**/*.swift']` filter), so it proves out on the **next Swift PR** — which should
show `claude-review` running to completion and posting its review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)