### PR TITLE
📝 Add error-handling How-To guide

### DIFF
--- a/Sources/TMDb/TMDb.docc/GettingStarted/CreatingTMDbClient.md
+++ b/Sources/TMDb/TMDb.docc/GettingStarted/CreatingTMDbClient.md
@@ -156,6 +156,9 @@ let tmdbClient = TMDbClient(
 )
 ```
 
+Retry and caching change how and when errors reach your code — see
+<doc:HandlingErrors> for the details.
+
 ## Using TMDbClient
 
 Once created, your instance of ``TMDbClient`` can be used to interact with the
@@ -169,3 +172,7 @@ let tmdbClient = TMDbClient(apiKey: "<your-tmdb-api-key>")
 let moviesToDiscover = try await tmdbClient.discover.movies().results
 let fightClub = try await tmdbClient.movies.details(forMovie: 550)
 ```
+
+## See Also
+
+- <doc:HandlingErrors>

--- a/Sources/TMDb/TMDb.docc/HowTos/HandlingErrors.md
+++ b/Sources/TMDb/TMDb.docc/HowTos/HandlingErrors.md
@@ -1,0 +1,83 @@
+# Handling Errors
+
+Understand the errors TMDb throws and recover from them gracefully.
+
+## Overview
+
+Every asynchronous method on a TMDb service is typed to throw
+``TMDbError``. For example, ``MovieService/details(forMovie:language:)`` is
+declared `async throws(TMDbError)`, so the concrete error type is known at
+the call site — there is no need to cast from a generic `Error`.
+
+``TMDbError`` conforms to
+[`LocalizedError`](https://developer.apple.com/documentation/foundation/localizederror),
+so `error.localizedDescription` returns a human-readable message for every
+case.
+
+## Error Cases
+
+``TMDbError`` enumerates the failures you can encounter:
+
+| Case | When it occurs |
+| ---- | -------------- |
+| ``TMDbError/badRequest(_:)`` | The request was malformed or rejected by the API (HTTP 400, 405, 406, 422), or a URL could not be built. |
+| ``TMDbError/unauthorised(_:)`` | Authentication failed (HTTP 401) — usually a missing or invalid API key, or an expired session. |
+| ``TMDbError/forbidden(_:)`` | The API key is valid but not permitted to access the resource (HTTP 403). |
+| ``TMDbError/notFound(_:)`` | The requested resource does not exist (HTTP 404). |
+| ``TMDbError/tooManyRequests(_:)`` | The API rate limit was exceeded (HTTP 429). |
+| ``TMDbError/serverError(_:)`` | TMDb reported a server-side failure (HTTP 5xx). |
+| ``TMDbError/network(_:)`` | The request never completed — offline, timed out, or a DNS / connection failure. The underlying error is attached. |
+| ``TMDbError/decode(_:)`` | A response was received but could not be decoded into the expected model. The underlying error is attached. |
+| ``TMDbError/invalidRating`` | A rating passed to an `addRating` method is out of range; it must be between `0.5` and `10.0` in increments of `0.5`. Validated on-device before any request is sent. |
+| ``TMDbError/unknown`` | An unexpected error that does not map to any of the above. |
+
+## Catching Errors
+
+Use a `do` / `catch` and switch on the cases you want to handle specially,
+falling back to `localizedDescription` for the rest:
+
+```swift
+let tmdbClient = TMDbClient(apiKey: "<your-tmdb-api-key>")
+
+do {
+    let movie = try await tmdbClient.movies.details(forMovie: 550)
+    print(movie.title)
+} catch TMDbError.notFound {
+    print("That movie doesn't exist.")
+} catch TMDbError.unauthorised {
+    print("Check your API key.")
+} catch TMDbError.tooManyRequests {
+    print("Rate limited — try again shortly.")
+} catch TMDbError.network(let underlying) {
+    print("Network problem: \(underlying.localizedDescription)")
+} catch TMDbError.decode {
+    print("The response couldn't be read.")
+} catch {
+    print("Something went wrong: \(error.localizedDescription)")
+}
+```
+
+Because the service methods use typed throws, the `catch` clauses match
+``TMDbError`` cases directly, and the final `catch` handles any case you did
+not name explicitly.
+
+## Interaction with Retry and Caching
+
+When you enable automatic retry (see <doc:CreatingTMDbClient>), TMDb
+transparently retries transient failures — rate limiting (HTTP 429), server
+errors (HTTP 5xx), and network errors — with exponential backoff, but **only
+for idempotent requests** (`GET` and `DELETE`). A non-idempotent `POST` (such
+as adding a rating) is never retried, so it is performed at most once.
+
+Retry is invisible to your `catch` blocks: an error is thrown only once the
+retries are exhausted. A request that stays rate-limited on every attempt, for
+instance, surfaces as ``TMDbError/tooManyRequests(_:)`` after the final
+attempt — you never see the intermediate failures.
+
+When response caching is enabled, a cache hit short-circuits the request
+entirely: the stored response is returned without touching the network or the
+retry logic, so a cached read cannot produce a network or rate-limit error.
+
+## See Also
+
+- <doc:CreatingTMDbClient>

--- a/Sources/TMDb/TMDb.docc/TMDb.md
+++ b/Sources/TMDb/TMDb.docc/TMDb.md
@@ -59,6 +59,7 @@ Watch providers provided by [JustWatch](https://www.justwatch.com).
 - <doc:/GeneratingImageURLs>
 - <doc:/ManagingUserAccounts>
 - <doc:/UsingLanguageModelTools>
+- <doc:/HandlingErrors>
 
 ### Movies
 

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -10,6 +10,23 @@ Format: **Feature / PR** · date · weight · *what worked* · *friction* ·
 
 ---
 
+## 2026-06-18 — 📝 Add error-handling How-To guide (#344) · lite (docs-only)
+
+- **Worked:** reading the real source first (`TMDbError+TMDbAPIError.swift` for the
+  status→case mapping, `RetryHTTPClient.swift` for retry semantics) meant the guide
+  documented *actual* behaviour — including the "error thrown only after retries are
+  exhausted" nuance from the dropped item 3 — rather than plausible-sounding
+  guesses. `make build-docs` (warnings-as-errors) was the real gate: it validated
+  every `` ``TMDbError/notFound(_:)`` `` enum-case link and `<doc:>` reference, so a
+  broken symbol link would have failed before the PR.
+- **Friction:** same recurring one — `make ci` ran the full unit+integration+release
+  matrix for a docs-only change; only `build-docs` + `lint-markdown` were meaningful.
+- **Deviations:** none — clean docs-only lite path (review auto-skipped, no Swift).
+- **Improvement:** reinforces the **docs/config-only fast gate** idea already logged
+  on #340/#343 — for a no-`.swift` diff, `make ci` could run just lint +
+  lint-markdown + build-docs. Three docs-only deliveries this session each paid the
+  full-matrix cost; worth implementing the fast gate in `/pr` step 4 now.
+
 ## 2026-06-18 — ♻️ Standardize details(...) parameter names to `<entity>ID` (#341) · lite
 
 - **Worked:** scouting the *actual* scope before planning (an `Explore` sweep over


### PR DESCRIPTION
## Summary

Every TMDb service method is typed `async throws(TMDbError)`, yet none of the
existing How-To guides showed error handling — consumers had to reverse-engineer
the `TMDbError` cases and how they interact with retry/cache. This adds a
dedicated guide.

## Changes

**Documentation:**
- 📝 New `TMDb.docc/HowTos/HandlingErrors.md`:
  - Overview — typed `throws(TMDbError)`; `TMDbError` is a `LocalizedError`.
  - A table of all 10 `TMDbError` cases and when each occurs (mapping verified
    against `TMDbError+TMDbAPIError.swift`).
  - A `do`/`catch` example switching on the actionable cases.
  - How automatic retry (idempotent requests only; error thrown only after
    retries are exhausted) and response caching (hits bypass network + retry)
    change when errors surface.
- 📝 Registered in the **How-To Guides** topic in `TMDb.docc/TMDb.md`.
- 📝 Cross-linked from `GettingStarted/CreatingTMDbClient.md` (retry/cache note
  + See Also).

## Testing

- ✅ `make ci` passes; `make build-docs` (warnings-as-errors) confirms every
  DocC symbol link and `<doc:>` reference resolves; `make lint-markdown` clean.
- Docs-only change — no Swift touched, so code review does not apply.

## Benefits

- **Production readiness**: consumers get a clear reference for catching and
  recovering from errors against a live, rate-limited API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)