### PR TITLE
🔒 Harden URL path interpolation & validate inputs at public boundaries

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -300,6 +300,22 @@ code), drives the Red-Green-Refactor loop one test at a time, and finishes only
 when the **test list is empty** and the suites are green, and expects the
 lint/format PostToolUse hook to reshape files after writes.
 
+> **"Fix every instance of pattern X" → enumerate ALL sites up front.** When the
+> plan's goal is to apply one change across every occurrence of a pattern (encode
+> every path interpolation, validate every public String input, rename every call
+> site), do a single **type-driven sweep first** and list the sites in the test
+> list before implementing — don't discover them piecemeal. Piecemeal discovery is
+> a recurring miss: a grep keyed on the wrong signal finds a subset, and the
+> stragglers surface one at a time across code review / security review / the
+> `claude-review` bot (PR #364 found a 4th encode site in review and three more
+> unvalidated methods from the bot, after both the plan sweep and `/security-review`
+> had each missed a different subset). Sweep by **type**, not by eyeballing: e.g.
+> `grep 'path = "/.*\('` for String-into-path interpolations *and* scan public
+> service signatures for `String`/`*.ID` params — `Int` IDs are injection-safe and
+> need nothing. Confirm the full list, then implement against it.
+>
+> ---
+>
 > **Consult the specialist skills — don't hand-roll their domains (mandatory).**
 > `/implement-plan`'s contract §4 already requires this, but it is easy to skip
 > under delivery momentum, so treat it as a hard checkpoint here too — including

