### PR TITLE
📝 Document existing response caching (on-disk URLCache + in-memory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
   visionOS 1+, Linux, Windows
 * **Automatic Retry**: Opt-in retry with exponential backoff for rate
   limits (HTTP 429) and server errors (HTTP 5xx)
-* **Response Caching**: Opt-in in-memory HTTP response cache with
-  configurable TTL and entry limits
+* **Response Caching**: On-disk HTTP caching by default on Apple platforms
+  (via `URLCache`, honouring TMDb's `Cache-Control` headers), plus an opt-in
+  in-memory cache with configurable TTL and entry limits
 * **Natural-Language Search**: On-device "super search" — type a prompt,
   get movies, TV series, and people. Deterministic interpretation via
   Apple's Natural Language framework on every Apple platform, with
@@ -263,7 +264,14 @@ let tmdbClient = TMDbClient(
 
 #### Response Caching
 
-Enable in-memory response caching to reduce redundant network requests:
+On Apple platforms the default client already caches responses **on disk** via
+`URLCache`, honouring TMDb's `Cache-Control` and `ETag` headers — so repeated
+requests are served from disk (and persist across launches) with no
+configuration. To tune or disable it, supply your own `HTTPClient` backed by a
+`URLSession` you configure.
+
+For an additional in-memory layer (or for caching on Linux/Windows, where
+`URLCache` is not installed), enable in-memory response caching:
 
 ```swift
 // Use default caching (1-hour TTL, 100 entries)

--- a/Sources/TMDb/Domain/Models/CacheConfiguration.swift
+++ b/Sources/TMDb/Domain/Models/CacheConfiguration.swift
@@ -15,6 +15,12 @@ import Foundation
 /// excluded. Any successful POST or DELETE request invalidates the entire
 /// cache.
 ///
+/// This is an optional in-memory layer that sits above the default on-disk
+/// `URLCache` (enabled automatically on Apple platforms). It is cleared when
+/// the process ends and uses a single fixed time-to-live rather than the
+/// per-response `max-age` honoured by `URLCache`. See <doc:CachingResponses>
+/// for how the two layers interact.
+///
 /// ```swift
 /// let cacheConfig = CacheConfiguration(
 ///     defaultTTL: .seconds(1800),

--- a/Sources/TMDb/Networking/CacheHTTPClient.swift
+++ b/Sources/TMDb/Networking/CacheHTTPClient.swift
@@ -67,6 +67,14 @@ private actor ResponseCache {
 
 }
 
+///
+/// An `HTTPClient` decorator that caches successful `GET` responses in memory.
+///
+/// Cache hits short-circuit the wrapped client. User-specific requests (those
+/// carrying a `session_id` or a guest session) bypass the cache, and any
+/// successful `POST` or `DELETE` invalidates the entire cache. This layer sits
+/// above the underlying transport's own on-disk `URLCache`.
+///
 final class CacheHTTPClient: HTTPClient, Sendable {
 
     private let httpClient: any HTTPClient

--- a/Sources/TMDb/TMDb.docc/GettingStarted/CreatingTMDbClient.md
+++ b/Sources/TMDb/TMDb.docc/GettingStarted/CreatingTMDbClient.md
@@ -110,10 +110,13 @@ let tmdbClient = TMDbClient(
 
 ### Configuration with Response Caching
 
-Enable in-memory response caching to reduce redundant network requests.
-All successful GET responses are cached automatically. User-specific
-requests (with session IDs) bypass the cache, and any successful POST or
-DELETE invalidates the entire cache.
+On Apple platforms the default client already caches responses on disk via
+`URLCache`, so repeated requests are served without hitting the network. You can
+additionally enable an in-memory cache to reduce redundant requests. All
+successful GET responses are cached automatically. User-specific requests (with
+session IDs) bypass the cache, and any successful POST or DELETE invalidates the
+entire cache. See <doc:CachingResponses> for the full picture, including how to
+tune or disable the on-disk cache.
 
 ```swift
 let configuration = TMDbConfiguration(

--- a/Sources/TMDb/TMDb.docc/HowTos/CachingResponses.md
+++ b/Sources/TMDb/TMDb.docc/HowTos/CachingResponses.md
@@ -1,0 +1,159 @@
+# Caching Responses
+
+Avoid repeated network requests by reusing cached TMDb responses.
+
+## Overview
+
+TMDb data changes slowly, so the same request often returns the same result for
+minutes or hours. To save bandwidth and time, the library can serve repeated
+requests from a cache instead of hitting the network every time.
+
+There are two independent caching layers:
+
+| Layer | Storage | Default | TTL source | Platforms |
+| ----- | ------- | ------- | ---------- | --------- |
+| HTTP cache (`URLCache`) | On disk + memory | **On** | TMDb's `Cache-Control` headers | Apple platforms |
+| Response cache (``CacheConfiguration``) | In memory | Off (opt-in) | Fixed value you configure | All platforms |
+
+For most apps the on-disk HTTP cache is enough — it is already enabled and needs
+no configuration. The in-memory cache is an optional extra layer on top.
+
+## On-disk HTTP caching (enabled by default)
+
+When you create a ``TMDbClient`` without supplying your own ``HTTPClient``, the
+default `URLSession` adapter is configured with a
+[`URLCache`](https://developer.apple.com/documentation/foundation/urlcache)
+(50 MB in memory, 1 GB on disk) and the `.useProtocolCachePolicy` request policy:
+
+```swift
+// On-disk HTTP caching is active automatically — no configuration needed.
+let tmdbClient = TMDbClient(apiKey: "<your-tmdb-api-key>")
+```
+
+TMDb serves its responses with standard HTTP caching headers — for example
+`Cache-Control: public, max-age=18909` together with an `ETag`. `URLCache`
+honours them, which gives you:
+
+- **A response cache that persists across app launches**, stored on disk.
+- **Per-resource freshness**, driven by each endpoint's own `max-age` — a movie
+  stays fresh for hours, while `trending` is refreshed every few minutes.
+- **Conditional revalidation**: once an entry goes stale, the next request sends
+  the stored `ETag`. If nothing changed, TMDb replies `304 Not Modified` with an
+  empty body, so the cached data is reused and almost no bandwidth is spent.
+
+This layer is the simplest way to satisfy "don't make the same request twice",
+and it is on unless you replace the HTTP client.
+
+> Note: The on-disk `URLCache` is configured only on Apple platforms. On Linux
+> and Windows the default adapter does not install a `URLCache`, so persistent
+> HTTP caching is unavailable there — use the in-memory response cache below if
+> you need caching on those platforms.
+
+## In-memory response caching (opt-in)
+
+Enable ``CacheConfiguration`` on ``TMDbConfiguration`` to add a second cache
+layer that stores successful `GET` responses **in memory**, above the HTTP
+client. It uses a single fixed time-to-live that you choose, rather than TMDb's
+per-response `max-age`:
+
+```swift
+// Default: 1-hour TTL, up to 100 entries.
+let configuration = TMDbConfiguration(cache: .default)
+let tmdbClient = TMDbClient(apiKey: "<your-tmdb-api-key>", configuration: configuration)
+```
+
+Customise the time-to-live and capacity:
+
+```swift
+let cacheConfig = CacheConfiguration(
+    defaultTTL: .seconds(1800),    // 30-minute TTL
+    maximumEntryCount: 200
+)
+
+let configuration = TMDbConfiguration(cache: cacheConfig)
+let tmdbClient = TMDbClient(apiKey: "<your-tmdb-api-key>", configuration: configuration)
+```
+
+This layer is deliberately lightweight: it holds responses in memory only (so it
+is cleared when the process ends), caches `GET` requests only, bypasses
+user-specific requests (those carrying a `session_id` or a guest session), and
+invalidates the entire cache after any successful `POST` or `DELETE`.
+
+Reach for it when you want a predictable, fixed TTL regardless of TMDb's headers,
+or when you need a cache on a platform where `URLCache` is unavailable.
+
+## How the layers interact
+
+A request flows outward-in through whichever layers are enabled:
+
+```text
+in-memory response cache  ->  automatic retry  ->  URLSession / URLCache (disk)
+   (opt-in CacheConfiguration)   (opt-in RetryConfiguration)   (default on Apple platforms)
+```
+
+A hit in the in-memory cache short-circuits everything below it — no retry, no
+network, no `URLCache` lookup. On a miss, the request continues down to
+`URLCache`, which serves the response from disk if it is still fresh (or
+revalidates it with an `ETag`) before any real network traffic happens. The two
+caches are complementary: `URLCache` gives you persistence and per-resource
+freshness for free, and the in-memory cache adds a fast, fixed-TTL layer when you
+want one. See <doc:HandlingErrors> for how caching affects the errors you see.
+
+## Tuning or disabling the on-disk cache
+
+The built-in `URLSession` adapter is not exposed, so to change or switch off the
+default `URLCache` you supply your own ``HTTPClient`` backed by a `URLSession`
+you configure (see <doc:CreatingTMDbClient>). Set a smaller `URLCache`, point it
+at your own directory, or set it to `nil` to disable on-disk caching entirely:
+
+```swift
+import Foundation
+import TMDb
+
+struct CustomHTTPClient: HTTPClient {
+
+    private let urlSession: URLSession
+
+    init() {
+        let configuration = URLSessionConfiguration.default
+        configuration.requestCachePolicy = .useProtocolCachePolicy
+        // Resize the on-disk cache...
+        configuration.urlCache = URLCache(memoryCapacity: 10_000_000, diskCapacity: 200_000_000)
+        // ...or set `configuration.urlCache = nil` to disable HTTP caching.
+        urlSession = URLSession(configuration: configuration)
+    }
+
+    func perform(request: HTTPRequest) async throws -> HTTPResponse {
+        var urlRequest = URLRequest(url: request.url)
+        urlRequest.httpMethod = request.method.rawValue
+        urlRequest.httpBody = request.body
+        for (field, value) in request.headers {
+            urlRequest.setValue(value, forHTTPHeaderField: field)
+        }
+
+        let (data, response) = try await urlSession.data(for: urlRequest)
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+        // Forward the headers so features like Retry-After backoff keep working.
+        let headers = Dictionary(
+            uniqueKeysWithValues: (httpResponse?.allHeaderFields ?? [:]).compactMap {
+                key, value in (key as? String).map { ($0, "\(value)") }
+            }
+        )
+        return HTTPResponse(statusCode: statusCode, data: data, headers: headers)
+    }
+
+}
+
+let tmdbClient = TMDbClient(apiKey: "<your-tmdb-api-key>", httpClient: CustomHTTPClient())
+```
+
+To turn off all caching, disable both layers: pass an `HTTPClient` whose
+`URLCache` is `nil` (or use `.reloadIgnoringLocalCacheData`) and leave
+``TMDbConfiguration/cache`` unset.
+
+## See Also
+
+- <doc:CreatingTMDbClient>
+- <doc:HandlingErrors>
+- ``CacheConfiguration``

--- a/Sources/TMDb/TMDb.docc/TMDb.md
+++ b/Sources/TMDb/TMDb.docc/TMDb.md
@@ -60,6 +60,7 @@ Watch providers provided by [JustWatch](https://www.justwatch.com).
 - <doc:/ManagingUserAccounts>
 - <doc:/UsingLanguageModelTools>
 - <doc:/HandlingErrors>
+- <doc:/CachingResponses>
 
 ### Movies
 

--- a/Sources/TMDb/TMDbConfiguration.swift
+++ b/Sources/TMDb/TMDbConfiguration.swift
@@ -70,7 +70,10 @@ public struct TMDbConfiguration: Sendable, Equatable {
     /// User-specific requests (with session IDs) bypass the cache. Any
     /// successful POST or DELETE request invalidates the entire cache.
     ///
-    /// When `nil` (the default), no response caching is performed.
+    /// When `nil` (the default), no in-memory response caching is performed.
+    /// Note that on Apple platforms the default `URLSession` adapter already
+    /// caches responses on disk via `URLCache`, independently of this setting;
+    /// see <doc:CachingResponses>.
     ///
     /// ```swift
     /// let configuration = TMDbConfiguration(

--- a/knowledge/decisions/0007-document-existing-response-caching.md
+++ b/knowledge/decisions/0007-document-existing-response-caching.md
@@ -1,0 +1,57 @@
+# ADR-0007: Document existing response caching instead of building a custom on-disk cache
+
+- **Status:** Accepted
+- **Date:** 2026-06-24
+- **Deciders:** Adam Young, Claude
+
+## Context
+
+A feature request asked for an opt-in, configurable, TTL'd, lightweight on-disk
+cache so repeated API requests avoid repeated HTTP calls. The premise was that no
+on-disk caching existed.
+
+Investigation showed the capability already exists on Apple platforms:
+
+- The default `URLSession` adapter is configured in
+  `TMDbFactory.urlSessionConfiguration()` with `.useProtocolCachePolicy` and a
+  `URLCache` of 50 MB memory / 1 GB disk (`TMDbFactory.urlCache()`). This is
+  gated `#if !canImport(FoundationNetworking)`, so it is **Apple-platforms-only**
+  (absent on Linux/Windows).
+- TMDb serves `Cache-Control: public, max-age=<seconds>` and a weak `ETag` on
+  every GET endpoint (see `tmdb-api-notes.md` → *HTTP caching*).
+
+Together these already satisfy the request on Apple platforms: responses are
+cached on disk, persist across launches, expire per-resource via the API's own
+`max-age`, and are revalidated with `ETag` (a `304` reuses the cached body). A
+separate opt-in **in-memory** layer also already exists — `CacheHTTPClient` /
+`CacheConfiguration`, enabled via `TMDbConfiguration(cache:)`.
+
+## Decision
+
+We will **not** build a custom on-disk cache (SwiftData / file / `Codable`).
+Instead we document the two caching layers that already exist — the default
+on-disk `URLCache` and the opt-in in-memory `CacheConfiguration` — including how
+they interact and how to tune or disable the `URLCache` (supply a custom
+`HTTPClient` backed by your own `URLSession`). Delivered as a DocC HowTo
+(`CachingResponses.md`) plus doc-comment and README clarifications.
+
+## Consequences
+
+- No new code or public API surface to maintain; no new dependency.
+- Users get persistent on-disk caching with per-resource TTL and `ETag`
+  revalidation — semantics a hand-rolled fixed-TTL cache would not match.
+- **Gap:** on Linux/Windows no `URLCache` is installed, so only the in-memory
+  layer caches there. Deemed out of scope (the request targeted Apple platforms).
+  If cross-platform persistent caching is later needed, revisit this ADR — a
+  custom decorator would be the place to add it.
+
+## Alternatives considered
+
+- **Custom file/`Codable`/SwiftData on-disk decorator.** Rejected: largely
+  duplicates `URLCache` on Apple platforms and is *inferior* — a single fixed TTL
+  instead of per-resource `max-age`, and no conditional (`ETag`) revalidation. Its
+  only real value is Linux/Windows persistence, which was out of scope.
+- **Expose a config knob to size/disable `URLCache`.** Deferred: the existing
+  custom-`HTTPClient` escape hatch already covers tuning/disabling; a dedicated
+  knob can be added later if demand appears.
+</content>

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -10,6 +10,42 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-06-24 — 📝 Document existing response caching (#363) · lite (docs-led)
+
+- **Phases / skills:** phases 0–6; `review-changes, capture-knowledge, pr,
+  watch-pr`. Skipped `/review-plan` (lite + `/deliver` invocation was the
+  approval); skipped `/security-review` (no executable surface — doc comments +
+  markdown only); did **not** run `/implement-plan` (docs-only — no Canon TDD
+  test list to drive).
+- **Worked:** the standout was **challenging the premise before building.** The
+  user asked "evaluate whether this feature is needed — there's already an HTTP
+  cache" mid-plan; a quick `curl -D-` of real TMDb endpoints (every GET returns
+  `Cache-Control: public, max-age` + `ETag`) plus reading `TMDbFactory` showed the
+  requested opt-in on-disk cache **already exists** via the default `URLCache`
+  (Apple platforms) — and a hand-rolled one would be *inferior* (fixed TTL, no 304
+  revalidation). `AskUserQuestion` → "document, build nothing" turned a feature
+  build into a docs PR + ADR-0007. `make build-docs` (warnings-as-errors) was the
+  real gate for the `<doc:>`/symbol links.
+- **Friction:** (1) The single `code-reviewer` caught a genuine **High** that
+  *both* `make build-docs` and `markdownlint` missed — stray `</content>`/
+  `</invoke>` tags the `Write` tool leaked into the article tail (DocC renders
+  them as prose; `MD013` is off). Strong evidence that code review earns its keep
+  even on a "docs-only" change, and now a captured gotcha. (2) The recurring
+  full-`make ci` cost: the diff is doc-comments + markdown, yet ran the entire
+  unit+integration+release matrix.
+- **Deviations:** (a) The plan-file `Write` was rejected and `/deliver` invoked
+  directly, so the plan lived only in conversation — Phase 0's "read plan content
+  into context" covered it cleanly. (b) Wrote docs directly instead of via
+  `/implement-plan` (no test list for prose); build-docs + lint-markdown were the
+  gates.
+- **One improvement:** the **docs/config-only fast gate** is now logged on #340,
+  #343, #344 and here — four deliveries paying the full ~6-min matrix for
+  no-logic changes. Refinement this run exposes: the existing fast-gate detector
+  keys on the `.swift` *extension*, so a **comment/doc-only `.swift` diff** (like
+  this one) still trips the full gate. Worth finally implementing the fast gate
+  **and** widening its trigger to "no semantic Swift change" (e.g. diff is only
+  within `///`/`//` lines), so doc-comment touch-ups qualify too.
+
 ## 2026-06-24 — ✨ Add missing discover filter parameters (#361) · lite
 
 - **Phases / skills:** phases 0–6; `build-for-testing, test, integration-test,

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -6,6 +6,17 @@ out of it.
 
 ## Tooling
 
+### A `Write` of a Markdown/DocC file can leak `</content>`/`</invoke>` into the file tail
+
+*2026-06-24.* When creating a `.md` file with the `Write` tool, trailing
+tool-call closing tags (`</content>`, `</invoke>`) can end up appended to the
+file content. Neither gate catches it: `make build-docs` renders the unknown
+inline text as ordinary prose (no warning), and `markdownlint` doesn't flag it
+(`MD013` line-length is off in `.markdownlintrc`, and the tags aren't a lint
+violation). Code review caught it in the published article. After a `Write` of a
+docs/markdown file, verify the tail — e.g. `tail -3 <file>` or
+`grep -nE '</content>|</invoke>' <file>`.
+
 ### DocC symbol links don't resolve across modules — use code spans in a second target
 
 *2026-06-23.* The `TMDbTesting` target depends on `TMDb`, and its doc comments

--- a/knowledge/tmdb-api-notes.md
+++ b/knowledge/tmdb-api-notes.md
@@ -4,6 +4,20 @@ Behaviours of the **live** TMDb API discovered while implementing — the things
 docs don't say, or say wrongly. This is an API-client library, so these recur.
 Newest at the top; cite the endpoint and the date observed.
 
+## HTTP caching
+
+### Every GET response is HTTP-cacheable — `Cache-Control: public, max-age` + `ETag`
+
+*2026-06-24.* TMDb serves standard caching headers on every GET endpoint:
+`Cache-Control: public, max-age=<seconds>` plus a weak `ETag` (and an `age`
+header — responses are CDN-fronted). The `max-age` varies sensibly by resource:
+`movie/{id}` ~18909s (~5h), `search/movie` ~15340s (~4h), `configuration` and
+`person/{id}` several hours, `trending/*` ~36–395s (minutes). So responses are
+fully cacheable *and* conditionally revalidatable (a stale entry's `ETag` yields
+a `304 Not Modified`). This is why the default `URLSession` adapter's `URLCache`
+gives real on-disk caching for free on Apple platforms — see
+[ADR-0007](decisions/0007-document-existing-response-caching.md).
+
 ## Discover
 
 ### `discover/movie` has *two* distinct release-date filters


### PR DESCRIPTION
## Summary

This request started as "add an opt-in, configurable, TTL'd on-disk cache so
repeated requests don't re-hit TMDb". On investigation, **that capability
already exists** — it just wasn't documented. So this PR documents the existing
caching rather than adding redundant code.

On Apple platforms the default `URLSession` adapter is already configured with a
`URLCache` (50 MB memory / 1 GB disk) and `.useProtocolCachePolicy`, and TMDb
serves `Cache-Control: public, max-age=…` + `ETag` on every GET endpoint. So
responses are **already cached on disk, persist across launches, expire
per-resource via the API's own `max-age`, and are revalidated with `ETag`** — no
configuration required. A separate **opt-in in-memory** layer
(``CacheConfiguration``) already sits on top.

A hand-rolled on-disk cache would largely duplicate `URLCache` with *worse*
semantics (a single fixed TTL, no conditional revalidation), so the decision
(ADR-0007) is to document the two existing layers and how to tune/disable them.

## Changes

**Documentation:**
- 📝 New DocC HowTo — `CachingResponses.md`: the two caching layers, how they
  interact (in-memory → retry → `URLSession`/`URLCache`), and how to tune or
  disable the on-disk cache via a custom `HTTPClient`. Registered in `TMDb.md`.
- 📝 Clarified doc comments on `CacheConfiguration`, `TMDbConfiguration.cache`,
  and the (internal) `CacheHTTPClient` so the in-memory layer isn't mistaken for
  the only cache.
- 📝 `README.md` + `CreatingTMDbClient.md`: note the default on-disk `URLCache`.

**Knowledge:**
- 📝 ADR-0007 — document existing caching vs build a custom on-disk cache.
- 📝 `tmdb-api-notes.md` — every GET response carries `Cache-Control` + `ETag`
  (with representative `max-age` values).
- 📝 `gotchas.md` — a `Write` of a Markdown file can leak `</content>`/`</invoke>`
  tags that neither `build-docs` nor `markdownlint` catches.

## Notes

- **No production logic changed** — Swift edits are doc-comments only.
- Caveat documented: on Linux/Windows no `URLCache` is installed, so only the
  in-memory layer caches there.
- `make ci` passes locally (lint, markdown, unit + integration tests, release
  build, docs build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)