### PR TITLE
✨ Add missing discover filter parameters

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -251,6 +251,19 @@ by whatever spawned the subshell — **not** this file; check the environment fi
 Record the worktree path and branch name in the ledger. The branch is what the PR
 and all later phases (`git diff origin/main...HEAD`, `/pr`, `/watch-pr`) operate on.
 
+**Edit via worktree paths, and verify your diff landed there — not on `main`.** A
+file `Read` *before* `EnterWorktree` (e.g. source you scoped in Phase 0) yields a
+**main-checkout** absolute path; continuing to `Edit` that exact path after entering
+writes to **`main`**, not the worktree (they share `.git` but have **separate
+working dirs**). The trap is self-concealing: the build/test then runs against the
+still-pristine worktree and returns **baseline** counts, so a green run "confirms"
+work that never landed. So: after entering, **re-`Read` source files before editing
+them**, and **before trusting the first green build, verify `git status` shows your
+diff in the worktree** (an empty diff + baseline test counts = edits went to `main`).
+Rescue stranded edits with a shared stash: `git -C <main-checkout> stash` then
+`git stash pop` in the worktree. (Same root cause as the fanned-out-subagent variant
+in `knowledge/gotchas.md` → *Edits can land in the main checkout*.)
+
 **Invoked from plan mode?** If you reach `/deliver` while in plan mode with an
 approved plan, that approval *is* Gate-1: exit plan mode (the plan file is your
 input — already read into context in Phase 0), enter the worktree, and proceed —

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -549,6 +549,17 @@ lost. Two cases:
   skill edits the auto recurring-pattern scan commits. Do this **before** Phase 7,
   and confirm it's pushed — otherwise teardown's `discard_changes` drops it.
 
+**Pushing the retro re-opens the gate — re-watch before merge.** In watch-only mode
+the retro / knowledge / skill commits are pushed to the **PR branch after** the
+ready gate, and **every push re-triggers `claude-review` and the CI matrix** — which
+can post a **new blocking thread** (the `main` ruleset requires thread resolution)
+or restart checks. So after the **last** post-gate push, **return to the `/watch-pr`
+loop once more**: re-sweep unresolved threads and re-confirm checks green before
+treating the PR as merge-ready or merging. "Ready" is only ever true of the *current*
+branch tip — never a tip you have since pushed past. (Bit `/deliver` on #361: a
+"ready, 0 threads" call made before the retro+skill pushes, whose re-reviews then
+raised a High thread that blocked the merge.)
+
 **Keep the file windowed.** After adding the entry, if `delivery-retros.md` holds
 more than **~12 full entries**, distil the oldest into its one-line archive table
 (`date · PR · weight · one-line outcome`) and drop the prose — per

