### PR TITLE
✨ Add AuthenticatedSession wrapper for AccountService

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,8 @@ with 94 auto-pagination methods.
 ### User Account Features (Authentication Required)
 
 Account features require an authenticated `Session`. Create one with the
-`AuthenticationService`, then read the account ID from the user's details:
+`AuthenticationService`, then bundle it with the account ID into an
+`AuthenticatedSession`:
 
 ```swift
 // Authenticate the user and create a session

--- a/README.md
+++ b/README.md
@@ -363,15 +363,13 @@ let authURL = tmdbClient.authentication.authenticateURL(for: token)
 // Present authURL to the user to approve the token, then:
 let session = try await tmdbClient.authentication.createSession(withToken: token)
 
-// Get the account ID
-let accountDetails = try await tmdbClient.account.details(session: session)
-let accountID = accountDetails.id
+// Bundle the account ID and session into one value
+let authenticatedSession = try await tmdbClient.account.authenticatedSession(for: session)
 
 // Add a movie to favourites
 try await tmdbClient.account.addFavourite(
     movie: movieID,
-    accountID: accountID,
-    session: session
+    authenticatedSession: authenticatedSession
 )
 
 // Rate a movie
@@ -379,8 +377,7 @@ try await tmdbClient.movies.addRating(8.5, toMovie: movieID, session: session)
 
 // Get the movie watchlist
 let watchlist = try await tmdbClient.account.movieWatchlist(
-    accountID: accountID,
-    session: session
+    authenticatedSession: authenticatedSession
 )
 ```
 

