### PR TITLE
♻️ Standardize details(...) parameter names to <entity>ID

### DIFF
--- a/Sources/TMDb/Domain/Services/Collections/CollectionService.swift
+++ b/Sources/TMDb/Domain/Services/Collections/CollectionService.swift
@@ -19,7 +19,7 @@ public protocol CollectionService: Sendable {
     /// [TMDb API - Collections: Details](https://developer.themoviedb.org/reference/collection-details)
     ///
     /// - Parameters:
-    ///    - id: The identifier of the collection.
+    ///    - collectionID: The identifier of the collection.
     ///    - language: ISO 639-1 language code to display results in. Defaults to the client's configured default
     /// language.
     ///
@@ -28,7 +28,7 @@ public protocol CollectionService: Sendable {
     /// - Returns: The matching collection.
     ///
     func details(
-        forCollection id: Collection.ID,
+        forCollection collectionID: Collection.ID,
         language: String?
     ) async throws(TMDbError) -> Collection
 

--- a/Sources/TMDb/Domain/Services/Collections/TMDbCollectionService.swift
+++ b/Sources/TMDb/Domain/Services/Collections/TMDbCollectionService.swift
@@ -19,11 +19,11 @@ final class TMDbCollectionService: CollectionService {
     }
 
     func details(
-        forCollection id: Collection.ID,
+        forCollection collectionID: Collection.ID,
         language: String? = nil
     ) async throws(TMDbError) -> Collection {
         let languageCode = language ?? configuration.defaultLanguage
-        let request = CollectionRequest(id: id, language: languageCode)
+        let request = CollectionRequest(id: collectionID, language: languageCode)
 
         return try await apiClient.perform(request)
     }

--- a/Sources/TMDb/Domain/Services/Keywords/KeywordService.swift
+++ b/Sources/TMDb/Domain/Services/Keywords/KeywordService.swift
@@ -18,13 +18,13 @@ public protocol KeywordService: Sendable {
     ///
     /// [TMDb API - Keywords: Details](https://developer.themoviedb.org/reference/keyword-details)
     ///
-    /// - Parameter id: The identifier of the keyword.
+    /// - Parameter keywordID: The identifier of the keyword.
     ///
     /// - Throws: TMDb error ``TMDbError``.
     ///
     /// - Returns: Matching keyword.
     ///
-    func details(forKeyword id: Keyword.ID) async throws(TMDbError) -> Keyword
+    func details(forKeyword keywordID: Keyword.ID) async throws(TMDbError) -> Keyword
 
     ///
     /// Returns a list of movies for a keyword.

--- a/Sources/TMDb/Domain/Services/Keywords/TMDbKeywordService.swift
+++ b/Sources/TMDb/Domain/Services/Keywords/TMDbKeywordService.swift
@@ -16,8 +16,8 @@ final class TMDbKeywordService: KeywordService {
         self.apiClient = apiClient
     }
 
-    func details(forKeyword id: Keyword.ID) async throws(TMDbError) -> Keyword {
-        let request = KeywordRequest(id: id)
+    func details(forKeyword keywordID: Keyword.ID) async throws(TMDbError) -> Keyword {
+        let request = KeywordRequest(id: keywordID)
 
         return try await apiClient.perform(request)
     }

--- a/Sources/TMDb/Domain/Services/Movies/MovieService.swift
+++ b/Sources/TMDb/Domain/Services/Movies/MovieService.swift
@@ -21,7 +21,7 @@ public protocol MovieService: Sendable {
     /// [TMDb API - Movies: Details](https://developer.themoviedb.org/reference/movie-details)
     ///
     /// - Parameters:
-    ///    - id: The identifier of the movie.
+    ///    - movieID: The identifier of the movie.
     ///    - language: ISO 639-1 language code to display results in. Defaults to the client's configured default
     /// language.
     ///
@@ -29,7 +29,7 @@ public protocol MovieService: Sendable {
     ///
     /// - Returns: The matching movie.
     ///
-    func details(forMovie id: Movie.ID, language: String?) async throws(TMDbError) -> Movie
+    func details(forMovie movieID: Movie.ID, language: String?) async throws(TMDbError) -> Movie
 
     ///
     /// Returns the primary information about a movie with appended data.
@@ -37,7 +37,7 @@ public protocol MovieService: Sendable {
     /// [TMDb API - Movies: Details](https://developer.themoviedb.org/reference/movie-details)
     ///
     /// - Parameters:
-    ///    - id: The identifier of the movie.
+    ///    - movieID: The identifier of the movie.
     ///    - appending: The additional data to append to the response.
     ///    - language: ISO 639-1 language code to display results in.
     ///     Defaults to the client's configured default language.
@@ -47,7 +47,7 @@ public protocol MovieService: Sendable {
     /// - Returns: The matching movie with appended data.
     ///
     func details(
-        forMovie id: Movie.ID,
+        forMovie movieID: Movie.ID,
         appending: MovieAppendOption,
         language: String?
     ) async throws(TMDbError) -> MovieDetailsResponse
@@ -505,7 +505,7 @@ public extension MovieService {
     /// [TMDb API - Movies: Details](https://developer.themoviedb.org/reference/movie-details)
     ///
     /// - Parameters:
-    ///    - id: The identifier of the movie.
+    ///    - movieID: The identifier of the movie.
     ///    - language: ISO 639-1 language code to display results in. Defaults to the client's configured default
     /// language.
     ///
@@ -513,8 +513,8 @@ public extension MovieService {
     ///
     /// - Returns: The matching movie.
     ///
-    func details(forMovie id: Movie.ID, language: String? = nil) async throws(TMDbError) -> Movie {
-        try await details(forMovie: id, language: language)
+    func details(forMovie movieID: Movie.ID, language: String? = nil) async throws(TMDbError) -> Movie {
+        try await details(forMovie: movieID, language: language)
     }
 
     ///
@@ -523,7 +523,7 @@ public extension MovieService {
     /// [TMDb API - Movies: Details](https://developer.themoviedb.org/reference/movie-details)
     ///
     /// - Parameters:
-    ///    - id: The identifier of the movie.
+    ///    - movieID: The identifier of the movie.
     ///    - appending: The additional data to append to the response.
     ///    - language: ISO 639-1 language code to display results in.
     ///     Defaults to the client's configured default language.
@@ -533,12 +533,12 @@ public extension MovieService {
     /// - Returns: The matching movie with appended data.
     ///
     func details(
-        forMovie id: Movie.ID,
+        forMovie movieID: Movie.ID,
         appending: MovieAppendOption,
         language: String? = nil
     ) async throws(TMDbError) -> MovieDetailsResponse {
         try await details(
-            forMovie: id,
+            forMovie: movieID,
             appending: appending,
             language: language
         )

--- a/Sources/TMDb/Domain/Services/Movies/TMDbMovieService.swift
+++ b/Sources/TMDb/Domain/Services/Movies/TMDbMovieService.swift
@@ -18,21 +18,21 @@ final class TMDbMovieService: MovieService {
         self.configuration = configuration
     }
 
-    func details(forMovie id: Movie.ID, language: String? = nil) async throws(TMDbError) -> Movie {
+    func details(forMovie movieID: Movie.ID, language: String? = nil) async throws(TMDbError) -> Movie {
         let languageCode = language ?? configuration.defaultLanguage
-        let request = MovieRequest(id: id, language: languageCode)
+        let request = MovieRequest(id: movieID, language: languageCode)
 
         return try await apiClient.perform(request)
     }
 
     func details(
-        forMovie id: Movie.ID,
+        forMovie movieID: Movie.ID,
         appending: MovieAppendOption,
         language: String? = nil
     ) async throws(TMDbError) -> MovieDetailsResponse {
         let languageCode = language ?? configuration.defaultLanguage
         let request = MovieDetailsAppendRequest(
-            id: id,
+            id: movieID,
             appendToResponse: appending,
             language: languageCode
         )

--- a/Sources/TMDb/Domain/Services/People/PersonService+Defaults.swift
+++ b/Sources/TMDb/Domain/Services/People/PersonService+Defaults.swift
@@ -15,7 +15,7 @@ public extension PersonService {
     /// [TMDb API - People: Details](https://developer.themoviedb.org/reference/person-details)
     ///
     /// - Parameters:
-    ///    - id: The identifier of the person.
+    ///    - personID: The identifier of the person.
     ///    - language: ISO 639-1 language code to display results in. Defaults to the client's configured default
     /// language.
     ///
@@ -24,10 +24,10 @@ public extension PersonService {
     /// - Returns: The matching person.
     ///
     func details(
-        forPerson id: Person.ID,
+        forPerson personID: Person.ID,
         language: String? = nil
     ) async throws(TMDbError) -> Person {
-        try await details(forPerson: id, language: language)
+        try await details(forPerson: personID, language: language)
     }
 
     ///
@@ -37,7 +37,7 @@ public extension PersonService {
     /// [TMDb API - People: Details](https://developer.themoviedb.org/reference/person-details)
     ///
     /// - Parameters:
-    ///    - id: The identifier of the person.
+    ///    - personID: The identifier of the person.
     ///    - appending: The additional data to append.
     ///    - language: ISO 639-1 language code to display results
     ///     in. Defaults to the client's configured default
@@ -48,12 +48,12 @@ public extension PersonService {
     /// - Returns: The matching person with appended data.
     ///
     func details(
-        forPerson id: Person.ID,
+        forPerson personID: Person.ID,
         appending: PersonAppendOption,
         language: String? = nil
     ) async throws(TMDbError) -> PersonDetailsResponse {
         try await details(
-            forPerson: id,
+            forPerson: personID,
             appending: appending,
             language: language
         )

--- a/Sources/TMDb/Domain/Services/People/PersonService.swift
+++ b/Sources/TMDb/Domain/Services/People/PersonService.swift
@@ -19,7 +19,7 @@ public protocol PersonService: Sendable {
     /// [TMDb API - People: Details](https://developer.themoviedb.org/reference/person-details)
     ///
     /// - Parameters:
-    ///    - id: The identifier of the person.
+    ///    - personID: The identifier of the person.
     ///    - language: ISO 639-1 language code to display results in. Defaults to the client's configured default
     /// language.
     ///
@@ -27,7 +27,7 @@ public protocol PersonService: Sendable {
     ///
     /// - Returns: The matching person.
     ///
-    func details(forPerson id: Person.ID, language: String?) async throws(TMDbError) -> Person
+    func details(forPerson personID: Person.ID, language: String?) async throws(TMDbError) -> Person
 
     ///
     /// Returns the primary information about a person with
@@ -36,7 +36,7 @@ public protocol PersonService: Sendable {
     /// [TMDb API - People: Details](https://developer.themoviedb.org/reference/person-details)
     ///
     /// - Parameters:
-    ///    - id: The identifier of the person.
+    ///    - personID: The identifier of the person.
     ///    - appending: The additional data to append.
     ///    - language: ISO 639-1 language code to display results
     ///     in. Defaults to the client's configured default
@@ -47,7 +47,7 @@ public protocol PersonService: Sendable {
     /// - Returns: The matching person with appended data.
     ///
     func details(
-        forPerson id: Person.ID,
+        forPerson personID: Person.ID,
         appending: PersonAppendOption,
         language: String?
     ) async throws(TMDbError) -> PersonDetailsResponse

--- a/Sources/TMDb/Domain/Services/People/TMDbPersonService.swift
+++ b/Sources/TMDb/Domain/Services/People/TMDbPersonService.swift
@@ -19,23 +19,23 @@ final class TMDbPersonService: PersonService {
     }
 
     func details(
-        forPerson id: Person.ID,
+        forPerson personID: Person.ID,
         language: String? = nil
     ) async throws(TMDbError) -> Person {
         let languageCode = language ?? configuration.defaultLanguage
-        let request = PersonRequest(id: id, language: languageCode)
+        let request = PersonRequest(id: personID, language: languageCode)
 
         return try await apiClient.perform(request)
     }
 
     func details(
-        forPerson id: Person.ID,
+        forPerson personID: Person.ID,
         appending: PersonAppendOption,
         language: String? = nil
     ) async throws(TMDbError) -> PersonDetailsResponse {
         let languageCode = language ?? configuration.defaultLanguage
         let request = PersonDetailsAppendRequest(
-            id: id,
+            id: personID,
             appendToResponse: appending,
             language: languageCode
         )

--- a/Sources/TMDb/Domain/Services/TVSeries/TMDbTVSeriesService.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/TMDbTVSeriesService.swift
@@ -18,9 +18,9 @@ final class TMDbTVSeriesService: TVSeriesService {
         self.configuration = configuration
     }
 
-    func details(forTVSeries id: TVSeries.ID, language: String? = nil) async throws(TMDbError) -> TVSeries {
+    func details(forTVSeries tvSeriesID: TVSeries.ID, language: String? = nil) async throws(TMDbError) -> TVSeries {
         let languageCode = language ?? configuration.defaultLanguage
-        let request = TVSeriesRequest(id: id, language: languageCode)
+        let request = TVSeriesRequest(id: tvSeriesID, language: languageCode)
 
         return try await apiClient.perform(request)
     }

--- a/Sources/TMDb/Domain/Services/TVSeries/TVSeriesService.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/TVSeriesService.swift
@@ -21,7 +21,7 @@ public protocol TVSeriesService: Sendable {
     /// [TMDb API - TV Series: Details](https://developer.themoviedb.org/reference/tv-series-details)
     ///
     /// - Parameters:
-    ///    - id: The identifier of the TV series.
+    ///    - tvSeriesID: The identifier of the TV series.
     ///    - language: ISO 639-1 language code to display results in. Defaults to the client's configured default
     /// language.
     ///
@@ -29,7 +29,7 @@ public protocol TVSeriesService: Sendable {
     ///
     /// - Returns: The matching TV series.
     ///
-    func details(forTVSeries id: TVSeries.ID, language: String?) async throws(TMDbError) -> TVSeries
+    func details(forTVSeries tvSeriesID: TVSeries.ID, language: String?) async throws(TMDbError) -> TVSeries
 
     ///
     /// Returns the primary information about a TV series with
@@ -531,7 +531,7 @@ public extension TVSeriesService {
     /// [TMDb API - TV Series: Details](https://developer.themoviedb.org/reference/tv-series-details)
     ///
     /// - Parameters:
-    ///    - id: The identifier of the TV series.
+    ///    - tvSeriesID: The identifier of the TV series.
     ///    - language: ISO 639-1 language code to display results in. Defaults to the client's configured default
     /// language.
     ///
@@ -540,10 +540,10 @@ public extension TVSeriesService {
     /// - Returns: The matching TV series.
     ///
     func details(
-        forTVSeries id: TVSeries.ID,
+        forTVSeries tvSeriesID: TVSeries.ID,
         language: String? = nil
     ) async throws(TMDbError) -> TVSeries {
-        try await details(forTVSeries: id, language: language)
+        try await details(forTVSeries: tvSeriesID, language: language)
     }
 
     ///

--- a/knowledge/decisions/0004-service-parameter-name-convention.md
+++ b/knowledge/decisions/0004-service-parameter-name-convention.md
@@ -1,0 +1,51 @@
+# ADR-0004: Service method parameter-name convention (`<entity>ID`)
+
+- **Status:** Accepted
+- **Date:** 2026-06-18
+- **Deciders:** Adam Young
+
+## Context
+
+Service protocols expose many entity-keyed methods (`details`, `credits`,
+`images`, …). The **external** argument label was already consistent everywhere
+(`forMovie:`, `forTVSeries:`, `forPerson:`, …), but the **internal** parameter
+name diverged: most methods used a domain-specific name (`movieID`, `tvSeriesID`,
+`personID`, `collectionID`, `keywordID`) while a handful of `details(...)`
+overloads used the generic `id`. The internal name is what Xcode shows as the
+autocomplete placeholder and what appears in the documented signature, so the
+inconsistency was a (minor) developer-experience wart.
+
+Across the service layer the split was lopsided: ~24 methods used `<entity>ID`
+and only 7 (`details(...)` outliers across 5 services) used `id`.
+
+Renaming an internal parameter name is **source- and ABI-compatible** (only the
+external label is part of the API contract — see
+[gotchas.md → Public API](../gotchas.md)), so neither direction required a major
+version bump or deprecation shims.
+
+## Decision
+
+We standardise on the domain-specific **`<entity>ID`** convention
+(`movieID` / `tvSeriesID` / `personID` / `collectionID` / `keywordID`) for the
+primary entity-ID parameter on service methods. The 7 `details(...)` outliers
+were renamed to match their siblings.
+
+`ChangesService` is intentionally **out of scope**: it uses `id` for the
+movie/TV/person change feeds alongside `seasonID` / `episodeID`, a separate,
+internally consistent surface. The internal `NaturalLanguageSearchDataSource`
+protocol (which uses `id`) is likewise not part of the public service convention.
+
+## Consequences
+
+- The public service surface presents a single, predictable parameter-name style
+  in autocomplete and generated docs.
+- New service methods should follow `<entity>ID`; a future reviewer can treat a
+  bare `id` on an entity-keyed service method as a lint-by-eye inconsistency.
+- Because the change is non-breaking, it shipped as a normal (non-major) release.
+
+## Alternatives considered
+
+- **Standardise on generic `id`** (the original code-review suggestion, argued as
+  "more fluent" since `forMovie:` already disambiguates). Rejected: it fights the
+  dominant existing style and would have renamed ~24 methods instead of 7, for a
+  larger diff and more churn with no compatibility benefit.

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -10,6 +10,31 @@ Format: **Feature / PR** · date · weight · *what worked* · *friction* ·
 
 ---
 
+## 2026-06-18 — ♻️ Standardize details(...) parameter names to `<entity>ID` (#341) · lite
+
+- **Worked:** scouting the *actual* scope before planning (an `Explore` sweep over
+  all 26 services) overturned two assumptions from the source review — the change
+  was non-breaking (internal names only) and the cheap, convention-aligned
+  direction (`<entity>ID`, 7 methods) was the **opposite** of the review's
+  recommendation (`id`, 24 methods). Re-confirming the decision with the user
+  before editing avoided a 24-method diff against the grain of the codebase.
+  Single-`code-reviewer` lite path fit the mechanical diff; build/tests/lint/review
+  all clean first time.
+- **Friction:** my raw `awk` line-length check flagged ~140 lines >100 chars and
+  briefly looked like a lint failure, but `make lint` reported 0 violations (the
+  enforced threshold ignores comment/URL lines and is higher than the documented
+  100 for code). Wasted a beat reconciling the two. Lesson: trust `make lint`, not
+  a hand-rolled length check.
+- **Deviations:** had to go back to the user mid-delivery to correct my own earlier
+  framing (I'd asked about deprecation/major-bump for a change that turned out
+  non-breaking). The right move, but a sign the *up-front* questions were asked
+  before the scope was actually understood.
+- **Improvement:** when a delivery originates from a review *finding* (not a
+  user-authored plan), scope it against the code (a quick `Explore` pass) **before**
+  asking the user any strategy questions — the finding's framing may be wrong, as
+  it was here (and for the dropped retry "fix"). Treat review findings as
+  hypotheses to verify, not approved plans.
+
 ## 2026-06-18 — ⚡️ Opt-in next-page prefetch (#337) · full
 
 - **Worked:** the full pipeline shone on the riskiest change of the effort (first

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -44,6 +44,26 @@ members). Every time, `swift build` / `make build-tests` reported **0 errors /
 - There is **no `GetBuildLog` tool** — for build-error detail inside Xcode use
   `mcp__xcode-tools__XcodeRefreshCodeIssuesInFile` on the flagged file(s).
 
+## Public API
+
+### Renaming a method's *internal* parameter name is source- and ABI-compatible
+
+*2026-06-18.* Renaming the **second** (internal) name in a parameter —
+e.g. `func details(forMovie id: Movie.ID)` → `func details(forMovie movieID: Movie.ID)` —
+is **not** a breaking change. Only the **external argument label** (`forMovie:`)
+is part of the function's name and the protocol-conformance / override contract;
+the internal name is implementation-local.
+
+- Call sites are unchanged (`details(forMovie: 550)` either way).
+- DocC symbol links are keyed on argument labels (`details(forMovie:language:)`),
+  so they don't break.
+- Conforming types need not match the internal name.
+
+Consequence: standardising service parameter names needs **no major version bump
+and no deprecation shims** — it only changes Xcode autocomplete placeholders and
+the documented signature. (We initially mis-scoped the `<entity>ID` rename as
+breaking; it isn't.) See [ADR-0004](decisions/0004-service-parameter-name-convention.md).
+
 ## Swift concurrency
 
 ### Deterministically testing that cancellation is *forwarded* into an unstructured `Task`


### PR DESCRIPTION
## Summary

Aligns the internal parameter names of the `details(...)` methods on five
services with each service's dominant `<entity>ID` convention. These were the
only methods using a generic `id` while every sibling (`credits`, `images`,
`videos`, …) already used `movieID` / `tvSeriesID` / `personID` / `collectionID`
/ `keywordID`. The result is a consistent, predictable parameter name in Xcode
autocomplete and in the documented signature.

**This is non-breaking.** Only *internal* parameter names change — the external
argument labels (`forMovie:`, `forTVSeries:`, …) and therefore every call site
and DocC symbol link are unchanged. It is source- and ABI-compatible: no major
version bump and no deprecation shims are required.

## Changes

**Refactor (`♻️`):**
- `MovieService` / `TMDbMovieService` — `details(forMovie id:)` → `forMovie movieID:` (both overloads)
- `TVSeriesService` / `TMDbTVSeriesService` — `details(forTVSeries id:)` → `forTVSeries tvSeriesID:`
- `PersonService` / `PersonService+Defaults` / `TMDbPersonService` — `details(forPerson id:)` → `forPerson personID:` (both overloads)
- `CollectionService` / `TMDbCollectionService` — `details(forCollection id:)` → `forCollection collectionID:`
- `KeywordService` / `TMDbKeywordService` — `details(forKeyword id:)` → `forKeyword keywordID:`
- Protocol declarations, default-argument extension overloads, concrete implementations, and `///` parameter docs all updated together.

**Out of scope (deliberately untouched):**
- `ChangesService` keeps `id` for its movie/TV/person change feeds (a separate, internally-consistent surface alongside `seasonID`/`episodeID`).
- The internal `NaturalLanguageSearchDataSource` protocol keeps `id`.

**Documentation (`📝`):**
- 📚 ADR-0004 records the `<entity>ID` convention decision and its rationale.
- 📚 `knowledge/gotchas.md` notes that renaming an internal parameter name is source/ABI-compatible.

## Testing

- ✅ `make ci` passes (lint, markdown lint, unit + integration tests, release build, docs build).
- ✅ Existing unit and integration tests pass unchanged — call sites are unaffected by an internal-name rename.
- ✅ Reviewed by the `code-reviewer` agent: 0 findings, ready to merge.

## Benefits

- **Consistent developer experience**: every entity-keyed service method now presents the same `<entity>ID` placeholder in autocomplete and docs.
- **Zero migration cost**: non-breaking, so consumers need no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)