### PR TITLE
📝 Make /deliver knowledge handoffs explicit and add recurring-pattern scan

### DIFF
--- a/.claude/skills/capture-knowledge/SKILL.md
+++ b/.claude/skills/capture-knowledge/SKILL.md
@@ -36,11 +36,13 @@ Quality over volume: a few high-signal entries beat a long dump.
 
 ## Steps
 
-1. **Start from the candidates list, if one exists.** If the caller kept a running
-   **knowledge-candidates** list while working (e.g. `/deliver`'s ledger), use it
-   as your input — that's the reliable source, jotted while the learnings were
-   fresh. Otherwise, reconstruct candidates by reviewing the work just done — the
-   diff, the dead-ends, the things you looked up, the decisions you made.
+1. **Start from the candidates list, if one exists.** If the caller passed a
+   **knowledge-candidates** list as the argument (`$ARGUMENTS` below — `/deliver`
+   pastes its ledger list here), use that as your input — that's the reliable
+   source, jotted while the learnings were fresh, and it reaches you intact even
+   if the caller's context was compacted. Otherwise, reconstruct candidates by
+   reviewing the work just done — the diff, the dead-ends, the things you looked
+   up, the decisions you made.
 2. **Filter** against "What NOT to capture". Drop the rest.
 3. **Check for duplicates** — skim the relevant `knowledge/` file; **update** an
    existing entry rather than adding a near-duplicate.

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -64,6 +64,39 @@ These are non-negotiable. Do them by default, without being reminded.
    (`<category>: <gist> [where]`). Phase 3.5 curates this list; reconstructing it
    at the end loses the best material (and may not survive compaction).
 
+## Auto mode (unattended)
+
+`/deliver auto` runs the **entire** pipeline with **no human interaction** — every
+mid-run decision that would normally stop and ask the user is instead resolved by
+an **adversarial panel** of three Opus subagents, and the conductor acts on their
+majority verdict and keeps going through Phase 6.
+
+**The panel.** At each decision point, convene three subagents in parallel, each
+given the same context (the decision, the evidence, the options):
+
+- **Proceed** — argues the case for continuing the pipeline.
+- **Stop** — argues the case for halting and handing back to the user.
+- **Devil's advocate** — attacks whichever way looks easiest, so the other two
+  can't converge on a comfortable answer unchallenged.
+
+Each returns a one-line verdict (`proceed` / `stop`) and its reasoning. **Majority
+wins.** The conductor records the outcome in the ledger and continues — `proceed`
+resumes the pipeline; `stop` ends the run with the usual status summary.
+
+**Audit trail.** For **every** panel convened, write a ledger entry recording: the
+**decision point**, the **three subagent verdicts**, the **majority outcome**, and
+a **one-line rationale**. The point of `auto` is autonomy *with* a full record of
+why each call was made — a run that went unattended must still be reviewable.
+
+**The one exception — never delegated.** A Phase 1 `blocker` where the plan would
+cause **data loss** or a **breaking change** is **always a hard stop**, even in
+`auto`. It is too consequential to hand to a panel: surface it to the user and
+wait. (Every other decision point — including all *other* Phase 1 blockers — goes
+to the panel.)
+
+Each decision point below marks its **Auto:** branch. In the default (attended)
+mode those branches do not apply — the pipeline stops and asks, as written.
+
 ## Delivery weight — auto-scale to risk (lite vs full)
 
 `/deliver` sizes its machinery to the change, automatically — no flag. Judge the
@@ -171,6 +204,9 @@ does not re-ask for approval.
     wrong, a breaking change, data-loss, etc.), **stop and surface it** before
     implementing. A blocker means the approved plan would do harm; that's worth the
     interruption. Improvements/`major`/`minor` are folded in and you proceed.
+    - **Auto:** a **data-loss or breaking-change** blocker is **always a hard
+      stop** (the never-delegated exception). For **any other** blocker, convene
+      the panel to decide proceed vs stop and act on the majority verdict.
 
 ## Phase 2 — Implement the plan
 