--- a/Sources/TMDb/Domain/Models/AuthenticatedSession.swift
+++ b/Sources/TMDb/Domain/Models/AuthenticatedSession.swift
@@ -1,0 +1,44 @@
+//
+//  AuthenticatedSession.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A model representing an authenticated TMDb user — a user's account
+/// identifier paired with the session that authorises requests on their behalf.
+///
+/// Many ``AccountService`` methods need both the account identifier and the
+/// session. Bundling them into a single value removes the need to thread the
+/// two through every call and keeps them from being mismatched. Obtain one with
+/// ``AccountService/authenticatedSession(for:)``, or construct it directly when
+/// the account identifier is already known.
+///
+/// - Important: ``session`` carries the user's session identifier, which is a
+///   credential. Persisting an `AuthenticatedSession` is the caller's
+///   responsibility and should use appropriately secure storage.
+///
+public struct AuthenticatedSession: Equatable, Hashable, Sendable {
+
+    /// The user's account identifier.
+    public let accountID: Int
+
+    /// The user's TMDb session.
+    public let session: Session
+
+    ///
+    /// Creates an authenticated session.
+    ///
+    /// - Parameters:
+    ///   - accountID: The user's account identifier.
+    ///   - session: The user's TMDb session.
+    ///
+    public init(accountID: Int, session: Session) {
+        self.accountID = accountID
+        self.session = session
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/Account/AccountService+AuthenticatedSession.swift
+++ b/Sources/TMDb/Domain/Services/Account/AccountService+AuthenticatedSession.swift
@@ -1,0 +1,713 @@
+//
+//  AccountService+AuthenticatedSession.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+public extension AccountService {
+
+    ///
+    /// Bundles a session together with its account identifier into an
+    /// ``AuthenticatedSession``.
+    ///
+    /// This is a convenience over fetching ``details(session:)`` and reading
+    /// its identifier manually. The returned value can then be passed to the
+    /// `authenticatedSession:` variants of the account methods.
+    ///
+    /// - Important: This performs a network request (it calls
+    ///   ``details(session:)``) and can therefore throw ``TMDbError``.
+    ///
+    /// - Parameter session: The user's TMDb session.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: An ``AuthenticatedSession`` pairing the account identifier
+    ///   with the session.
+    ///
+    func authenticatedSession(
+        for session: Session
+    ) async throws(TMDbError) -> AuthenticatedSession {
+        let details = try await details(session: session)
+        return AuthenticatedSession(accountID: details.id, session: session)
+    }
+
+    ///
+    /// Returns a list of the user's favourited movies.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - page: The page of results to return.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The matching movies as a pageable list.
+    ///
+    func favouriteMovies(
+        sortedBy: FavouriteSort? = nil,
+        page: Int? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) async throws(TMDbError) -> MoviePageableList {
+        try await favouriteMovies(
+            sortedBy: sortedBy,
+            page: page,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns a list of the user's favourited TV series.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - page: The page of results to return.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The matching TV series as a pageable list.
+    ///
+    func favouriteTVSeries(
+        sortedBy: FavouriteSort? = nil,
+        page: Int? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) async throws(TMDbError) -> TVSeriesPageableList {
+        try await favouriteTVSeries(
+            sortedBy: sortedBy,
+            page: page,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Adds a movie to the user's favourites.
+    ///
+    /// - Parameters:
+    ///   - movieID: The identifier of the movie.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    func addFavourite(
+        movie movieID: Movie.ID,
+        authenticatedSession: AuthenticatedSession
+    ) async throws(TMDbError) {
+        try await addFavourite(
+            movie: movieID,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Removes a movie from the user's favourites.
+    ///
+    /// - Parameters:
+    ///   - movieID: The identifier of the movie.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    func removeFavourite(
+        movie movieID: Movie.ID,
+        authenticatedSession: AuthenticatedSession
+    ) async throws(TMDbError) {
+        try await removeFavourite(
+            movie: movieID,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Adds a TV series to the user's favourites.
+    ///
+    /// - Parameters:
+    ///   - tvSeriesID: The identifier of the TV series.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    func addFavourite(
+        tvSeries tvSeriesID: TVSeries.ID,
+        authenticatedSession: AuthenticatedSession
+    ) async throws(TMDbError) {
+        try await addFavourite(
+            tvSeries: tvSeriesID,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Removes a TV series from the user's favourites.
+    ///
+    /// - Parameters:
+    ///   - tvSeriesID: The identifier of the TV series.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    func removeFavourite(
+        tvSeries tvSeriesID: TVSeries.ID,
+        authenticatedSession: AuthenticatedSession
+    ) async throws(TMDbError) {
+        try await removeFavourite(
+            tvSeries: tvSeriesID,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns a list of movies on the user's watchlist.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - page: The page of results to return.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The matching movies as a pageable list.
+    ///
+    func movieWatchlist(
+        sortedBy: WatchlistSort? = nil,
+        page: Int? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) async throws(TMDbError) -> MoviePageableList {
+        try await movieWatchlist(
+            sortedBy: sortedBy,
+            page: page,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns a list of TV series on the user's watchlist.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - page: The page of results to return.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The matching TV series as a pageable list.
+    ///
+    func tvSeriesWatchlist(
+        sortedBy: WatchlistSort? = nil,
+        page: Int? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) async throws(TMDbError) -> TVSeriesPageableList {
+        try await tvSeriesWatchlist(
+            sortedBy: sortedBy,
+            page: page,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Adds a movie to the user's watchlist.
+    ///
+    /// - Parameters:
+    ///   - movieID: The identifier of the movie.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    func addToWatchlist(
+        movie movieID: Movie.ID,
+        authenticatedSession: AuthenticatedSession
+    ) async throws(TMDbError) {
+        try await addToWatchlist(
+            movie: movieID,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Removes a movie from the user's watchlist.
+    ///
+    /// - Parameters:
+    ///   - movieID: The identifier of the movie.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    func removeFromWatchlist(
+        movie movieID: Movie.ID,
+        authenticatedSession: AuthenticatedSession
+    ) async throws(TMDbError) {
+        try await removeFromWatchlist(
+            movie: movieID,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Adds a TV series to the user's watchlist.
+    ///
+    /// - Parameters:
+    ///   - tvSeriesID: The identifier of the TV series.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    func addToWatchlist(
+        tvSeries tvSeriesID: TVSeries.ID,
+        authenticatedSession: AuthenticatedSession
+    ) async throws(TMDbError) {
+        try await addToWatchlist(
+            tvSeries: tvSeriesID,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Removes a TV series from the user's watchlist.
+    ///
+    /// - Parameters:
+    ///   - tvSeriesID: The identifier of the TV series.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    func removeFromWatchlist(
+        tvSeries tvSeriesID: TVSeries.ID,
+        authenticatedSession: AuthenticatedSession
+    ) async throws(TMDbError) {
+        try await removeFromWatchlist(
+            tvSeries: tvSeriesID,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns a list of movies the user has rated.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - page: The page of results to return.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The matching movies as a pageable list.
+    ///
+    func ratedMovies(
+        sortedBy: RatedSort? = nil,
+        page: Int? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) async throws(TMDbError) -> MoviePageableList {
+        try await ratedMovies(
+            sortedBy: sortedBy,
+            page: page,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns a list of TV series the user has rated.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - page: The page of results to return.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The matching TV series as a pageable list.
+    ///
+    func ratedTVSeries(
+        sortedBy: RatedSort? = nil,
+        page: Int? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) async throws(TMDbError) -> TVSeriesPageableList {
+        try await ratedTVSeries(
+            sortedBy: sortedBy,
+            page: page,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns a list of TV episodes the user has rated.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - page: The page of results to return.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The matching TV episodes as a pageable list.
+    ///
+    func ratedTVEpisodes(
+        sortedBy: RatedSort? = nil,
+        page: Int? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) async throws(TMDbError) -> TVEpisodePageableList {
+        try await ratedTVEpisodes(
+            sortedBy: sortedBy,
+            page: page,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns a list of the user's custom lists.
+    ///
+    /// - Parameters:
+    ///   - page: The page of results to return.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The user's lists as a pageable list.
+    ///
+    func lists(
+        page: Int? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) async throws(TMDbError) -> MediaListSummaryPageableList {
+        try await lists(
+            page: page,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns an async sequence of all the user's favourited movies across all
+    /// pages.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Returns: An async sequence that yields individual ``MovieListItem`` objects.
+    ///
+    func allFavouriteMovies(
+        sortedBy: FavouriteSort? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) -> PagedAsyncSequence<MovieListItem> {
+        allFavouriteMovies(
+            sortedBy: sortedBy,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns an async sequence of all the user's favourited TV series across
+    /// all pages.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Returns: An async sequence that yields individual ``TVSeriesListItem`` objects.
+    ///
+    func allFavouriteTVSeries(
+        sortedBy: FavouriteSort? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) -> PagedAsyncSequence<TVSeriesListItem> {
+        allFavouriteTVSeries(
+            sortedBy: sortedBy,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns an async sequence of all movies on the user's watchlist across
+    /// all pages.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Returns: An async sequence that yields individual ``MovieListItem`` objects.
+    ///
+    func allWatchlistMovies(
+        sortedBy: WatchlistSort? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) -> PagedAsyncSequence<MovieListItem> {
+        allWatchlistMovies(
+            sortedBy: sortedBy,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns an async sequence of all TV series on the user's watchlist across
+    /// all pages.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Returns: An async sequence that yields individual ``TVSeriesListItem`` objects.
+    ///
+    func allWatchlistTVSeries(
+        sortedBy: WatchlistSort? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) -> PagedAsyncSequence<TVSeriesListItem> {
+        allWatchlistTVSeries(
+            sortedBy: sortedBy,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns an async sequence of all movies the user has rated across all
+    /// pages.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Returns: An async sequence that yields individual ``MovieListItem`` objects.
+    ///
+    func allRatedMovies(
+        sortedBy: RatedSort? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) -> PagedAsyncSequence<MovieListItem> {
+        allRatedMovies(
+            sortedBy: sortedBy,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns an async sequence of all TV series the user has rated across all
+    /// pages.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Returns: An async sequence that yields individual ``TVSeriesListItem`` objects.
+    ///
+    func allRatedTVSeries(
+        sortedBy: RatedSort? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) -> PagedAsyncSequence<TVSeriesListItem> {
+        allRatedTVSeries(
+            sortedBy: sortedBy,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns an async sequence of all TV episodes the user has rated across
+    /// all pages.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Returns: An async sequence that yields individual ``TVEpisode`` objects.
+    ///
+    func allRatedTVEpisodes(
+        sortedBy: RatedSort? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) -> PagedAsyncSequence<TVEpisode> {
+        allRatedTVEpisodes(
+            sortedBy: sortedBy,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns an async sequence of all the user's custom lists across all pages.
+    ///
+    /// - Parameter authenticatedSession: The user's authenticated session.
+    ///
+    /// - Returns: An async sequence that yields individual ``MediaListSummary`` objects.
+    ///
+    func allLists(
+        authenticatedSession: AuthenticatedSession
+    ) -> PagedAsyncSequence<MediaListSummary> {
+        allLists(
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns an async sequence of all the user's favourited movie pages.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages of ``MovieListItem`` objects.
+    ///
+    func allFavouriteMoviesPages(
+        sortedBy: FavouriteSort? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) -> PagedPagesAsyncSequence<MovieListItem> {
+        allFavouriteMoviesPages(
+            sortedBy: sortedBy,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns an async sequence of all the user's favourited TV series pages.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages of ``TVSeriesListItem`` objects.
+    ///
+    func allFavouriteTVSeriesPages(
+        sortedBy: FavouriteSort? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) -> PagedPagesAsyncSequence<TVSeriesListItem> {
+        allFavouriteTVSeriesPages(
+            sortedBy: sortedBy,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns an async sequence of all the user's movie watchlist pages.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages of ``MovieListItem`` objects.
+    ///
+    func allWatchlistMoviesPages(
+        sortedBy: WatchlistSort? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) -> PagedPagesAsyncSequence<MovieListItem> {
+        allWatchlistMoviesPages(
+            sortedBy: sortedBy,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns an async sequence of all the user's TV series watchlist pages.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages of ``TVSeriesListItem`` objects.
+    ///
+    func allWatchlistTVSeriesPages(
+        sortedBy: WatchlistSort? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) -> PagedPagesAsyncSequence<TVSeriesListItem> {
+        allWatchlistTVSeriesPages(
+            sortedBy: sortedBy,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns an async sequence of all the user's rated movie pages.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages of ``MovieListItem`` objects.
+    ///
+    func allRatedMoviesPages(
+        sortedBy: RatedSort? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) -> PagedPagesAsyncSequence<MovieListItem> {
+        allRatedMoviesPages(
+            sortedBy: sortedBy,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns an async sequence of all the user's rated TV series pages.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages of ``TVSeriesListItem`` objects.
+    ///
+    func allRatedTVSeriesPages(
+        sortedBy: RatedSort? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) -> PagedPagesAsyncSequence<TVSeriesListItem> {
+        allRatedTVSeriesPages(
+            sortedBy: sortedBy,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns an async sequence of all the user's rated TV episode pages.
+    ///
+    /// - Parameters:
+    ///   - sortedBy: How results should be sorted.
+    ///   - authenticatedSession: The user's authenticated session.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages of ``TVEpisode`` objects.
+    ///
+    func allRatedTVEpisodesPages(
+        sortedBy: RatedSort? = nil,
+        authenticatedSession: AuthenticatedSession
+    ) -> PagedPagesAsyncSequence<TVEpisode> {
+        allRatedTVEpisodesPages(
+            sortedBy: sortedBy,
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+    ///
+    /// Returns an async sequence of all the user's custom list pages.
+    ///
+    /// - Parameter authenticatedSession: The user's authenticated session.
+    ///
+    /// - Returns: An async sequence that yields ``PageableListResult`` pages of ``MediaListSummary`` objects.
+    ///
+    func allListsPages(
+        authenticatedSession: AuthenticatedSession
+    ) -> PagedPagesAsyncSequence<MediaListSummary> {
+        allListsPages(
+            accountID: authenticatedSession.accountID,
+            session: authenticatedSession.session
+        )
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/Account/AccountService+AuthenticatedSession.swift
+++ b/Sources/TMDb/Domain/Services/Account/AccountService+AuthenticatedSession.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+// swiftlint:disable file_length
+
 public extension AccountService {
 
     ///
@@ -711,3 +713,5 @@ public extension AccountService {
     }
 
 }
+
+// swiftlint:enable file_length

--- a/Sources/TMDb/TMDb.docc/Extensions/AccountService.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/AccountService.md
@@ -6,61 +6,97 @@
 
 - ``details(session:)``
 
+### Authenticated Session
+
+- ``authenticatedSession(for:)``
+
 ### Favourite Movies
 
+- ``favouriteMovies(sortedBy:page:authenticatedSession:)``
 - ``favouriteMovies(sortedBy:page:accountID:session:)``
+- ``addFavourite(movie:authenticatedSession:)``
 - ``addFavourite(movie:accountID:session:)``
+- ``removeFavourite(movie:authenticatedSession:)``
 - ``removeFavourite(movie:accountID:session:)``
 
 ### Favourite TV Series
 
+- ``favouriteTVSeries(sortedBy:page:authenticatedSession:)``
 - ``favouriteTVSeries(sortedBy:page:accountID:session:)``
+- ``addFavourite(tvSeries:authenticatedSession:)``
 - ``addFavourite(tvSeries:accountID:session:)``
+- ``removeFavourite(tvSeries:authenticatedSession:)``
 - ``removeFavourite(tvSeries:accountID:session:)``
 
 ### Movie Watchlist
 
+- ``movieWatchlist(sortedBy:page:authenticatedSession:)``
 - ``movieWatchlist(sortedBy:page:accountID:session:)``
+- ``addToWatchlist(movie:authenticatedSession:)``
 - ``addToWatchlist(movie:accountID:session:)``
+- ``removeFromWatchlist(movie:authenticatedSession:)``
 - ``removeFromWatchlist(movie:accountID:session:)``
 
 ### TV Series Watchlist
 
+- ``tvSeriesWatchlist(sortedBy:page:authenticatedSession:)``
 - ``tvSeriesWatchlist(sortedBy:page:accountID:session:)``
+- ``addToWatchlist(tvSeries:authenticatedSession:)``
 - ``addToWatchlist(tvSeries:accountID:session:)``
+- ``removeFromWatchlist(tvSeries:authenticatedSession:)``
 - ``removeFromWatchlist(tvSeries:accountID:session:)``
 
 ### Rated Movies
 
+- ``ratedMovies(sortedBy:page:authenticatedSession:)``
 - ``ratedMovies(sortedBy:page:accountID:session:)``
 
 ### Rated TV Series
 
+- ``ratedTVSeries(sortedBy:page:authenticatedSession:)``
 - ``ratedTVSeries(sortedBy:page:accountID:session:)``
 
 ### Rated TV Episodes
 
+- ``ratedTVEpisodes(sortedBy:page:authenticatedSession:)``
 - ``ratedTVEpisodes(sortedBy:page:accountID:session:)``
 
 ### Custom Lists
 
+- ``lists(page:authenticatedSession:)``
 - ``lists(page:accountID:session:)``
 
 ### Auto-Pagination
 
+- ``allFavouriteMovies(sortedBy:authenticatedSession:)``
 - ``allFavouriteMovies(sortedBy:accountID:session:)``
+- ``allFavouriteTVSeries(sortedBy:authenticatedSession:)``
 - ``allFavouriteTVSeries(sortedBy:accountID:session:)``
+- ``allWatchlistMovies(sortedBy:authenticatedSession:)``
 - ``allWatchlistMovies(sortedBy:accountID:session:)``
+- ``allWatchlistTVSeries(sortedBy:authenticatedSession:)``
 - ``allWatchlistTVSeries(sortedBy:accountID:session:)``
+- ``allRatedMovies(sortedBy:authenticatedSession:)``
 - ``allRatedMovies(sortedBy:accountID:session:)``
+- ``allRatedTVSeries(sortedBy:authenticatedSession:)``
 - ``allRatedTVSeries(sortedBy:accountID:session:)``
+- ``allRatedTVEpisodes(sortedBy:authenticatedSession:)``
 - ``allRatedTVEpisodes(sortedBy:accountID:session:)``
+- ``allLists(authenticatedSession:)``
 - ``allLists(accountID:session:)``
+- ``allFavouriteMoviesPages(sortedBy:authenticatedSession:)``
 - ``allFavouriteMoviesPages(sortedBy:accountID:session:)``
+- ``allFavouriteTVSeriesPages(sortedBy:authenticatedSession:)``
 - ``allFavouriteTVSeriesPages(sortedBy:accountID:session:)``
+- ``allWatchlistMoviesPages(sortedBy:authenticatedSession:)``
 - ``allWatchlistMoviesPages(sortedBy:accountID:session:)``
+- ``allWatchlistTVSeriesPages(sortedBy:authenticatedSession:)``
 - ``allWatchlistTVSeriesPages(sortedBy:accountID:session:)``
+- ``allRatedMoviesPages(sortedBy:authenticatedSession:)``
 - ``allRatedMoviesPages(sortedBy:accountID:session:)``
+- ``allRatedTVSeriesPages(sortedBy:authenticatedSession:)``
 - ``allRatedTVSeriesPages(sortedBy:accountID:session:)``
+- ``allRatedTVEpisodesPages(sortedBy:authenticatedSession:)``
 - ``allRatedTVEpisodesPages(sortedBy:accountID:session:)``
+- ``allListsPages(authenticatedSession:)``
 - ``allListsPages(accountID:session:)``

--- a/Sources/TMDb/TMDb.docc/HowTos/ManagingUserAccounts.md
+++ b/Sources/TMDb/TMDb.docc/HowTos/ManagingUserAccounts.md
@@ -32,17 +32,20 @@ let session = try await tmdbClient.authentication.createSession(
 )
 ```
 
-## Getting the Account ID
+## Creating an Authenticated Session
 
-Retrieve the user's account details to get their account ID, which is
-required for favorites, watchlists, and rated item requests.
+Favorites, watchlists, and rated-item requests need both the user's account
+ID and their session. Bundle them once into an ``AuthenticatedSession`` and
+pass that single value to every account call.
 
 ```swift
-let accountDetails = try await tmdbClient.account.details(
-    session: session
-)
-let accountID = accountDetails.id
+// Performs a network request and throws TMDbError.
+let authenticatedSession = try await tmdbClient.account
+    .authenticatedSession(for: session)
 ```
+
+> If you already hold the account ID, construct one directly with
+> ``AuthenticatedSession/init(accountID:session:)`` — no network request.
 
 ## Managing Favorites
 
@@ -52,21 +55,18 @@ Add and remove movies and TV series from the user's favorites.
 // Add a movie to favorites
 try await tmdbClient.account.addFavourite(
     movie: 550,
-    accountID: accountID,
-    session: session
+    authenticatedSession: authenticatedSession
 )
 
 // Get favorite movies
 let favouriteMovies = try await tmdbClient.account.favouriteMovies(
-    accountID: accountID,
-    session: session
+    authenticatedSession: authenticatedSession
 )
 
 // Remove from favorites
 try await tmdbClient.account.removeFavourite(
     movie: 550,
-    accountID: accountID,
-    session: session
+    authenticatedSession: authenticatedSession
 )
 ```
 
@@ -76,21 +76,18 @@ try await tmdbClient.account.removeFavourite(
 // Add a movie to watchlist
 try await tmdbClient.account.addToWatchlist(
     movie: 550,
-    accountID: accountID,
-    session: session
+    authenticatedSession: authenticatedSession
 )
 
 // Get movie watchlist
 let watchlist = try await tmdbClient.account.movieWatchlist(
-    accountID: accountID,
-    session: session
+    authenticatedSession: authenticatedSession
 )
 
 // Remove from watchlist
 try await tmdbClient.account.removeFromWatchlist(
     movie: 550,
-    accountID: accountID,
-    session: session
+    authenticatedSession: authenticatedSession
 )
 ```
 
@@ -106,8 +103,7 @@ try await tmdbClient.movies.addRating(
 
 // Get rated movies
 let ratedMovies = try await tmdbClient.account.ratedMovies(
-    accountID: accountID,
-    session: session
+    authenticatedSession: authenticatedSession
 )
 
 // Delete a rating

--- a/Sources/TMDb/TMDb.docc/TMDb.md
+++ b/Sources/TMDb/TMDb.docc/TMDb.md
@@ -390,6 +390,7 @@ Watch providers provided by [JustWatch](https://www.justwatch.com).
 ### Account
 
 - ``AccountService``
+- ``AuthenticatedSession``
 - ``AccountDetails``
 - ``AccountAvatar``
 - ``AccountAvatar/Gravatar``

--- a/Tests/TMDbTests/Domain/Models/AuthenticatedSessionTests.swift
+++ b/Tests/TMDbTests/Domain/Models/AuthenticatedSessionTests.swift
@@ -1,0 +1,53 @@
+//
+//  AuthenticatedSessionTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.models))
+struct AuthenticatedSessionTests {
+
+    @Test("init stores the account identifier and session")
+    func initStoresAccountIDAndSession() {
+        let session = Session(success: true, sessionID: "abc123")
+
+        let authenticatedSession = AuthenticatedSession(accountID: 42, session: session)
+
+        #expect(authenticatedSession.accountID == 42)
+        #expect(authenticatedSession.session == session)
+    }
+
+    @Test("equates only when both the account identifier and session match")
+    func equatable() {
+        let session = Session(success: true, sessionID: "abc123")
+        let other = Session(success: true, sessionID: "xyz789")
+
+        #expect(
+            AuthenticatedSession(accountID: 42, session: session)
+                == AuthenticatedSession(accountID: 42, session: session)
+        )
+        #expect(
+            AuthenticatedSession(accountID: 42, session: session)
+                != AuthenticatedSession(accountID: 43, session: session)
+        )
+        #expect(
+            AuthenticatedSession(accountID: 42, session: session)
+                != AuthenticatedSession(accountID: 42, session: other)
+        )
+    }
+
+    @Test("equal values hash equally")
+    func hashable() {
+        let session = Session(success: true, sessionID: "abc123")
+        let first = AuthenticatedSession(accountID: 42, session: session)
+        let second = AuthenticatedSession(accountID: 42, session: session)
+
+        #expect(Set([first, second]).count == 1)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Account/TMDbAccountServiceAuthenticatedSessionTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Account/TMDbAccountServiceAuthenticatedSessionTests.swift
@@ -72,11 +72,17 @@ struct TMDbAccountServiceAuthenticatedSessionTests {
     func favouriteTVSeriesForwardsAuthenticatedSession() async throws {
         let expectedResult = TVSeriesPageableList.mock()
         apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = FavouriteTVSeriesRequest(
+            sortedBy: nil,
+            page: nil,
+            accountID: accountID,
+            sessionID: session.sessionID
+        )
 
         let result = try await service.favouriteTVSeries(authenticatedSession: authenticatedSession)
 
         #expect(result == expectedResult)
-        #expect(apiClient.lastRequest is FavouriteTVSeriesRequest)
+        #expect(apiClient.lastRequest as? FavouriteTVSeriesRequest == expectedRequest)
     }
 
     @Test("addFavourite(movie:) forwards the authenticated session")
@@ -149,22 +155,34 @@ struct TMDbAccountServiceAuthenticatedSessionTests {
     func movieWatchlistForwardsAuthenticatedSession() async throws {
         let expectedResult = MoviePageableList.mock()
         apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = MovieWatchlistRequest(
+            sortedBy: nil,
+            page: nil,
+            accountID: accountID,
+            sessionID: session.sessionID
+        )
 
         let result = try await service.movieWatchlist(authenticatedSession: authenticatedSession)
 
         #expect(result == expectedResult)
-        #expect(apiClient.lastRequest is MovieWatchlistRequest)
+        #expect(apiClient.lastRequest as? MovieWatchlistRequest == expectedRequest)
     }
 
     @Test("tvSeriesWatchlist forwards the authenticated session")
     func tvSeriesWatchlistForwardsAuthenticatedSession() async throws {
         let expectedResult = TVSeriesPageableList.mock()
         apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = TVSeriesWatchlistRequest(
+            sortedBy: nil,
+            page: nil,
+            accountID: accountID,
+            sessionID: session.sessionID
+        )
 
         let result = try await service.tvSeriesWatchlist(authenticatedSession: authenticatedSession)
 
         #expect(result == expectedResult)
-        #expect(apiClient.lastRequest is TVSeriesWatchlistRequest)
+        #expect(apiClient.lastRequest as? TVSeriesWatchlistRequest == expectedRequest)
     }
 
     @Test("addToWatchlist(movie:) forwards the authenticated session")
@@ -254,22 +272,34 @@ struct TMDbAccountServiceAuthenticatedSessionTests {
     func ratedTVSeriesForwardsAuthenticatedSession() async throws {
         let expectedResult = TVSeriesPageableList.mock()
         apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = RatedTVSeriesRequest(
+            sortedBy: nil,
+            page: nil,
+            accountID: accountID,
+            sessionID: session.sessionID
+        )
 
         let result = try await service.ratedTVSeries(authenticatedSession: authenticatedSession)
 
         #expect(result == expectedResult)
-        #expect(apiClient.lastRequest is RatedTVSeriesRequest)
+        #expect(apiClient.lastRequest as? RatedTVSeriesRequest == expectedRequest)
     }
 
     @Test("ratedTVEpisodes forwards the authenticated session")
     func ratedTVEpisodesForwardsAuthenticatedSession() async throws {
         let expectedResult = TVEpisodePageableList.mock()
         apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = RatedTVEpisodesRequest(
+            sortedBy: nil,
+            page: nil,
+            accountID: accountID,
+            sessionID: session.sessionID
+        )
 
         let result = try await service.ratedTVEpisodes(authenticatedSession: authenticatedSession)
 
         #expect(result == expectedResult)
-        #expect(apiClient.lastRequest is RatedTVEpisodesRequest)
+        #expect(apiClient.lastRequest as? RatedTVEpisodesRequest == expectedRequest)
     }
 
     // MARK: - Lists
@@ -278,11 +308,16 @@ struct TMDbAccountServiceAuthenticatedSessionTests {
     func listsForwardsAuthenticatedSession() async throws {
         let expectedResult = MediaListSummaryPageableList.mock()
         apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = AccountListsRequest(
+            page: nil,
+            accountID: accountID,
+            sessionID: session.sessionID
+        )
 
         let result = try await service.lists(authenticatedSession: authenticatedSession)
 
         #expect(result == expectedResult)
-        #expect(apiClient.lastRequest is AccountListsRequest)
+        #expect(apiClient.lastRequest as? AccountListsRequest == expectedRequest)
     }
 
     // MARK: - Pagination
@@ -351,6 +386,87 @@ struct TMDbAccountServiceAuthenticatedSessionTests {
 
         #expect(pages == 1)
         #expect(apiClient.lastRequest is AccountListsRequest)
+    }
+
+    @Test("allFavouriteTVSeries forwards the authenticated session")
+    func allFavouriteTVSeriesForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(TVSeriesPageableList.mock(page: 1, totalPages: 1)))
+
+        for try await _ in service.allFavouriteTVSeries(authenticatedSession: authenticatedSession) {}
+
+        #expect(apiClient.lastRequest is FavouriteTVSeriesRequest)
+    }
+
+    @Test("allWatchlistTVSeries forwards the authenticated session")
+    func allWatchlistTVSeriesForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(TVSeriesPageableList.mock(page: 1, totalPages: 1)))
+
+        for try await _ in service.allWatchlistTVSeries(authenticatedSession: authenticatedSession) {}
+
+        #expect(apiClient.lastRequest is TVSeriesWatchlistRequest)
+    }
+
+    @Test("allRatedTVSeries forwards the authenticated session")
+    func allRatedTVSeriesForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(TVSeriesPageableList.mock(page: 1, totalPages: 1)))
+
+        for try await _ in service.allRatedTVSeries(authenticatedSession: authenticatedSession) {}
+
+        #expect(apiClient.lastRequest is RatedTVSeriesRequest)
+    }
+
+    @Test("allRatedTVEpisodes forwards the authenticated session")
+    func allRatedTVEpisodesForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(TVEpisodePageableList.mock(page: 1, totalPages: 1)))
+
+        for try await _ in service.allRatedTVEpisodes(authenticatedSession: authenticatedSession) {}
+
+        #expect(apiClient.lastRequest is RatedTVEpisodesRequest)
+    }
+
+    @Test("allFavouriteTVSeriesPages forwards the authenticated session")
+    func allFavouriteTVSeriesPagesForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(TVSeriesPageableList.mock(page: 1, totalPages: 1)))
+
+        for try await _ in service.allFavouriteTVSeriesPages(authenticatedSession: authenticatedSession) {}
+
+        #expect(apiClient.lastRequest is FavouriteTVSeriesRequest)
+    }
+
+    @Test("allWatchlistTVSeriesPages forwards the authenticated session")
+    func allWatchlistTVSeriesPagesForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(TVSeriesPageableList.mock(page: 1, totalPages: 1)))
+
+        for try await _ in service.allWatchlistTVSeriesPages(authenticatedSession: authenticatedSession) {}
+
+        #expect(apiClient.lastRequest is TVSeriesWatchlistRequest)
+    }
+
+    @Test("allRatedMoviesPages forwards the authenticated session")
+    func allRatedMoviesPagesForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(MoviePageableList.mock(page: 1, totalPages: 1)))
+
+        for try await _ in service.allRatedMoviesPages(authenticatedSession: authenticatedSession) {}
+
+        #expect(apiClient.lastRequest is RatedMoviesRequest)
+    }
+
+    @Test("allRatedTVSeriesPages forwards the authenticated session")
+    func allRatedTVSeriesPagesForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(TVSeriesPageableList.mock(page: 1, totalPages: 1)))
+
+        for try await _ in service.allRatedTVSeriesPages(authenticatedSession: authenticatedSession) {}
+
+        #expect(apiClient.lastRequest is RatedTVSeriesRequest)
+    }
+
+    @Test("allRatedTVEpisodesPages forwards the authenticated session")
+    func allRatedTVEpisodesPagesForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(TVEpisodePageableList.mock(page: 1, totalPages: 1)))
+
+        for try await _ in service.allRatedTVEpisodesPages(authenticatedSession: authenticatedSession) {}
+
+        #expect(apiClient.lastRequest is RatedTVEpisodesRequest)
     }
 
 }

--- a/Tests/TMDbTests/Domain/Services/Account/TMDbAccountServiceAuthenticatedSessionTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Account/TMDbAccountServiceAuthenticatedSessionTests.swift
@@ -9,8 +9,10 @@ import Foundation
 import Testing
 @testable import TMDb
 
+// swiftlint:disable file_length
+
 @Suite(.tags(.services, .account))
-struct TMDbAccountServiceAuthenticatedSessionTests {
+struct TMDbAccountServiceAuthenticatedSessionTests { // swiftlint:disable:this type_body_length
 
     var service: TMDbAccountService!
     var apiClient: MockAPIClient!
@@ -470,3 +472,5 @@ struct TMDbAccountServiceAuthenticatedSessionTests {
     }
 
 }
+
+// swiftlint:enable file_length

--- a/Tests/TMDbTests/Domain/Services/Account/TMDbAccountServiceAuthenticatedSessionTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Account/TMDbAccountServiceAuthenticatedSessionTests.swift
@@ -1,0 +1,356 @@
+//
+//  TMDbAccountServiceAuthenticatedSessionTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.services, .account))
+struct TMDbAccountServiceAuthenticatedSessionTests {
+
+    var service: TMDbAccountService!
+    var apiClient: MockAPIClient!
+    var session: Session!
+    let accountID = 123
+
+    init() {
+        self.session = Session(success: true, sessionID: "abc123")
+        self.apiClient = MockAPIClient()
+        self.service = TMDbAccountService(apiClient: apiClient)
+    }
+
+    private var authenticatedSession: AuthenticatedSession {
+        AuthenticatedSession(accountID: accountID, session: session)
+    }
+
+    // MARK: - authenticatedSession(for:)
+
+    @Test("authenticatedSession(for:) bundles the account identifier with the session")
+    func authenticatedSessionForSessionBundlesAccountIDAndSession() async throws {
+        apiClient.addResponse(.success(AccountDetails.mock(id: 999)))
+
+        let result = try await service.authenticatedSession(for: session)
+
+        #expect(result.accountID == 999)
+        #expect(result.session == session)
+        #expect(apiClient.lastRequest as? AccountRequest == AccountRequest(sessionID: session.sessionID))
+    }
+
+    @Test("authenticatedSession(for:) propagates an error from details")
+    func authenticatedSessionForSessionPropagatesError() async throws {
+        apiClient.addResponse(.failure(.unauthorised()))
+
+        await #expect(throws: TMDbError.unauthorised()) {
+            _ = try await service.authenticatedSession(for: session)
+        }
+    }
+
+    // MARK: - Favourites
+
+    @Test("favouriteMovies forwards the authenticated session")
+    func favouriteMoviesForwardsAuthenticatedSession() async throws {
+        let expectedResult = MoviePageableList.mock()
+        apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = FavouriteMoviesRequest(
+            sortedBy: nil,
+            page: nil,
+            accountID: accountID,
+            sessionID: session.sessionID
+        )
+
+        let result = try await service.favouriteMovies(authenticatedSession: authenticatedSession)
+
+        #expect(result == expectedResult)
+        #expect(apiClient.lastRequest as? FavouriteMoviesRequest == expectedRequest)
+    }
+
+    @Test("favouriteTVSeries forwards the authenticated session")
+    func favouriteTVSeriesForwardsAuthenticatedSession() async throws {
+        let expectedResult = TVSeriesPageableList.mock()
+        apiClient.addResponse(.success(expectedResult))
+
+        let result = try await service.favouriteTVSeries(authenticatedSession: authenticatedSession)
+
+        #expect(result == expectedResult)
+        #expect(apiClient.lastRequest is FavouriteTVSeriesRequest)
+    }
+
+    @Test("addFavourite(movie:) forwards the authenticated session")
+    func addFavouriteMovieForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(SuccessResult(success: true)))
+        let expectedRequest = AddFavouriteRequest(
+            showType: .movie,
+            showID: 550,
+            isFavourite: true,
+            accountID: accountID,
+            sessionID: session.sessionID
+        )
+
+        try await service.addFavourite(movie: 550, authenticatedSession: authenticatedSession)
+
+        #expect(apiClient.lastRequest as? AddFavouriteRequest == expectedRequest)
+    }
+
+    @Test("addFavourite(tvSeries:) forwards the authenticated session")
+    func addFavouriteTVSeriesForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(SuccessResult(success: true)))
+        let expectedRequest = AddFavouriteRequest(
+            showType: .tvSeries,
+            showID: 1234,
+            isFavourite: true,
+            accountID: accountID,
+            sessionID: session.sessionID
+        )
+
+        try await service.addFavourite(tvSeries: 1234, authenticatedSession: authenticatedSession)
+
+        #expect(apiClient.lastRequest as? AddFavouriteRequest == expectedRequest)
+    }
+
+    @Test("removeFavourite(movie:) forwards the authenticated session")
+    func removeFavouriteMovieForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(SuccessResult(success: true)))
+        let expectedRequest = AddFavouriteRequest(
+            showType: .movie,
+            showID: 550,
+            isFavourite: false,
+            accountID: accountID,
+            sessionID: session.sessionID
+        )
+
+        try await service.removeFavourite(movie: 550, authenticatedSession: authenticatedSession)
+
+        #expect(apiClient.lastRequest as? AddFavouriteRequest == expectedRequest)
+    }
+
+    @Test("removeFavourite(tvSeries:) forwards the authenticated session")
+    func removeFavouriteTVSeriesForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(SuccessResult(success: true)))
+        let expectedRequest = AddFavouriteRequest(
+            showType: .tvSeries,
+            showID: 1234,
+            isFavourite: false,
+            accountID: accountID,
+            sessionID: session.sessionID
+        )
+
+        try await service.removeFavourite(tvSeries: 1234, authenticatedSession: authenticatedSession)
+
+        #expect(apiClient.lastRequest as? AddFavouriteRequest == expectedRequest)
+    }
+
+    // MARK: - Watchlist
+
+    @Test("movieWatchlist forwards the authenticated session")
+    func movieWatchlistForwardsAuthenticatedSession() async throws {
+        let expectedResult = MoviePageableList.mock()
+        apiClient.addResponse(.success(expectedResult))
+
+        let result = try await service.movieWatchlist(authenticatedSession: authenticatedSession)
+
+        #expect(result == expectedResult)
+        #expect(apiClient.lastRequest is MovieWatchlistRequest)
+    }
+
+    @Test("tvSeriesWatchlist forwards the authenticated session")
+    func tvSeriesWatchlistForwardsAuthenticatedSession() async throws {
+        let expectedResult = TVSeriesPageableList.mock()
+        apiClient.addResponse(.success(expectedResult))
+
+        let result = try await service.tvSeriesWatchlist(authenticatedSession: authenticatedSession)
+
+        #expect(result == expectedResult)
+        #expect(apiClient.lastRequest is TVSeriesWatchlistRequest)
+    }
+
+    @Test("addToWatchlist(movie:) forwards the authenticated session")
+    func addToWatchlistMovieForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(SuccessResult(success: true)))
+        let expectedRequest = AddToWatchlistRequest(
+            showType: .movie,
+            showID: 550,
+            isInWatchlist: true,
+            accountID: accountID,
+            sessionID: session.sessionID
+        )
+
+        try await service.addToWatchlist(movie: 550, authenticatedSession: authenticatedSession)
+
+        #expect(apiClient.lastRequest as? AddToWatchlistRequest == expectedRequest)
+    }
+
+    @Test("removeFromWatchlist(tvSeries:) forwards the authenticated session")
+    func removeFromWatchlistTVSeriesForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(SuccessResult(success: true)))
+        let expectedRequest = AddToWatchlistRequest(
+            showType: .tvSeries,
+            showID: 1234,
+            isInWatchlist: false,
+            accountID: accountID,
+            sessionID: session.sessionID
+        )
+
+        try await service.removeFromWatchlist(tvSeries: 1234, authenticatedSession: authenticatedSession)
+
+        #expect(apiClient.lastRequest as? AddToWatchlistRequest == expectedRequest)
+    }
+
+    @Test("addToWatchlist(tvSeries:) forwards the authenticated session")
+    func addToWatchlistTVSeriesForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(SuccessResult(success: true)))
+        let expectedRequest = AddToWatchlistRequest(
+            showType: .tvSeries,
+            showID: 1234,
+            isInWatchlist: true,
+            accountID: accountID,
+            sessionID: session.sessionID
+        )
+
+        try await service.addToWatchlist(tvSeries: 1234, authenticatedSession: authenticatedSession)
+
+        #expect(apiClient.lastRequest as? AddToWatchlistRequest == expectedRequest)
+    }
+
+    @Test("removeFromWatchlist(movie:) forwards the authenticated session")
+    func removeFromWatchlistMovieForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(SuccessResult(success: true)))
+        let expectedRequest = AddToWatchlistRequest(
+            showType: .movie,
+            showID: 550,
+            isInWatchlist: false,
+            accountID: accountID,
+            sessionID: session.sessionID
+        )
+
+        try await service.removeFromWatchlist(movie: 550, authenticatedSession: authenticatedSession)
+
+        #expect(apiClient.lastRequest as? AddToWatchlistRequest == expectedRequest)
+    }
+
+    // MARK: - Rated
+
+    @Test("ratedMovies forwards the authenticated session")
+    func ratedMoviesForwardsAuthenticatedSession() async throws {
+        let expectedResult = MoviePageableList.mock()
+        apiClient.addResponse(.success(expectedResult))
+        let expectedRequest = RatedMoviesRequest(
+            sortedBy: nil,
+            page: nil,
+            accountID: accountID,
+            sessionID: session.sessionID
+        )
+
+        let result = try await service.ratedMovies(authenticatedSession: authenticatedSession)
+
+        #expect(result == expectedResult)
+        #expect(apiClient.lastRequest as? RatedMoviesRequest == expectedRequest)
+    }
+
+    @Test("ratedTVSeries forwards the authenticated session")
+    func ratedTVSeriesForwardsAuthenticatedSession() async throws {
+        let expectedResult = TVSeriesPageableList.mock()
+        apiClient.addResponse(.success(expectedResult))
+
+        let result = try await service.ratedTVSeries(authenticatedSession: authenticatedSession)
+
+        #expect(result == expectedResult)
+        #expect(apiClient.lastRequest is RatedTVSeriesRequest)
+    }
+
+    @Test("ratedTVEpisodes forwards the authenticated session")
+    func ratedTVEpisodesForwardsAuthenticatedSession() async throws {
+        let expectedResult = TVEpisodePageableList.mock()
+        apiClient.addResponse(.success(expectedResult))
+
+        let result = try await service.ratedTVEpisodes(authenticatedSession: authenticatedSession)
+
+        #expect(result == expectedResult)
+        #expect(apiClient.lastRequest is RatedTVEpisodesRequest)
+    }
+
+    // MARK: - Lists
+
+    @Test("lists forwards the authenticated session")
+    func listsForwardsAuthenticatedSession() async throws {
+        let expectedResult = MediaListSummaryPageableList.mock()
+        apiClient.addResponse(.success(expectedResult))
+
+        let result = try await service.lists(authenticatedSession: authenticatedSession)
+
+        #expect(result == expectedResult)
+        #expect(apiClient.lastRequest is AccountListsRequest)
+    }
+
+    // MARK: - Pagination
+
+    @Test("allFavouriteMovies forwards the authenticated session")
+    func allFavouriteMoviesForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(MoviePageableList.mock(page: 1, totalPages: 1)))
+
+        var items = [MovieListItem]()
+        for try await item in service.allFavouriteMovies(authenticatedSession: authenticatedSession) {
+            items.append(item)
+        }
+
+        #expect(!items.isEmpty)
+        #expect(apiClient.lastRequest is FavouriteMoviesRequest)
+    }
+
+    @Test("allWatchlistMovies forwards the authenticated session")
+    func allWatchlistMoviesForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(MoviePageableList.mock(page: 1, totalPages: 1)))
+
+        for try await _ in service.allWatchlistMovies(authenticatedSession: authenticatedSession) {}
+
+        #expect(apiClient.lastRequest is MovieWatchlistRequest)
+    }
+
+    @Test("allRatedMovies forwards the authenticated session")
+    func allRatedMoviesForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(MoviePageableList.mock(page: 1, totalPages: 1)))
+
+        for try await _ in service.allRatedMovies(authenticatedSession: authenticatedSession) {}
+
+        #expect(apiClient.lastRequest is RatedMoviesRequest)
+    }
+
+    @Test("allLists forwards the authenticated session")
+    func allListsForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(MediaListSummaryPageableList.mock(page: 1, totalPages: 1)))
+
+        for try await _ in service.allLists(authenticatedSession: authenticatedSession) {}
+
+        #expect(apiClient.lastRequest is AccountListsRequest)
+    }
+
+    @Test("allFavouriteMoviesPages forwards the authenticated session")
+    func allFavouriteMoviesPagesForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(MoviePageableList.mock(page: 1, totalPages: 1)))
+
+        var pages = 0
+        for try await _ in service.allFavouriteMoviesPages(authenticatedSession: authenticatedSession) {
+            pages += 1
+        }
+
+        #expect(pages == 1)
+        #expect(apiClient.lastRequest is FavouriteMoviesRequest)
+    }
+
+    @Test("allListsPages forwards the authenticated session")
+    func allListsPagesForwardsAuthenticatedSession() async throws {
+        apiClient.addResponse(.success(MediaListSummaryPageableList.mock(page: 1, totalPages: 1)))
+
+        var pages = 0
+        for try await _ in service.allListsPages(authenticatedSession: authenticatedSession) {
+            pages += 1
+        }
+
+        #expect(pages == 1)
+        #expect(apiClient.lastRequest is AccountListsRequest)
+    }
+
+}

--- a/knowledge/decisions/0005-authenticated-session-additive-overloads.md
+++ b/knowledge/decisions/0005-authenticated-session-additive-overloads.md
@@ -1,0 +1,70 @@
+# ADR-0005: `AuthenticatedSession` via additive extension overloads
+
+- **Status:** Accepted
+- **Date:** 2026-06-18
+- **Deciders:** Adam Young
+
+## Context
+
+`AccountService` threads two arguments — `accountID: Int` and `session: Session`
+— through every account-scoped method: 16 core methods plus 16 auto-pagination
+methods (`AccountService+Pagination.swift`), 32 in total. Callers must obtain the
+account id (from `details(session:).id`) and carry both values everywhere, which
+is verbose and easy to mismatch.
+
+We wanted a single first-class "authenticated user" value to pass instead. The
+constraint that shaped the design: `AccountService` is a **`public protocol`**
+(external code can conform to it), the project builds with **`--Werror`**
+(warnings are errors), and the package's own `+Pagination` / `+Defaults`
+extensions call the existing methods internally.
+
+## Decision
+
+Add a public value type **`AuthenticatedSession`** (`accountID` + `session`;
+`Equatable, Hashable, Sendable`) and **32 `authenticatedSession:` overloads** as
+**protocol-extension defaults** that forward to the existing
+`(accountID:session:)` methods, plus a convenience
+`AccountService.authenticatedSession(for:)` that fetches `details(session:)` and
+bundles the result.
+
+The change is **purely additive and non-breaking**:
+
+- The new overloads are **extension defaults, not protocol requirements**. Adding
+  a requirement to a public protocol is source-breaking for every external
+  conformer; an extension default is not.
+- The existing `(accountID:session:)` methods are **left in place and not
+  deprecated**.
+- `AuthenticatedSession` is **not `Codable`** — no API endpoint produces it, and
+  adding `Codable` speculatively would bake a permanent serialization contract
+  for a credential (`session.sessionID`). Persistence, if needed, is the caller's
+  secure-storage responsibility.
+- All 32 methods are covered (not just the 16 obvious core methods), so the
+  wrapper is usable end-to-end including auto-pagination.
+
+## Consequences
+
+- Consumers get a one-value API (`favouriteMovies(authenticatedSession:)`) while
+  existing call sites keep working unchanged — ships as a **minor** release.
+- Two parallel surfaces now exist per method. The DocC `AccountService.md` lists
+  both, with the `authenticatedSession:` form documented as preferred.
+- If the `(accountID:session:)` forms are ever to be retired, that is a **major**
+  version's work (they are protocol requirements), and the internal `+Pagination`
+  / `+Defaults` callers must migrate first (see Alternatives).
+
+## Alternatives considered
+
+- **New methods as protocol requirements** (so the new form is "canonical").
+  Rejected: source-breaking for external conformers — the exact opposite of the
+  goal.
+- **Deprecate the old `(accountID:session:)` methods** ("deprecate-and-add").
+  Rejected: on a public protocol the requirements can't be removed in a minor
+  release regardless, and because the package's own extensions call them, a
+  `@available(*, deprecated)` would emit warnings that fail the `--Werror` build
+  until every internal caller migrated. On a public, internally-consumed
+  protocol, "deprecate-and-add" realistically reduces to "add an extension and
+  document the new form as preferred" — which is what we did.
+- **Add `Codable` to `AuthenticatedSession`** for "remembered login". Rejected as
+  YAGNI; revisit with a fixture-pinned format if a real need appears.
+
+Relates to [ADR-0004](0004-service-parameter-name-convention.md) (the other
+recent AccountService API-ergonomics decision).

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -10,6 +10,31 @@ Format: **Feature / PR** · date · weight · *what worked* · *friction* ·
 
 ---
 
+## 2026-06-18 — ✨ AuthenticatedSession wrapper for AccountService (#346) · full
+
+- **Worked:** the full pipeline earned its keep on the only genuinely risky change
+  of the session. `/review-plan`'s three critics **unanimously** caught three
+  blockers *before* a line was written — (1) adding methods as public-protocol
+  *requirements* would break external conformers, (2) the 16 auto-pagination
+  methods were omitted from scope, (3) deprecating the old forms would cascade
+  `--Werror` failures through the package's own internal callers — which reversed
+  the user's earlier "deprecate-and-add" choice to a clean additive design. The
+  fan-out `/review-changes` then caught real coverage gaps (9 untested pagination
+  forwards). 2,700 unit tests, ADR-0005.
+- **Friction:** local `make ci` reported lint **green**, but the PR's CI `Lint`
+  job failed on `file_length`/`type_body_length` for the two new oversized files —
+  a real local-vs-CI lint discrepancy that cost a CI round-trip. Adding the
+  `swiftlint:disable` directives (matching `AccountService+Pagination.swift`'s
+  precedent) fixed it; a fresh `make lint` then agreed with CI.
+- **Deviations:** stopped mid-Phase-1 to surface the deprecation blocker to the
+  user (legitimate per the contract — it reversed an explicit prior decision).
+- **Improvement:** the local-vs-CI lint gap is the highest-value fix. `make ci`'s
+  lint step passed locally on violations CI caught (stale SwiftLint cache, or a
+  config/path difference) — so the mandatory gate gave a false green. Recommend
+  `/pr` run a fresh `make lint` (or `swiftlint --no-cache`) as part of step 4,
+  rather than trusting `make ci`'s lint leg, so file-size violations on new files
+  surface locally.
+
 ## 2026-06-18 — 📝 Add error-handling How-To guide (#344) · lite (docs-only)
 
 - **Worked:** reading the real source first (`TMDbError+TMDbAPIError.swift` for the

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -46,6 +46,23 @@ members). Every time, `swift build` / `make build-tests` reported **0 errors /
 
 ## Public API
 
+### Growing a public protocol additively: extension defaults, and the `--Werror` deprecation trap
+
+*2026-06-18.* Two traps when adding API to a **`public protocol`** (e.g.
+`AccountService`) — see [ADR-0005](decisions/0005-authenticated-session-additive-overloads.md):
+
+- **Adding a method as a protocol *requirement* is source-breaking** for every
+  external type that conforms to the protocol (they suddenly lack an
+  implementation). To add API non-breakingly, declare it as a **protocol-extension
+  default**, never a new requirement.
+- **Deprecating a method the package calls internally fails the build.** The build
+  runs `--Werror`, so a `@available(*, deprecated)` method that the library's own
+  code still calls (e.g. `AccountService+Pagination` calling the base account
+  methods) turns those internal call sites into deprecation-warning *errors*. To
+  deprecate such a method you must migrate every in-`Sources` caller first — or, on
+  a public protocol whose requirements can't be removed in a minor release anyway,
+  simply don't deprecate (add the new form and document it as preferred).
+
 ### Renaming a method's *internal* parameter name is source- and ABI-compatible
 
 *2026-06-18.* Renaming the **second** (internal) name in a parameter —


### PR DESCRIPTION
## Summary

Adds an `AuthenticatedSession` value that bundles the `accountID` + `session`
pair which `AccountService` methods previously threaded as two separate
arguments. This collapses account-scoped call sites to a single value and makes
"an authenticated user" a first-class type. **Fully additive and non-breaking** —
no protocol requirements changed, nothing deprecated, all existing methods and
tests untouched.

## Changes

**New model (`✨`):**
- ✨ `AuthenticatedSession` — `accountID` + `session`; `Equatable`, `Hashable`,
  `Sendable` (deliberately not `Codable`). `session.sessionID` is a credential;
  persistence is the caller's responsibility.

**New API (`✨`, all as protocol-extension defaults — additive):**
- ✨ `AccountService.authenticatedSession(for:)` — fetches `details(session:)`
  and bundles the result (documented as performing a network request / throwing).
- ✨ 32 `authenticatedSession:` overloads — the 16 core account methods + the 16
  auto-pagination methods — each forwarding to the existing
  `(accountID:session:)` form.

**Tests (`✅`):**
- ✅ `AuthenticatedSession` value-semantics tests; `authenticatedSession(for:)`
  happy + error path; per-shape full-request-equality (proving accountID/session
  passthrough) + both movie/tvSeries variants; smoke tests for every pagination
  forward. 2,700 unit tests pass.

**Documentation (`📝`):**
- 📝 ADR-0005 (additive-overloads design + why not requirements / not deprecated)
  and a public-protocol gotcha; DocC catalog, `ManagingUserAccounts` How-To, and
  README account example updated to the single-value flow.

## Benefits

- **Cleaner account API**: `favouriteMovies(authenticatedSession:)` instead of
  threading `accountID:` + `session:` through every call.
- **Zero migration cost**: non-breaking; existing code keeps working.

## Testing

- ✅ `make ci` passes (lint, markdown lint, unit + integration tests, release
  build, docs build). Reviewed via fan-out `/review-changes` — 0 Critical/High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)