### PR TITLE
🔧 Run /deliver in an isolated git worktree, torn down on merge

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -13,14 +13,18 @@ keeps going across the long session until the PR is ready.
 
 ```text
 you approve the plan ─▶ /deliver ─▶ worktree ─▶ [review-plan] ─▶ implement ─▶
-  code-review + fix ─▶ capture ─▶ /pr reviewed ─▶ /watch-pr ─▶ GATE: ready-to-merge ─▶ retro ─▶ teardown
-                                                                   ▲ the only hard stop          ▲ on merge
+  code-review + fix ─▶ capture ─▶ /pr reviewed ─▶ /watch-pr ─▶ GATE: ready-to-merge ─▶ retro
+                                                                   ▲ the only hard stop
+  … then, when the PR actually merges (maybe a later session): teardown (Phase 7)
 ```
 
-Every `/deliver` runs in its **own git worktree** (Phase 0.5), so your main
-checkout stays free — you can keep working (or run a second `/deliver`) on another
-branch concurrently without fighting over the working tree or `.build`. The
-worktree and its `.build` are **torn down on merge** (Phase 6 teardown).
+Every `/deliver` runs in its **own git worktree** (Phase 0.5), so your **main
+checkout on disk stays free** — a second Claude session, Xcode, or a manual build
+can use it while this delivery runs (and you can launch a second `/deliver` in
+another session), with no fighting over the working tree or `.build`. (This very
+session is busy delivering; what's freed is the checkout, for *other* tools and
+sessions.) The worktree and its `.build` are **torn down on merge** (Phase 7
+teardown).
 
 **Invoking `/deliver` on an approved plan is itself the plan-approval gate.** From
 there it runs **autonomously** to a single hard stop — **ready-to-merge** — pausing
@@ -50,7 +54,7 @@ These are non-negotiable. Do them by default, without being reminded.
    dedicated git worktree (a new branch off `origin/main`) **before** `/review-plan`
    or any file edit, and all work happens there — so the user's main checkout is
    never touched and stays free for concurrent work. `CLAUDE.md` forbids editing
-   `main`; the worktree guarantees it. On merge, tear the worktree down (Phase 6).
+   `main`; the worktree guarantees it. On merge, tear the worktree down (Phase 7).
 4. **A red gate triages before it stops.** If `make ci` or a check fails, first
    classify **in-diff vs pre-existing** (Phase 4). A failure your diff caused → fix
    test-first and re-run; only **stop** if it can't converge in the cap. A
@@ -188,35 +192,64 @@ user's main checkout (`CLAUDE.md` forbids editing `main`; Contract §3). **Every
 `/deliver` runs in its own git worktree** so the user's checkout stays free for
 concurrent work.
 
+**First, GC any stale worktree from a prior delivery** (this run is the garbage
+collector for the *previous* one's deferred merge — Phase 7 only fires on an
+in-session merge, and the common path is "merged later, elsewhere"). Sweep the
+worktree dirs and reclaim any whose PR has since merged:
+
+```bash
+for wt in .claude/worktrees/*/; do
+  br=$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null) || continue
+  state=$(gh pr view "$br" --json state --jq .state 2>/dev/null)
+  if [ "$state" = "MERGED" ]; then
+    git worktree remove --force "$wt" && git branch -D "$br" 2>/dev/null
+  fi
+done
+```
+
+This keeps `.claude/worktrees/` (each carrying a multi-GB `.build`) from
+accumulating across deliveries the user merged in the GitHub UI or a later session.
+
 **Enter the worktree** with the harness's `EnterWorktree` tool, naming it from the
 plan with a conventional prefix — `feature/<slug>` for new work, `fix/<slug>` for a
 bug fix, etc.:
 
 - `EnterWorktree(name: "feature/<slug>")` creates `.claude/worktrees/feature/<slug>/`
