### PR TITLE
♻️ Add explicit Sendable conformance to URLSessionHTTPClientAdapter

### DIFF
--- a/Sources/TMDb/Adapters/URLSessionHTTPClientAdapter.swift
+++ b/Sources/TMDb/Adapters/URLSessionHTTPClientAdapter.swift
@@ -11,7 +11,7 @@ import Foundation
     import FoundationNetworking
 #endif
 
-final class URLSessionHTTPClientAdapter: HTTPClient {
+final class URLSessionHTTPClientAdapter: HTTPClient, Sendable {
 
     private let urlSession: URLSession
 
@@ -63,7 +63,10 @@ extension URLSessionHTTPClientAdapter {
 extension URLSessionHTTPClientAdapter {
 
     #if canImport(FoundationNetworking)
-        // Thread-safe: all access to `task` is guarded by `lock`.
+        /// `@unchecked Sendable` is safe here: `URLSessionDataTask` is itself
+        /// thread-safe, and the box's only mutable state (`task`) is fully
+        /// guarded by `lock`, so the box can be shared across the
+        /// cancellation handler and the continuation closure without a data race.
         private final class DataTaskBox: @unchecked Sendable {
             private let lock = NSLock()
             private var task: URLSessionDataTask?

--- a/Tests/TMDbTests/Adapters/URLSessionHTTPClientAdapterTests.swift
+++ b/Tests/TMDbTests/Adapters/URLSessionHTTPClientAdapterTests.swift
@@ -162,8 +162,8 @@ final class URLSessionHTTPClientAdapterTests {
     func conformsToSendable() {
         func requireSendable(_: (some Sendable).Type) {}
 
-        // Compiles only while the adapter is `Sendable`; guards the explicit
-        // conformance against accidental regression.
+        // Compiles only while the adapter remains `Sendable`; guards against a
+        // future change that would make it non-Sendable.
         requireSendable(URLSessionHTTPClientAdapter.self)
     }
 

--- a/Tests/TMDbTests/Adapters/URLSessionHTTPClientAdapterTests.swift
+++ b/Tests/TMDbTests/Adapters/URLSessionHTTPClientAdapterTests.swift
@@ -158,4 +158,13 @@ final class URLSessionHTTPClientAdapterTests {
         #expect(result2 == header2Value)
     }
 
+    @Test("URLSessionHTTPClientAdapter conforms to Sendable")
+    func conformsToSendable() {
+        func requireSendable(_: (some Sendable).Type) {}
+
+        // Compiles only while the adapter is `Sendable`; guards the explicit
+        // conformance against accidental regression.
+        requireSendable(URLSessionHTTPClientAdapter.self)
+    }
+
 }

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -10,6 +10,23 @@ Format: **Feature / PR** · date · weight · *what worked* · *friction* ·
 
 ---
 
+## 2026-06-18 — ♻️ Explicit `Sendable` on `URLSessionHTTPClientAdapter` (#343) · lite
+
+- **Worked:** grounding the plan in the actual code first paid off again — reading
+  the adapter revealed it is `internal` and already enforced as `Sendable` via
+  `HTTPClient: Sendable`, so the change was correctly framed as
+  clarity/future-proofing rather than the bug fix the source review implied. The
+  `code-reviewer` confirmed all three safety claims and caught one honest Low (the
+  compile-time assertion guards Sendability "by any route", not the explicit
+  annotation) — applied the reword and moved on.
+- **Friction:** none of note. `make ci` again ran the full ~6-min gate for a
+  ~14-line change (same docs/low-risk fast-path gap noted on #340).
+- **Deviations:** none — clean lite path (skip critics, single reviewer).
+- **Improvement:** the compile-time `requireSendable(_:)` assertion is a nice
+  reusable idiom for pinning `Sendable` on concurrency-sensitive types; consider a
+  one-line note in `knowledge/gotchas.md` if it recurs (didn't capture yet — single
+  use so far).
+
 ## 2026-06-18 — ♻️ Standardize details(...) parameter names to `<entity>ID` (#341) · lite
 
 - **Worked:** scouting the *actual* scope before planning (an `Explore` sweep over


### PR DESCRIPTION
## Summary

Makes the `Sendable` conformance of `URLSessionHTTPClientAdapter` (the default
HTTP transport) explicit. The adapter already conformed to `HTTPClient`, which
inherits `Sendable`, so the compiler already enforced its Sendability — this
states it on the declaration so the conformance is self-documenting and stays
robust if `HTTPClient` ever stops inheriting `Sendable`.

## Changes

**Refactor (`♻️`):**
- `URLSessionHTTPClientAdapter.swift` — add explicit `, Sendable` to the
  declaration. Safe and constraint-neutral: the sole stored property is an
  immutable `URLSession` (itself `Sendable` on Apple and FoundationNetworking),
  so it compiles unchanged on every platform including the Linux CI leg.
- Expand the `DataTaskBox` `@unchecked Sendable` justification comment — the
  only mutable state (`task`) is fully `NSLock`-guarded and `URLSessionDataTask`
  is thread-safe, so the box is safe to share across the cancellation handler
  and the continuation closure.

**Tests (`✅`):**
- Add a compile-time Sendability assertion (`requireSendable(URLSessionHTTPClientAdapter.self)`)
  that fails the build if the adapter ever became non-`Sendable`.

## Testing

- ✅ `make ci` passes (lint, markdown lint, unit + integration tests, release build, docs build).
- ✅ All 2,664 unit tests pass; builds clean on the FoundationNetworking/Linux path too.
- ✅ Reviewed by the `code-reviewer` agent — 0 Critical/High/Medium; one Low comment-wording note applied.

## Benefits

- **Self-documenting concurrency**: the default adapter's thread-safety contract is now explicit at its declaration and locked in by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)