### PR TITLE
🔧 Add entry/exit criteria and auto-start to /deliver

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -12,10 +12,10 @@ the existing skills and the `code-reviewer` agent, adds the safety gates, and
 keeps going across the long session until the PR is ready.
 
 ```text
-you approve the plan ─▶ /deliver ─▶ worktree ─▶ [review-plan] ─▶ implement ─▶
-  code-review + fix ─▶ security-review + fix ─▶ capture ─▶ /pr reviewed ─▶
-  /watch-pr ─▶ GATE: ready-to-merge ─▶ retro
-               ▲ the only hard stop
+you approve the plan ─▶ /deliver ─▶ entry gate (ACs?) ─▶ worktree ─▶ [review-plan] ─▶
+  implement ─▶ code-review + fix ─▶ security-review + fix ─▶ capture ─▶
+  rubric check (ACs met?) ─▶ /pr reviewed ─▶ /watch-pr ─▶ GATE: ready-to-merge ─▶ retro
+                                                            ▲ the only hard stop
   … then, when the PR actually merges (maybe a later session): teardown (Phase 7)
 ```
 
@@ -77,6 +77,12 @@ These are non-negotiable. Do them by default, without being reminded.
    surprising live-API behaviour, or a non-obvious decision. One line each
    (`<category>: <gist> [where]`). Phase 3.5 curates this list; reconstructing it
    at the end loses the best material (and may not survive compaction).
+8. **Auto-start after plan-mode approval.** When a plan has just been approved via
+   `ExitPlanMode` in this session, invoke `/deliver` immediately — **do not ask
+   "shall I start?" or "ready to proceed?"**. The plan-mode approval IS the start
+   signal. The only legitimate reason to pause before starting is if Phase 0's
+   entry gate fires (missing acceptance criteria) — that is a plan problem, not a
+   confirmation prompt.
 
 ## Auto mode (unattended)
 
@@ -180,6 +186,23 @@ it never bloats or biases the main window:
   block the pipeline on it.
 - **Judge the delivery weight** (lite vs full) from the plan, and open the
   `TaskCreate` ledger (Contract §6).
+- **Entry gate — acceptance criteria required.** Plans are expected in the form
+  *"As a \<user-type\> I want \<feature\> so that \<reason\>"* followed by
+  acceptance criteria and any elaboration. Locate the acceptance criteria in the
+  plan:
+  - **If acceptance criteria are present:** extract them verbatim as the **delivery
+    rubric** and record them in the ledger. Proceed silently.
+  - **If acceptance criteria are absent:** stop and ask the user to add them before
+    proceeding — do not enter the worktree or begin implementation. Be specific:
+    *"The plan has no acceptance criteria. Please add them so there is a clear
+    definition of done (e.g. 'Given X, when Y, then Z')."*
+  - **Auto:** convene the panel on a missing-AC stop. **Proceed** majority → note
+    the gap in the ledger, continue without a rubric (Phase 3.6 becomes a no-op).
+    **Stop** majority → surface to the user.
+
+  The delivery rubric (extracted ACs) travels through the run and is consumed in
+  Phase 3.6.
+
 - **Read the plan's content into context now — before the worktree.** Phase 0.5's
   `EnterWorktree` switches the working directory and **clears the CWD-scoped plans
   cache**, so the active plan reference can be lost after the switch. Locate and
@@ -468,6 +491,36 @@ Do this **before** `/pr` so the notes are committed in the **same PR** as the
 change. Capturing nothing is a valid outcome — don't manufacture entries. The
 `knowledge/` files are Markdown, so they add no review noise (the GitHub reviewer
 ignores `**/*.md`); keep entries tidy by hand.
+
+## Phase 3.6 — Rubric verification (exit gate)
+
+Retrieve the delivery rubric (the acceptance criteria extracted in Phase 0) from
+the ledger. If none were extracted — the plan lacked ACs and the auto panel chose
+to proceed — **skip this phase entirely**.
+
+For each AC, verify the committed diff satisfies it:
+
+- **A behaviour criterion** (decoding, error handling, an API call shape) → scan
+  the diff (`git diff origin/main...HEAD`) for the relevant code path, or run a
+  targeted test (`swift test --filter …`) if one covers it directly.
+- **A test-coverage criterion** → confirm the test file and assertion exist in
+  the diff.
+- **An integration criterion** → confirm the integration test exists; the live
+  run already passed in Phase 2, so no re-run is needed.
+
+**For each criterion:**
+
+- **Satisfied** → mark it off in the ledger, no action.
+- **Not satisfied** → fix it test-first (`canon-tdd`), commit, and re-verify. If
+  a gap cannot be closed without a plan change, note it in the PR description with
+  the reason.
+
+This check is lightweight — reading a diff against a short list, not a full review.
+Do it inline (no subagent needed). If every item passes in a quick scan, this phase
+takes seconds. Only gaps trigger work.
+
+The rubric answers a different question than CI: *"did we build what the plan
+said?"* not *"did the build pass?"*
 
 ## Phase 4 — Create the PR
 