--- a/Sources/TMDb/Domain/Services/Authentication/TMDbAuthenticationService.swift
+++ b/Sources/TMDb/Domain/Services/Authentication/TMDbAuthenticationService.swift
@@ -46,6 +46,7 @@ final class TMDbAuthenticationService: AuthenticationService {
     }
 
     func createSession(withV4AccessToken v4AccessToken: String) async throws(TMDbError) -> Session {
+        try Self.validate(accessToken: v4AccessToken)
         let request = CreateSessionFromV4AccessTokenRequest(
             accessToken: v4AccessToken
         )
@@ -54,6 +55,7 @@ final class TMDbAuthenticationService: AuthenticationService {
     }
 
     func createSession(withCredential credential: Credential) async throws(TMDbError) -> Session {
+        try Self.validate(credential: credential)
         let token = try await requestToken()
 
         let request = ValidateTokenWithLoginRequest(
@@ -78,6 +80,27 @@ final class TMDbAuthenticationService: AuthenticationService {
         let request = ValidateKeyRequest()
 
         return try await apiClient.perform(request).success
+    }
+
+}
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+extension TMDbAuthenticationService {
+
+    private static func validate(accessToken: String) throws(TMDbError) {
+        guard !accessToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw .badRequest("Access token must not be empty")
+        }
+    }
+
+    private static func validate(credential: Credential) throws(TMDbError) {
+        guard !credential.username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw .badRequest("Username must not be empty")
+        }
+
+        guard !credential.password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw .badRequest("Password must not be empty")
+        }
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Credits/Requests/CreditRequest.swift
+++ b/Sources/TMDb/Domain/Services/Credits/Requests/CreditRequest.swift
@@ -10,7 +10,7 @@ import Foundation
 final class CreditRequest: DecodableAPIRequest<Credit> {
 
     init(id: Credit.ID) {
-        let path = "/credit/\(id)"
+        let path = "/credit/\(id.urlPathSegmentEncoded)"
 
         super.init(path: path)
     }

--- a/Sources/TMDb/Domain/Services/Credits/TMDbCreditService.swift
+++ b/Sources/TMDb/Domain/Services/Credits/TMDbCreditService.swift
@@ -17,9 +17,21 @@ final class TMDbCreditService: CreditService {
     }
 
     func details(forCredit id: Credit.ID) async throws(TMDbError) -> Credit {
+        try Self.validate(id: id)
         let request = CreditRequest(id: id)
 
         return try await apiClient.perform(request)
+    }
+
+}
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+extension TMDbCreditService {
+
+    private static func validate(id: Credit.ID) throws(TMDbError) {
+        guard !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw .badRequest("Credit ID must not be empty")
+        }
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Find/Requests/FindByIDRequest.swift
+++ b/Sources/TMDb/Domain/Services/Find/Requests/FindByIDRequest.swift
@@ -14,7 +14,7 @@ final class FindByIDRequest: DecodableAPIRequest<FindResults> {
         externalSource: ExternalSource,
         language: String? = nil
     ) {
-        let path = "/find/\(externalID)"
+        let path = "/find/\(externalID.urlPathSegmentEncoded)"
         let queryItems = APIRequestQueryItems(
             externalSource: externalSource,
             language: language

--- a/Sources/TMDb/Domain/Services/Find/TMDbFindService.swift
+++ b/Sources/TMDb/Domain/Services/Find/TMDbFindService.swift
@@ -23,6 +23,7 @@ final class TMDbFindService: FindService {
         externalSource: ExternalSource,
         language: String? = nil
     ) async throws(TMDbError) -> FindResults {
+        try Self.validate(externalID: externalID)
         let languageCode = language ?? configuration.defaultLanguage
         let request = FindByIDRequest(
             externalID: externalID,
@@ -31,6 +32,17 @@ final class TMDbFindService: FindService {
         )
 
         return try await apiClient.perform(request)
+    }
+
+}
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+extension TMDbFindService {
+
+    private static func validate(externalID: String) throws(TMDbError) {
+        guard !externalID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw .badRequest("External ID must not be empty")
+        }
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Lists/TMDbListService.swift
+++ b/Sources/TMDb/Domain/Services/Lists/TMDbListService.swift
@@ -52,6 +52,7 @@ final class TMDbListService: ListService {
         isPublic: Bool? = nil,
         session: Session
     ) async throws(TMDbError) -> CreateListResult {
+        try Self.validate(name: name)
         let request = CreateListRequest(
             name: name,
             description: description,
@@ -93,6 +94,17 @@ final class TMDbListService: ListService {
         let request = ClearListRequest(listID: listID, sessionID: session.sessionID)
 
         _ = try await apiClient.perform(request)
+    }
+
+}
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+extension TMDbListService {
+
+    private static func validate(name: String) throws(TMDbError) {
+        guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw .badRequest("List name must not be empty")
+        }
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Reviews/Requests/ReviewRequest.swift
+++ b/Sources/TMDb/Domain/Services/Reviews/Requests/ReviewRequest.swift
@@ -10,7 +10,7 @@ import Foundation
 final class ReviewRequest: DecodableAPIRequest<Review> {
 
     init(id: Review.ID) {
-        let path = "/review/\(id)"
+        let path = "/review/\(id.urlPathSegmentEncoded)"
 
         super.init(path: path)
     }

--- a/Sources/TMDb/Domain/Services/Reviews/TMDbReviewService.swift
+++ b/Sources/TMDb/Domain/Services/Reviews/TMDbReviewService.swift
@@ -19,9 +19,21 @@ final class TMDbReviewService: ReviewService {
     func details(
         forReview id: Review.ID
     ) async throws(TMDbError) -> Review {
+        try Self.validate(id: id)
         let request = ReviewRequest(id: id)
 
         return try await apiClient.perform(request)
+    }
+
+}
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+extension TMDbReviewService {
+
+    private static func validate(id: Review.ID) throws(TMDbError) {
+        guard !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw .badRequest("Review ID must not be empty")
+        }
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVEpisodeGroups/Requests/TVEpisodeGroupRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVEpisodeGroups/Requests/TVEpisodeGroupRequest.swift
@@ -11,7 +11,7 @@ final class TVEpisodeGroupRequest:
 DecodableAPIRequest<TVEpisodeGroup> {
 
     init(id: TVEpisodeGroup.ID) {
-        let path = "/tv/episode_group/\(id)"
+        let path = "/tv/episode_group/\(id.urlPathSegmentEncoded)"
 
         super.init(path: path)
     }

--- a/Sources/TMDb/Domain/Services/TVEpisodeGroups/TMDbTVEpisodeGroupService.swift
+++ b/Sources/TMDb/Domain/Services/TVEpisodeGroups/TMDbTVEpisodeGroupService.swift
@@ -19,9 +19,21 @@ final class TMDbTVEpisodeGroupService: TVEpisodeGroupService {
     func details(
         forTVEpisodeGroup id: TVEpisodeGroup.ID
     ) async throws(TMDbError) -> TVEpisodeGroup {
+        try Self.validate(id: id)
         let request = TVEpisodeGroupRequest(id: id)
 
         return try await apiClient.perform(request)
+    }
+
+}
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+extension TMDbTVEpisodeGroupService {
+
+    private static func validate(id: TVEpisodeGroup.ID) throws(TMDbError) {
+        guard !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw .badRequest("TV episode group ID must not be empty")
+        }
     }
 
 }

--- a/Sources/TMDb/Extensions/String+URLPathSegment.swift
+++ b/Sources/TMDb/Extensions/String+URLPathSegment.swift
@@ -1,0 +1,27 @@
+//
+//  String+URLPathSegment.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+extension String {
+
+    ///
+    /// The string percent-encoded for safe use as a single URL path segment.
+    ///
+    /// Every character other than the RFC 3986 *unreserved* set
+    /// (`A`–`Z`, `a`–`z`, `0`–`9`, `-`, `.`, `_`, `~`) is percent-encoded, so an
+    /// interpolated value cannot break out of its segment to inject additional
+    /// path components (`/`), a query string (`?`), or a fragment (`#`).
+    ///
+    var urlPathSegmentEncoded: String {
+        var allowedCharacters = CharacterSet.alphanumerics
+        allowedCharacters.insert(charactersIn: "-._~")
+
+        return addingPercentEncoding(withAllowedCharacters: allowedCharacters) ?? self
+    }
+
+}

--- a/Tests/TMDbIntegrationTests/AuthenticationIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/AuthenticationIntegrationTests.swift
@@ -87,4 +87,11 @@ struct AuthenticationIntegrationTests {
         #expect(url.absoluteString.contains("redirect_to") == true)
     }
 
+    @Test("createSession with empty v4 access token throws bad request")
+    func createSessionWithEmptyV4AccessTokenThrowsBadRequest() async throws {
+        await #expect(throws: TMDbError.self) {
+            _ = try await authenticationService.createSession(withV4AccessToken: "   ")
+        }
+    }
+
 }

--- a/Tests/TMDbIntegrationTests/FindIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/FindIntegrationTests.swift
@@ -58,4 +58,11 @@ struct FindIntegrationTests {
         #expect(results.personResults.isEmpty)
     }
 
+    @Test("find with empty external ID throws bad request")
+    func findWithEmptyExternalIDThrowsBadRequest() async throws {
+        await #expect(throws: TMDbError.self) {
+            _ = try await findService.find(externalID: "", externalSource: .imdbID)
+        }
+    }
+
 }

--- a/Tests/TMDbIntegrationTests/ListIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/ListIntegrationTests.swift
@@ -130,4 +130,19 @@ struct ListIntegrationTests {
         try await listService.delete(list: listID, session: session)
     }
 
+    @Test("create with empty name throws bad request")
+    func createWithEmptyNameThrowsBadRequest() async throws {
+        let session = Session(success: true, sessionID: "test-session")
+
+        await #expect(throws: TMDbError.self) {
+            _ = try await listService.create(
+                name: "",
+                description: nil,
+                language: nil,
+                isPublic: nil,
+                session: session
+            )
+        }
+    }
+
 }

--- a/Tests/TMDbTests/Domain/Services/Authentication/TMDbAuthenticationServiceTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Authentication/TMDbAuthenticationServiceTests.swift
@@ -282,4 +282,35 @@ struct TMDbAuthenticationServiceTests {
         }
     }
 
+    @Test("createSession with empty v4 access token throws bad request and performs no request")
+    func createSessionWithEmptyV4AccessTokenThrowsBadRequest() async throws {
+        await #expect(throws: TMDbError.badRequest("Access token must not be empty")) {
+            _ = try await service.createSession(withV4AccessToken: "   ")
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
+    @Test("createSession with empty username throws bad request and performs no request")
+    func createSessionWithEmptyUsernameThrowsBadRequest() async throws {
+        let credential = Credential(username: " ", password: "pass123")
+
+        await #expect(throws: TMDbError.badRequest("Username must not be empty")) {
+            _ = try await service.createSession(withCredential: credential)
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
+    @Test("createSession with empty password throws bad request and performs no request")
+    func createSessionWithEmptyPasswordThrowsBadRequest() async throws {
+        let credential = Credential(username: "test", password: "")
+
+        await #expect(throws: TMDbError.badRequest("Password must not be empty")) {
+            _ = try await service.createSession(withCredential: credential)
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
 }

--- a/Tests/TMDbTests/Domain/Services/Credits/Requests/CreditRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Credits/Requests/CreditRequestTests.swift
@@ -28,6 +28,13 @@ struct CreditRequestTests {
         )
     }
 
+    @Test("path percent-encodes an ID containing unsafe characters")
+    func pathPercentEncodesUnsafeID() {
+        let request = CreditRequest(id: "abc/def?x=y")
+
+        #expect(request.path == "/credit/abc%2Fdef%3Fx%3Dy")
+    }
+
     @Test("queryItems is empty")
     func queryItemsIsEmpty() {
         #expect(request.queryItems.isEmpty)

--- a/Tests/TMDbTests/Domain/Services/Credits/TMDbCreditServiceTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Credits/TMDbCreditServiceTests.swift
@@ -53,4 +53,22 @@ struct TMDbCreditServiceTests {
         }
     }
 
+    @Test("details with empty ID throws bad request and performs no request")
+    func detailsWithEmptyIDThrowsBadRequest() async throws {
+        await #expect(throws: TMDbError.badRequest("Credit ID must not be empty")) {
+            _ = try await service.details(forCredit: "")
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
+    @Test("details with whitespace ID throws bad request and performs no request")
+    func detailsWithWhitespaceIDThrowsBadRequest() async throws {
+        await #expect(throws: TMDbError.badRequest("Credit ID must not be empty")) {
+            _ = try await service.details(forCredit: "  \n ")
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
 }

--- a/Tests/TMDbTests/Domain/Services/Find/Requests/FindByIDRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Find/Requests/FindByIDRequestTests.swift
@@ -26,6 +26,14 @@ struct FindByIDRequestTests {
         #expect(request.path == "/find/81189")
     }
 
+    @Test("path percent-encodes an external ID containing query-injection characters")
+    func pathPercentEncodesUnsafeExternalID() {
+        let request = FindByIDRequest(externalID: "tt0111161?injected=x", externalSource: .imdbID)
+
+        #expect(request.path == "/find/tt0111161%3Finjected%3Dx")
+        #expect(!request.path.contains("?"))
+    }
+
     @Test("queryItems with IMDb external source")
     func queryItemsWithIMDbExternalSource() {
         let request = FindByIDRequest(externalID: "tt0111161", externalSource: .imdbID)

--- a/Tests/TMDbTests/Domain/Services/Find/TMDbFindServiceTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Find/TMDbFindServiceTests.swift
@@ -96,4 +96,22 @@ struct TMDbFindServiceTests {
         }
     }
 
+    @Test("find with empty external ID throws bad request and performs no request")
+    func findWithEmptyExternalIDThrowsBadRequest() async throws {
+        await #expect(throws: TMDbError.badRequest("External ID must not be empty")) {
+            _ = try await service.find(externalID: "", externalSource: .imdbID)
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
+    @Test("find with whitespace external ID throws bad request and performs no request")
+    func findWithWhitespaceExternalIDThrowsBadRequest() async throws {
+        await #expect(throws: TMDbError.badRequest("External ID must not be empty")) {
+            _ = try await service.find(externalID: "  \n ", externalSource: .imdbID)
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
 }

--- a/Tests/TMDbTests/Domain/Services/Lists/TMDbListServiceManagementTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Lists/TMDbListServiceManagementTests.swift
@@ -180,4 +180,22 @@ struct TMDbListServiceManagementTests {
         }
     }
 
+    @Test("create with empty name throws bad request and performs no request")
+    func createWithEmptyNameThrowsBadRequest() async throws {
+        await #expect(throws: TMDbError.badRequest("List name must not be empty")) {
+            _ = try await service.create(name: "", session: session)
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
+    @Test("create with whitespace name throws bad request and performs no request")
+    func createWithWhitespaceNameThrowsBadRequest() async throws {
+        await #expect(throws: TMDbError.badRequest("List name must not be empty")) {
+            _ = try await service.create(name: " \t\n ", session: session)
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
 }

--- a/Tests/TMDbTests/Domain/Services/Reviews/Requests/ReviewRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Reviews/Requests/ReviewRequestTests.swift
@@ -28,6 +28,13 @@ struct ReviewRequestTests {
         )
     }
 
+    @Test("path percent-encodes an ID containing unsafe characters")
+    func pathPercentEncodesUnsafeID() {
+        let request = ReviewRequest(id: "abc/def?x=y")
+
+        #expect(request.path == "/review/abc%2Fdef%3Fx%3Dy")
+    }
+
     @Test("queryItems is empty")
     func queryItemsIsEmpty() {
         #expect(request.queryItems.isEmpty)

--- a/Tests/TMDbTests/Domain/Services/Reviews/TMDbReviewServiceTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Reviews/TMDbReviewServiceTests.swift
@@ -53,4 +53,22 @@ struct TMDbReviewServiceTests {
         }
     }
 
+    @Test("details with empty ID throws bad request and performs no request")
+    func detailsWithEmptyIDThrowsBadRequest() async throws {
+        await #expect(throws: TMDbError.badRequest("Review ID must not be empty")) {
+            _ = try await service.details(forReview: "")
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
+    @Test("details with whitespace ID throws bad request and performs no request")
+    func detailsWithWhitespaceIDThrowsBadRequest() async throws {
+        await #expect(throws: TMDbError.badRequest("Review ID must not be empty")) {
+            _ = try await service.details(forReview: "  \n ")
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
 }

--- a/Tests/TMDbTests/Domain/Services/TVEpisodeGroups/Requests/TVEpisodeGroupRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/TVEpisodeGroups/Requests/TVEpisodeGroupRequestTests.swift
@@ -28,6 +28,13 @@ struct TVEpisodeGroupRequestTests {
         )
     }
 
+    @Test("path percent-encodes an ID containing unsafe characters")
+    func pathPercentEncodesUnsafeID() {
+        let request = TVEpisodeGroupRequest(id: "abc/def?x=y")
+
+        #expect(request.path == "/tv/episode_group/abc%2Fdef%3Fx%3Dy")
+    }
+
     @Test("queryItems is empty")
     func queryItemsIsEmpty() {
         #expect(request.queryItems.isEmpty)

--- a/Tests/TMDbTests/Domain/Services/TVEpisodeGroups/TMDbTVEpisodeGroupServiceTests.swift
+++ b/Tests/TMDbTests/Domain/Services/TVEpisodeGroups/TMDbTVEpisodeGroupServiceTests.swift
@@ -56,4 +56,22 @@ struct TMDbTVEpisodeGroupServiceTests {
         }
     }
 
+    @Test("details with empty ID throws bad request and performs no request")
+    func detailsWithEmptyIDThrowsBadRequest() async throws {
+        await #expect(throws: TMDbError.badRequest("TV episode group ID must not be empty")) {
+            _ = try await service.details(forTVEpisodeGroup: "")
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
+    @Test("details with whitespace ID throws bad request and performs no request")
+    func detailsWithWhitespaceIDThrowsBadRequest() async throws {
+        await #expect(throws: TMDbError.badRequest("TV episode group ID must not be empty")) {
+            _ = try await service.details(forTVEpisodeGroup: "  \n ")
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
 }

--- a/Tests/TMDbTests/Extensions/String+URLPathSegmentTests.swift
+++ b/Tests/TMDbTests/Extensions/String+URLPathSegmentTests.swift
@@ -1,0 +1,40 @@
+//
+//  String+URLPathSegmentTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+struct StringURLPathSegmentTests {
+
+    @Test("plain alphanumeric identifier is unchanged")
+    func plainIdentifierUnchanged() {
+        #expect("tt0111161".urlPathSegmentEncoded == "tt0111161")
+    }
+
+    @Test("unreserved characters are left unchanged")
+    func unreservedCharactersUnchanged() {
+        #expect("a-b_c.d~e".urlPathSegmentEncoded == "a-b_c.d~e")
+    }
+
+    @Test("question mark is percent-encoded")
+    func questionMarkEncoded() {
+        #expect("id?injected=x".urlPathSegmentEncoded == "id%3Finjected%3Dx")
+    }
+
+    @Test("forward slash is percent-encoded")
+    func forwardSlashEncoded() {
+        #expect("a/b".urlPathSegmentEncoded == "a%2Fb")
+    }
+
+    @Test("space, hash, and path-traversal characters are percent-encoded")
+    func otherUnsafeCharactersEncoded() {
+        #expect("a b#c".urlPathSegmentEncoded == "a%20b%23c")
+        #expect("../x".urlPathSegmentEncoded == "..%2Fx")
+    }
+
+}

--- a/Tests/TMDbTests/Extensions/String+URLPathSegmentTests.swift
+++ b/Tests/TMDbTests/Extensions/String+URLPathSegmentTests.swift
@@ -11,6 +11,11 @@ import Testing
 
 struct StringURLPathSegmentTests {
 
+    @Test("empty string encodes to empty string")
+    func emptyStringUnchanged() {
+        #expect("".urlPathSegmentEncoded == "")
+    }
+
     @Test("plain alphanumeric identifier is unchanged")
     func plainIdentifierUnchanged() {
         #expect("tt0111161".urlPathSegmentEncoded == "tt0111161")

--- a/knowledge/decisions/0007-percent-encode-url-path-segments.md
+++ b/knowledge/decisions/0007-percent-encode-url-path-segments.md
@@ -1,0 +1,53 @@
+# ADR-0007: Percent-encode user-supplied URL path segments with the RFC 3986 unreserved set
+
+- **Status:** Accepted
+- **Date:** 2026-06-24
+- **Deciders:** Adam Young (security-review-driven delivery)
+
+## Context
+
+A handful of request builders interpolate a caller-supplied `String` directly
+into the request path, e.g. `"/find/\(externalID)"`. Unlike query items (which
+go through `URLComponents`/`URLQueryItem` and are percent-encoded), a raw string
+in the path is parsed by `URL(string:)` in `TMDbAPIClient`, so characters like
+`?` and `#` let the value break out of its path segment and inject a query string
+or fragment. There were **four** such sites — `FindByIDRequest`,
+`CreditRequest`, `TVEpisodeGroupRequest`, `ReviewRequest` (all take `String`
+IDs); every other path uses `Int` IDs, which are injection-safe.
+
+The fix needs a single reusable encoder. The open question was *which* allowed
+character set to pass to `addingPercentEncoding(withAllowedCharacters:)`.
+
+## Decision
+
+We will percent-encode a path segment against the **RFC 3986 *unreserved* set**
+only — `CharacterSet.alphanumerics` plus `-._~` — via a `String`
+`urlPathSegmentEncoded` helper, and apply it at every site where a `String` is
+interpolated into a request path.
+
+## Consequences
+
+- Every character outside the unreserved set (including `/`, `?`, `#`, `=`, `&`,
+  spaces, `%` itself) is percent-encoded, so a segment is maximally inert and
+  trivially reviewable — "only unreserved survives" needs no case analysis.
+- No legitimate identifier is altered: real TMDb IDs (IMDb `tt…`, hex
+  credit/episode-group/review IDs, Wikidata `Q…`) are already unreserved, so the
+  encoded form is byte-identical to the input.
+- To find all sites needing this, grep for `path = "/…\(stringVar)"` — only
+  `String`-typed interpolations are at risk; `Int` IDs need nothing.
+- End-to-end caveat (not a regression): `TMDbAPIClient.urlFromPath` round-trips
+  the path through `URLComponents`, which re-encodes `?`/`#` but decodes `%2F`
+  back to a literal `/`. Query/fragment injection is fully prevented; an injected
+  `/` only adds path segments within the force-locked `api.themoviedb.org` host
+  (path-only, no SSRF). See `knowledge/gotchas.md` → *URLComponents path
+  round-trip*.
+
+## Alternatives considered
+
+- **`CharacterSet.urlPathAllowed.subtracting("/")`** — rejected. `.urlPathAllowed`
+  permits the sub-delimiters (`= & ; : @ + , $ ! * ' ( )`), leaving them literal.
+  Harmless for the locked host, but it forces a "which sub-delimiters matter?"
+  analysis on every reviewer; the unreserved-only set sidesteps that entirely.
+- **Encoding centrally in `TMDbAPIClient`** — rejected. The path already contains
+  `/` separators that must *not* be encoded, so the client can't blanket-encode;
+  encoding the variable segment at the interpolation site is the correct seam.

--- a/knowledge/decisions/0008-percent-encode-url-path-segments.md
+++ b/knowledge/decisions/0008-percent-encode-url-path-segments.md
@@ -1,4 +1,4 @@
-# ADR-0007: Percent-encode user-supplied URL path segments with the RFC 3986 unreserved set
+# ADR-0008: Percent-encode user-supplied URL path segments with the RFC 3986 unreserved set
 
 - **Status:** Accepted
 - **Date:** 2026-06-24

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -10,6 +10,37 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-06-24 — 🔒 Harden URL path interpolation & validate inputs (#364) · lite
+
+- **Phases / skills:** phases 0–6; `test, integration-test, review-changes,
+  security-review, capture-knowledge, pr, watch-pr`. Skipped `/review-plan` (lite;
+  plan built from a careful Explore sweep + the originating security review).
+- **Worked:** the **Phase 3.4 security review earned its place** — it traced the
+  encoding *end-to-end* through `TMDbAPIClient.urlFromPath`'s `URLComponents`
+  round-trip and confirmed query/fragment injection is genuinely blocked (not just
+  at the string layer), while surfacing the subtle `%2F`→`/` decode and correctly
+  bounding it as path-only on a locked host. That trace is what made the fix
+  trustworthy and produced ADR-0008 + the gotcha. Reusing the existing
+  `TMDbSearchService.validate` pattern kept validation uniform and review-clean.
+- **Friction — a repeated blind spot for `String`-typed IDs.** The *same class* of
+  site kept being found later than it should: my planning grep **and** the initial
+  `/security-review` both missed sites; Phase 3 code review found a 4th
+  String-into-path builder (`ReviewRequest`); then `claude-review` flagged **three
+  more** public service methods taking `String` IDs with no empty guard
+  (`CreditService`/`ReviewService`/`TVEpisodeGroupService` `.details(for…:)`). Each
+  pass found a subset. A type-driven sweep up front (grep `path = "/…\(` for
+  String interpolations **and** scan public service signatures for `String`/`*.ID`
+  params) would have enumerated all of them in one shot.
+- **Deviations:** none material — heeded the worktree edit-path gotcha (re-`Read`
+  via worktree paths after the pre-`EnterWorktree` reads; no main-checkout edits).
+  Minor: the `TaskCreate` ledger is CWD-scoped, so it was lost on `EnterWorktree`
+  and had to be recreated inside the worktree. The retro commit also hit a
+  same-day ADR-number collision with #363 (both claimed 0007) — renumbered to
+  0008 during the rebase.
+- **One improvement:** when a delivery's goal is "fix every instance of pattern X",
+  do one **type-driven enumeration of all sites up front** and list them in the
+  plan, rather than discovering them incrementally across review passes.
+
 ## 2026-06-24 — 📝 Document existing response caching (#363) · lite (docs-led)
 
 - **Phases / skills:** phases 0–6; `review-changes, capture-knowledge, pr,

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -201,6 +201,30 @@ and no deprecation shims** — it only changes Xcode autocomplete placeholders a
 the documented signature. (We initially mis-scoped the `<entity>ID` rename as
 breaking; it isn't.) See [ADR-0004](decisions/0004-service-parameter-name-convention.md).
 
+## Networking
+
+### `URLComponents` path round-trip in `TMDbAPIClient.urlFromPath` decodes `%2F`
+
+*2026-06-24.* `TMDbAPIClient.urlFromPath` rebuilds the request URL by reading and
+re-assigning `URLComponents.path` (to prefix the API base path). Two non-obvious
+Foundation behaviours interact here:
+
+- The `URLComponents.path` **getter percent-decodes** (`%3F` → `?`), and the
+  **setter re-encodes** characters invalid in a path component when serialising
+  via `.url` (`?` → `%3F`, `#` → `%23`).
+- But `/` is a *valid* path separator, so an encoded `%2F` decodes to a literal
+  `/` on the getter and is **not** re-encoded — it round-trips into extra path
+  segments.
+
+Consequence for the `urlPathSegmentEncoded` hardening
+([ADR-0007](decisions/0007-percent-encode-url-path-segments.md)): percent-encoding
+a user string before interpolating it into a request path **does** prevent
+query/fragment injection end-to-end, but an injected `/` still becomes a real
+separator. That residual is path-only — `urlFromPath` force-overrides
+`scheme`/`host` to `https://api.themoviedb.org`, so it cannot redirect off-host
+(no SSRF). If you ever need to neutralise `/` too, encode after the round-trip
+(set `percentEncodedPath`) rather than relying on the segment encoder alone.
+
 ## Swift concurrency
 
 ### Deterministically testing that cancellation is *forwarded* into an unstructured `Task`

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -217,7 +217,7 @@ Foundation behaviours interact here:
   segments.
 
 Consequence for the `urlPathSegmentEncoded` hardening
-([ADR-0007](decisions/0007-percent-encode-url-path-segments.md)): percent-encoding
+([ADR-0008](decisions/0008-percent-encode-url-path-segments.md)): percent-encoding
 a user string before interpolating it into a request path **does** prevent
 query/fragment injection end-to-end, but an injected `/` still becomes a real
 separator. That residual is path-only — `urlFromPath` force-overrides

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,30 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-06-24 — "Fix every instance of X" deliveries: enumerate all sites up front · applied
+
+- **Pattern:** for a delivery whose goal is "apply change C to every occurrence of
+  pattern X", the sites get found **piecemeal across review passes** rather than
+  enumerated up front. In #364 (encode every String-into-path interpolation + validate
+  every public String input), the plan grep and `/security-review` each missed a
+  *different* subset: Phase 3 code review found a 4th encode site (`ReviewRequest`),
+  then the `claude-review` bot flagged three more unvalidated `String`-ID service
+  methods. Each pass caught a subset; none enumerated the whole class. Echoes #361's
+  coverage gap (one of N parallel cases — TV `withoutWatchProviders` — had only unit
+  coverage), the same "incomplete enumeration of N parallel instances" shape.
+- **Decision:** **applied** (user-approved in the Phase 6 scan). `/deliver` Phase 2:
+  added a blockquote — when the plan's goal is "fix every instance of pattern X", do a
+  single **type-driven sweep first** and list all sites in the test list before
+  implementing; sweep by type (e.g. `grep 'path = "/.*\('` for String-into-path
+  interpolations *and* scan public service signatures for `String`/`*.ID` params; `Int`
+  IDs are safe) rather than eyeballing. Landed in `.claude/skills/deliver/SKILL.md`
+  Phase 2 (PR #364).
+- **Rationale:** piecemeal discovery means a grep keyed on the wrong signal silently
+  finds a subset and the stragglers surface one at a time across code/security review —
+  late, scattered, and easy to ship incomplete. One type-driven enumeration up front
+  makes "did I get them all?" a single answerable question.
+- **Reconsider when:** n/a (applied).
+
 ### 2026-06-24 — Verify checks positively (COMPLETED+SUCCESS on current tip), not "no failures" · applied
 
 - **Pattern:** misreading a still-running required check as green. In #361 a


### PR DESCRIPTION
## Summary

Defensive security hardening surfaced by a `/security-review` pass. Two related,
additive changes — no public API signatures change:

1. **Percent-encode user-supplied strings interpolated into URL request paths.**
   Query items already go through `URLComponents` encoding, but a raw `String` in
   the path is parsed by `URL(string:)`, so characters like `?`/`#` let a value
   break out of its path segment and inject a query string or fragment.
2. **Validate empty/whitespace inputs at the remaining public service boundaries**,
   reusing the existing `TMDbSearchService` validate-then-throw pattern.

## Changes

**New helper:**
- 🔒 `String.urlPathSegmentEncoded` — percent-encodes everything outside the
  RFC 3986 *unreserved* set (alphanumerics + `-._~`). Applied at all four
  `String`-into-path request sites: `FindByIDRequest`, `CreditRequest`,
  `TVEpisodeGroupRequest`, `ReviewRequest`. (`Int`-typed ID paths are
  injection-safe and untouched.)

**Input validation (throws `TMDbError.badRequest`, performs no network request):**
- ✅ `FindService.find(externalID:)`
- ✅ `ListService.create(name:)`
- ✅ `AuthenticationService.createSession(withV4AccessToken:)` and
  `createSession(withCredential:)` (username & password)

**Tests:**
- ✅ Unit tests for the encoder (unreserved/`?`/`/`/`=`/`#`/space/`../`/empty),
  each request's encoded path, and each service's empty + whitespace rejection
  (asserting no request is issued).
- ✅ Integration tests mirroring the `SearchIntegrationTests` validation precedent
  for find/list/auth empty inputs.

**Documentation:**
- 📝 ADR-0007 (why the RFC 3986 unreserved set, not `urlPathAllowed`-minus-slash)
  and a `gotchas.md` note on the `TMDbAPIClient.urlFromPath` `URLComponents`
  round-trip that bounds the end-to-end guarantee.

## Benefits

- **Closes a query/fragment-injection vector** across four request builders —
  verified effective end-to-end through `TMDbAPIClient`'s URL construction.
- **Consistent input validation** at public boundaries, matching the project's
  existing convention.
- **No behavioural change for valid inputs** — real TMDb identifiers are already
  unreserved, so their encoded form is byte-identical.

## Verification

- `make ci` green locally (lint, markdown lint, unit + integration tests, release
  build, docs build).
- Unit: 2809 passing · Integration: 285 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)