### PR TITLE
✨ Add networks property to TVSeason

### DIFF
--- a/Sources/TMDb/Domain/Models/TVSeason.swift
+++ b/Sources/TMDb/Domain/Models/TVSeason.swift
@@ -60,6 +60,11 @@ public struct TVSeason: Identifiable, Codable, Equatable, Hashable, Sendable {
     public let episodes: [TVEpisode]?
 
     ///
+    /// Networks that aired this TV season.
+    ///
+    public let networks: [Network]?
+
+    ///
     /// Creates a TV season object.
     ///
     /// - Parameters:
@@ -72,6 +77,7 @@ public struct TVSeason: Identifiable, Codable, Equatable, Hashable, Sendable {
     ///    - voteAverage: Average vote score.
     ///    - episodeCount: Number of episodes in this TV season.
     ///    - episodes: Episodes in this TV season.
+    ///    - networks: Networks that aired this TV season.
     ///
     public init(
         id: Int,
@@ -82,7 +88,8 @@ public struct TVSeason: Identifiable, Codable, Equatable, Hashable, Sendable {
         posterPath: URL? = nil,
         voteAverage: Double? = nil,
         episodeCount: Int? = nil,
-        episodes: [TVEpisode]? = nil
+        episodes: [TVEpisode]? = nil,
+        networks: [Network]? = nil
     ) {
         self.id = id
         self.name = name
@@ -93,6 +100,7 @@ public struct TVSeason: Identifiable, Codable, Equatable, Hashable, Sendable {
         self.voteAverage = voteAverage
         self.episodeCount = episodeCount
         self.episodes = episodes
+        self.networks = networks
     }
 
 }
@@ -109,6 +117,7 @@ extension TVSeason {
         case voteAverage
         case episodeCount
         case episodes
+        case networks
     }
 
     /// Creates a new instance by decoding from the given decoder.
@@ -147,6 +156,7 @@ extension TVSeason {
             Int.self, forKey: .episodeCount
         )
         self.episodes = try container.decodeIfPresent([TVEpisode].self, forKey: .episodes)
+        self.networks = try container.decodeIfPresent([Network].self, forKey: .networks)
     }
 
 }

--- a/Tests/TMDbIntegrationTests/TVSeasonIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/TVSeasonIntegrationTests.swift
@@ -49,6 +49,18 @@ struct TVSeasonIntegrationTests {
         #expect(voteAverage >= 0)
     }
 
+    @Test("details includes networks")
+    func detailsIncludesNetworks() async throws {
+        let seasonNumber = 1
+        let tvSeriesID = 1399
+
+        let season = try await tvSeasonService.details(
+            forSeason: seasonNumber, inTVSeries: tvSeriesID
+        )
+
+        #expect(!(season.networks ?? []).isEmpty)
+    }
+
     @Test("aggregateCredits")
     func aggregateCredits() async throws {
         let seasonNumber = 2

--- a/Tests/TMDbTests/Domain/Models/TVSeasonDetailsResponseTests.swift
+++ b/Tests/TMDbTests/Domain/Models/TVSeasonDetailsResponseTests.swift
@@ -71,6 +71,7 @@ struct TVSeasonDetailsResponseTests {
         #expect(result.season.id == 3624)
         #expect(result.season.name == "Season 1")
         #expect(result.season.seasonNumber == 1)
+        #expect(result.season.networks != nil)
         #expect(result.credits == nil)
         #expect(result.aggregateCredits == nil)
         #expect(result.images == nil)

--- a/Tests/TMDbTests/Domain/Models/TVSeasonTests.swift
+++ b/Tests/TMDbTests/Domain/Models/TVSeasonTests.swift
@@ -37,6 +37,17 @@ struct TVSeasonTests {
         #expect(result.voteAverage == tvSeason.voteAverage)
         #expect(result.episodeCount == tvSeason.episodeCount)
         #expect(result.episodes == tvSeason.episodes)
+        #expect(result.networks == tvSeason.networks)
+        #expect(result.networks?.first?.id == 49)
+    }
+
+    @Test("JSON decoding of TVSeason without networks returns nil networks", .tags(.decoding))
+    func decodeWithoutNetworksReturnsNilNetworks() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            TVSeason.self, fromResource: "tv-season-empty-air-date"
+        )
+
+        #expect(result.networks == nil)
     }
 
     private let tvSeason = TVSeason(
@@ -50,7 +61,15 @@ struct TVSeasonTests {
         posterPath: URL(string: "/zwaj4egrhnXOBIit1tyb4Sbt3KP.jpg"),
         voteAverage: 8.3,
         episodeCount: 10,
-        episodes: nil
+        episodes: nil,
+        networks: [
+            Network(
+                id: 49,
+                name: "HBO",
+                logoPath: URL(string: "/tuomPhY2UtuPTqqFnKMVHvSb724.png"),
+                originCountry: "US"
+            )
+        ]
     )
 
 }

--- a/Tests/TMDbTests/Mocks/Models/TVSeason+Mock.swift
+++ b/Tests/TMDbTests/Mocks/Models/TVSeason+Mock.swift
@@ -19,7 +19,8 @@ extension TVSeason {
         posterPath: URL? = nil,
         voteAverage: Double? = nil,
         episodeCount: Int? = 10,
-        episodes: [TVEpisode]? = .mocks
+        episodes: [TVEpisode]? = .mocks,
+        networks: [Network]? = nil
     ) -> TVSeason {
         TVSeason(
             id: id,
@@ -30,7 +31,8 @@ extension TVSeason {
             posterPath: posterPath,
             voteAverage: voteAverage,
             episodeCount: episodeCount,
-            episodes: episodes
+            episodes: episodes,
+            networks: networks
         )
     }
 

--- a/Tests/TMDbTests/Resources/json/tv-season.json
+++ b/Tests/TMDbTests/Resources/json/tv-season.json
@@ -3,6 +3,14 @@
     "episode_count": 10,
     "id": 3624,
     "name": "Season 1",
+    "networks": [
+        {
+            "id": 49,
+            "name": "HBO",
+            "logo_path": "/tuomPhY2UtuPTqqFnKMVHvSb724.png",
+            "origin_country": "US"
+        }
+    ],
     "overview": "Trouble is brewing in the Seven Kingdoms of Westeros. For the driven inhabitants of this visionary world, control of Westeros' Iron Throne holds the lure of great power. But in a land where the seasons can last a lifetime, winter is coming...and beyond the Great Wall that protects them, an ancient evil has returned. In Season One, the story centers on three primary areas: the Stark and the Lannister families, whose designs on controlling the throne threaten a tenuous peace; the dragon princess Daenerys, heir to the former dynasty, who waits just over the Narrow Sea with her malevolent brother Viserys; and the Great Wall--a massive barrier of ice where a forgotten danger is stirring.",
     "poster_path": "/zwaj4egrhnXOBIit1tyb4Sbt3KP.jpg",
     "season_number": 1,

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -10,6 +10,33 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-06-19 — ✨ Add `networks` property to TVSeason (#349) · full
+
+- **Phases / skills:** phases 0–6; `review-plan, implement-plan, build-for-testing,
+  test, integration-test, lint, review-changes, capture-knowledge, pr, watch-pr`.
+- **Worked:** the work originated from a schema-diff scan (8 models vs the live
+  OpenAPI spec) that found exactly one field-level gap — a precise, pre-verified
+  target. `/review-plan`'s critics caught a real test trap *before* any code (the
+  `Network`-Equatable / over-populated-mock pitfall) and surfaced a free extra
+  assertion (networks surfacing through the shared `TVSeasonDetailsResponse`
+  decoder); both folded into the plan, so implementation hit zero surprises and
+  `/review-changes` came back 0/0/0 + one advisory Low.
+- **Friction:** local `make ci` went red on `lint-markdown` over an **unrelated,
+  pre-existing** `.claude/skills/deliver/SKILL.md:347` MD028 — a file not in the
+  diff. Root cause: the **local** `make lint-markdown` lints `.claude/**`, but the
+  **CI** job (`ci.yml:120`) lints only `README.md` + `**/*.docc/**` — so the local
+  gate can fail on `.claude/` markdown that the authoritative gate never checks.
+  Cost a triage detour to prove it was non-blocking.
+- **Deviations:** user changed `merge` → watch-only mid-run (honoured: stopped at
+  the gate). Did **not** route the markdown red to `/fix-integration-failures`
+  (that's for integration flakes); triaged it as local-gate-only and proceeded,
+  verifying the real legs (build-docs, build-release, unit, TVSeason integration)
+  passed individually.
+- **Improvement:** reconcile the **local `make lint-markdown` scope with CI's** —
+  either narrow the Makefile target to match `ci.yml` (`README.md` + docc), or add
+  `.claude/**` to the CI job so the two gates agree. Today a green CI can sit behind
+  a red local `make ci`, which repeatedly mis-signals "your change broke the gate."
+
 ## 2026-06-18 — ✨ AuthenticatedSession wrapper for AccountService (#346) · full
 
 - **Worked:** the full pipeline earned its keep on the only genuinely risky change

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -44,6 +44,27 @@ members). Every time, `swift build` / `make build-tests` reported **0 errors /
 - There is **no `GetBuildLog` tool** — for build-error detail inside Xcode use
   `mcp__xcode-tools__XcodeRefreshCodeIssuesInFile` on the flagged file(s).
 
+## Testing
+
+### Model-decode equality tests: build the expected value directly, not from an over-populated mock
+
+*2026-06-19.* `Network` is `Equatable` over **all six** stored properties
+(`id`, `name`, `logoPath`, `originCountry`, `headquarters`, `homepage`), and both
+the `Network.mock()` helper and `Network.hbo` default `headquarters` **and**
+`homepage` to **non-nil** values. When a decode test compares a decoded value
+against an expected one built from a **minimal** JSON fixture entry (only
+`id`/`name`/`logo_path`/`origin_country`), building the expected value with the
+mock makes `#expect(decoded == expected)` **fail** on the two extra non-nil
+fields.
+
+- Construct the expected value **directly** — e.g.
+  `Network(id:name:logoPath:originCountry:)`, leaving `headquarters`/`homepage`
+  nil — so it matches exactly what the fixture decodes to. `TVSeasonTests` and
+  `TVSeriesTests` both do this for their `networks` assertions.
+- Generalises to **any** `Equatable` model whose `*+Mocks` helper over-populates
+  optional fields: a mock is for convenience construction, not for asserting
+  decode equality against a sparse fixture.
+
 ## Public API
 
 ### Growing a public protocol additively: extension defaults, and the `--Werror` deprecation trap

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,30 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-06-19 — Reconcile local `make ci` lint scope with CI · deferred
+
+- **Pattern:** the local `make ci` lint gate and the authoritative GitHub CI lint
+  gate disagree on what counts as a violation, so `make ci` mis-signals — twice
+  now, in opposite directions. #347: local SwiftLint cached a **false green** on
+  new files that CI's clean checkout failed. #349: local `make lint-markdown`
+  lints `.claude/**` and went **red** on `.claude/skills/deliver/SKILL.md:347`
+  (MD028), but CI's markdown job (`ci.yml:120`) lints only `README.md` + docc, so
+  CI is green on it. Both stem from the two gates having different scopes/caches.
+- **Decision:** **deferred** — surfaced to the user. The real fix is a **repo
+  config** change (narrow the Makefile `lint-markdown` to match `ci.yml`, *or* add
+  `.claude/**` to the CI markdown job and fix the pre-existing MD028), which is
+  outside the Phase-6 scan's remit (it edits SKILL.md files, not the Makefile/CI).
+  The #347 half is already mitigated in `/pr` (the `--no-cache` re-lint step).
+- **Rationale:** a green CI sitting behind a red local `make ci` repeatedly costs
+  a triage detour and risks a real local failure being dismissed as "just the
+  scope thing". But the fix belongs in `Makefile`/`ci.yml`, not a skill, so it
+  needs the user's call rather than an auto-applied skill edit.
+- **Reconsider when:** the user aligns the two scopes in repo config (then close
+  as applied), or the disagreement recurs a third time — at which point add an
+  explicit "local lint-markdown over-covers `.claude/**`; a red there on a file
+  not in your diff is a known local-only artifact" triage note to `/deliver`
+  Phase 4 and `/pr` step 4 (a skill-level mitigation that *is* in remit).
+
 ### 2026-06-18 — Telemetry (phases completed + skills invoked) in retro · applied
 
 - **Pattern:** retros captured friction but no signal on which skills fire, which

--- a/knowledge/tmdb-api-notes.md
+++ b/knowledge/tmdb-api-notes.md
@@ -20,6 +20,23 @@ Newest at the top; cite the endpoint and the date observed.
   its response schema. Don't look for shared model definitions — read the
   endpoint's own schema.
 
+## TV seasons
+
+### `tv-season-details` returns top-level `networks` and `_id`
+
+*2026-06-19, `/3/tv/{series_id}/season/{season_number}`.*
+
+- The season-details response carries a **top-level `networks`** array (the
+  networks that aired the season — e.g. Game of Thrones S1 → HBO, id 49), mapped
+  onto `TVSeason.networks` as `[Network]?`. It arrives on the **base** endpoint —
+  no append-to-response option is needed.
+- The response also has a top-level **`_id`** string (TMDb's internal
+  Mongo-style document id). It is **intentionally unmapped**, consistent with how
+  other models ignore `_id`.
+- `TVSeason`'s decoder is reused by `TVSeasonDetailsResponse.init(from:)` (via
+  `try TVSeason(from: decoder)`), so `networks` also surfaces on the appended
+  details response for free.
+
 ## Decoding resilience
 
 ### Unknown enum-like string values should decode resiliently


### PR DESCRIPTION
## Summary

The `tv-season-details` endpoint returns a top-level `networks` array — the networks that aired the season (e.g. Game of Thrones S1 → HBO) — but `TVSeason` did not decode it. This was the only field-level gap found in a schema-diff scan of the package's high-traffic models against the live OpenAPI spec.

This PR maps it onto `TVSeason` as an additive optional `networks: [Network]?`, mirroring the existing `TVSeries.networks` precedent exactly.

## Changes

**Model:**
- ✨ Added `public let networks: [Network]?` to `TVSeason` (with `///` doc), a `networks` `CodingKeys` case, a `decodeIfPresent` line in `init(from:)`, and a `networks: [Network]? = nil` parameter **appended last** in the memberwise init — so all (label-based) call sites are source-compatible.

**Tests:**
- ✅ Unit tests for both decode branches: populated (updated `tv-season.json` fixture) and `nil` (via `tv-season-empty-air-date.json`, which omits `networks`).
- ✅ Assertion that `networks` surfaces through the shared `TVSeason(from:)` decoder used by `TVSeasonDetailsResponse`.
- ✅ Live integration test (`detailsIncludesNetworks`, GoT S1) — behaviour-based (`!(season.networks ?? []).isEmpty`) to avoid live-data brittleness.
- ✅ `TVSeason+Mock` updated with the new parameter.

**Documentation / Knowledge:**
- 📝 `knowledge/tmdb-api-notes.md`: documented that `tv-season-details` returns top-level `networks` (now mapped) and `_id` (intentionally unmapped).
- 📝 `knowledge/gotchas.md`: captured the `Network`-Equatable test trap (the expected value must be built directly, not from an over-populating mock).

## Benefits

- **Completeness**: consumers can now read which networks aired a TV season, closing the last schema gap for `TVSeason`.
- **Backwards-compatible**: purely additive optional property; no source break. Minor version bump (→ 18.2.0).

## Verification

- `make lint` clean, unit tests 2701/2701, TVSeason integration 12/12 (incl. the new test), `build-release` 0 warnings, `build-docs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)