### PR TITLE
📝 Encode PR rebase-before-ready, stacking & background-watch into skills

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -327,10 +327,16 @@ Record the PR number/URL in the ledger.
 
 ## Phase 5 — Watch to ready  → GATE: ready-to-merge
 
-Invoke **`/watch-pr`** in **watch-only** mode (do not pass `merge`). It resolves
+Invoke **`/watch-pr`** in **watch-only** mode (do not pass `merge`), and **run it in
+the background** so the user can keep interacting while CI churns. It resolves
 review threads and fixes failing checks (its §1c routes a pre-existing/unrelated
 integration failure to `/fix-integration-failures`, per Contract §4), looping until
 the PR is **ready** (green checks, threads resolved) or **stuck**.
+
+**Ready means mergeable *now*.** Before the gate, `/watch-pr` brings the branch up
+to date with `main` (`gh pr update-branch`) and waits for the re-run, so a PR
+reported ready isn't `BEHIND` and waiting on a rebase — the user can merge straight
+away. (See `/watch-pr` §3.)
 
 **THE GATE — hard stop at ready-to-merge.** When the PR is ready, **stop and hand
 it to the user for the final merge** — `/deliver` does not merge by default. Report

--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -13,6 +13,11 @@ Repo is `adamayoung/TMDb`; `gh` is authenticated.
 include `merge` (e.g. `/watch-pr merge` or "merge when ready"), enable
 **merge-when-ready**; otherwise run in **watch-only** mode.
 
+**Run in the background.** Watching blocks on CI for minutes at a time, so run the
+watch as a background task — the user can keep interacting while it runs, and is
+pinged when the PR needs attention or is ready. Don't tie up the foreground on a
+wait loop.
+
 ## 0. Find the PR
 
 ```bash
@@ -106,16 +111,34 @@ fixing here:
 
 ## 3. Ready / merge
 
-The PR is **ready** when every review thread is resolved AND no check is failing
-or pending.
+The PR is **ready** when every review thread is resolved, no check is failing or
+pending, AND the branch is **up to date with `main`** (the `main` ruleset requires
+it before merge).
+
+**Rebase before declaring ready, never after.** `main` advances while you watch
+(other PRs merge), leaving the branch `BEHIND`. The moment the PR is otherwise
+green, bring it up to date — `gh pr update-branch <number>` (a merge of `main`; no
+force-push) — and wait for the re-triggered CI to go green again *before* you call
+it ready. "Ready" must mean "mergeable right now": never surface a `BEHIND` PR as
+ready and leave the user waiting on a rebase + re-run. Update **once** at the ready
+point, not eagerly on every `main` advance — each update re-runs the full ~4–7 min
+CI matrix.
 
 - **Watch-only**: report "PR is ready" with a short summary (threads handled,
-  checks green) and stop.
+  checks green, branch up to date) and stop — wait for the user's explicit
+  go-ahead before merging.
 - **Merge-when-ready**: on ready, merge and clean up, then report the result:
 
   ```bash
   gh pr merge --squash --delete-branch
   ```
+
+**Several PRs queued?** Merge in dependency order. Stack one on another (base the
+later PR on the earlier branch) **only** when they genuinely depend on each other
+or the merge order is fixed up front — then merging the first leaves the next
+already up to date, with no second rebase. Keep *independent* PRs on separate
+`main`-based branches and rely on the rebase-before-ready rule above rather than
+coupling unrelated work.
 
 ## Guardrails
 


### PR DESCRIPTION
## Summary

Bakes three confirmed merge-workflow preferences into the skills that run them, so the behaviour is enforced in the flow rather than relying on memory alone.

## Changes

**`/watch-pr` (§3 Ready/merge):**
- 📝 **Rebase before declaring ready, never after** — `main` advances while watching (other PRs merge), leaving the branch `BEHIND`. Now: once a PR is otherwise green, `gh pr update-branch` and wait for the re-run *before* calling it ready, so "ready" means "mergeable right now". Update once at the ready point (not eagerly — each update re-runs the full CI matrix).
- 📝 **Stack only dependent PRs** — chain PRs in merge order only when they genuinely depend on each other or the order is fixed; keep independent fixes on separate `main`-based branches.

**`/watch-pr` (Mode) + `/deliver` (Phase 5):**
- 📝 **Run the watch in the background** so the user can keep interacting; notify, don't auto-merge in watch-only mode.

## Why

PR #350 surfaced all three gaps: it was reported "ready" but went `BEHIND` once #349 merged (needing an `update-branch` + re-watch), and the foreground was tied up on the watch loop. These edits close the loop.

## Verification

- `make lint-markdown` clean across all four scopes (including the now-CI-linted `.claude/**`).
- No Swift / build-affecting files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)