--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -26,6 +26,10 @@ gh pr view --json number,url,state,headRefName,mergeStateStatus,statusCheckRollu
 
 - No PR for the current branch → stop and tell the user (suggest `/pr`).
 - State not `OPEN` → stop and report.
+- **`reviewThreads` is not a valid `gh pr view --json` field** — adding it causes
+  `gh` to error silently (empty stdout), which breaks any JSON parsing downstream.
+  Thread data must come from `gh api graphql`; delegate to `/review-pr-threads`
+  which already does this correctly.
 
 Keep a **run ledger** in your working notes: resolved thread IDs, a topic
 signature per handled thread (`path:line` + short gist), and a fix-attempt

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -10,6 +10,27 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-06-24 — 🔧 Add entry/exit criteria and auto-start to /deliver (#365) · lite
+
+- **Phases / skills:** phases 0–6; `pr, watch-pr`. Skipped `/review-plan` (lite +
+  plan approved via ExitPlanMode this session); skipped `/implement-plan`
+  (markdown-only — no TDD test list); skipped code review + security review (no
+  Swift changed).
+- **Worked:** the fast-gate detector caught this as docs/config-only correctly —
+  only `make lint-markdown` ran locally, CI resolved in under 2 minutes. Deriving
+  the changes directly from the conversation (Looper article → gap analysis →
+  plan) kept the plan tight and the edits focused. The three changes (entry gate,
+  Phase 3.6, Contract §8) landed cleanly in one commit with no review friction.
+- **Friction:** the auto-start behaviour (Contract §8) can only be captured in the
+  skill itself and memory — there's no harness hook that fires on ExitPlanMode
+  approval, so it relies on the model reading the contract. That's a soft guarantee.
+- **Deviations:** Plan had no formal acceptance criteria (the first delivery under
+  the new entry gate!) — the circular dependency was noted and the Verification
+  section stood in. Phase 3.6 was accordingly a no-op for this run.
+- **One improvement:** the entry gate prompts for ACs but doesn't suggest a format
+  or example in context — the prompt could include a one-line example inline
+  ("e.g. 'Given X, when Y, then Z'") to reduce back-and-forth.
+
 ## 2026-06-24 — 🔒 Harden URL path interpolation & validate inputs (#364) · lite
 
 - **Phases / skills:** phases 0–6; `test, integration-test, review-changes,

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -30,6 +30,12 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 - **One improvement:** the entry gate prompts for ACs but doesn't suggest a format
   or example in context — the prompt could include a one-line example inline
   ("e.g. 'Given X, when Y, then Z'") to reduce back-and-forth.
+- **Gotcha — `reviewThreads` is not a valid `gh pr view --json` field.** Adding it
+  causes `gh` to error with empty stdout; any JSON parsing then fails with
+  `JSONDecodeError: Expecting value: line 1 column 1`. Thread data must be fetched
+  via `gh api graphql` — `/review-pr-threads` already does this correctly. Added a
+  guard note to `watch-pr/SKILL.md §0`. Do not add `reviewThreads` (or `comments`)
+  to `gh pr view --json` calls.
 
 ## 2026-06-24 — 🔒 Harden URL path interpolation & validate inputs (#364) · lite
 


### PR DESCRIPTION
## Summary

Borrows two ideas from the Looper loop-design tool to make \`/deliver\` more
intentional: an **entry gate** that requires acceptance criteria before any
work starts, and an **exit gate** that verifies the implementation actually
satisfies those criteria before the PR is opened.

Also adds a **Contract §8** so plan-mode approval auto-starts \`/deliver\`
without a confirmation prompt.

## Changes

**\`.claude/skills/deliver/SKILL.md\`:**

- ✨ **Phase 0 entry gate** — requires acceptance criteria in the plan
  (user-story format: *As a \<user\> I want \<feature\> so that \<reason\>* +
  ACs). Extracts them verbatim as the delivery rubric recorded in the ledger.
  Stops and prompts the user to add ACs if absent; auto-mode convenes the panel.
- ✨ **New Phase 3.6 — Rubric verification** — after capture-knowledge and
  before the PR, verifies each AC is satisfied by the committed diff. Fixes
  gaps test-first; notes unfixable ones in the PR description. No-op if no
  rubric was extracted.
- 🔧 **Contract §8 — Auto-start after plan approval** — after \`ExitPlanMode\`
  is approved in a session, invoke \`/deliver\` immediately without asking
  "shall I start?".
- 📝 Updated pipeline diagram to show the entry gate and rubric check steps.

## Benefits

- **Clearer definition of done**: ACs extracted at Phase 0 give every
  delivery an explicit, plan-specific rubric — not just "CI green".
- **Catches intent drift**: Phase 3.6 answers "did we build what the plan
  said?" independently of whether the build passed.
- **Less friction**: plan approval is now a single action, not two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)