### PR TITLE
🔧 Re-lint new Swift files without the cache in /pr skill

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -47,6 +47,13 @@ git diff --name-only main...HEAD | grep -qE '\.swift$' || echo "no-swift → ski
         ```
 
         The PR's own CI still runs the full matrix regardless, so this only trims the **local** gate; it never lowers what actually guards `main`. When in doubt, run full `make ci`.
+    - **Re-lint new Swift files without the cache.** `make ci`'s lint leg is `swiftlint --strict .` (Makefile), and SwiftLint **caches results** (`~/Library/Caches/SwiftLint`). On **newly-added** `.swift` files this has been seen to report a **false green** locally — passing `file_length` / `type_body_length` that the PR's CI `Lint` job (a clean checkout, no cache) then fails on. So **when the diff adds any new `.swift` file** (`git diff --name-only --diff-filter=A main...HEAD | grep -q '\.swift$'`), run a cache-bypassing lint before trusting the gate:
+
+        ```bash
+        swiftlint lint --strict --no-cache .
+        ```
+
+        Fix anything it flags (oversized files: split, or add a `// swiftlint:disable` directive matching the `AccountService+Pagination.swift` precedent) and re-run. This catches file-size violations locally instead of on a CI round-trip.
 5. *(skip in `reviewed` mode or when no Swift changed)* Spawn the `code-reviewer` agent to perform a code review of all changes (pass the git diff output as context)
 6. *(skip in `reviewed` mode or when no Swift changed)* Summarize the code review findings:
     - List any critical or high-severity issues that should be addressed


### PR DESCRIPTION
## Summary

Hardens the `/pr` skill's pre-PR gate against a SwiftLint caching false-green.
`make ci`'s lint leg is `swiftlint --strict .` (Makefile), and SwiftLint caches
results in `~/Library/Caches/SwiftLint`. On **newly-added** `.swift` files this
was observed reporting a local green for `file_length` / `type_body_length`
violations that the PR's clean-checkout CI `Lint` job then failed — costing a CI
round-trip (seen on #346).

## Changes

**`.claude/skills/pr/SKILL.md`:**
- 🔧 Step 4 now runs `swiftlint lint --strict --no-cache .` whenever the diff
  **adds** a new `.swift` file (`git diff --diff-filter=A`), before trusting the
  gate — with guidance to fix oversized files by splitting or adding a
  `// swiftlint:disable` directive (matching the `AccountService+Pagination.swift`
  precedent).

## Benefits

- **No more lint false-greens on new files**: file-size violations surface
  locally instead of on a CI round-trip. The PR's CI Lint job remains the
  ultimate authority; this just front-runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)