### PR TITLE
🔧 Silence Homebrew untrusted-tap warning in CI/Integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,10 @@ jobs:
 
       - name: Install xcsift
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
-        run: brew install xcsift
+        run: |
+          # Drop runner-preinstalled taps Homebrew's trust policy warns about.
+          brew untap aws/tap azure/bicep 2>/dev/null || true
+          brew install xcsift
 
       - name: Build
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,7 +75,10 @@ jobs:
           needs.changes.outputs.swift == 'true'
           || github.event_name == 'workflow_dispatch'
           || github.event_name == 'schedule'
-        run: brew install xcsift
+        run: |
+          # Drop runner-preinstalled taps Homebrew's trust policy warns about.
+          brew untap aws/tap azure/bicep 2>/dev/null || true
+          brew install xcsift
 
       - name: Build
         if: >-


### PR DESCRIPTION
## Summary

The scheduled `Integration` run surfaced a warning annotation during the
**Install xcsift** step. It is emitted by Homebrew, not our code: the
GitHub-hosted runner image pre-taps `aws/tap` and `azure/bicep`, and
Homebrew's new trust policy warns about untrusted taps on every
`brew install`. This makes the run noisy even when it succeeds.

## Changes

**CI workflows:**
- 🔧 Untap `aws/tap` and `azure/bicep` (guarded with `|| true` so it's a
  no-op when they're absent) before `brew install xcsift` in both
  `ci.yml` and `integration.yml`.

## Benefits

- **Warning-clean runs**: removes the only non-notice annotation from
  successful build/integration runs.
- **Future-proof**: avoids the deprecated `HOMEBREW_NO_REQUIRE_TAP_TRUST`
  escape hatch Homebrew plans to remove; uses Homebrew's recommended
  remedy (untap) instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)