--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -102,6 +102,14 @@ fixing here:
   changes). A converging PR should see each push's inline batch shrink; if the same
   severity-gated topic reappears across pushes, treat it as noise per the rule
   above (reply with the earlier SHA, resolve, don't re-edit).
+- **Re-sweep after every push — "ready" is only true of the current tip.** Any push
+  to the branch (a check fix, *and* a caller's post-gate commit such as a `/deliver`
+  retro or skill edit) re-triggers `claude-review`, which can post a fresh
+  Critical/High thread that **blocks the merge** (`required_review_thread_resolution`).
+  Never declare ready off a thread/check snapshot taken *before* the latest push:
+  after the last push settles, run one more full pass (thread sweep + check
+  re-confirm) before §3. A single early "0 unresolved" check is not a standing
+  guarantee.
 - End the loop when a full pass resolves no new threads and has no actionable
   check failures. Hard backstop: ~10 passes, then report and stop.
 - Waiting: use `gh pr checks --watch` for in-flight CI. When only waiting on a

--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -123,6 +123,22 @@ The PR is **ready** when every review thread is resolved, no check is failing or
 pending, AND the branch is **up to date with `main`** (the `main` ruleset requires
 it before merge).
 
+**Verify check completeness explicitly — a running check is not a pass.** "No check
+failing" is **not** the same as "all checks passed": a check still `IN_PROGRESS` /
+`QUEUED` has **no conclusion yet**, so a filter like `select(.conclusion!="SUCCESS")`
+or "are there any failures?" reports it as *absent*, not *pending* — reading as green
+when it isn't. Confirm readiness positively: **every required check has
+`status == COMPLETED` and `conclusion == SUCCESS` on the current tip.** Concretely,
+assert `[.statusCheckRollup[] | select(.status!="COMPLETED")]` is **empty** before
+calling it green, and **dedup stale duplicate entries** (the rollup keeps a row per
+run, so an earlier tip's passed "Build and Test" can sit alongside the current tip's
+`IN_PROGRESS` one — key on the latest run per check name). Do **not** infer green
+from a `gh pr checks --watch` exit alone; re-read the rollup. And when
+`mergeStateStatus` is `BLOCKED`, **rule out a pending required check first** (it is
+the common cause) before attributing the block to a review/policy rule like
+code-owner review. (Bit #361: a still-running "Build and Test" was misread as green
+and `BLOCKED` was wrongly pinned on code-owner review.)
+
 **Rebase before declaring ready, never after.** `main` advances while you watch
 (other PRs merge), leaving the branch `BEHIND`. The moment the PR is otherwise
 green, bring it up to date — `gh pr update-branch <number>` (a merge of `main`; no

--- a/Sources/TMDb/Domain/APIClient/APIRequestQueryItem.swift
+++ b/Sources/TMDb/Domain/APIClient/APIRequestQueryItem.swift
@@ -56,6 +56,7 @@ extension APIRequestQueryItem.Name {
     static let withoutKeywords = APIRequestQueryItem.Name("without_keywords")
     static let withNetworks = APIRequestQueryItem.Name("with_networks")
     static let withWatchProviders = APIRequestQueryItem.Name("with_watch_providers")
+    static let withoutWatchProviders = APIRequestQueryItem.Name("without_watch_providers")
     static let withRuntimeGreaterThan = APIRequestQueryItem.Name("with_runtime.gte")
     static let withRuntimeLessThan = APIRequestQueryItem.Name("with_runtime.lte")
     static let voteAverageGreaterThan = APIRequestQueryItem.Name("vote_average.gte")
@@ -65,8 +66,12 @@ extension APIRequestQueryItem.Name {
     static let includeVideo = APIRequestQueryItem.Name("include_video")
     static let primaryReleaseDateGreaterThan = APIRequestQueryItem.Name("primary_release_date.gte")
     static let primaryReleaseDateLessThan = APIRequestQueryItem.Name("primary_release_date.lte")
+    static let releaseDateGreaterThan = APIRequestQueryItem.Name("release_date.gte")
+    static let releaseDateLessThan = APIRequestQueryItem.Name("release_date.lte")
     static let firstAirDateGreaterThan = APIRequestQueryItem.Name("first_air_date.gte")
     static let firstAirDateLessThan = APIRequestQueryItem.Name("first_air_date.lte")
+    static let includeNullFirstAirDates =
+        APIRequestQueryItem.Name("include_null_first_air_dates")
     static let airDateGreaterThan = APIRequestQueryItem.Name("air_date.gte")
     static let airDateLessThan = APIRequestQueryItem.Name("air_date.lte")
 

--- a/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverMovieFilter+Fluent.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverMovieFilter+Fluent.swift
@@ -265,6 +265,9 @@ extension DiscoverMovieFilter {
             withOriginCountry: withOriginCountry,
             withoutCompanies: withoutCompanies,
             watchMonetizationTypes: watchMonetizationTypes,
+            releaseDateMin: releaseDateMin,
+            releaseDateMax: releaseDateMax,
+            withoutWatchProviders: withoutWatchProviders,
             genresJoin: genresJoin ?? self.genresJoin,
             keywordsJoin: keywordsJoin ?? self.keywordsJoin
         )

--- a/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverMovieFilter.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverMovieFilter.swift
@@ -153,6 +153,21 @@ public struct DiscoverMovieFilter: Equatable, Hashable, Sendable {
     public let watchMonetizationTypes: [WatchMonetizationType]?
 
     ///
+    /// Minimum movie release date (any release type).
+    ///
+    public let releaseDateMin: Date?
+
+    ///
+    /// Maximum movie release date (any release type).
+    ///
+    public let releaseDateMax: Date?
+
+    ///
+    /// A list of watch provider identifiers to exclude.
+    ///
+    public let withoutWatchProviders: [WatchProvider.ID]?
+
+    ///
     /// The logical operator used to join ``genres``.
     ///
     /// When `nil`, genres are combined using a logical AND (comma), matching
@@ -202,6 +217,9 @@ public struct DiscoverMovieFilter: Equatable, Hashable, Sendable {
     ///   - withOriginCountry: Filter by origin country.
     ///   - withoutCompanies: Production company identifiers to exclude.
     ///   - watchMonetizationTypes: Filter by monetization type.
+    ///   - releaseDateMin: Minimum movie release date (any release type).
+    ///   - releaseDateMax: Maximum movie release date (any release type).
+    ///   - withoutWatchProviders: Watch provider identifiers to exclude.
     ///   - genresJoin: The logical operator used to join ``genres``.
     ///   - keywordsJoin: The logical operator used to join ``keywords``.
     ///
@@ -234,6 +252,9 @@ public struct DiscoverMovieFilter: Equatable, Hashable, Sendable {
         withOriginCountry: String? = nil,
         withoutCompanies: [Company.ID]? = nil,
         watchMonetizationTypes: [WatchMonetizationType]? = nil,
+        releaseDateMin: Date? = nil,
+        releaseDateMax: Date? = nil,
+        withoutWatchProviders: [WatchProvider.ID]? = nil,
         genresJoin: DiscoverFilterJoin? = nil,
         keywordsJoin: DiscoverFilterJoin? = nil
     ) {
@@ -265,6 +286,9 @@ public struct DiscoverMovieFilter: Equatable, Hashable, Sendable {
         self.withOriginCountry = withOriginCountry
         self.withoutCompanies = withoutCompanies
         self.watchMonetizationTypes = watchMonetizationTypes
+        self.releaseDateMin = releaseDateMin
+        self.releaseDateMax = releaseDateMax
+        self.withoutWatchProviders = withoutWatchProviders
         self.genresJoin = genresJoin
         self.keywordsJoin = keywordsJoin
     }

--- a/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverTVSeriesFilter+Fluent.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverTVSeriesFilter+Fluent.swift
@@ -256,6 +256,8 @@ extension DiscoverTVSeriesFilter {
             watchMonetizationTypes: watchMonetizationTypes,
             screenedTheatrically: screenedTheatrically,
             withPeople: withPeople,
+            withoutWatchProviders: withoutWatchProviders,
+            includeNullFirstAirDates: includeNullFirstAirDates,
             genresJoin: genresJoin ?? self.genresJoin,
             keywordsJoin: keywordsJoin ?? self.keywordsJoin
         )

--- a/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverTVSeriesFilter.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverTVSeriesFilter.swift
@@ -153,6 +153,16 @@ public struct DiscoverTVSeriesFilter: Equatable, Hashable, Sendable {
     public let withPeople: [Person.ID]?
 
     ///
+    /// A list of watch provider identifiers to exclude.
+    ///
+    public let withoutWatchProviders: [WatchProvider.ID]?
+
+    ///
+    /// Include TV series that have a null first air date.
+    ///
+    public let includeNullFirstAirDates: Bool?
+
+    ///
     /// The logical operator used to join ``genres``.
     ///
     /// When `nil`, genres are combined using a logical AND (comma), matching
@@ -202,6 +212,9 @@ public struct DiscoverTVSeriesFilter: Equatable, Hashable, Sendable {
     ///   - screenedTheatrically: Filter for theatrically screened
     ///     series.
     ///   - withPeople: A list of Person identifiers to filter by.
+    ///   - withoutWatchProviders: Watch provider identifiers to exclude.
+    ///   - includeNullFirstAirDates: Include TV series that have a null
+    ///     first air date.
     ///   - genresJoin: The logical operator used to join ``genres``.
     ///   - keywordsJoin: The logical operator used to join ``keywords``.
     ///
@@ -234,6 +247,8 @@ public struct DiscoverTVSeriesFilter: Equatable, Hashable, Sendable {
         watchMonetizationTypes: [WatchMonetizationType]? = nil,
         screenedTheatrically: Bool? = nil,
         withPeople: [Person.ID]? = nil,
+        withoutWatchProviders: [WatchProvider.ID]? = nil,
+        includeNullFirstAirDates: Bool? = nil,
         genresJoin: DiscoverFilterJoin? = nil,
         keywordsJoin: DiscoverFilterJoin? = nil
     ) {
@@ -265,6 +280,8 @@ public struct DiscoverTVSeriesFilter: Equatable, Hashable, Sendable {
         self.watchMonetizationTypes = watchMonetizationTypes
         self.screenedTheatrically = screenedTheatrically
         self.withPeople = withPeople
+        self.withoutWatchProviders = withoutWatchProviders
+        self.includeNullFirstAirDates = includeNullFirstAirDates
         self.genresJoin = genresJoin
         self.keywordsJoin = keywordsJoin
     }

--- a/Sources/TMDb/Domain/Services/Discover/Requests/DiscoverMoviesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Requests/DiscoverMoviesRequest.swift
@@ -71,6 +71,14 @@ private extension APIRequestQueryItems {
             }
         }
 
+        if let releaseDateMin = filter.releaseDateMin {
+            self[.releaseDateGreaterThan] = Self.dateString(from: releaseDateMin)
+        }
+
+        if let releaseDateMax = filter.releaseDateMax {
+            self[.releaseDateLessThan] = Self.dateString(from: releaseDateMax)
+        }
+
         applyVoteAndRuntimeFilters(from: filter)
         applyContentAndProviderFilters(from: filter)
     }
@@ -135,6 +143,12 @@ private extension APIRequestQueryItems {
             )
         }
 
+        if let withoutWatchProviders = filter.withoutWatchProviders {
+            self[.withoutWatchProviders] = Self.idsQueryItemValue(
+                for: withoutWatchProviders
+            )
+        }
+
         if let watchRegion = filter.watchRegion {
             self[.watchRegion] = watchRegion
         }
@@ -190,6 +204,10 @@ private extension APIRequestQueryItems {
                 .map(\.rawValue)
                 .joined(separator: "|")
         }
+    }
+
+    static func dateString(from date: Date) -> String {
+        DateFormatter.theMovieDatabase.string(from: date)
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Discover/Requests/DiscoverTVSeriesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Requests/DiscoverTVSeriesRequest.swift
@@ -146,8 +146,18 @@ private extension APIRequestQueryItems {
             )
         }
 
+        if let withoutWatchProviders = filter.withoutWatchProviders {
+            self[.withoutWatchProviders] = Self.idsQueryItemValue(
+                for: withoutWatchProviders
+            )
+        }
+
         if let watchRegion = filter.watchRegion {
             self[.watchRegion] = watchRegion
+        }
+
+        if let includeNullFirstAirDates = filter.includeNullFirstAirDates {
+            self[.includeNullFirstAirDates] = includeNullFirstAirDates
         }
 
         applyExtendedFilters(from: filter)

--- a/Tests/TMDbIntegrationTests/DiscoverIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/DiscoverIntegrationTests.swift
@@ -128,6 +128,15 @@ struct DiscoverIntegrationTests {
         #expect(!tvSeriesList.results.isEmpty)
     }
 
+    @Test("TV series without watch providers")
+    func tvSeriesWithoutWatchProviders() async throws {
+        let filter = DiscoverTVSeriesFilter(withoutWatchProviders: [8])
+
+        let tvSeriesList = try await discoverService.tvSeries(filter: filter)
+
+        #expect(!tvSeriesList.results.isEmpty)
+    }
+
     @Test("TV series with genres joined by OR")
     func tvSeriesWithGenresJoinedByOr() async throws {
         let filter = DiscoverTVSeriesFilter()

--- a/Tests/TMDbIntegrationTests/DiscoverIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/DiscoverIntegrationTests.swift
@@ -80,6 +80,27 @@ struct DiscoverIntegrationTests {
         #expect(orTotal >= andTotal)
     }
 
+    @Test("movies with release date range")
+    func moviesWithReleaseDateRange() async throws {
+        let filter = DiscoverMovieFilter(
+            releaseDateMin: Date(timeIntervalSince1970: 1_704_067_200), // 2024-01-01
+            releaseDateMax: Date(timeIntervalSince1970: 1_735_603_200) // 2024-12-31
+        )
+
+        let movieList = try await discoverService.movies(filter: filter)
+
+        #expect(!movieList.results.isEmpty)
+    }
+
+    @Test("movies without watch providers")
+    func moviesWithoutWatchProviders() async throws {
+        let filter = DiscoverMovieFilter(withoutWatchProviders: [8])
+
+        let movieList = try await discoverService.movies(filter: filter)
+
+        #expect(!movieList.results.isEmpty)
+    }
+
     @Test("TV series")
     func tvSeries() async throws {
         let tvSeriesList = try await discoverService.tvSeries()
@@ -94,6 +115,15 @@ struct DiscoverIntegrationTests {
         let tvSeriesList = try await discoverService.tvSeries(
             filter: filter
         )
+
+        #expect(!tvSeriesList.results.isEmpty)
+    }
+
+    @Test("TV series including null first air dates")
+    func tvSeriesIncludingNullFirstAirDates() async throws {
+        let filter = DiscoverTVSeriesFilter(includeNullFirstAirDates: true)
+
+        let tvSeriesList = try await discoverService.tvSeries(filter: filter)
 
         #expect(!tvSeriesList.results.isEmpty)
     }

--- a/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverMovieFilterFluentTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverMovieFilterFluentTests.swift
@@ -205,6 +205,9 @@ struct DiscoverMovieFilterFluentTests {
             withOriginCountry: "GB",
             withoutCompanies: [6],
             watchMonetizationTypes: [.flatrate],
+            releaseDateMin: Date(timeIntervalSince1970: 1_000_000),
+            releaseDateMax: Date(timeIntervalSince1970: 2_000_000),
+            withoutWatchProviders: [9],
             genresJoin: .or,
             keywordsJoin: .or
         )

--- a/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverMovieFilterTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverMovieFilterTests.swift
@@ -9,6 +9,8 @@ import Foundation
 import Testing
 @testable import TMDb
 
+// swiftlint:disable file_length
+
 @Suite(.tags(.filters, .discover))
 struct DiscoverMovieFilterTests { // swiftlint:disable:this type_body_length
 
@@ -44,6 +46,34 @@ struct DiscoverMovieFilterTests { // swiftlint:disable:this type_body_length
         #expect(filter.withOriginCountry == nil)
         #expect(filter.withoutCompanies == nil)
         #expect(filter.watchMonetizationTypes == nil)
+        #expect(filter.releaseDateMin == nil)
+        #expect(filter.releaseDateMax == nil)
+        #expect(filter.withoutWatchProviders == nil)
+    }
+
+    @Test("init with release date range sets release date properties")
+    func initWithReleaseDateRangeSetsReleaseDateProperties() {
+        let releaseDateMin = Date(iso8601: "2024-01-01T00:00:00Z")
+        let releaseDateMax = Date(iso8601: "2024-12-31T00:00:00Z")
+
+        let filter = DiscoverMovieFilter(
+            releaseDateMin: releaseDateMin,
+            releaseDateMax: releaseDateMax
+        )
+
+        #expect(filter.releaseDateMin == releaseDateMin)
+        #expect(filter.releaseDateMax == releaseDateMax)
+    }
+
+    @Test("init with without watch providers sets property")
+    func initWithWithoutWatchProvidersSetsProperty() {
+        let withoutWatchProviders = [8, 9]
+
+        let filter = DiscoverMovieFilter(
+            withoutWatchProviders: withoutWatchProviders
+        )
+
+        #expect(filter.withoutWatchProviders == withoutWatchProviders)
     }
 
     @Test("init with people sets people property")
@@ -308,7 +338,10 @@ struct DiscoverMovieFilterTests { // swiftlint:disable:this type_body_length
             withCrew: [1223],
             withOriginCountry: "US",
             withoutCompanies: withoutCompanies,
-            watchMonetizationTypes: monetizationTypes
+            watchMonetizationTypes: monetizationTypes,
+            releaseDateMin: Date(iso8601: "2024-01-01T00:00:00Z"),
+            releaseDateMax: Date(iso8601: "2024-12-31T00:00:00Z"),
+            withoutWatchProviders: [11, 12]
         )
 
         #expect(filter.people == people)
@@ -339,6 +372,9 @@ struct DiscoverMovieFilterTests { // swiftlint:disable:this type_body_length
         #expect(filter.withOriginCountry == "US")
         #expect(filter.withoutCompanies == withoutCompanies)
         #expect(filter.watchMonetizationTypes == monetizationTypes)
+        #expect(filter.releaseDateMin == Date(iso8601: "2024-01-01T00:00:00Z"))
+        #expect(filter.releaseDateMax == Date(iso8601: "2024-12-31T00:00:00Z"))
+        #expect(filter.withoutWatchProviders == [11, 12])
     }
 
     @Test("primary release year filter on returns correct date bounds")

--- a/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverTVSeriesFilterFluentTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverTVSeriesFilterFluentTests.swift
@@ -198,6 +198,8 @@ struct DiscoverTVSeriesFilterFluentTests {
             watchMonetizationTypes: [.flatrate],
             screenedTheatrically: true,
             withPeople: [2],
+            withoutWatchProviders: [9],
+            includeNullFirstAirDates: true,
             genresJoin: .or,
             keywordsJoin: .or
         )

--- a/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverTVSeriesFilterTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverTVSeriesFilterTests.swift
@@ -44,6 +44,26 @@ struct DiscoverTVSeriesFilterTests { // swiftlint:disable:this type_body_length
         #expect(filter.watchMonetizationTypes == nil)
         #expect(filter.screenedTheatrically == nil)
         #expect(filter.withPeople == nil)
+        #expect(filter.withoutWatchProviders == nil)
+        #expect(filter.includeNullFirstAirDates == nil)
+    }
+
+    @Test("init with without watch providers sets property")
+    func initWithWithoutWatchProvidersSetsProperty() {
+        let withoutWatchProviders = [8, 9]
+
+        let filter = DiscoverTVSeriesFilter(
+            withoutWatchProviders: withoutWatchProviders
+        )
+
+        #expect(filter.withoutWatchProviders == withoutWatchProviders)
+    }
+
+    @Test("init with include null first air dates sets property")
+    func initWithIncludeNullFirstAirDatesSetsProperty() {
+        let filter = DiscoverTVSeriesFilter(includeNullFirstAirDates: true)
+
+        #expect(filter.includeNullFirstAirDates == true)
     }
 
     @Test("init with original language sets original language property")
@@ -301,7 +321,9 @@ struct DiscoverTVSeriesFilterTests { // swiftlint:disable:this type_body_length
             withoutCompanies: [999],
             watchMonetizationTypes: monetizationTypes,
             screenedTheatrically: true,
-            withPeople: [287]
+            withPeople: [287],
+            withoutWatchProviders: [11, 12],
+            includeNullFirstAirDates: true
         )
 
         #expect(filter.originalLanguage == "en")
@@ -332,6 +354,8 @@ struct DiscoverTVSeriesFilterTests { // swiftlint:disable:this type_body_length
         #expect(filter.watchMonetizationTypes == monetizationTypes)
         #expect(filter.screenedTheatrically == true)
         #expect(filter.withPeople == [287])
+        #expect(filter.withoutWatchProviders == [11, 12])
+        #expect(filter.includeNullFirstAirDates == true)
     }
 
 }

--- a/Tests/TMDbTests/Domain/Services/Discover/Requests/DiscoverMoviesRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Requests/DiscoverMoviesRequestTests.swift
@@ -9,6 +9,8 @@ import Foundation
 import Testing
 @testable import TMDb
 
+// swiftlint:disable file_length
+
 @Suite(.tags(.requests, .discover))
 struct DiscoverMoviesRequestTests { // swiftlint:disable:this type_body_length
 
@@ -104,6 +106,40 @@ struct DiscoverMoviesRequestTests { // swiftlint:disable:this type_body_length
                 "primary_release_date.lte": "2025-12-31"
             ]
         )
+    }
+
+    @Test("queryItems with release date range")
+    func queryItemsWithReleaseDateRange() {
+        let filter = DiscoverMovieFilter(
+            releaseDateMin: Date(iso8601: "2024-01-01T00:00:00Z"),
+            releaseDateMax: Date(iso8601: "2024-12-31T00:00:00Z")
+        )
+        let request = DiscoverMoviesRequest(filter: filter)
+
+        #expect(
+            request.queryItems == [
+                "release_date.gte": "2024-01-01",
+                "release_date.lte": "2024-12-31"
+            ]
+        )
+    }
+
+    @Test("queryItems with release date min only")
+    func queryItemsWithReleaseDateMinOnly() {
+        let filter = DiscoverMovieFilter(
+            releaseDateMin: Date(iso8601: "2024-01-01T00:00:00Z")
+        )
+        let request = DiscoverMoviesRequest(filter: filter)
+
+        #expect(request.queryItems == ["release_date.gte": "2024-01-01"])
+    }
+
+    @Test("queryItems with without watch providers")
+    func queryItemsWithWithoutWatchProviders() {
+        let filter = DiscoverMovieFilter(withoutWatchProviders: [8, 9])
+        let request = DiscoverMoviesRequest(filter: filter)
+
+        #expect(request.queryItems == ["without_watch_providers": "8,9"])
     }
 
     @Test("queryItems with vote average range")

--- a/Tests/TMDbTests/Domain/Services/Discover/Requests/DiscoverTVSeriesRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Requests/DiscoverTVSeriesRequestTests.swift
@@ -275,6 +275,24 @@ struct DiscoverTVSeriesRequestTests { // swiftlint:disable:this type_body_length
         )
     }
 
+    @Test("queryItems with without watch providers")
+    func queryItemsWithWithoutWatchProviders() {
+        let filter = DiscoverTVSeriesFilter(withoutWatchProviders: [8, 9])
+        let request = DiscoverTVSeriesRequest(filter: filter)
+
+        #expect(request.queryItems == ["without_watch_providers": "8,9"])
+    }
+
+    @Test("queryItems with include null first air dates")
+    func queryItemsWithIncludeNullFirstAirDates() {
+        let filter = DiscoverTVSeriesFilter(includeNullFirstAirDates: true)
+        let request = DiscoverTVSeriesRequest(filter: filter)
+
+        #expect(
+            request.queryItems == ["include_null_first_air_dates": "true"]
+        )
+    }
+
     @Test("queryItems with screened theatrically")
     func queryItemsWithScreenedTheatrically() {
         let filter = DiscoverTVSeriesFilter(

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -10,6 +10,37 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-06-24 — ✨ Add missing discover filter parameters (#361) · lite
+
+- **Phases / skills:** phases 0–6; `build-for-testing, test, integration-test,
+  lint, review-changes, capture-knowledge, pr, watch-pr`. Skipped `/review-plan`
+  (lite + the plan was already adversarially reviewed earlier this session by the
+  3-agent finding-verification pass).
+- **Worked:** lite-weight scoping was correct — single-`code-reviewer` review
+  converged **round 1 with 0 critical/high/medium**. The codebase's existing
+  *"no-op mutation preserves every other populated field"* guard test made the
+  real risk (new fields silently dropped by the ~30-arg fluent `copy()` helpers)
+  trivial to cover: extend `fullyPopulatedFilter`, and a missing pass-through
+  fails loudly. Verifying the finding against the live API up front caught the
+  `release_date.*` vs `primary_release_date.*` semantic distinction before coding.
+- **Friction:** (1) **The big one — edits landed in the main checkout, not the
+  worktree.** I `Read` the source files in Phase 0 *before* `EnterWorktree`, so
+  their absolute paths pointed at `main`; continuing to `Edit` those paths after
+  entering wrote to `main`. Worse, the build/test then ran against the *pristine*
+  worktree and returned **baseline** counts (2792/282), masking that nothing had
+  landed — only an empty `git status` in the worktree exposed it. Recovered via a
+  shared stash (`git -C main stash` → `git -C worktree stash pop`). (2) The
+  `Date(iso8601:)` test helper is `TMDbTests`-only, so an integration test using
+  it failed to compile — but only once the integration target actually built.
+- **Deviations:** an unplanned mid-Phase-2 stash-rescue to move the change off
+  `main` into the worktree; otherwise the pipeline ran as written.
+- **One improvement:** `/deliver` Phase 0 already reads the *plan* into context
+  before the worktree, but reading *source* files there is a trap — their paths
+  become stale on `EnterWorktree`. Phase 0.5 should add a hard checkpoint: after
+  entering, **verify `git status` shows the diff in the worktree before trusting
+  the first green build**. (This is the **second** delivery to hit main-vs-worktree
+  path confusion — see #359 — so it's now a recurring pattern worth a skill edit.)
+
 ## 2026-06-23 — ✨ Add `TMDbTesting` public mocks & sample-data library (#359) · full
 
 - **Phases / skills:** phases 0–6; `review-plan, implement-plan, build-for-testing,

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -39,7 +39,15 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
   and the `main` merge each re-ran `claude-review`, which posted that thread **after**
   my one-time thread check. The thread also **blocked the merge** (the `main`
   ruleset requires `required_review_thread_resolution`), so "ready" was wrong on two
-  counts.
+  counts. (4) **Misread `BLOCKED` as code-owner review when a required check was
+  still running.** A filtered rollup query (`select(.conclusion!="SUCCESS")`) hid a
+  still-`IN_PROGRESS` "Build and Test" (no conclusion yet ⇒ absent from the filter),
+  compounded by a stale passed copy of the same check from an earlier tip — so I
+  reported "all green" and pinned the merge block on the un-satisfiable code-owner
+  self-review. The user caught it. Lesson: confirm **every required check is
+  `COMPLETED`+`SUCCESS` on the current tip** (assert nothing is `status!=COMPLETED`),
+  and when `BLOCKED`, rule out a **pending required check** before blaming a review
+  rule.
 - **Deviations:** an unplanned mid-Phase-2 stash-rescue to move the change off
   `main` into the worktree; and a post-gate fix loop (add the missing TV
   `withoutWatchProviders` integration test, resolve the bot thread) before the merge

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -32,8 +32,19 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
   shared stash (`git -C main stash` → `git -C worktree stash pop`). (2) The
   `Date(iso8601:)` test helper is `TMDbTests`-only, so an integration test using
   it failed to compile — but only once the integration target actually built.
+  (3) **Asymmetric integration coverage, then a stale "ready" call.** Three of the
+  four new params got a live integration test but TV `withoutWatchProviders` got
+  only unit coverage — `claude-review` flagged it **High**. Worse, I'd declared the
+  PR "ready, 0 unresolved threads" *before* re-checking: the retro/skill-fix pushes
+  and the `main` merge each re-ran `claude-review`, which posted that thread **after**
+  my one-time thread check. The thread also **blocked the merge** (the `main`
+  ruleset requires `required_review_thread_resolution`), so "ready" was wrong on two
+  counts.
 - **Deviations:** an unplanned mid-Phase-2 stash-rescue to move the change off
-  `main` into the worktree; otherwise the pipeline ran as written.
+  `main` into the worktree; and a post-gate fix loop (add the missing TV
+  `withoutWatchProviders` integration test, resolve the bot thread) before the merge
+  could proceed — i.e. the `/watch-pr` thread sweep had to actually run per-push,
+  not once.
 - **One improvement:** `/deliver` Phase 0 already reads the *plan* into context
   before the worktree, but reading *source* files there is a trap — their paths
   become stale on `EnterWorktree`. Phase 0.5 should add a hard checkpoint: after

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -32,14 +32,26 @@ job (container `swift:6.1-jammy`, runs `swift build --build-tests`). So when Doc
 isn't available locally to run `make build-linux`, the PR's CI is the authoritative
 off-Apple check — don't treat a missing local Linux build as a blocker.
 
-### Workflow file-generation agents can write to the wrong worktree
+### Edits can land in the main checkout instead of the active worktree
 
-*2026-06-23.* When fanning out file-writing subagents from inside a git worktree,
-some wrote files to the **main checkout** path (`…/TMDb/Sources/…`) instead of the
-active worktree, despite the worktree path being given as their working directory.
-Give such agents **absolute worktree paths** for every file they create, and
-**verify output landed in the worktree** (and the main checkout stayed clean)
-before building.
+*2026-06-23 / updated 2026-06-24.* Two variants of the same trap when working in a
+git worktree (e.g. `/deliver`):
+
+- **Fanned-out subagents** — file-writing subagents sometimes wrote to the **main
+  checkout** path (`…/TMDb/Sources/…`) instead of the active worktree, despite the
+  worktree path being their working directory. Give them **absolute worktree
+  paths** for every file.
+- **The conductor's own edits** — files `Read` *before* `EnterWorktree` yield
+  **main-checkout absolute paths**; continuing to `Edit` those exact paths after
+  entering the worktree writes to `main`, not the worktree (they share `.git` but
+  have **separate working dirs**). The build/test then runs against the *pristine*
+  worktree and returns **baseline** counts (e.g. unchanged total), masking that the
+  edits never landed. After `EnterWorktree`, re-`Read`/edit via worktree paths.
+
+Either way: **verify `git status` shows your diff *in the worktree*** (and the main
+checkout stayed clean) before trusting a green run. To rescue edits already made on
+`main`: `git -C <main> stash` then `git -C <worktree> stash pop` (stash is shared
+across worktrees).
 
 ### swiftlint `file_length` / `type_body_length` — split into a `+Feature` extension file
 
@@ -239,3 +251,16 @@ in a '@Sendable' closure"*.
 - A custom `Decodable` with per-property branches (e.g. `append_to_response`
   optionals) needs a fixture covering **all** branches, plus a "without appended
   data" test asserting the optionals are `nil`. Untested branches hide bugs.
+
+### `Date(iso8601:)` test helper exists only in the `TMDbTests` target
+
+*2026-06-24.* The `Date(iso8601: "…")` convenience initialiser is defined in
+`Tests/TMDbTests/TestUtils/Date+ISO8601.swift`, which belongs to the **`TMDbTests`**
+(unit) target only — it is **not** visible to **`TMDbIntegrationTests`**. Using it
+in an integration test fails to compile with a misleading *"argument passed to call
+that takes no arguments"* (Swift resolves `Date(...)` to the argument-less
+`Date()`). The integration target has no date-from-string helper; build dates there
+with `Date(timeIntervalSince1970:)` (the existing convention, e.g. the `video.publishedAt`
+assertions). This only surfaces when the **integration** target compiles, so a
+`make test` that builds all targets — or `/integration-test` — catches it; a
+unit-only check may not.

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,24 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-06-24 — Post-gate pushes re-open the gate: re-sweep threads/checks after the last push · applied
+
+- **Pattern:** declaring a PR "ready, 0 unresolved threads" off a snapshot taken
+  *before* later pushes. In #361 the ready call was made in Phase 5, then Phase 6
+  pushed the retro + a skill edit and the branch was updated with `main` — each push
+  re-ran `claude-review`, which posted a **High** thread *after* the snapshot. The
+  unresolved thread then **blocked the merge** (`required_review_thread_resolution`).
+  Single occurrence (below the recurring-scan bar), but user-directed.
+- **Decision:** **applied** (user-directed). `/deliver` Phase 6: added "Pushing the
+  retro re-opens the gate — re-watch before merge" (return to the `/watch-pr` loop
+  after the last post-gate push; "ready" is only true of the current tip).
+  `/watch-pr` §2 Loop guard: added "Re-sweep after every push" making the per-push
+  thread+check re-confirm explicit. Both landed in PR #361; logged here.
+- **Rationale:** every push re-triggers the review bot and CI, so a pre-push "ready"
+  is stale; cheap to re-sweep, and a missed Critical/High thread is a hard merge
+  blocker, not advisory.
+- **Reconsider when:** n/a (applied).
+
 ### 2026-06-24 — Phase 0.5 checkpoint: edit via worktree paths, verify the diff landed · applied
 
 - **Pattern:** edits landing in the **main checkout** instead of the active

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,27 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-06-24 — Phase 0.5 checkpoint: edit via worktree paths, verify the diff landed · applied
+
+- **Pattern:** edits landing in the **main checkout** instead of the active
+  worktree, masked by a green build/test that merely re-ran the *pristine* worktree
+  and returned baseline counts. Recurred across two deliveries: **#359** (fanned-out
+  generation subagents wrote to the main-checkout path) and **#361** (the conductor
+  `Read` source files in Phase 0 *before* `EnterWorktree`, then `Edit`ed those
+  now-stale main-checkout absolute paths). #359 was captured only as a `gotchas.md`
+  note, never as a skill change — so it recurred.
+- **Decision:** **applied** (user-approved in the Phase 6 scan). Added a bolded
+  checkpoint at the end of `/deliver` Phase 0.5: after `EnterWorktree`, re-`Read`
+  source before editing, and **verify `git status` shows the diff in the worktree
+  before trusting the first green build** (empty diff + baseline counts = edits went
+  to `main`); rescue via shared stash. Landed in `.claude/skills/deliver/SKILL.md`
+  Phase 0.5 (PR #361). Also generalized the `gotchas.md` entry to cover the conductor
+  variant and proposed+saved a cross-project wiki entry.
+- **Rationale:** a green run that silently validated nothing is the most dangerous
+  failure mode in an autonomous pipeline; a cheap `git status` check converts it from
+  a late, confusing discovery into an immediate one.
+- **Reconsider when:** n/a (applied).
+
 ### 2026-06-23 — Add a "update the personal wiki" step after the retro · applied
 
 - **Pattern:** `/deliver` Phase 6 captured durable learnings into the

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,25 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-06-24 — Verify checks positively (COMPLETED+SUCCESS on current tip), not "no failures" · applied
+
+- **Pattern:** misreading a still-running required check as green. In #361 a
+  filtered rollup (`select(.conclusion!="SUCCESS")`) omitted an `IN_PROGRESS`
+  "Build and Test" (no conclusion yet ⇒ not a "failure"), and a stale passed copy of
+  the same check from an earlier tip reinforced the false green — so `mergeStateStatus:
+  BLOCKED` was wrongly attributed to the un-satisfiable code-owner self-review rather
+  than the pending check. User caught it. Single occurrence, user-directed.
+- **Decision:** **applied** (user-directed). `/watch-pr` §3: added "Verify check
+  completeness explicitly — a running check is not a pass": assert nothing is
+  `status!=COMPLETED`, require `conclusion==SUCCESS` per required check on the current
+  tip, dedup stale per-tip duplicates, don't infer green from a `--watch` exit, and
+  when `BLOCKED` rule out a pending required check before blaming a review/policy
+  rule. Landed in PR #361.
+- **Rationale:** "no failures" ≠ "all passed" — a pending check has no conclusion and
+  slips through failure-filters; a false-green merge readiness call wastes a round
+  trip and (here) produced a wrong root-cause diagnosis.
+- **Reconsider when:** n/a (applied).
+
 ### 2026-06-24 — Post-gate pushes re-open the gate: re-sweep threads/checks after the last push · applied
 
 - **Pattern:** declaring a PR "ready, 0 unresolved threads" off a snapshot taken

--- a/knowledge/tmdb-api-notes.md
+++ b/knowledge/tmdb-api-notes.md
@@ -4,6 +4,26 @@ Behaviours of the **live** TMDb API discovered while implementing — the things
 docs don't say, or say wrongly. This is an API-client library, so these recur.
 Newest at the top; cite the endpoint and the date observed.
 
+## Discover
+
+### `discover/movie` has *two* distinct release-date filters
+
+*2026-06-24.* `release_date.gte`/`.lte` and `primary_release_date.gte`/`.lte` are
+**not** the same parameter. `primary_release_date.*` bounds only a movie's
+**primary** release; `release_date.*` bounds **any** release type (and pairs with
+`with_release_type` + `region`). They return different result sets — so a client
+needs both. In this package: the year-granular `primaryReleaseYear` filter maps to
+`primary_release_date.*`, and the `Date`-granular `releaseDateMin`/`releaseDateMax`
+maps to `release_date.*`.
+
+### TMDb silently ignores unknown query parameters (returns 200)
+
+*2026-06-24.* `discover/movie` and `discover/tv` return **HTTP 200** for a bogus
+query key rather than erroring, so a misspelled or unsupported parameter looks like
+it "works" but is a no-op. To confirm a parameter is real and effective, compare
+**result counts** with vs without it (a bogus key yields the *unfiltered* count) —
+status code alone proves nothing.
+
 ## OpenAPI spec
 
 ### The spec is ~3 MB minified JSON on a single line


### PR DESCRIPTION
## Summary

Exposes four TMDb `/discover` query parameters the package did not previously surface, as **additive, source-compatible** filter fields (all new `init` params default to `nil`). Closes the discover-filter gaps identified in an external API-coverage review (verified against the live API).

## Changes

**`DiscoverMovieFilter` (movie):**
- ✨ `releaseDateMin` / `releaseDateMax` (`Date?`) → `release_date.gte` / `release_date.lte`
- ✨ `withoutWatchProviders` (`[WatchProvider.ID]?`) → `without_watch_providers`

**`DiscoverTVSeriesFilter` (TV):**
- ✨ `withoutWatchProviders` (`[WatchProvider.ID]?`) → `without_watch_providers`
- ✨ `includeNullFirstAirDates` (`Bool?`) → `include_null_first_air_dates`

**Plumbing:**
- 📝 New query-item names in `APIRequestQueryItem`; mappings in `DiscoverMoviesRequest` / `DiscoverTVSeriesRequest` (movie dates formatted via the existing `DateFormatter.theMovieDatabase`, mirroring the TV `firstAirDate*` fields).
- ♻️ New fields threaded through **both** fluent `copy()` helpers so a fluent-chained filter never silently drops them.

**Tests:**
- ✅ Unit tests for init storage, query-item mapping (incl. min-only edge case), and default-`nil` assertions.
- ✅ The "no-op mutation preserves every other populated field" guard tests extended to cover the new fields (catches a `copy()` drop regression).
- ✅ Integration tests validating each new parameter against the **live** API.

**Knowledge:**
- 📝 `knowledge/tmdb-api-notes.md`: `release_date.*` vs `primary_release_date.*` are distinct filters; TMDb silently 200s on unknown query params (compare result counts to verify effectiveness).
- 📝 `knowledge/gotchas.md`: `Date(iso8601:)` helper is `TMDbTests`-only.

## Design note

`release_date.*` (any release type) is **deliberately distinct** from the existing year-granular `primaryReleaseYear`, which maps to `primary_release_date.*` (primary release only) — both are now expressible.

## Review

Reviewed via the project `code-reviewer` (✅ ready to merge; 0 Critical/High/Medium). One Low advisory only: the movie release-date formatter uses the local-timezone `DateFormatter.theMovieDatabase` — a **pre-existing, consistent** pattern shared with the TV date fields, out of scope for this additive change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)