### PR TITLE
✨ Add movieCredits language-model tool to TMDbToolbox

### DIFF
--- a/Sources/TMDb/Domain/LanguageModelTools/TMDbClient+LanguageModelTools.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/TMDbClient+LanguageModelTools.swift
@@ -52,6 +52,14 @@
         }
 
         ///
+        /// A FoundationModels tool that fetches the principal cast and crew for a
+        /// movie by its TMDb id.
+        ///
+        var movieCreditsTool: any Tool {
+            TMDbToolbox(client: self).movieCredits
+        }
+
+        ///
         /// A FoundationModels tool that fetches full details for a TV series by its
         /// TMDb id.
         ///

--- a/Sources/TMDb/Domain/LanguageModelTools/TMDbToolbox.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/TMDbToolbox.swift
@@ -99,6 +99,7 @@
             [
                 search,
                 movieDetails,
+                movieCredits,
                 tvSeriesDetails,
                 personFilmography,
                 trending,
@@ -119,6 +120,14 @@
         ///
         public var movieDetails: any Tool {
             MovieDetailsTool(movieService: movieService, language: language)
+        }
+
+        ///
+        /// A tool that fetches the principal cast and crew for a movie by its TMDb
+        /// id.
+        ///
+        public var movieCredits: any Tool {
+            MovieCreditsTool(movieService: movieService, language: language)
         }
 
         ///

--- a/Sources/TMDb/Domain/LanguageModelTools/ToolOutputFormatter+Credits.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/ToolOutputFormatter+Credits.swift
@@ -1,0 +1,84 @@
+//
+//  ToolOutputFormatter+Credits.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+// MARK: - Credits blocks
+
+extension ToolOutputFormatter {
+
+    /// The maximum number of cast members shown in a credits block.
+    static let creditsCastLimit = 10
+
+    /// The maximum number of crew members shown in a credits block.
+    static let creditsCrewLimit = 8
+
+    /// The crew jobs shown in a credits block, in display-priority order.
+    ///
+    /// Limiting to these key creative roles keeps the block focused and within the
+    /// model's context window; other crew (editors, composers, …) are omitted.
+    private static let keyCrewJobs = [
+        "Director",
+        "Writer",
+        "Screenplay",
+        "Story",
+        "Producer",
+        "Executive Producer"
+    ]
+
+    ///
+    /// Formats a movie's principal cast and crew as a compact block.
+    ///
+    /// Every line leads with a TMDb `id` so the model can chain calls — taking a
+    /// cast or crew member's `id` and passing it to a filmography tool. The cast is
+    /// the top-billed members by order; the crew is limited to the key creative
+    /// roles (director, writers, producers) so the block stays within the on-device
+    /// model's context window.
+    ///
+    /// - Parameter credits: The credits to format.
+    ///
+    /// - Returns: The formatted block.
+    ///
+    static func block(for credits: ShowCredits) -> String {
+        var lines = ["credits | \(credits.id)"]
+        lines.append(contentsOf: castLines(credits.cast))
+        lines.append(contentsOf: crewLines(credits.crew))
+
+        return lines.joined(separator: "\n")
+    }
+
+    private static func castLines(_ cast: [CastMember]) -> [String] {
+        guard !cast.isEmpty else {
+            return ["no cast listed"]
+        }
+
+        return cast
+            .sorted { $0.order < $1.order }
+            .prefix(creditsCastLimit)
+            .map { "cast | \($0.id) | \(sanitize($0.name)) as \(sanitize($0.character))" }
+    }
+
+    private static func crewLines(_ crew: [CrewMember]) -> [String] {
+        let keyCrew = crew
+            .filter { keyCrewJobs.contains($0.job) }
+            .sorted { jobPriority($0.job) < jobPriority($1.job) }
+
+        var seen = Set<String>()
+        let deduped = keyCrew.filter { seen.insert("\($0.id)|\($0.job)").inserted }
+        let limited = deduped.prefix(creditsCrewLimit)
+        guard !limited.isEmpty else {
+            return ["no crew listed"]
+        }
+
+        return limited.map { "crew | \($0.id) | \(sanitize($0.name)) — \($0.job)" }
+    }
+
+    private static func jobPriority(_ job: String) -> Int {
+        keyCrewJobs.firstIndex(of: job) ?? keyCrewJobs.count
+    }
+
+}

--- a/Sources/TMDb/Domain/LanguageModelTools/ToolOutputFormatter+Credits.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/ToolOutputFormatter+Credits.swift
@@ -74,7 +74,7 @@ extension ToolOutputFormatter {
             return ["no crew listed"]
         }
 
-        return limited.map { "crew | \($0.id) | \(sanitize($0.name)) — \($0.job)" }
+        return limited.map { "crew | \($0.id) | \(sanitize($0.name)) — \(sanitize($0.job))" }
     }
 
     private static func jobPriority(_ job: String) -> Int {

--- a/Sources/TMDb/Domain/LanguageModelTools/ToolOutputFormatter.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/ToolOutputFormatter.swift
@@ -347,7 +347,7 @@ extension ToolOutputFormatter {
 
     /// Replaces the field delimiter and newlines so they cannot corrupt a line's
     /// `kind | id | …` structure, and collapses runs of whitespace.
-    private static func sanitize(_ text: String) -> String {
+    static func sanitize(_ text: String) -> String {
         let replaced = text
             .replacingOccurrences(of: "|", with: "/")
             .replacingOccurrences(of: "\n", with: " ")

--- a/Sources/TMDb/Domain/LanguageModelTools/Tools/MovieCreditsTool.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/Tools/MovieCreditsTool.swift
@@ -1,0 +1,63 @@
+//
+//  MovieCreditsTool.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && !os(tvOS)
+    import Foundation
+    import FoundationModels
+
+    ///
+    /// A language model tool that fetches the principal cast and crew for a movie
+    /// by its TMDb id.
+    ///
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
+    struct MovieCreditsTool: Tool {
+
+        let name = "movieCredits"
+        let description = """
+        Get the principal cast and crew (top-billed cast plus director and writers) \
+        for a movie by its TMDb id. Get the id from search.
+        """
+
+        private let movieService: any MovieService
+        private let language: String?
+
+        init(movieService: any MovieService, language: String? = nil) {
+            self.movieService = movieService
+            self.language = language
+        }
+
+        ///
+        /// The arguments for a movie credits lookup.
+        ///
+        @Generable
+        struct Arguments {
+            /// The TMDb movie id.
+            @Guide(description: "The TMDb movie id, for example from search", .minimum(1))
+            var movieID: Int
+        }
+
+        func call(arguments: Arguments) async throws -> String {
+            do {
+                let credits = try await movieService.credits(
+                    forMovie: arguments.movieID,
+                    language: language
+                )
+                return ToolOutputFormatter.block(for: credits)
+            } catch {
+                if let message = ToolErrorMapper.message(
+                    for: error,
+                    entity: "movie",
+                    id: arguments.movieID
+                ) {
+                    return message
+                }
+                throw error
+            }
+        }
+
+    }
+#endif

--- a/Sources/TMDb/TMDb.docc/Extensions/TMDbClient.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/TMDbClient.md
@@ -45,6 +45,7 @@
 - ``languageModelTools``
 - ``searchTool``
 - ``movieDetailsTool``
+- ``movieCreditsTool``
 - ``tvSeriesDetailsTool``
 - ``personFilmographyTool``
 - ``trendingTool``

--- a/Sources/TMDb/TMDb.docc/Extensions/TMDbToolbox.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/TMDbToolbox.md
@@ -14,6 +14,7 @@
 
 - ``search``
 - ``movieDetails``
+- ``movieCredits``
 - ``tvSeriesDetails``
 - ``personFilmography``
 - ``trending``

--- a/Tests/TMDbIntegrationTests/LanguageModelToolsIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/LanguageModelToolsIntegrationTests.swift
@@ -50,6 +50,17 @@
         }
 
         @available(macOS 26, *)
+        @Test("movie credits returns an id-bearing credits block for a known movie")
+        func movieCredits() async throws {
+            let tool = MovieCreditsTool(movieService: client.movies)
+            let output = try await tool.call(arguments: .init(movieID: fightClubID))
+
+            #expect(output.hasPrefix("credits | \(fightClubID)"))
+            #expect(output.contains("cast | "))
+            #expect(output.localizedCaseInsensitiveContains("Brad Pitt"))
+        }
+
+        @available(macOS 26, *)
         @Test("tv series details returns a block for a known series")
         func tvSeriesDetails() async throws {
             let tool = TVSeriesDetailsTool(tvSeriesService: client.tvSeries)

--- a/Tests/TMDbTests/Domain/LanguageModelTools/MovieCreditsToolTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/MovieCreditsToolTests.swift
@@ -1,0 +1,86 @@
+//
+//  MovieCreditsToolTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(FoundationModels) && os(macOS)
+    import Foundation
+    import Testing
+    @testable import TMDb
+
+    @Suite(.tags(.languageModelTools))
+    struct MovieCreditsToolTests {
+
+        private struct DummyError: Error {}
+
+        private let apiClient = MockAPIClient()
+
+        @available(macOS 26, *)
+        private var tool: MovieCreditsTool {
+            MovieCreditsTool(movieService: TMDbMovieService(apiClient: apiClient))
+        }
+
+        @available(macOS 26, *)
+        @Test("returns a credits block carrying the movie and person ids")
+        func returnsCreditsBlock() async throws {
+            apiClient.addResponse(
+                .success(
+                    ShowCredits.mock(
+                        id: 27205,
+                        cast: [.mock(id: 6193, name: "Leonardo DiCaprio", character: "Cobb", order: 0)],
+                        crew: [.mock(id: 525, name: "Christopher Nolan", job: "Director")]
+                    )
+                )
+            )
+
+            let output = try await tool.call(arguments: .init(movieID: 27205))
+
+            #expect(output.contains("credits | 27205"))
+            #expect(output.contains("cast | 6193 | Leonardo DiCaprio as Cobb"))
+            #expect(output.contains("crew | 525 | Christopher Nolan — Director"))
+        }
+
+        @available(macOS 26, *)
+        @Test("caps cast at ten and keeps only key crew jobs")
+        func capsCastAndFiltersCrew() async throws {
+            let cast = (0 ..< 15).map {
+                CastMember.mock(id: $0, name: "Actor \($0)", character: "Role \($0)", order: $0)
+            }
+            let crew = [
+                CrewMember.mock(id: 100, name: "A Director", job: "Director"),
+                CrewMember.mock(id: 200, name: "An Editor", job: "Editor")
+            ]
+            apiClient.addResponse(.success(ShowCredits.mock(id: 1, cast: cast, crew: crew)))
+
+            let output = try await tool.call(arguments: .init(movieID: 1))
+            let lines = output.components(separatedBy: "\n")
+
+            #expect(lines.count(where: { $0.hasPrefix("cast |") }) == 10)
+            #expect(output.contains("crew | 100 | A Director — Director"))
+            #expect(!output.contains("Editor"))
+        }
+
+        @available(macOS 26, *)
+        @Test("recovers from not found with a readable message")
+        func recoversFromNotFound() async throws {
+            apiClient.addResponse(.failure(.notFound()))
+
+            let output = try await tool.call(arguments: .init(movieID: 999))
+
+            #expect(output == "No TMDb movie with id 999 found.")
+        }
+
+        @available(macOS 26, *)
+        @Test("rethrows infrastructure errors")
+        func rethrowsInfrastructureErrors() async {
+            apiClient.addResponse(.failure(.network(DummyError())))
+
+            await #expect(throws: TMDbError.self) {
+                _ = try await tool.call(arguments: .init(movieID: 1))
+            }
+        }
+
+    }
+#endif

--- a/Tests/TMDbTests/Domain/LanguageModelTools/TMDbClientLanguageModelToolsTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/TMDbClientLanguageModelToolsTests.swift
@@ -17,9 +17,9 @@
         private let client = TMDbClient(apiKey: "test-api-key")
 
         @available(macOS 26, *)
-        @Test("languageModelTools exposes the seven tools")
+        @Test("languageModelTools exposes the eight tools")
         func languageModelToolsCount() {
-            #expect(client.languageModelTools.count == 7)
+            #expect(client.languageModelTools.count == 8)
         }
 
         @available(macOS 26, *)
@@ -27,6 +27,7 @@
         func individualToolProperties() {
             #expect(client.searchTool.name == "search")
             #expect(client.movieDetailsTool.name == "movieDetails")
+            #expect(client.movieCreditsTool.name == "movieCredits")
             #expect(client.tvSeriesDetailsTool.name == "tvSeriesDetails")
             #expect(client.personFilmographyTool.name == "personFilmography")
             #expect(client.trendingTool.name == "trending")

--- a/Tests/TMDbTests/Domain/LanguageModelTools/TMDbToolboxTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/TMDbToolboxTests.swift
@@ -31,9 +31,9 @@
         }
 
         @available(macOS 26, *)
-        @Test("all exposes the seven tools")
-        func allHasSevenTools() {
-            #expect(makeToolbox().all.count == 7)
+        @Test("all exposes the eight tools")
+        func allHasEightTools() {
+            #expect(makeToolbox().all.count == 8)
         }
 
         @available(macOS 26, *)
@@ -43,6 +43,7 @@
             #expect(
                 names == [
                     "discoverMovies",
+                    "movieCredits",
                     "movieDetails",
                     "personFilmography",
                     "search",
@@ -76,6 +77,7 @@
             let toolbox = makeToolbox()
             #expect(toolbox.search.name == "search")
             #expect(toolbox.movieDetails.name == "movieDetails")
+            #expect(toolbox.movieCredits.name == "movieCredits")
             #expect(toolbox.tvSeriesDetails.name == "tvSeriesDetails")
             #expect(toolbox.personFilmography.name == "personFilmography")
             #expect(toolbox.trending.name == "trending")

--- a/Tests/TMDbTests/Domain/LanguageModelTools/ToolOutputFormatterCreditsTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/ToolOutputFormatterCreditsTests.swift
@@ -140,4 +140,21 @@ struct ToolOutputFormatterCreditsTests {
         #expect(block.contains("cast | 5 | A / B as Hero Villain"))
     }
 
+    @Test("credits sanitizes pipe characters in a crew name so they cannot corrupt a line")
+    func creditsSanitizesCrewName() throws {
+        let credits = ShowCredits.mock(
+            id: 1,
+            cast: [],
+            crew: [.mock(id: 9, name: "Nolan | Jr", job: "Director")]
+        )
+
+        let crewLine = try #require(
+            ToolOutputFormatter.block(for: credits)
+                .components(separatedBy: "\n")
+                .first { $0.hasPrefix("crew |") }
+        )
+
+        #expect(crewLine == "crew | 9 | Nolan / Jr — Director")
+    }
+
 }

--- a/Tests/TMDbTests/Domain/LanguageModelTools/ToolOutputFormatterCreditsTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/ToolOutputFormatterCreditsTests.swift
@@ -1,0 +1,143 @@
+//
+//  ToolOutputFormatterCreditsTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.languageModelTools))
+struct ToolOutputFormatterCreditsTests {
+
+    @Test("credits block leads with the credits id header")
+    func creditsBlockHeader() {
+        let credits = ShowCredits.mock(
+            id: 27205,
+            cast: [.mock(id: 6193, name: "Leonardo DiCaprio", character: "Cobb", order: 0)],
+            crew: [.mock(id: 525, name: "Christopher Nolan", job: "Director")]
+        )
+
+        let block = ToolOutputFormatter.block(for: credits)
+
+        #expect(block.hasPrefix("credits | 27205"))
+    }
+
+    @Test("credits cast lines lead with the person id and pair name with character")
+    func creditsCastLines() {
+        let credits = ShowCredits.mock(
+            id: 1,
+            cast: [
+                .mock(id: 819, name: "Edward Norton", character: "The Narrator", order: 0),
+                .mock(id: 287, name: "Brad Pitt", character: "Tyler Durden", order: 1)
+            ],
+            crew: []
+        )
+
+        let block = ToolOutputFormatter.block(for: credits)
+
+        #expect(block.contains("cast | 819 | Edward Norton as The Narrator"))
+        #expect(block.contains("cast | 287 | Brad Pitt as Tyler Durden"))
+    }
+
+    @Test("credits cast is sorted by billing order")
+    func creditsCastSortedByOrder() {
+        let credits = ShowCredits.mock(
+            id: 1,
+            cast: [
+                .mock(id: 2, name: "Second Billed", character: "B", order: 1),
+                .mock(id: 1, name: "Top Billed", character: "A", order: 0)
+            ],
+            crew: []
+        )
+
+        let lines = ToolOutputFormatter.block(for: credits).components(separatedBy: "\n")
+        let castLines = lines.filter { $0.hasPrefix("cast |") }
+
+        #expect(castLines.first == "cast | 1 | Top Billed as A")
+        #expect(castLines.last == "cast | 2 | Second Billed as B")
+    }
+
+    @Test("credits cast is capped at ten members")
+    func creditsCastCapped() {
+        let cast = (0 ..< 15).map {
+            CastMember.mock(id: $0, name: "Actor \($0)", character: "Role \($0)", order: $0)
+        }
+        let credits = ShowCredits.mock(id: 1, cast: cast, crew: [])
+
+        let castLines = ToolOutputFormatter.block(for: credits)
+            .components(separatedBy: "\n")
+            .filter { $0.hasPrefix("cast |") }
+
+        #expect(castLines.count == 10)
+    }
+
+    @Test("credits crew keeps only key jobs, in priority order")
+    func creditsCrewKeyJobs() {
+        let credits = ShowCredits.mock(
+            id: 1,
+            cast: [],
+            crew: [
+                .mock(id: 10, name: "An Editor", job: "Editor"),
+                .mock(id: 20, name: "A Writer", job: "Writer"),
+                .mock(id: 30, name: "A Director", job: "Director")
+            ]
+        )
+
+        let lines = ToolOutputFormatter.block(for: credits).components(separatedBy: "\n")
+        let crewLines = lines.filter { $0.hasPrefix("crew |") }
+
+        #expect(crewLines.contains("crew | 30 | A Director — Director"))
+        #expect(crewLines.contains("crew | 20 | A Writer — Writer"))
+        #expect(!lines.contains { $0.contains("Editor") })
+        // Director outranks Writer in the key-job priority order.
+        #expect(crewLines.first == "crew | 30 | A Director — Director")
+    }
+
+    @Test("credits crew is deduplicated by person and job")
+    func creditsCrewDeduplicated() {
+        let credits = ShowCredits.mock(
+            id: 1,
+            cast: [],
+            crew: [
+                .mock(id: 30, creditID: "a", name: "A Director", job: "Director"),
+                .mock(id: 30, creditID: "b", name: "A Director", job: "Director")
+            ]
+        )
+
+        let crewLines = ToolOutputFormatter.block(for: credits)
+            .components(separatedBy: "\n")
+            .filter { $0.hasPrefix("crew |") }
+
+        #expect(crewLines == ["crew | 30 | A Director — Director"])
+    }
+
+    @Test("credits block reports gracefully when cast and crew are empty")
+    func creditsBlockEmpty() {
+        let credits = ShowCredits.mock(id: 7, cast: [], crew: [])
+
+        let block = ToolOutputFormatter.block(for: credits)
+
+        #expect(block.hasPrefix("credits | 7"))
+        #expect(block.contains("no cast listed"))
+        #expect(block.contains("no crew listed"))
+    }
+
+    @Test("credits sanitizes pipe and newline characters in names and characters")
+    func creditsSanitizesDelimiters() {
+        let credits = ShowCredits.mock(
+            id: 1,
+            cast: [.mock(id: 5, name: "A | B", character: "Hero\nVillain", order: 0)],
+            crew: []
+        )
+
+        let block = ToolOutputFormatter.block(for: credits)
+
+        #expect(!block.contains("A | B"))
+        #expect(!block.contains("\nVillain"))
+        #expect(block.contains("cast | 5 | A / B as Hero Villain"))
+    }
+
+}

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -10,6 +10,37 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-06-23 — ✨ Add `movieCredits` language-model tool to TMDbToolbox (#357) · lite
+
+- **Phases / skills:** phases 0–6; `implement-plan, build-for-testing, test,
+  integration-test, lint, review-changes, capture-knowledge, pr, watch-pr`
+  (skipped `review-plan` — lite).
+- **Worked:** lite path fit a mechanical mirror of `MovieDetailsTool`; reading the
+  sibling source first meant a faithful copy with zero implementation surprises
+  (2714 unit tests green first try). The **`swiftlint --no-cache` step in `/pr`
+  step 4** (the #346 improvement) earned its keep: adding the credits block tipped
+  the formatter file/test over `file_length`/`type_body_length`, caught **locally**
+  and fixed by splitting into a `+Credits` extension file + separate `@Suite`
+  before any CI round-trip.
+- **Friction — the standout:** the local `code-reviewer`'s adversarial pass
+  **dropped a real High** — "missing integration test for `movieCredits`" — with
+  the false reasoning *"no sibling toolbox tool has a per-tool integration test."*
+  In fact `Tests/TMDbIntegrationTests/LanguageModelToolsIntegrationTests.swift` has
+  one per tool; the reviewer only inspected the per-tool **unit** tests and never
+  listed the integration dir. The `claude-review` bot on the PR caught it
+  correctly, costing a post-PR fix + a second full CI run. Phase 3 is supposed to
+  converge Critical/High *before* the PR; a fabricated "siblings don't either"
+  dismissal defeated that.
+- **Deviations:** the integration-test gap was fixed in **Phase 5 (watch-pr)**, not
+  Phase 3, because the local review wrongly cleared it.
+- **Improvement:** when a reviewer is about to drop a "missing integration test"
+  (or any "siblings don't do this either") finding, it must **verify the
+  sibling-convention claim by listing the actual directory** (here
+  `Tests/TMDbIntegrationTests/`) — not assume from the unit-test dir. Worth a line
+  in `.github/CODE_REVIEW.md` / the `code-reviewer` adversarial-pass guidance:
+  *an adversarial drop that rests on a factual claim about sibling code must check
+  that claim against the tree.*
+
 ## 2026-06-19 — ✨ Add `networks` property to TVSeason (#349) · full
 
 - **Phases / skills:** phases 0–6; `review-plan, implement-plan, build-for-testing,

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -6,6 +6,24 @@ out of it.
 
 ## Tooling
 
+### swiftlint `file_length` / `type_body_length` — split into a `+Feature` extension file
+
+*2026-06-22.* Adding a new `block(for:)` formatter plus its helpers to
+`ToolOutputFormatter.swift` (and the matching cases to `ToolOutputFormatterTests.swift`)
+tipped both over swiftlint limits: **`file_length` is 400 lines**, and
+**`type_body_length` is 250** (excluding comments/whitespace). The fix is the
+pattern the codebase already uses for large types — move the new code into a
+dedicated `Type+Feature.swift` extension file (e.g. `ToolOutputFormatter+Credits.swift`)
+and put new tests in a **separate `@Suite struct`** file.
+
+- **Gotcha when splitting an extension across files:** `private` members are
+  visible only within the **same file's** extensions. A helper shared by the new
+  file (here `sanitize(_:)`) must be promoted from `private static` to internal
+  `static` — `fileprivate` won't reach across files either. `internal` carries no
+  `///`-doc requirement (only `public` does), so promoting it is cheap.
+- Worth checking the line count before piling onto any already-large
+  formatter/aggregator file.
+
 ### SourceKit live diagnostics lag newly-created files — trust the build
 
 *2026-06-18.* After `Write`ing a **new** `.swift` file and referencing its


### PR DESCRIPTION
## Summary

Adds an eighth FoundationModels `Tool`, `movieCredits`, to `TMDbToolbox`, filling a
gap in the conversational-assistant surface: nothing previously answered *"who stars
in / who directed THIS movie?"*. `movieDetails` returns only overview/runtime/
genres/rating/year, and `personFilmography` goes the opposite direction (person →
their films). The new tool returns a movie's principal cast and crew as compact,
id-leading text the model can chain into `personFilmography`.

It mirrors the existing `MovieDetailsTool` exactly and is **Apple-platforms only**
(gated `#if canImport(FoundationModels) && !os(tvOS)`). The backing API,
`MovieService.credits(forMovie:language:)`, already existed and is integration-tested
— this change is purely the toolbox wrapper plus formatting.

## Changes

**New Tool:**
- ✨ `MovieCreditsTool` — fetches `ShowCredits` and formats them; same
  `@Generable` arguments, `.minimum(1)` guide, and `ToolErrorMapper`
  recover-or-rethrow flow as `MovieDetailsTool`.

**Formatter:**
- ✨ `ToolOutputFormatter.block(for: ShowCredits)` in a dedicated
  `ToolOutputFormatter+Credits.swift` extension. Header `credits | <movieID>`;
  top-billed cast (sorted by order, capped at 10) as `cast | <id> | <name> as
  <character>`; key crew only (Director/Writer/Screenplay/Story/Producer/Executive
  Producer, priority-ordered, deduped by id+job, capped at 8) as `crew | <id> |
  <name> — <job>`; graceful "no cast/crew listed" empties. All fields sanitized.
- ♻️ `sanitize(_:)` promoted `private`→internal for cross-file reuse.

**Wiring:**
- ✨ `TMDbToolbox.movieCredits` accessor, added to `all` (7 → 8 tools).
- ✨ `TMDbClient.movieCreditsTool` shorthand.

**Tests:**
- ✅ `MovieCreditsToolTests` — id-carrying block, cast cap + crew filtering,
  not-found recovery, infra-error rethrow.
- ✅ `ToolOutputFormatterCreditsTests` — header, cast format/order/cap, crew
  key-job filter/priority/dedup, empty-state, and delimiter sanitization.
- ✅ Updated `TMDbToolboxTests` and `TMDbClientLanguageModelToolsTests` (count 7 → 8,
  new accessor + shorthand).

**Documentation:**
- 📝 `TMDbToolbox.md` and `TMDbClient.md` DocC catalogs list the new tool/shorthand.
- 📝 Captured a swiftlint `file_length`/`type_body_length` + extension-split gotcha
  in `knowledge/gotchas.md`.

## Benefits

- **Closes a capability gap**: the assistant can now answer cast/director questions
  directly instead of only person → filmography.
- **Chainable output**: every line leads with a TMDb id, so the model can pivot from
  a credit to `personFilmography`.
- **Consistent & low-risk**: a faithful mirror of an existing tool over an
  already-integration-tested endpoint; `make ci` green (lint, markdown, unit +
  integration tests, release build, docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)