### PR TITLE
🔧 Align CI markdown lint scope with make ci + fix MD028

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -344,7 +344,7 @@ summarise what's blocking.
 > the run and report what's blocking. The ready-to-merge gate itself is **not** a
 > panel decision: in `auto` it behaves exactly as the `merge` opt-in below — once
 > the PR is ready, proceed to Phase 6 (and merge if `merge` was passed).
-
+>
 > **Opt-in auto-merge:** if the user explicitly passes `merge` to `/deliver`,
 > forward it to `/watch-pr` (`/watch-pr merge`) so it squash-merges once ready, and
 > the gate becomes "report the merge" instead of stopping. Default is watch-only.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,9 @@ jobs:
               - '.github/workflows/ci.yml'
             markdown:
               - 'README.md'
+              - 'CLAUDE.md'
               - '**/*.docc/**/*.md'
+              - '.claude/**/*.md'
               - '.github/workflows/ci.yml'
 
   lint:
@@ -117,7 +119,7 @@ jobs:
 
       - name: Lint Markdown
         if: needs.changes.outputs.markdown == 'true' || github.event_name == 'workflow_dispatch'
-        run: markdownlint "README.md" "**/*.docc/**/*.md"
+        run: markdownlint "README.md" "CLAUDE.md" "**/*.docc/**/*.md" ".claude/**/*.md"
 
   build-test:
     name: Build and Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     container:
-      image: docker://ghcr.io/igorshubovych/markdownlint-cli:v0.41.0
+      image: docker://ghcr.io/igorshubovych/markdownlint-cli:v0.48.0
     steps:
       - name: No changes detected
         if: needs.changes.outputs.markdown != 'true' && github.event_name != 'workflow_dispatch'


### PR DESCRIPTION
## Summary

The local `make lint-markdown` and the GitHub CI `Lint Markdown` job linted **different file sets** *and* ran **different markdownlint versions**, so a markdown violation could pass one gate and fail the other.

| | `make ci` (local) | CI (before) |
|---|---|---|
| `README.md` | ✅ | ✅ |
| `CLAUDE.md` | ✅ | ❌ |
| `**/*.docc/**/*.md` | ✅ | ✅ |
| `.claude/**/*.md` | ✅ | ❌ |
| markdownlint version | `0.48.0` (brew) | `v0.41.0` (docker) |

This caused a real mis-signal in delivery #349: the local `make ci` gate went **red** on a pre-existing MD028 violation in `.claude/skills/deliver/SKILL.md` that CI never checked (so it had been merged green via #348).

## Changes

**CI scope alignment (`.github/workflows/ci.yml`):**
- 🔧 Added `CLAUDE.md` and `.claude/**/*.md` to both the markdown **path filter** and the `markdownlint` command, so CI lints the identical set `make lint-markdown` does.

**CI version alignment (`.github/workflows/ci.yml`):**
- 🔧 Pinned the markdownlint-cli docker image `v0.41.0` → **`v0.48.0`** to match the local brew version. The older v0.41.0 raised **MD038 false positives** on the legitimate literal-double-backtick DocC idiom (`` ``Symbol`` ``) in `document-swift/SKILL.md` — the spaces there are *required* for rendering, and the newer v0.48.0 (like local) correctly allows them. Aligning the version is the right fix, not mangling valid markdown.

**Fix the lone real violation (`.claude/skills/deliver/SKILL.md`):**
- 🔧 MD028 (blank line inside blockquote) at line 347 — joined the two adjacent gate/merge admonitions into a single blockquote.

## Verification

- `make lint-markdown` exits 0 across all four scopes locally.
- This PR's own CI `Lint Markdown` job (now v0.48.0, full scope) is **green** — the true end-to-end proof that local and CI now agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)