### PR TITLE
📝 Make the knowledge base self-maintaining (retention rules in skills)

### DIFF
--- a/.claude/skills/capture-knowledge/SKILL.md
+++ b/.claude/skills/capture-knowledge/SKILL.md
@@ -52,12 +52,19 @@ Quality over volume: a few high-signal entries beat a long dump.
    - Decisions: copy `decisions/0000-template.md` to
      `decisions/NNNN-<kebab-title>.md` (next free number), fill in Status / Date /
      Context / Decision / Consequences / Alternatives. Cross-link related ADRs.
-5. **Keep it tidy by hand** — blank lines around headings/lists/code fences, a
+5. **Retire what's no longer true.** The base is a **cache of current truths, not
+   an archive** (git history is the archive — see
+   [`knowledge/README.md`](../../../knowledge/README.md) → *Maintenance &
+   retention*). While you're in `gotchas.md` / `tmdb-api-notes.md`, scan the
+   neighbouring entries and **delete** any now obsolete — an upstream bug fixed, a
+   pinned version lifted, the code removed, a quirk that no longer reproduces. The
+   file should describe the present, not narrate the past.
+6. **Keep it tidy by hand** — blank lines around headings/lists/code fences, a
    language on every fence, one `#` H1 per file. Note `knowledge/` is **not** in
-   the `make lint-markdown` scope (only `README.md` + `.docc` are), so there's no
-   CI gate on these files — readability is on you. Aim for ~80-col prose; long
-   `jq`/URL lines are fine.
-6. **Update `knowledge/README.md`** only if you added a new file or category (the
+   the `make lint-markdown` scope (which covers `README.md`, `CLAUDE.md`,
+   `**/*.docc/**`, and `.claude/**`), so there's no CI gate on these files —
+   readability is on you. Aim for ~80-col prose; long `jq`/URL lines are fine.
+7. **Update `knowledge/README.md`** only if you added a new file or category (the
    per-entry index inside each file is enough otherwise).
 
 ## Return

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -379,16 +379,27 @@ entries** for recurring friction or deviations — the recurring-pattern scan be
 formalizes this. Commit the retro with the PR when possible (watch-only), or as a
 small follow-up when auto-merged.
 
+**Keep the file windowed.** After adding the entry, if `delivery-retros.md` holds
+more than **~12 full entries**, distil the oldest into its one-line archive table
+(`date · PR · weight · one-line outcome`) and drop the prose — per
+[`knowledge/README.md`](../../../knowledge/README.md) → *Maintenance & retention*.
+An old retro's lesson already lives in the skills and `skill-improvement-log.md`;
+the table preserves the telemetry without the bulk.
+
 ### Recurring-pattern scan (after committing the retro)
 
 Once the retro entry is committed, do a structured cross-delivery scan — this is
 what turns one-off retros into reviewed skill improvements:
 
-1. **Read the whole history.** Read all of
-   [`knowledge/delivery-retros.md`](../../../knowledge/delivery-retros.md),
+1. **Read the recent window + the log.** Read the **~last 12** entries of
+   [`knowledge/delivery-retros.md`](../../../knowledge/delivery-retros.md) (the
+   rolling window — older deliveries are archived to one-liners, so this is the
+   whole live history anyway), **all** of
    [`knowledge/skill-improvement-log.md`](../../../knowledge/skill-improvement-log.md),
    and **every** `SKILL.md` under `.claude/skills/` (including the sub-skills those
-   skills reference).
+   skills reference). The bounded retro read keeps the scan's cost flat as history
+   grows: a recurrence worth acting on shows up in the recent window, and anything
+   already settled lives in the log.
 2. **Find what recurs.** For any friction, deviation, or improvement suggestion
    that appears in **more than one** retro entry, write a numbered proposal in
    this exact format:

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -31,16 +31,21 @@ The base is a **cache of currently-true facts, not an archive** — git history 
 the archive. Keep it lean so a reader (or agent) finds the signal fast. The files
 age differently:
 
-- **Append-only logs** (`delivery-retros.md`, `skill-improvement-log.md`) grow one
-  entry per delivery/scan, so cap them with a **rolling window**:
-  - Keep roughly the **last ~12 entries** in full prose.
-  - Distil older ones into a compact one-line archive table
-    (`date · PR · weight · one-line outcome`) and drop the prose — the telemetry
-    (which skills fired, where deliveries stopped) survives; the bulk doesn't.
-  - A retro entry's job is to feed the Phase 6 recurring-pattern scan; once its
-    lesson is folded into a skill and recorded `applied` in
-    `skill-improvement-log.md`, the prose is spent. The scan need only read the
-    recent window plus the log — not the full history.
+- **Append-only logs** grow one entry per delivery/scan — but the two age
+  differently:
+  - **`delivery-retros.md`** — cap with a **rolling window**: keep roughly the
+    **last ~12 entries** in full prose, and distil older ones into a compact
+    one-line archive table (`date · PR · weight · one-line outcome`), dropping the
+    prose. The telemetry (which skills fired, where deliveries stopped) survives;
+    the bulk doesn't. A retro's job is to feed the Phase 6 recurring-pattern scan;
+    once its lesson is folded into a skill and recorded `applied` in
+    `skill-improvement-log.md`, the prose is spent — the scan reads only the recent
+    window plus the log, never the full history.
+  - **`skill-improvement-log.md`** is the scan's **dedup memory**, so it is *not*
+    windowed the same way: keep **every** `deferred`/`rejected` entry (their
+    "Reconsider when" is exactly what stops a settled *no* being re-proposed). Only
+    an old `applied` entry — whose fix already lives in the skill — may be condensed
+    to a one-liner. It grows slowly and each entry is load-bearing.
 - **Curated reference** (`gotchas.md`, `tmdb-api-notes.md`) should *plateau*, not
   grow forever. **Retire entries that are no longer true:** when an upstream bug is
   fixed, a pinned version is lifted, the code is removed, or a quirk no longer


### PR DESCRIPTION
## Summary

Follow-up to #352 (which wrote the retention *policy*). This bakes the policy into the skills that run it, so the knowledge base stays lean **automatically** rather than relying on manual pruning.

## Part 1 — distillation: a no-op right now (by design)

Both append-only logs are **under** the ~12-entry window — `delivery-retros.md` has **8** entries, `skill-improvement-log.md` has **7**. Archiving any of them now would only destroy recent, relevant signal, so nothing is distilled in this PR. The skills below will distil automatically the moment a log exceeds the window.

## Part 2 — self-maintenance baked into the skills

**`/deliver` Phase 6:**
- After writing a retro, **window `delivery-retros.md`** — distil entries past ~12 into the one-line archive table.
- **Bound the recurring-pattern scan's read** to the recent window + the full log (not the entire retro history) — keeps the scan's cost flat as history grows (it was O(n²): every delivery re-read all retros).

**`/capture-knowledge`:**
- New step: **"Retire what's no longer true"** — delete obsoleted `gotchas.md` / `tmdb-api-notes.md` entries while editing (git is the archive).
- Refreshed a stale aside (the markdown-lint scope now includes `CLAUDE.md` + `.claude/**` after #350).

**`knowledge/README.md`:**
- Refines the #352 policy: **`skill-improvement-log.md` is the scan's dedup memory**, so it is *not* windowed like retros — every `deferred`/`rejected` entry is kept (their "Reconsider when" is what stops a settled *no* being re-proposed); only old `applied` entries may be condensed.

## Verification

- `make lint-markdown` clean (incl. the now-CI-linted `.claude/**`).
- No Swift / build-affecting files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)