@@ -234,6 +270,8 @@ reconcile) for a large/multi-unit one. Then converge:
    Critical/High findings remain.
 4. **Cap at 3 iterations.** If Critical/High issues persist after three rounds,
    stop and surface them to the user — don't loop forever or paper over them.
+   - **Auto:** convene the panel. **Proceed** → note the unresolved Critical/High
+     findings in the PR description and continue; **stop** → surface to the user.
 
 Medium/Low findings: apply the cheap, clearly-correct ones; note the rest in the
 PR description rather than blocking on them.
@@ -276,6 +314,8 @@ then push the branch and open the PR with a gitmoji title and structured body.
    test/file against `git diff --name-only main...HEAD`.
 2. **In-diff genuine failure** → it's yours: fix it (test-first), commit, re-run
    `make ci`. Only **stop and report** if it can't converge.
+   - **Auto:** when it can't converge, convene the panel. **Proceed** → open the
+     PR with the known-failing check noted in its description; **stop** → report.
 3. **Pre-existing / unrelated** — the failing test isn't in your diff and (for a
    live integration test) often passes in isolation / on a re-run → it's a `main`
    problem, not yours. Hand it to **`/fix-integration-failures`** (it fixes the
@@ -297,6 +337,13 @@ it to the user for the final merge** — `/deliver` does not merge by default. R
 the PR URL and its ready state, then run Phase 6. If `/watch-pr` reports the PR is
 **stuck** (a check it can't fix, or a human-decision review thread), stop and
 summarise what's blocking.
+
+> **Auto:** on a stuck PR, convene the panel to decide **wait-and-retry vs stop**.
+> **Proceed** (majority to keep trying) → schedule a later re-check with
+> `ScheduleWakeup` and resume `/watch-pr` when it fires; **stop** (majority) → end
+> the run and report what's blocking. The ready-to-merge gate itself is **not** a
+> panel decision: in `auto` it behaves exactly as the `merge` opt-in below — once
+> the PR is ready, proceed to Phase 6 (and merge if `merge` was passed).
 
 > **Opt-in auto-merge:** if the user explicitly passes `merge` to `/deliver`,
 > forward it to `/watch-pr` (`/watch-pr merge`) so it squash-merges once ready, and
@@ -355,6 +402,10 @@ what turns one-off retros into reviewed skill improvements:
    wait for **explicit approval on each one** before changing anything. If no
    *new* pattern recurs across multiple entries, **say so and stop** — emit no
    proposals.
+   - **Auto:** don't wait for the user. The panel reviews **each** proposal and
+     **applies approved ones directly** (edit the skill, commit). Rejected
+     proposals are still recorded in `skill-improvement-log.md` with the panel's
+     rationale (step 4).
 4. **Record every decision in the log.** For each proposal you presented, append
    an entry to
    [`knowledge/skill-improvement-log.md`](../../../knowledge/skill-improvement-log.md)

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -118,6 +118,12 @@ it never bloats or biases the main window:
   mis-framed — a non-breaking change mistaken for breaking, a false-positive
   "bug", a "fix" that was really a clarity tweak.
 - **State the goal** in a sentence so every downstream phase is anchored to it.
+- **Pull relevant context from the wiki** (best-effort). If the personal `wiki`
+  MCP is available, call `get_context` on the goal to surface any of Adam's
+  durable preferences, prior decisions, or conventions that bear on the approach,
+  and let them calibrate the plan and the review emphasis. **Degrade silently** if
+  the wiki MCP is absent (a contributor's machine, a headless/cron run) — never
+  block the pipeline on it.
 - **Judge the delivery weight** (lite vs full) from the plan, and open the
   `TaskCreate` ledger (Contract §6).
 
@@ -304,6 +310,10 @@ Reflect on *this* delivery and write a dated entry to
 [`knowledge/delivery-retros.md`](../../../knowledge/delivery-retros.md):
 
 - **Feature / PR**, date, and delivery weight (lite/full).
+- **Phases completed / Skills invoked** — a compact one-liner each (e.g. phases
+  `0–6`; skills `review-plan, implement-plan, review-changes, capture-knowledge,
+  pr, watch-pr`). This is telemetry for the recurring-pattern scan: over time it
+  shows which skills fire, which phases get skipped, and where deliveries stop.
 - **What worked** — one or two things the pipeline did well.
 - **Friction** — where it was rough, slow, or stopped unnecessarily.
 - **Deviations** — anywhere you had to depart from this skill to do the right
@@ -322,8 +332,9 @@ Once the retro entry is committed, do a structured cross-delivery scan — this 
 what turns one-off retros into reviewed skill improvements:
 
 1. **Read the whole history.** Read all of
-   [`knowledge/delivery-retros.md`](../../../knowledge/delivery-retros.md) and
-   **every** `SKILL.md` under `.claude/skills/` (including the sub-skills those
+   [`knowledge/delivery-retros.md`](../../../knowledge/delivery-retros.md),
+   [`knowledge/skill-improvement-log.md`](../../../knowledge/skill-improvement-log.md),
+   and **every** `SKILL.md` under `.claude/skills/` (including the sub-skills those
    skills reference).
 2. **Find what recurs.** For any friction, deviation, or improvement suggestion
    that appears in **more than one** retro entry, write a numbered proposal in
@@ -336,10 +347,20 @@ what turns one-off retros into reviewed skill improvements:
    Proposed change: [exact new wording and location]
    Rationale: [one sentence on why this eliminates the pattern]
 
+   **Skip any pattern already decided in `skill-improvement-log.md`** — one
+   already **applied** (the fix is in the skill), or **deferred/rejected** (don't
+   re-propose a settled *no*; only resurface it if its recorded "reconsider when…"
+   condition now holds).
 3. **Stop and ask.** **Do not edit any skill files.** Present the proposals and
    wait for **explicit approval on each one** before changing anything. If no
-   pattern recurs across multiple entries, **say so and stop** — emit no
+   *new* pattern recurs across multiple entries, **say so and stop** — emit no
    proposals.
+4. **Record every decision in the log.** For each proposal you presented, append
+   an entry to
+   [`knowledge/skill-improvement-log.md`](../../../knowledge/skill-improvement-log.md)
+   — **applied** (with the skill + commit it landed in), **deferred**, or
+   **rejected** (with the rationale and any "reconsider when…" condition). This is
+   what stops the scan re-proposing a settled call next time.
 
 ## When the pipeline stops
 

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -249,9 +249,9 @@ in the ledger (Contract §7) as the skill argument** (`$ARGUMENTS`) — paste th
 list lines into the invocation rather than assuming the skill can still see the
 ledger in context. The ledger may have been summarised away by now; the argument
 travels with the call, so the candidates reach the skill even after compaction.
-Its job here is to **curate** that list — filter
-to the durable, non-obvious, reusable items, dedup against existing `knowledge/`
-entries, and write them into the right file (gotchas / API notes / a new ADR for
+Its job here is to **curate** that list — filter to the durable, non-obvious,
+reusable items, dedup against existing `knowledge/` entries, and write them into
+the right file (gotchas / API notes / a new ADR for
 decisions). Starting from the running list is the whole point — it captures the
 learnings you'd have forgotten by now.
 

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -109,6 +109,14 @@ it never bloats or biases the main window:
 - **A plan must exist.** Locate it the way `/review-plan` does (named target →
   plan-mode plan → most recent plan in the conversation). If there is no plan,
   stop and tell the user to run `/plan` first — do not invent one.
+- **If the plan originates from a review finding, verify it first.** When the
+  delivery comes from a code-review / source-review *finding* rather than a
+  user-authored plan, treat the finding as a **hypothesis, not an approved
+  plan**: do a quick `Explore` pass to confirm it against the actual code (Is it
+  real? Is the framing right? Breaking or not?) **before** drafting the plan or
+  asking the user any strategy questions. Review findings have repeatedly been
+  mis-framed — a non-breaking change mistaken for breaking, a false-positive
+  "bug", a "fix" that was really a clarity tweak.
 - **State the goal** in a sentence so every downstream phase is anchored to it.
 - **Judge the delivery weight** (lite vs full) from the plan, and open the
   `TaskCreate` ledger (Contract §6).

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -358,9 +358,12 @@ what turns one-off retros into reviewed skill improvements:
 4. **Record every decision in the log.** For each proposal you presented, append
    an entry to
    [`knowledge/skill-improvement-log.md`](../../../knowledge/skill-improvement-log.md)
-   — **applied** (with the skill + commit it landed in), **deferred**, or
-   **rejected** (with the rationale and any "reconsider when…" condition). This is
-   what stops the scan re-proposing a settled call next time.
+   **in the five-field format documented at the top of that file** (date · title ·
+   status; Pattern / Decision / Rationale / Reconsider when) — **applied** (with
+   the skill + commit it landed in), **deferred**, or **rejected**. The **Decision**
+   (status) and **Reconsider when** fields are exactly what step 2's dedup keys on,
+   so keep them on every entry; this is what stops the scan re-proposing a settled
+   call next time.
 
 ## When the pipeline stops
 

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -230,8 +230,12 @@ mode (Phase 4) so it won't deep-review the identical code again.
 
 ## Phase 3.5 — Capture learnings
 
-Invoke **`/capture-knowledge`**, handing it the **knowledge-candidates list** you
-kept in the ledger (Contract §7). Its job here is to **curate** that list — filter
+Invoke **`/capture-knowledge`**, **passing the knowledge-candidates list you kept
+in the ledger (Contract §7) as the skill argument** (`$ARGUMENTS`) — paste the
+list lines into the invocation rather than assuming the skill can still see the
+ledger in context. The ledger may have been summarised away by now; the argument
+travels with the call, so the candidates reach the skill even after compaction.
+Its job here is to **curate** that list — filter
 to the durable, non-obvious, reusable items, dedup against existing `knowledge/`
 entries, and write them into the right file (gotchas / API notes / a new ADR for
 decisions). Starting from the running list is the whole point — it captures the
@@ -300,9 +304,34 @@ Reflect on *this* delivery and write a dated entry to
   sub-skill) suggested by this run.
 
 Keep it to a handful of bullets — a log, not a ceremony. Then **scan recent
-entries**: if the same friction or deviation recurs across deliveries, fold the fix
-into the relevant skill (and say you're doing so). Commit the retro with the PR when
-possible (watch-only), or as a small follow-up when auto-merged.
+entries** for recurring friction or deviations — the recurring-pattern scan below
+formalizes this. Commit the retro with the PR when possible (watch-only), or as a
+small follow-up when auto-merged.
+
+### Recurring-pattern scan (after committing the retro)
+
+Once the retro entry is committed, do a structured cross-delivery scan — this is
+what turns one-off retros into reviewed skill improvements:
+
+1. **Read the whole history.** Read all of
+   [`knowledge/delivery-retros.md`](../../../knowledge/delivery-retros.md) and
+   **every** `SKILL.md` under `.claude/skills/` (including the sub-skills those
+   skills reference).
+2. **Find what recurs.** For any friction, deviation, or improvement suggestion
+   that appears in **more than one** retro entry, write a numbered proposal in
+   this exact format:
+
+   Pattern: [what keeps happening]
+   Seen in: [retro dates / feature names]
+   Skill: [relative path to SKILL.md]
+   Current text: [exact existing wording, or "missing"]
+   Proposed change: [exact new wording and location]
+   Rationale: [one sentence on why this eliminates the pattern]
+
+3. **Stop and ask.** **Do not edit any skill files.** Present the proposals and
+   wait for **explicit approval on each one** before changing anything. If no
+   pattern recurs across multiple entries, **say so and stop** — emit no
+   proposals.
 
 ## When the pipeline stops
 

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -13,6 +13,8 @@ this directory; the detail lives here and is read on demand.
 | [`decisions/`](decisions/) | **ADRs** — Architecture Decision Records, one per decision, numbered + dated. Use for any non-obvious design choice and its rationale. |
 | [`gotchas.md`](gotchas.md) | Implementation quirks, things that bit us, tooling traps, and anything that needed a web search / lookup to resolve. |
 | [`tmdb-api-notes.md`](tmdb-api-notes.md) | Behaviours of the **live TMDb API** discovered while implementing (nullable/absent fields, undocumented quirks, response-shape surprises). |
+| [`delivery-retros.md`](delivery-retros.md) | A short retrospective per feature delivered via `/deliver` (its Phase 6) — what worked, friction, deviations, one improvement. |
+| [`skill-improvement-log.md`](skill-improvement-log.md) | Decisions on every skill-improvement proposal from `/deliver`'s Phase 6 recurring-pattern scan (applied / deferred / rejected), so the scan doesn't re-propose settled calls. |
 
 ## How to use it
 

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -5,8 +5,8 @@ at the top. The point is **continuous improvement**: when the same friction or
 deviation recurs across entries, fold the fix into the relevant skill. Keep each
 entry to a handful of bullets — a log, not a ceremony.
 
-Format: **Feature / PR** · date · weight · *what worked* · *friction* ·
-*deviations* · *one improvement*.
+Format: **Feature / PR** · date · weight · *phases completed / skills invoked* ·
+*what worked* · *friction* · *deviations* · *one improvement*.
 
 ---
 

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -1,0 +1,86 @@
+# Skill-Improvement Log
+
+A durable record of every skill-improvement proposal raised by `/deliver`'s
+**Phase 6 recurring-pattern scan**, and the decision on it. Newest at the top.
+
+**Why this exists:** the Phase 6 scan surfaces proposals and waits for approval.
+Without a memory of past decisions, it would re-propose ideas already **applied**
+or deliberately **deferred/rejected** — wasting attention and re-litigating
+settled calls. The scan **consults this log before proposing** and skips any
+pattern already decided here. Record both the *yes* and the *no* (with rationale)
+— the *no*s are what stop the loop repeating itself.
+
+Status values: **applied** · **deferred** · **rejected**.
+
+Format per entry:
+
+```text
+### <date> — <short title> · <applied|deferred|rejected>
+- **Pattern:** what kept recurring (and the retro entries it appeared in).
+- **Decision:** what was agreed, and where it landed (skill + commit/PR) if applied.
+- **Rationale:** one or two sentences — why this call. For deferred/rejected,
+  the condition under which it should be reconsidered.
+```
+
+---
+
+### 2026-06-18 — Telemetry (phases completed + skills invoked) in retro · applied
+
+- **Pattern:** retros captured friction but no signal on which skills fire, which
+  phases run, or where sessions stop — leaving the recurring-pattern scan
+  under-informed.
+- **Decision:** added "Phases completed" + "Skills invoked" lines to the retro
+  entry format (`/deliver` Phase 6 + `delivery-retros.md` header).
+- **Rationale:** near-zero cost, additive, and builds the signal the scan needs
+  over time.
+
+### 2026-06-18 — Wiki get_context in Phase 0 · applied
+
+- **Pattern:** the personal wiki (Adam's engineering knowledge) was never read by
+  the pipeline — sophisticated tooling, but uncalibrated to how Adam thinks.
+- **Decision:** Phase 0 now pulls relevant wiki context (best-effort, guarded "if
+  the wiki MCP is available") to calibrate the approach before planning.
+- **Rationale:** matches Adam's global "consult the wiki silently before
+  non-trivial decisions". Worded to degrade silently off Adam's machine, since
+  these skill files ship in the public repo.
+
+### 2026-06-18 — Close the loop: this improvement log · applied
+
+- **Pattern:** the Phase 6 scan proposed but had no memory of past decisions, so
+  it would re-propose already-decided patterns.
+- **Decision:** created this file; Phase 6 scan consults it first and records each
+  decision after.
+- **Rationale:** makes the recurring-pattern scan converge instead of looping.
+
+### 2026-06-18 — Phase 0: verify review-originated findings against code · applied
+
+- **Pattern:** a delivery originating from a code/source-review *finding* was
+  acted on as if approved — strategy questions or a drafted plan preceded any
+  check against the actual code, and the framing repeatedly turned out wrong
+  (#340, #341, #343).
+- **Decision:** added a Phase 0 precondition to treat a review-originated finding
+  as a hypothesis and confirm it against the code (a quick `Explore` pass) before
+  planning or asking strategy questions. Landed in `/deliver` Phase 0 (PR #348).
+- **Rationale:** catches a mis-framed finding before it reaches the user.
+
+### 2026-06-18 — `/review-plan` critics load Adam's heuristics · deferred
+
+- **Pattern:** the three Opus critics apply generic Swift/TMDb standards, not
+  Adam's specific engineering opinions.
+- **Decision:** **deferred.** Not implemented.
+- **Rationale:** the critics' value is adversarial *independence*; feeding them
+  "Adam prefers X" risks confirmation over challenge, exactly when a critic is
+  most useful. **Reconsider only** as "load durable *constraints*/ADRs the critics
+  may cite", never "load opinions to agree with" — and only after confirming wiki
+  MCP reachability inside the review-plan Workflow.
+
+### 2026-06-18 — File-based `.claude/deliver-state.json` ledger · deferred
+
+- **Pattern:** the `TaskCreate` phase ledger is ephemeral; a long interrupted
+  session has no durable recovery path beyond "read the ledger if it survived".
+- **Decision:** **deferred.** Not implemented.
+- **Rationale:** `TaskCreate` + the checkpoint commits + git history already give
+  a real recovery path; a committed JSON state file adds PR noise (or, if
+  gitignored, isn't on the branch for anyone else). **Reconsider only if**
+  interruptions actually bite — and prefer the lighter "checkpoint the ledger into
+  the PR description" over a new state machine.

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -18,9 +18,15 @@ Format per entry:
 ### <date> — <short title> · <applied|deferred|rejected>
 - **Pattern:** what kept recurring (and the retro entries it appeared in).
 - **Decision:** what was agreed, and where it landed (skill + commit/PR) if applied.
-- **Rationale:** one or two sentences — why this call. For deferred/rejected,
-  the condition under which it should be reconsidered.
+- **Rationale:** one or two sentences — why this call.
+- **Reconsider when:** (deferred/rejected only) the condition under which the scan
+  should resurface this — or `n/a` for applied entries. The Phase 6 scan reads this
+  field to decide whether a settled *no* may be re-proposed.
 ```
+
+Keep this five-field shape on every entry so the scan can parse the log
+consistently — in particular **Decision** (status) and **Reconsider when** are the
+two fields the dedup step keys on.
 
 ---
 
@@ -33,6 +39,7 @@ Format per entry:
   entry format (`/deliver` Phase 6 + `delivery-retros.md` header).
 - **Rationale:** near-zero cost, additive, and builds the signal the scan needs
   over time.
+- **Reconsider when:** n/a (applied).
 
 ### 2026-06-18 — Wiki get_context in Phase 0 · applied
 
@@ -43,6 +50,7 @@ Format per entry:
 - **Rationale:** matches Adam's global "consult the wiki silently before
   non-trivial decisions". Worded to degrade silently off Adam's machine, since
   these skill files ship in the public repo.
+- **Reconsider when:** n/a (applied).
 
 ### 2026-06-18 — Close the loop: this improvement log · applied
 
@@ -51,6 +59,7 @@ Format per entry:
 - **Decision:** created this file; Phase 6 scan consults it first and records each
   decision after.
 - **Rationale:** makes the recurring-pattern scan converge instead of looping.
+- **Reconsider when:** n/a (applied).
 
 ### 2026-06-18 — Phase 0: verify review-originated findings against code · applied
 
@@ -62,6 +71,7 @@ Format per entry:
   as a hypothesis and confirm it against the code (a quick `Explore` pass) before
   planning or asking strategy questions. Landed in `/deliver` Phase 0 (PR #348).
 - **Rationale:** catches a mis-framed finding before it reaches the user.
+- **Reconsider when:** n/a (applied).
 
 ### 2026-06-18 — `/review-plan` critics load Adam's heuristics · deferred
 
@@ -70,9 +80,10 @@ Format per entry:
 - **Decision:** **deferred.** Not implemented.
 - **Rationale:** the critics' value is adversarial *independence*; feeding them
   "Adam prefers X" risks confirmation over challenge, exactly when a critic is
-  most useful. **Reconsider only** as "load durable *constraints*/ADRs the critics
-  may cite", never "load opinions to agree with" — and only after confirming wiki
-  MCP reachability inside the review-plan Workflow.
+  most useful.
+- **Reconsider when:** scoped narrowly to "load durable *constraints*/ADRs the
+  critics may cite" (never "load opinions to agree with"), and only after
+  confirming wiki MCP reachability inside the review-plan Workflow.
 
 ### 2026-06-18 — File-based `.claude/deliver-state.json` ledger · deferred
 
@@ -81,6 +92,6 @@ Format per entry:
 - **Decision:** **deferred.** Not implemented.
 - **Rationale:** `TaskCreate` + the checkpoint commits + git history already give
   a real recovery path; a committed JSON state file adds PR noise (or, if
-  gitignored, isn't on the branch for anyone else). **Reconsider only if**
-  interruptions actually bite — and prefer the lighter "checkpoint the ledger into
-  the PR description" over a new state machine.
+  gitignored, isn't on the branch for anyone else).
+- **Reconsider when:** interruptions actually bite — and even then prefer the
+  lighter "checkpoint the ledger into the PR description" over a new state machine.


### PR DESCRIPTION
## Summary

Two related fixes to the delivery-pipeline skill docs. Both close gaps where the
intended behaviour relied on context that compaction can erase, or on wording
that was too vague to act on consistently.

## Changes

**`/deliver` Phase 3.5 + `/capture-knowledge` Step 1:**
- 📝 Make the knowledge-candidates handoff explicit: `/deliver` now passes the
  candidates list to `/capture-knowledge` **as the skill argument**
  (`$ARGUMENTS`), rather than assuming the skill can still see the `TaskCreate`
  ledger in context. The argument travels with the call, so the candidates reach
  the skill even after the ledger has been summarised away. `/capture-knowledge`
  Step 1 now names the same channel.

**`/deliver` Phase 6:**
- 📝 Replace the vague trailing "fold the fix into the relevant skill" sentence
  with a structured, **gated** recurring-pattern scan: after committing the retro,
  read all of `knowledge/delivery-retros.md` and every `SKILL.md`, emit numbered
  proposals in a fixed six-field format for any pattern that recurs across **more
  than one** retro entry, and **stop for explicit per-proposal approval** before
  editing any skill file. Turns one-off retros into reviewed skill improvements
  instead of silent self-edits.
- 📝 Reconcile the existing trailing sentence (one clause) so it hands off to the
  new block instead of contradicting its "do not edit, wait for approval" rule.

## Benefits

- **Compaction-proof**: the knowledge handoff no longer depends on ledger content
  surviving in the conductor's context.
- **Reviewed, not silent**: cross-delivery skill changes now go through an
  explicit approval gate with a consistent proposal format.

## Notes

Docs-only change to `.claude/skills/**` (not in any lint/CI scope and no Swift
touched), so the full `make ci` gate does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)