-  on a **new branch off `origin/main`** (the default `fresh` base) and switches the
-  session into it. This is the sanctioned auto-use of `EnterWorktree` for `/deliver`
-  (Contract §3 + memory) — do it without asking.
+  and switches the session into it. By default (`worktree.baseRef: fresh`) the branch
+  is cut from **`origin/main`**; if the user has set `worktree.baseRef: head`, it's
+  cut from local HEAD instead — so don't assume `origin/main` unconditionally. This
+  is the sanctioned auto-use of `EnterWorktree` for `/deliver` (Contract §3 +
+  memory) — do it without asking. **Note the `fresh` consequence:** the worktree is
+  cut from `origin/main`, so any **uncommitted or local-only** state (including the
+  on-disk plan file, if it isn't committed) is **absent** — which is why Phase 0
+  reads the plan's content into the conversation first.
 - **Already in a worktree?** (e.g. the user entered one manually.) Don't nest — use
   the current worktree and just create the branch in it (`git checkout -b
   feature/<slug>`). `EnterWorktree` refuses to nest anyway.
 
-**Propagate local credentials into the worktree.** `.claude/settings.local.json` is
-**gitignored**, so a fresh worktree won't have it — and it holds the
-`TMDB_API_KEY` / `TMDB_USERNAME` / `TMDB_PASSWORD` that `make integration-test` /
-`make ci` need (and the permission allowlist). Copy it from the main checkout
-immediately after entering:
+**Restore the local permission allowlist in the worktree.** Credentials are **not**
+the concern — `TMDB_API_KEY` / `USERNAME` / `PASSWORD` are injected into the
+session's **process environment** at startup (CWD-independent), and `make ci` /
+`make integration-test` read them straight from the environment, so a subshell in
+the worktree inherits them regardless. What a fresh worktree lacks is the
+**gitignored `.claude/settings.local.json`**, which also holds the **permission
+allowlist** — and whether the harness re-reads it from the new CWD is unverified, so
+without it an autonomous run could stall on permission prompts. Copy it in as cheap
+insurance:
 
 ```bash
-# CWD is now the worktree root; --git-common-dir resolves the main checkout.
-cp "$(dirname "$(git rev-parse --git-common-dir)")/.claude/settings.local.json" \
-   .claude/settings.local.json 2>/dev/null || true
+# CWD is the worktree; the main checkout is the first entry of `git worktree list`.
+main_root=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
+mkdir -p .claude
+cp "$main_root/.claude/settings.local.json" .claude/settings.local.json 2>/dev/null || true
 ```
 
-It stays gitignored in the worktree, so it won't be committed. If the integration
-leg later fails with missing credentials, this copy is the first thing to check.
+It stays gitignored in the worktree, so it won't be committed. If `make ci`'s
+integration leg fails on **credentials**, the cause is the *env* not being inherited
+by whatever spawned the subshell — **not** this file; check the environment first.
 
 Record the worktree path and branch name in the ledger. The branch is what the PR
-and all later phases (`git diff main...HEAD`, `/pr`, `/watch-pr`) operate on.
+and all later phases (`git diff origin/main...HEAD`, `/pr`, `/watch-pr`) operate on.
 
 **Invoked from plan mode?** If you reach `/deliver` while in plan mode with an
 approved plan, that approval *is* Gate-1: exit plan mode (the plan file is your
@@ -256,7 +289,7 @@ the lint/format PostToolUse hook to reshape files after writes.
 It also **commits at logical checkpoints** as it goes — each commit a coherent,
 green, lint-clean increment (`/implement-plan`'s *Commit at logical points*). This
 matters for the pipeline: Phase 3 reviews **committed** history (`git diff
-main...HEAD`), so committing as you implement means the review sees the real
+origin/main...HEAD`), so committing as you implement means the review sees the real
 change rather than an empty diff.
 
 Do not advance until `/implement-plan` reports an empty test list with `/test`
@@ -266,7 +299,7 @@ delivery weight from the actual diff now (a "lite" plan that ballooned is `full`
 ## Phase 3 — Code review + fix loop
 
 **Skip this phase entirely if the change has no Swift source.** `/review-changes`
-self-gates (it returns immediately when `git diff main...HEAD` touches no
+self-gates (it returns immediately when `git diff origin/main...HEAD` touches no
 `*.swift`), so a docs-only / config-only delivery sails straight to Phase 3.5
 with no review. Code review is for Swift.
 
@@ -301,7 +334,7 @@ reconcile) for a large/multi-unit one. Then converge:
    `canon-tdd` — failing test that captures the defect, then the fix — then re-run
    `/test` (+ `/integration-test` if behaviour changed) and **commit the fix**.
    The commit is required: `/review-changes` diffs **committed** history
-   (`main...HEAD`), so an uncommitted fix would re-review as still-broken and never
+   (`origin/main...HEAD`), so an uncommitted fix would re-review as still-broken and never
    converge.
 3. **Re-invoke `/review-changes`** on the updated (committed) diff. Repeat until no
    Critical/High findings remain.
@@ -348,7 +381,7 @@ then push the branch and open the PR with a gitmoji title and structured body.
 **If `make ci` fails, triage before you stop** (Contract §4):
 
 1. **Which check, and is it in your diff?** Read the failure. Compare the failing
-   test/file against `git diff --name-only main...HEAD`.
+   test/file against `git diff --name-only origin/main...HEAD`.
 2. **In-diff genuine failure** → it's yours: fix it (test-first), commit, re-run
    `make ci`. Only **stop and report** if it can't converge.
    - **Auto:** when it can't converge, convene the panel. **Proceed** → open the
@@ -416,8 +449,19 @@ Reflect on *this* delivery and write a dated entry to
 
 Keep it to a handful of bullets — a log, not a ceremony. Then **scan recent
 entries** for recurring friction or deviations — the recurring-pattern scan below
-formalizes this. Commit the retro with the PR when possible (watch-only), or as a
-small follow-up when auto-merged.
+formalizes this.
+
+**Commit *and push* the retro before teardown — never leave it as a worktree-only
+commit.** Phase 7's teardown discards the worktree, so an unpushed retro commit is
+lost. Two cases:
+
+- **Watch-only (PR still open)** — commit the retro on the PR branch and **push it**
+  (`git push`), so it rides the open PR. (This is the common path.)
+- **`merge`/auto mode (branch already merged + deleted in Phase 5)** — the PR branch
+  is gone, so commit the retro on a **fresh branch off `origin/main`** and open a
+  small follow-up PR (or push straight if policy allows); the same applies to any
+  skill edits the auto recurring-pattern scan commits. Do this **before** Phase 7,
+  and confirm it's pushed — otherwise teardown's `discard_changes` drops it.
 
 **Keep the file windowed.** After adding the entry, if `delivery-retros.md` holds
 more than **~12 full entries**, distil the oldest into its one-line archive table
@@ -487,13 +531,33 @@ worktree down once the PR is merged** — this reclaims both the worktree **and*
 - **Watch-only (default)** — the worktree **stays** at the gate (Phase 5). When the
   merge happens *within this session* (the user says "merge" and you do it, or a
   later turn confirms the PR is `MERGED`), tear down **then**. If the session ends
-  with the PR still open, **leave the worktree** — the harness prompts keep/remove
-  at session exit, and the work must survive until it's merged.
+  with the PR still open, **leave the worktree** — the work must survive until it's
+  merged. Interactive sessions get a harness keep/remove prompt at exit; **headless /
+  `auto` runs have no one to answer it**, so a merged-later worktree is reclaimed not
+  here but by the **Phase 0.5 GC sweep at the start of the *next* delivery** (it
+  removes any worktree whose PR has since merged). That sweep is the backstop that
+  keeps unattended runs from leaking disk.
 - **Stuck / blocked / abandoned** — **never** tear down. Keep the worktree so the
   work can be resumed.
 
-**How to tear down** — only after confirming the PR is actually merged
-(`gh pr view <n> --json state --jq .state` → `MERGED`):
+**How to tear down** — two preconditions, both required:
+
+1. **The PR is actually merged** — `gh pr view <n> --json state --jq .state` → `MERGED`.
+2. **The worktree has no unsaved work beyond what's merged** — `MERGED` only
+   guarantees the *pushed* feature commits are on `main`; it says nothing about a
+   commit made (or a file edited) **after** the last push, e.g. the retro. Verify
+   the tree is clean **and** fully pushed before discarding:
+
+   ```bash
+   git status --porcelain                                  # must be empty (no uncommitted work)
+   test "$(git rev-parse HEAD)" = "$(git rev-parse @{u})"  # HEAD must equal its pushed upstream
+   ```
+
+   If either check fails, there is worktree-only work not yet on `main` — **stop**,
+   land it (push it / move it to a follow-up off `origin/main`, per Phase 6), and
+   only then tear down. Do **not** discard it.
+
+Then:
 
 ```text
 ExitWorktree(action: "remove", discard_changes: true)
@@ -501,15 +565,19 @@ ExitWorktree(action: "remove", discard_changes: true)
 
 - `remove` deletes the worktree directory (which **is** its `.build` — the multi-GB
   reclaim) and the local branch, then returns the session to the main checkout.
-- `discard_changes: true` is required here: a **squash**-merge lands the work as a
-  *new* commit on `main`, so the worktree branch's own commits aren't literally on
-  `main` and `ExitWorktree` would otherwise refuse. Discarding them is safe **only
-  because** you confirmed `MERGED` — the change is preserved on `main`. Never pass
-  it before confirming the merge.
+- `discard_changes: true` is needed only because a **squash**-merge lands the work
+  as a *new* commit on `main`, so the branch's pushed-and-merged commits aren't
+  *literally* on `main` and `ExitWorktree` would otherwise refuse. It is safe
+  **only because** precondition 2 proved there's nothing un-merged left to lose —
+  not merely because the PR is `MERGED`. Never pass it on an unverified tree.
 
-After teardown, optionally fast-forward the user's main checkout so it reflects the
-merge (`git fetch origin && git merge --ff-only origin/main`). Report the reclaimed
-worktree in the final summary.
+After teardown, the session is back in the main checkout — **leave it as you found
+it**. Do *not* auto-`merge --ff-only` it: the user may be actively working there
+(the whole point of the worktree) with uncommitted or diverged state, and the FF
+would fail noisily or fight their work. Only if it is **clean and on `main`**
+(`git status --porcelain` empty) may you fast-forward it (`git fetch origin &&
+git merge --ff-only origin/main`); otherwise just note "main checkout left as-is
+(N commits behind)". Report the reclaimed worktree in the final summary.
 
 ## When the pipeline stops
 

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -12,10 +12,15 @@ the existing skills and the `code-reviewer` agent, adds the safety gates, and
 keeps going across the long session until the PR is ready.
 
 ```text
-you approve the plan ─▶ /deliver ─▶ branch ─▶ [review-plan] ─▶ implement ─▶
-  code-review + fix ─▶ capture ─▶ /pr reviewed ─▶ /watch-pr ─▶ GATE: ready-to-merge ─▶ retro
-                                                                   ▲ the only hard stop
+you approve the plan ─▶ /deliver ─▶ worktree ─▶ [review-plan] ─▶ implement ─▶
+  code-review + fix ─▶ capture ─▶ /pr reviewed ─▶ /watch-pr ─▶ GATE: ready-to-merge ─▶ retro ─▶ teardown
+                                                                   ▲ the only hard stop          ▲ on merge
 ```
+
+Every `/deliver` runs in its **own git worktree** (Phase 0.5), so your main
+checkout stays free — you can keep working (or run a second `/deliver`) on another
+branch concurrently without fighting over the working tree or `.build`. The
+worktree and its `.build` are **torn down on merge** (Phase 6 teardown).
 
 **Invoking `/deliver` on an approved plan is itself the plan-approval gate.** From
 there it runs **autonomously** to a single hard stop — **ready-to-merge** — pausing
@@ -41,8 +46,11 @@ These are non-negotiable. Do them by default, without being reminded.
    `/pr`, `/watch-pr`, and `/fix-integration-failures` (`/review-changes` is what
    spawns the `code-reviewer` agent or the review Workflow). This skill only
    sequences and gates; the expertise lives in those pieces.
-3. **Never work on `main`.** Branch first — before `/review-plan` or any file edit
-   (see *Phase 0.5*). `CLAUDE.md` forbids editing `main`.
+3. **Never work on `main` — always in a fresh worktree.** Phase 0.5 enters a
+   dedicated git worktree (a new branch off `origin/main`) **before** `/review-plan`
+   or any file edit, and all work happens there — so the user's main checkout is
+   never touched and stays free for concurrent work. `CLAUDE.md` forbids editing
+   `main`; the worktree guarantees it. On merge, tear the worktree down (Phase 6).
 4. **A red gate triages before it stops.** If `make ci` or a check fails, first
    classify **in-diff vs pre-existing** (Phase 4). A failure your diff caused → fix
    test-first and re-run; only **stop** if it can't converge in the cap. A
@@ -136,6 +144,13 @@ it never bloats or biases the main window:
 - **The gate stays in the main agent.** Subagents are non-interactive; the
   ready-to-merge gate is handed to the user, so the conductor — not a subagent —
   owns it. Phases hand off via **git / disk / the PR**, not via context.
+- **The work happens in a worktree, the session stays put.** The conductor
+  `EnterWorktree`s in Phase 0.5 so the delivery's branch and its multi-GB `.build`
+  live in `.claude/worktrees/<branch>/`, isolated from the user's main checkout.
+  This is what lets a second `/deliver` (or hand work) run concurrently — separate
+  worktrees get separate `.build` directories automatically (the scratch path is
+  CWD-relative), so their builds don't collide. No `SCRATCH_PATH` override is needed
+  for this; that flag is only for *multiple agents sharing one* working directory.
 
 ## Phase 0 — Preconditions
 
@@ -159,33 +174,55 @@ it never bloats or biases the main window:
   block the pipeline on it.
 - **Judge the delivery weight** (lite vs full) from the plan, and open the
   `TaskCreate` ledger (Contract §6).
+- **Read the plan's content into context now — before the worktree.** Phase 0.5's
+  `EnterWorktree` switches the working directory and **clears the CWD-scoped plans
+  cache**, so the active plan reference can be lost after the switch. Locate and
+  **read the plan file fully here** (its content travels with the conversation),
+  so Phase 1+ can work from it inside the worktree without re-finding it.
 
-## Phase 0.5 — Ensure a feature branch (before any edit)
+## Phase 0.5 — Enter an isolated worktree (before any edit)
 
 Do this **before** Phase 1 — `/review-plan` applies its consensus by editing the
-plan, and if the plan is a **tracked file** that edit must not land on `main`
-(`CLAUDE.md` forbids editing `main`; Contract §3). Branch first, then nothing
-downstream can touch `main`.
+plan, and all of implementation happens next; none of it may touch `main` or the
+user's main checkout (`CLAUDE.md` forbids editing `main`; Contract §3). **Every
+`/deliver` runs in its own git worktree** so the user's checkout stays free for
+concurrent work.
+
+**Enter the worktree** with the harness's `EnterWorktree` tool, naming it from the
+plan with a conventional prefix — `feature/<slug>` for new work, `fix/<slug>` for a
+bug fix, etc.:
+
+- `EnterWorktree(name: "feature/<slug>")` creates `.claude/worktrees/feature/<slug>/`
+  on a **new branch off `origin/main`** (the default `fresh` base) and switches the
+  session into it. This is the sanctioned auto-use of `EnterWorktree` for `/deliver`
+  (Contract §3 + memory) — do it without asking.
+- **Already in a worktree?** (e.g. the user entered one manually.) Don't nest — use
+  the current worktree and just create the branch in it (`git checkout -b
+  feature/<slug>`). `EnterWorktree` refuses to nest anyway.
+
+**Propagate local credentials into the worktree.** `.claude/settings.local.json` is
+**gitignored**, so a fresh worktree won't have it — and it holds the
+`TMDB_API_KEY` / `TMDB_USERNAME` / `TMDB_PASSWORD` that `make integration-test` /
+`make ci` need (and the permission allowlist). Copy it from the main checkout
+immediately after entering:
 
 ```bash
-git branch --show-current
+# CWD is now the worktree root; --git-common-dir resolves the main checkout.
+cp "$(dirname "$(git rev-parse --git-common-dir)")/.claude/settings.local.json" \
+   .claude/settings.local.json 2>/dev/null || true
 ```
 
-If on `main` (or any protected base), create a branch off `main` with a
-conventional prefix derived from the plan — `feature/<slug>` for new work,
-`fix/<slug>` for a bug fix, etc.:
+It stays gitignored in the worktree, so it won't be committed. If the integration
+leg later fails with missing credentials, this copy is the first thing to check.
 
-```bash
-git checkout -b feature/<slug>
-```
-
-Record the branch name in the ledger. If already on a suitable feature branch,
-keep it.
+Record the worktree path and branch name in the ledger. The branch is what the PR
+and all later phases (`git diff main...HEAD`, `/pr`, `/watch-pr`) operate on.
 
 **Invoked from plan mode?** If you reach `/deliver` while in plan mode with an
 approved plan, that approval *is* Gate-1: exit plan mode (the plan file is your
-input), branch, and proceed — there's no separate `ExitPlanMode`-then-approve
-dance, and no second "is the plan ok?" prompt.
+input — already read into context in Phase 0), enter the worktree, and proceed —
+there's no separate `ExitPlanMode`-then-approve dance, and no second "is the plan
+ok?" prompt.
 
 ## Phase 1 — Harden the plan (no separate approval stop)
 
@@ -340,9 +377,11 @@ away. (See `/watch-pr` §3.)
 
 **THE GATE — hard stop at ready-to-merge.** When the PR is ready, **stop and hand
 it to the user for the final merge** — `/deliver` does not merge by default. Report
-the PR URL and its ready state, then run Phase 6. If `/watch-pr` reports the PR is
-**stuck** (a check it can't fix, or a human-decision review thread), stop and
-summarise what's blocking.
+the PR URL and its ready state, then run Phase 6. The **worktree stays in place**
+at the gate (the PR branch lives there); it's torn down only on merge (Phase 7). If
+`/watch-pr` reports the PR is **stuck** (a check it can't fix, or a human-decision
+review thread), stop and summarise what's blocking — **keep the worktree** so the
+work can be resumed.
 
 > **Auto:** on a stuck PR, convene the panel to decide **wait-and-retry vs stop**.
 > **Proceed** (majority to keep trying) → schedule a later re-check with
@@ -354,6 +393,7 @@ summarise what's blocking.
 > **Opt-in auto-merge:** if the user explicitly passes `merge` to `/deliver`,
 > forward it to `/watch-pr` (`/watch-pr merge`) so it squash-merges once ready, and
 > the gate becomes "report the merge" instead of stopping. Default is watch-only.
+> Either way, a confirmed merge triggers **Phase 7 teardown**.
 
 ## Phase 6 — Retrospective (continuous improvement)
 
@@ -432,6 +472,44 @@ what turns one-off retros into reviewed skill improvements:
    (status) and **Reconsider when** fields are exactly what step 2's dedup keys on,
    so keep them on every entry; this is what stops the scan re-proposing a settled
    call next time.
+
+## Phase 7 — Teardown on merge (reclaim the worktree)
+
+A delivery's worktree carries a full `.build` (here **~3 GB** after the CI gate, on
+top of the source). Leaving one per delivery accumulates fast, so **tear the
+worktree down once the PR is merged** — this reclaims both the worktree **and** its
+`.build` in one step.
+
+**The trigger is the merge, and only the merge:**
+
+- **`merge` mode** — `/watch-pr merge` squash-merged the PR. Tear down immediately
+  after.
+- **Watch-only (default)** — the worktree **stays** at the gate (Phase 5). When the
+  merge happens *within this session* (the user says "merge" and you do it, or a
+  later turn confirms the PR is `MERGED`), tear down **then**. If the session ends
+  with the PR still open, **leave the worktree** — the harness prompts keep/remove
+  at session exit, and the work must survive until it's merged.
+- **Stuck / blocked / abandoned** — **never** tear down. Keep the worktree so the
+  work can be resumed.
+
+**How to tear down** — only after confirming the PR is actually merged
+(`gh pr view <n> --json state --jq .state` → `MERGED`):
+
+```text
+ExitWorktree(action: "remove", discard_changes: true)
+```
+
+- `remove` deletes the worktree directory (which **is** its `.build` — the multi-GB
+  reclaim) and the local branch, then returns the session to the main checkout.
+- `discard_changes: true` is required here: a **squash**-merge lands the work as a
+  *new* commit on `main`, so the worktree branch's own commits aren't literally on
+  `main` and `ExitWorktree` would otherwise refuse. Discarding them is safe **only
+  because** you confirmed `MERGED` — the change is preserved on `main`. Never pass
+  it before confirming the merge.
+
+After teardown, optionally fast-forward the user's main checkout so it reflects the
+merge (`git fetch origin && git merge --ff-only origin/main`). Report the reclaimed
+worktree in the final summary.
 
 ## When the pipeline stops
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -17,37 +17,35 @@ include `reviewed` (or `skip-review`), an upstream step already ran the
 Swift, so a docs-only / config-only PR needs none:
 
 ```bash
-git diff --name-only main...HEAD | grep -qE '\.swift$' || echo "no-swift → skip review"
+git diff --name-only origin/main...HEAD | grep -qE '\.swift$' || echo "no-swift → skip review"
 ```
 
 1. Run `/format` to format code
 2. **Commit all outstanding work.** Run `git status`. If the working tree has **any** uncommitted or unstaged changes (the feature work, plus the formatting from step 1), stage and commit them — the PR reflects **committed history only**, so anything left uncommitted will be **missing from the PR**. First **verify no secrets, `.env`, or build artifacts** are included (per CLAUDE.md — `.env` must stay gitignored; check `git status` before `git add`). Use a descriptive gitmoji message (or several logical commits if the work spans concerns); formatting-only changes can use "🎨 apply code formatting". If the tree is already clean (e.g. work was committed during `/deliver`), this is a no-op.
-3. **Rebase onto the latest `main`.** Bring local `main` up to date with remote, then rebase the feature branch onto it — do this **before** `make ci` so the gate (and the eventual PR) reflects the real merge result, not stale code:
+3. **Rebase onto the latest `origin/main`.** Fetch the remote and rebase the feature branch directly onto `origin/main` — do this **before** `make ci` so the gate (and the eventual PR) reflects the real merge result, not stale code:
 
     ```bash
     git fetch origin
-    git checkout main && git merge --ff-only origin/main   # local main == remote main
-    git checkout -                                          # back to the feature branch
-    git rebase main
+    git rebase origin/main
     ```
 
-    - If `git merge --ff-only` fails, local `main` has diverged from `origin/main` — **stop** and investigate; do not force it.
+    - **Rebase onto `origin/main`, not local `main`** — this is **worktree-safe**. A `/deliver` runs inside a git worktree, and `git checkout main` there fails (`fatal: 'main' is already used by worktree …`) whenever the main checkout is on `main`; rebasing onto `origin/main` avoids checking `main` out at all and uses the true remote base directly.
     - If `git rebase` reports conflicts, **stop**, resolve them, then continue. Never skip or force past a conflict you don't understand.
     - The rebase rewrites the branch tip, so a branch that was **already pushed** will need `git push --force-with-lease` at the push step below.
-    - Already on / branched directly off an up-to-date `main` with nothing to replay → this is a fast no-op.
+    - Already branched off an up-to-date `origin/main` with nothing to replay → this is a fast no-op.
 4. Run the pre-PR gate — **MANDATORY; it must pass before going further.** Run it directly (do not delegate). If it fails, stop and fix — **commit the fixes** — then re-run; never open a PR on a red gate. Scale the gate to the diff:
     - **Default — full `make ci`.** The gate CLAUDE.md requires before any PR: lint, markdown lint, unit tests, integration tests, the release build, and the docs build. Use this whenever **any** code or build-affecting file changed.
     - **Docs/config-only fast gate.** When the diff touches **no build- or test-affecting files** — i.e. no `*.swift` **and** none of `Makefile`, `Package.swift`, `Package.resolved`, `*.xctestplan`, or `.github/**` — the test/release-build legs of `make ci` have nothing to exercise. Run only the meaningful checks instead: `make lint && make lint-markdown && make build-docs` (drop `build-docs` if no `*.docc/**` changed). Detect this with:
 
         ```bash
-        git diff --name-only main...HEAD \
+        git diff --name-only origin/main...HEAD \
           | grep -qE '\.swift$|^Makefile$|^Package\.(swift|resolved)$|\.xctestplan$|^\.github/' \
           && echo "code/build touched → full make ci" \
           || echo "docs/config-only → fast gate"
         ```
 
         The PR's own CI still runs the full matrix regardless, so this only trims the **local** gate; it never lowers what actually guards `main`. When in doubt, run full `make ci`.
-    - **Re-lint new Swift files without the cache.** `make ci`'s lint leg is `swiftlint --strict .` (Makefile), and SwiftLint **caches results** (`~/Library/Caches/SwiftLint`). On **newly-added** `.swift` files this has been seen to report a **false green** locally — passing `file_length` / `type_body_length` that the PR's CI `Lint` job (a clean checkout, no cache) then fails on. So **when the diff adds any new `.swift` file** (`git diff --name-only --diff-filter=A main...HEAD | grep -q '\.swift$'`), run a cache-bypassing lint before trusting the gate:
+    - **Re-lint new Swift files without the cache.** `make ci`'s lint leg is `swiftlint --strict .` (Makefile), and SwiftLint **caches results** (`~/Library/Caches/SwiftLint`). On **newly-added** `.swift` files this has been seen to report a **false green** locally — passing `file_length` / `type_body_length` that the PR's CI `Lint` job (a clean checkout, no cache) then fails on. So **when the diff adds any new `.swift` file** (`git diff --name-only --diff-filter=A origin/main...HEAD | grep -q '\.swift$'`), run a cache-bypassing lint before trusting the gate:
 
         ```bash
         swiftlint lint --strict --no-cache .

--- a/.claude/skills/review-changes/SKILL.md
+++ b/.claude/skills/review-changes/SKILL.md
@@ -31,7 +31,7 @@ Code review exists to review **Swift**. If the diff touches no Swift source,
 there is nothing to review — return immediately, don't spawn any reviewer.
 
 ```bash
-git diff --name-only main...HEAD | grep -qE '\.swift$' || echo "no-swift"
+git diff --name-only origin/main...HEAD | grep -qE '\.swift$' || echo "no-swift"
 ```
 
 If that prints `no-swift` (no `*.swift` files changed — e.g. a docs-only,
@@ -43,7 +43,7 @@ code review skipped." Do not run §1–§3. (JSON fixtures under
 ## 1. Scope the change
 
 ```bash
-git diff --stat main...HEAD
+git diff --stat origin/main...HEAD
 ```
 
 Judge size (heuristic, not a rigid count):
@@ -58,13 +58,13 @@ genuinely broad.
 
 ## 2a. Small change → single agent
 
-Spawn the **`code-reviewer`** agent on `git diff main...HEAD`. It follows
+Spawn the **`code-reviewer`** agent on `git diff origin/main...HEAD`. It follows
 `.github/CODE_REVIEW.md` including its own adversarial self-pass, and returns the
 full severity-graded report. Pass that report back to the caller. Done.
 
 ## 2b. Large change → fan-out + verify Workflow
 
-Invoke the **`Workflow`** tool with the script below and `args: { base: "main" }`.
+Invoke the **`Workflow`** tool with the script below and `args: { base: "origin/main" }`.
 It fans out one reviewer per dimension (each following the spec, focused on a
 single lens), dedups, **adversarially verifies every Critical/High** finding with
 an independent skeptic (dropping any that don't survive), and returns the
@@ -81,7 +81,7 @@ export const meta = {
   model: 'opus',
 }
 
-const BASE = (args && args.base) || 'main'
+const BASE = (args && args.base) || 'origin/main'
 const SPEC = '.github/CODE_REVIEW.md'
 
 const DIMENSIONS = [

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ junit-swift-testing.xml
 # Claude
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+.claude/worktrees/
 
 # Git worktrees
 .worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -589,6 +589,12 @@ git checkout -b <branch-name>
 Use a descriptive branch name with a conventional prefix
 (`feature/`, `fix/`, `chore/`, `docs/`, etc.).
 
+> **`/deliver` goes further** — it runs the whole delivery in its own **git
+> worktree** (under `.claude/worktrees/`, branched off `origin/main`) so the main
+> checkout stays free for concurrent work, and tears the worktree down on merge.
+> The branch-off-`main` rule above is the floor; the worktree is how `/deliver`
+> meets it. See `.claude/skills/deliver/SKILL.md` (Phases 0.5 + 7).
+
 ## Creating Pull Requests
 
 > The **`/pr`** skill automates this whole section (commit outstanding work →


### PR DESCRIPTION
## Summary

Updates the `/deliver` pipeline to run in its **own git worktree** so the main
checkout stays free for concurrent work (a second session, Xcode, manual builds,
or a second `/deliver`), and to **tear the worktree down on merge** to reclaim its
~3 GB `.build`. Motivated by not being able to work on another feature while a
`/deliver` ran.

The change is **process/docs only** — it edits skill instructions (`.claude/skills/`),
`.gitignore`, and `CLAUDE.md`. No Swift, no build config.

A key correction up front: **concurrent worktree builds need no build-dir config** —
`swift build`'s scratch path is CWD-relative, so each worktree gets its own `.build`
automatically. `SCRATCH_PATH` (already in the Makefile) is only for *multiple agents
sharing one directory*, not for separate worktrees.

## Changes

**`/deliver` (`.claude/skills/deliver/SKILL.md`):**
- 🔧 Phase 0.5 now `EnterWorktree`s (branch off `origin/main`) instead of
  `git checkout -b`, and restores the gitignored `.claude/settings.local.json`
  (the permission allowlist) into the worktree.
- 🔧 Phase 0 reads the plan into context first (EnterWorktree clears the CWD-scoped
  plans cache; a `fresh` worktree won't contain an uncommitted plan file).
- ✨ Phase 7 — Teardown: on a **confirmed merge** *and* a clean, fully-pushed tree,
  `ExitWorktree(remove, discard_changes:true)` reclaims the worktree + its `.build`.
- ✨ Phase 0.5 **GC sweep**: each run reclaims any prior worktree whose PR has since
  merged — the backstop for watch-only / headless runs merged later or elsewhere.

**Worktree-safety fixes across the pipeline (found by adversarial review):**
- 🐛 **Critical:** `/pr` step 3 did `git checkout main`, which **fails inside a
  worktree** (`'main' is already used by worktree`) whenever the main checkout is on
  `main`. Rewritten to `git fetch origin && git rebase origin/main`; diff bases moved
  to `origin/main...HEAD` across `/pr`, `/review-changes`, and `/deliver`.

**Repo config:**
- 🔧 `.gitignore`: add `.claude/worktrees/` (was only ignored via local
  `.git/info/exclude`).
- 📝 `CLAUDE.md`: Branching section points to the worktree behaviour.

## Review

Put through a **3-critic adversarial review** before opening. Consensus applied:
the Critical `/pr` break; teardown made safe against discarding post-push commits
(e.g. the retro); the Phase 6→7 label fix; the GC sweep for orphaned worktrees; a
corrected `settings.local.json` rationale (credentials come from the inherited
session env, not the file); and reworded concurrency claims.

## Benefits

- **Concurrency**: deliver a feature without pinning the main checkout to its branch
  or `.build` — work on something else in parallel.
- **Disk hygiene**: worktrees (and their multi-GB `.build`) are reclaimed on merge,
  with a next-run GC backstop for the merged-later case.
- **Correctness**: the pipeline's git commands are now worktree-safe and diff against
  the true `origin/main` base.

> Note: this branches `fresh` from `origin/main`, so the new worktree behaviour goes
> live only once merged — the *first* `/deliver` after merge is what exercises teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)