### PR TITLE
📝 Add maintenance & retention policy to knowledge base

### DIFF
--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -25,6 +25,36 @@ this directory; the detail lives here and is read on demand.
   runs automatically before a PR in the `/deliver` pipeline.
 - Keep entries **concise and dated**. Link related entries and ADRs.
 
+## Maintenance & retention
+
+The base is a **cache of currently-true facts, not an archive** — git history is
+the archive. Keep it lean so a reader (or agent) finds the signal fast. The files
+age differently:
+
+- **Append-only logs** (`delivery-retros.md`, `skill-improvement-log.md`) grow one
+  entry per delivery/scan, so cap them with a **rolling window**:
+  - Keep roughly the **last ~12 entries** in full prose.
+  - Distil older ones into a compact one-line archive table
+    (`date · PR · weight · one-line outcome`) and drop the prose — the telemetry
+    (which skills fired, where deliveries stopped) survives; the bulk doesn't.
+  - A retro entry's job is to feed the Phase 6 recurring-pattern scan; once its
+    lesson is folded into a skill and recorded `applied` in
+    `skill-improvement-log.md`, the prose is spent. The scan need only read the
+    recent window plus the log — not the full history.
+- **Curated reference** (`gotchas.md`, `tmdb-api-notes.md`) should *plateau*, not
+  grow forever. **Retire entries that are no longer true:** when an upstream bug is
+  fixed, a pinned version is lifted, the code is removed, or a quirk no longer
+  reproduces, **delete** the entry (git preserves it). Describe the present, not
+  the past.
+- **ADRs** (`decisions/`) are one immutable file per decision — don't edit an
+  Accepted ADR; **supersede** it with a new one that links back. This already
+  scales; no window needed.
+- **Don't pre-split a file.** Split a section into its own file only when it
+  genuinely dominates (e.g. `gotchas.md` → `gotchas/tooling.md`), mirroring the
+  project's "promote a boundary only when the pain shows up" rule. The dated `###`
+  headings (newest at top) are the index — keep them grep-friendly so a reader can
+  pull one entry without reading the whole file.
+
 ## Relationship to other stores
 
 This repo base is the **canonical, shareable** record (committed, reviewed in


### PR DESCRIPTION
## Summary

The `knowledge/` base grows append-only with no retention policy — `delivery-retros.md` and `skill-improvement-log.md` gain an entry per delivery/scan forever, and `gotchas.md` / `tmdb-api-notes.md` never retire stale entries. This adds a **Maintenance & retention** section to `knowledge/README.md` so the base stays lean and high-signal.

The framing: **the base is a cache of currently-true facts, not an archive — git history is the archive.**

## Policy added

- **Append-only logs** (retros, skill-improvement-log) → **rolling window**: keep ~last 12 entries in full prose; distil older ones into a one-line archive table (`date · PR · weight · outcome`). Also fixes the Phase 6 scan's O(n²) "re-read all retros" cost — it need only read the recent window + the log.
- **Curated reference** (gotchas, api-notes) → **retire** entries that are no longer true (delete; git preserves them).
- **ADRs** → already scale (one immutable file each); supersede rather than edit.
- **Don't pre-split** a file; split a section only when it dominates (mirrors the project's "promote a boundary only when the pain shows up" rule).

## Scope

**Policy only** by request — no changes to `capture-knowledge` / `deliver` skills, and no distillation of the current retros yet. Those can follow once the policy is agreed.

## Verification

- `make lint-markdown` clean (incl. the now-CI-linted `.claude/**` and `knowledge/` is unaffected).
- No Swift / build-affecting files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)