### PR TITLE
🔧 /deliver: add a wiki-update step after the retrospective

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -489,6 +489,27 @@ more than **~12 full entries**, distil the oldest into its one-line archive tabl
 An old retro's lesson already lives in the skills and `skill-improvement-log.md`;
 the table preserves the telemetry without the bulk.
 
+### Update the personal wiki (after the retro)
+
+The retro distils this delivery's durable learnings, so it is the natural moment
+to feed the **personal `wiki`** (Adam's cross-project engineering knowledge, via
+the `wiki` MCP). The retro/`knowledge/` base is *project-specific*; the wiki is
+for **generalizable, reusable opinions, heuristics, and patterns** — the things
+that would apply on the next project too (a design stance, a concurrency or
+testing heuristic, a tooling gotcha that isn't TMDb-specific).
+
+- **Degrade silently if the `wiki` MCP is absent** (a contributor's machine, a
+  headless/cron run) — never block on it.
+- **Search first** (`search_wiki`/`search_entries`) and prefer **updating** a
+  near-match over creating a duplicate.
+- **Propose, don't autonomously save.** The wiki tooling reserves `add_entry`/
+  `update_entry` for Adam's explicit approval — use **`propose_entry`** to render
+  each candidate for review, and only `add_entry`/`update_entry` once Adam
+  approves. Cite the wiki when an answer later draws on it.
+- **Be selective** — one or two high-signal entries beat a dump; skip anything
+  that's only project-specific (that already lives in `knowledge/`) or already in
+  the wiki. Capturing nothing is a valid outcome.
+
 ### Recurring-pattern scan (after committing the retro)
 
 Once the retro entry is committed, do a structured cross-delivery scan — this is

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,25 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-06-23 — Add a "update the personal wiki" step after the retro · applied
+
+- **Pattern:** `/deliver` Phase 6 captured durable learnings into the
+  project-specific `knowledge/` base and `skill-improvement-log`, but never fed
+  the **personal `wiki`** (Adam's cross-project engineering knowledge) — so
+  generalizable opinions/heuristics from a delivery weren't being kept where they
+  carry to the next project. Surfaced when Adam asked, post-merge, "anything to
+  update in my wiki?" and then "updating my wiki should be a step after the retro."
+- **Decision:** **applied** (user-directed). Added an "Update the personal wiki
+  (after the retro)" subsection to `/deliver` Phase 6: search first, propose via
+  `propose_entry` (review-gated — never autonomous `add_entry`/`update_entry`),
+  be selective (generalizable only; project-specific stays in `knowledge/`), and
+  degrade silently if the `wiki` MCP is absent. Landed in
+  `.claude/skills/deliver/SKILL.md` Phase 6.
+- **Rationale:** the retro already distils the delivery's learnings, so it's the
+  cheapest moment to lift the *generalizable* ones into the durable, cross-project
+  store; gating on `propose_entry` respects the wiki tooling's approval model.
+- **Reconsider when:** n/a (applied).
+
 ### 2026-06-23 — Hard checkpoint to consult swift-concurrency / swift-testing-expert · applied
 
 - **Pattern:** in #359 the concurrency-sensitive work (an `NSLock`/`@unchecked


### PR DESCRIPTION
## Summary

Adds a wiki-update step to `/deliver`'s Phase 6, after the retrospective — so the
**generalizable** learnings from a delivery get lifted into Adam's cross-project
personal `wiki` (the `wiki` MCP), not just the project-specific `knowledge/` base.

## Changes

**`.claude/skills/deliver/SKILL.md` (Phase 6):**
- 🔧 New "Update the personal wiki (after the retro)" subsection: search first,
  **propose via `propose_entry`** (review-gated — never autonomous
  `add_entry`/`update_entry`), keep it to generalizable opinions/heuristics
  (project-specific stays in `knowledge/`), be selective, and **degrade silently**
  if the `wiki` MCP is absent.

**`knowledge/skill-improvement-log.md`:**
- 📝 Logged the change (applied, user-directed).

## Why

The retro already distils a delivery's durable learnings, so it's the cheapest
moment to lift the cross-project ones into the wiki. Gating on `propose_entry`
respects the wiki tooling's approval model (it reserves saves for Adam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)