### PR TITLE
🔧 Use the GitHub MCP instead of the gh CLI in the local skills

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -220,17 +220,20 @@ concurrent work.
 **First, GC any stale worktree from a prior delivery** (this run is the garbage
 collector for the *previous* one's deferred merge — Phase 7 only fires on an
 in-session merge, and the common path is "merged later, elsewhere"). Sweep the
-worktree dirs and reclaim any whose PR has since merged:
+worktree dirs and reclaim any whose PR has since merged. Get every PR's state in
+**one** call — `mcp__github__list_pull_requests` (owner/repo from the `origin` remote,
+`state: all`, `perPage: 100`) — and build a `head.ref → merged?` map (a merged PR
+reports `state: closed` + `merged: true`). Then, for each worktree branch the map
+marks **merged**, remove it:
 
 ```bash
-for wt in .claude/worktrees/*/; do
-  br=$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null) || continue
-  state=$(gh pr view "$br" --json state --jq .state 2>/dev/null)
-  if [ "$state" = "MERGED" ]; then
-    git worktree remove --force "$wt" && git branch -D "$br" 2>/dev/null
-  fi
-done
+# For each $wt under .claude/worktrees/ whose branch ($br) the map marks merged:
+git worktree remove --force "$wt" && git branch -D "$br" 2>/dev/null
 ```
+
+(The branch→merged map comes from the MCP call above; the shell step only does the
+removal — tool calls can't run inside a bash loop. Get branches with
+`git -C "$wt" rev-parse --abbrev-ref HEAD`.)
 
 This keeps `.claude/worktrees/` (each carrying a multi-GB `.build`) from
 accumulating across deliveries the user merged in the GitHub UI or a later session.
@@ -544,7 +547,8 @@ then push the branch and open the PR with a gitmoji title and structured body.
    live integration test) often passes in isolation / on a re-run → it's a `main`
    problem, not yours. Hand it to **`/fix-integration-failures`** (it fixes the
    flake on its own branch off `main`, runs `make ci`, and merges), then bring this
-   branch up to date (`git merge main` / `gh pr update-branch`) and re-run the gate.
+   branch up to date (`git merge main` / `mcp__github__update_pull_request_branch`)
+   and re-run the gate.
    Don't patch an unrelated test onto this feature branch, and don't hard-stop on it.
 
 Record the PR number/URL in the ledger.
@@ -558,7 +562,8 @@ integration failure to `/fix-integration-failures`, per Contract §4), looping u
 the PR is **ready** (green checks, threads resolved) or **stuck**.
 
 **Ready means mergeable *now*.** Before the gate, `/watch-pr` brings the branch up
-to date with `main` (`gh pr update-branch`) and waits for the re-run, so a PR
+to date with `main` (`mcp__github__update_pull_request_branch`) and waits for the
+re-run, so a PR
 reported ready isn't `BEHIND` and waiting on a rebase — the user can merge straight
 away. (See `/watch-pr` §3.)
 
@@ -729,7 +734,8 @@ worktree down once the PR is merged** — this reclaims both the worktree **and*
 
 **How to tear down** — two preconditions, both required:
 
-1. **The PR is actually merged** — `gh pr view <n> --json state --jq .state` → `MERGED`.
+1. **The PR is actually merged** — `mcp__github__pull_request_read` method `get`
+   (owner/repo from the `origin` remote, `pullNumber: <n>`) → `merged: true`.
 2. **The worktree has no unsaved work beyond what's merged** — `MERGED` only
    guarantees the *pushed* feature commits are on `main`; it says nothing about a
    commit made (or a file edited) **after** the last push, e.g. the retro. Verify

--- a/.claude/skills/diagnose-ci-failure/SKILL.md
+++ b/.claude/skills/diagnose-ci-failure/SKILL.md
@@ -42,10 +42,14 @@ fixes, and local-reproduction command.
 Use the first that applies:
 
 - A path or run id the caller handed you.
-- The current branch's run via the `gh` CLI:
+- The current branch's run via the **GitHub MCP** (owner/repo from the `origin`
+  remote): `mcp__github__actions_list` method `list_workflow_runs`
+  (`resource_id: ci.yml`, `workflow_runs_filter: { branch: <branch> }`), then
+  `mcp__github__get_job_logs` (`run_id: <id>`, `failed_only: true`,
+  `return_content: true`). (`mcp__github__pull_request_read` method
+  `get_check_runs` also shows which job is red.) **Headless / no MCP:**
   `gh run list --workflow CI --branch "$(git branch --show-current)" --limit 1`,
-  then `gh run view <id> --log-failed`. (`gh pr checks` also shows which job is
-  red.)
+  then `gh run view <id> --log-failed`.
 - CI pipes build/test output through **xcsift** in `github-actions` format, so
   the failing lines are GitHub `::error::` annotations carrying `file:line` —
   read those first.

--- a/.claude/skills/diagnose-ci-failure/references/_index.md
+++ b/.claude/skills/diagnose-ci-failure/references/_index.md
@@ -1,7 +1,9 @@
 # CI failure diagnosis — reference index
 
 Each CI job has its own failure signature and reference file. Identify the
-failing job (`gh pr checks`, or `gh run view <id> --log-failed`), then open the
+failing job (`mcp__github__pull_request_read` method `get_check_runs`, or
+`mcp__github__get_job_logs` with `failed_only` — `gh pr checks` /
+`gh run view <id> --log-failed` when headless without the MCP), then open the
 matching file.
 
 | Failing job (`name:` in ci.yml) | Reference | When to use |

--- a/.claude/skills/diagnose-integration-failure/SKILL.md
+++ b/.claude/skills/diagnose-integration-failure/SKILL.md
@@ -63,10 +63,11 @@ Keep it under ~150 words.
 
 0. **Determine the trigger** (it sets the cause ranking above). If the caller told
    you (e.g. `/watch-pr` / `/fix-pr-checks` diagnose a **PR** run), use that.
-   Otherwise read it from the run:
-   `gh run view <id> --json event,displayTitle` → `event` is `pull_request`,
-   `push`, or `schedule`. If you can't tell, assume **PR/push** when a local diff
-   vs `main` exists, else scheduled.
+   Otherwise read it from the run with `mcp__github__actions_get` method
+   `get_workflow_run` (owner/repo from the `origin` remote, `resource_id: <id>`) →
+   `event` is `pull_request`, `push`, or `schedule` (headless / no MCP:
+   `gh run view <id> --json event,displayTitle`). If you can't tell, assume
+   **PR/push** when a local diff vs `main` exists, else scheduled.
 
 1. **Locate the failure log**, in this order — use the first that exists:
    - A path the caller handed you (e.g. `failure-log.txt` in the working
@@ -74,7 +75,12 @@ Keep it under ~150 words.
    - `.build/last-integration-test.log` — written by the `/integration-test`
      skill. If you (or the user) haven't run the tests yet locally, run
      `/integration-test` first, then read this log.
-   - Otherwise, find the failing run with the `gh` CLI:
+   - Otherwise, find the failing run with the **GitHub MCP** (owner/repo from
+     `origin`): `mcp__github__actions_list` method `list_workflow_runs`
+     (`resource_id: integration.yml`, `workflow_runs_filter: { status: completed }`,
+     then filter to `conclusion == "failure"`), and read its log with
+     `mcp__github__get_job_logs` (`run_id: <id>`, `failed_only: true`,
+     `return_content: true`). Headless / no MCP:
      `gh run list --workflow Integration --status failure --limit 1` then
      `gh run view <id> --log-failed`.
 

--- a/.claude/skills/fix-integration-failures/SKILL.md
+++ b/.claude/skills/fix-integration-failures/SKILL.md
@@ -41,19 +41,27 @@ once green. Otherwise stop at **ready-to-merge** and hand off (default).
 
 ## 0. Find the failing run
 
-```bash
-gh run list --workflow Integration --status failure --limit 5 \
-  --json databaseId,event,headBranch,conclusion,createdAt,displayTitle
-```
+> **Interactive vs headless.** The steps below use the **GitHub MCP**
+> (`mcp__github__*`, owner/repo from the `origin` remote). When this skill runs
+> **headless** from `integration-failure.yml` — a CI runner, where the user-scoped
+> MCP is **not** mounted — use the `gh` equivalents instead (given inline at each
+> step and in *Running headless* below); that path stays 100% `gh`/`git`.
+
+Find the failing run with `mcp__github__actions_list` method `list_workflow_runs`
+(owner/repo from `origin`, `resource_id: integration.yml`,
+`workflow_runs_filter: { event: schedule, status: completed }`). The `status` enum has
+no `failure` value, so filter the results to `conclusion == "failure"` yourself.
 
 - Prefer the most recent **`schedule`** (or `workflow_dispatch`) run on `main`.
-- Note its `databaseId` (the run id) and `event` (sets the cause ranking).
+- Note its run `id` and `event` (sets the cause ranking).
 - No failing run → report "Integration is green, nothing to fix" and stop.
+- **Headless:** `gh run list --workflow Integration --status failure --limit 5 --json databaseId,event,headBranch,conclusion,createdAt,displayTitle`.
 
 ## 1. Diagnose
 
-Invoke **`/diagnose-integration-failure`**, handing it the run id (it will
-`gh run view <id> --log-failed`). It returns the three-section analysis — Summary,
+Invoke **`/diagnose-integration-failure`**, handing it the run id (it fetches the
+failed-job logs — via `mcp__github__get_job_logs`, or `gh run view --log-failed` when
+headless). It returns the three-section analysis — Summary,
 Likely cause (ranked; for a scheduled run it leads with backend/data drift, **not**
 a code regression), and Suggested fix. Use that ranking to choose the path below.
 
@@ -62,13 +70,19 @@ a code regression), and Suggested fix. Use that ranking to choose the path below
 If the diagnosis points to **case 3** (HTTP 429 / rate-limit, a timeout near the
 30-min cap, or a truncated log with no assertion failure):
 
+Re-run the failed jobs with `mcp__github__actions_run_trigger` method
+`rerun_failed_jobs` (owner/repo from `origin`, `run_id: <id>`), then block on the
+re-run with `gh run watch <run-id>` (the MCP has no blocking-wait equivalent). After
+it returns, re-read the conclusion with `mcp__github__actions_get` method
+`get_workflow_run` (`resource_id: <id>`) — don't trust the rerun call to surface it.
+
 ```bash
-gh run rerun <run-id> --failed
-gh run watch <run-id>
+gh run watch <run-id>   # blocking wait — kept on gh
 ```
 
 - **Green on re-run** → it was transient. Report and stop; no PR needed.
 - **Fails the same way again** → treat as deterministic; go to §3.
+- **Headless:** `gh run rerun <run-id> --failed` then `gh run watch <run-id>`.
 
 (The integration client already retries 429/5xx with backoff, so a true transient
 that survives a re-run is uncommon — a repeat failure is usually real drift.)

--- a/.claude/skills/fix-pr-checks/SKILL.md
+++ b/.claude/skills/fix-pr-checks/SKILL.md
@@ -11,7 +11,9 @@ over the checks failing *right now* — it diagnoses and fixes them, pushes once
 and returns. Waiting on pending checks and deciding whether to sweep again belong
 to the caller (you, or `/watch-pr`).
 
-Repo is `adamayoung/TMDb`; `gh` is authenticated.
+Repo is `adamayoung/TMDb`. GitHub reads use the **GitHub MCP** (`mcp__github__*`);
+`gh` is authenticated and used for the blocking CI wait. If an MCP call fails with
+**401/403** (PAT expired or missing scope), fall back to the equivalent `gh` command.
 
 ## It stands on the diagnosis skills
 
@@ -45,22 +47,28 @@ This skill is the **act-on-it** layer: route → fix → verify → commit → p
 
 ## 0. Find the PR
 
-```bash
-gh pr view --json number,url,state,headRefName
-```
+Find the open PR for the current branch with `mcp__github__list_pull_requests`
+(owner/repo from the `origin` remote, `head: <owner>:<branch>`, `state: open`), or
+read a specific one with `mcp__github__pull_request_read` method `get`. Take
+`number`/`html_url`/`state`/`head.ref` from the result.
 
 - An explicit PR number in the arguments overrides the current branch.
 - No PR for the current branch → stop and tell the user (suggest `/pr`).
-- State not `OPEN` → stop and report.
+- State not `open` → stop and report.
 
 ## 1. List the checks
 
-```bash
-gh pr checks --json name,state,bucket,link
-```
+Use `mcp__github__pull_request_read` method `get_check_runs` (owner/repo from
+`origin`, `pullNumber: <n>`) — the individual CI/CD check runs for the head
+commit. Classify each by `status` + `conclusion`:
 
-Classify by `bucket`: `fail` = fix it (below); `pending` = report and leave for
-the caller to wait on; `pass` / `skipping` / neutral (`claude-review`) = ignore.
+- **fix it** (below): `conclusion` is `failure` / `timed_out` / `cancelled` /
+  `action_required`.
+- **pending** (report, leave for the caller to wait on): `status` is not
+  `completed` (`queued` / `in_progress`).
+- **ignore**: `conclusion` is `success` / `skipped` / `neutral` (e.g.
+  `claude-review`).
+
 If nothing is failing, return immediately (note any pending checks).
 
 ## 2. Diagnose each failing check (Haiku)

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -64,7 +64,7 @@ git diff --name-only origin/main...HEAD | grep -qE '\.swift$' || echo "no-swift 
 8. **Ensure a clean working tree before pushing.** Re-run `git status`; commit anything still outstanding (e.g. review fixes from steps 5–7, or `make ci` fixes) so the push includes **everything**. The tree must be clean before proceeding. Then run `git diff origin/main...HEAD` to understand all changes going into the PR.
 9. Analyze the commits and changes to generate an appropriate title and summary
 10. Push the current branch to remote (`git push -u origin <branch>` if not yet pushed; otherwise `git push` — use `git push --force-with-lease` if you rebased in step 3)
-11. Create a PR using `gh pr create` with:
+11. Create a PR with the **GitHub MCP** — `mcp__github__create_pull_request` (owner/repo from the `origin` remote, `base: main`, `head: <branch>`, plus `title`/`body`). The branch must already be pushed (step 10). If the call fails with **401/403** (PAT expired or missing scope), fall back to `gh pr create` with the same title/body. Provide:
     - **IMPORTANT: Title MUST start with a gitmoji prefix** (e.g., "✨ Add new feature", "🐛 Fix bug", "📝 Improve documentation")
         - Refer to <https://gitmoji.dev> to use the correct emoji
         - Common: ✨ feature, 🐛 bugfix, ♻️ refactor, ✅ tests, 📝 docs, 🔧 config, 🎨 style

--- a/.claude/skills/review-pr-threads/SKILL.md
+++ b/.claude/skills/review-pr-threads/SKILL.md
@@ -12,7 +12,11 @@ threads that are unresolved *right now* — it does not wait for new reviews to
 arrive. The caller (you, or `/watch-pr`) decides whether to run it again after a
 push triggers a fresh review.
 
-Repo is `adamayoung/TMDb`; `gh` is authenticated.
+Repo is `adamayoung/TMDb`. GitHub reads (find the PR, fetch threads) and the
+**resolve** use the **GitHub MCP** (`mcp__github__*`); the thread **reply** stays on
+`gh api graphql` — the MCP reply tool needs a numeric REST comment id that the thread
+read doesn't expose, whereas the GraphQL reply takes the thread node id we already
+have. `gh` is authenticated.
 
 ## Principles
 
@@ -37,33 +41,24 @@ Repo is `adamayoung/TMDb`; `gh` is authenticated.
 
 ## 0. Find the PR
 
-```bash
-gh pr view --json number,url,state,headRefName
-```
+Find the open PR for the current branch with `mcp__github__list_pull_requests`
+(owner/repo from the `origin` remote, `head: <owner>:<branch>`, `state: open`), or
+read a specific one with `mcp__github__pull_request_read` method `get`
+(`pullNumber: <n>`). Take `number`/`html_url`/`state`/`head.ref` from the result.
 
 - An explicit PR number in the skill arguments overrides the current branch.
 - No PR for the current branch → stop and tell the user (suggest `/pr`).
-- State not `OPEN` → stop and report.
+- State not `open` → stop and report.
 
 ## 1. Fetch unresolved threads
 
-```bash
-gh api graphql -f query='
-query($owner:String!,$name:String!,$number:Int!){
-  repository(owner:$owner,name:$name){
-    pullRequest(number:$number){
-      reviewThreads(first:100){
-        nodes{
-          id isResolved isOutdated path line
-          comments(first:50){ nodes{ author{login} body createdAt } }
-        }
-      }
-    }
-  }
-}' -f owner=adamayoung -f name=TMDb -F number=<NUMBER>
-```
+Use `mcp__github__pull_request_read` method `get_review_comments` (owner/repo from
+`origin`, `pullNumber: <n>`). It returns review **threads**, each with metadata
+(`isResolved`, `isOutdated`, `isCollapsed`), the thread **node id** (`PRRT_…`, used to
+resolve in §2), `path`/`line`, and the grouped comments. Paginate with
+`perPage`/`after` (the `endCursor` from the previous page's `pageInfo`) if needed.
 
-Process each thread where `isResolved` is `false` and whose `id` is not already
+Process each thread where `isResolved` is `false` and whose thread id is not already
 in the ledger.
 
 ## 2. Handle each thread
@@ -81,7 +76,10 @@ For each unresolved thread:
 3. **No fix warranted** (disagree / out of scope / a question / already done) →
    make no code change; you'll say why in the reply.
 4. **Reply** on the thread — what you assessed and whether you fixed it (include
-   the commit SHA when you did):
+   the commit SHA when you did). This step stays on `gh api graphql`: the GraphQL
+   reply takes the thread **node id** (`PRRT_…`) we already have from §1, whereas the
+   MCP `add_reply_to_pull_request_comment` needs a numeric REST comment id that
+   `get_review_comments` doesn't return.
 
    ```bash
    gh api graphql -f query='mutation($id:ID!,$body:String!){
@@ -89,13 +87,9 @@ For each unresolved thread:
    }' -f id=<THREAD_ID> -f body='<your feedback>'
    ```
 
-5. **Resolve** the thread:
-
-   ```bash
-   gh api graphql -f query='mutation($id:ID!){
-     resolveReviewThread(input:{threadId:$id}){ thread{ isResolved } }
-   }' -f id=<THREAD_ID>
-   ```
+5. **Resolve** the thread with `mcp__github__pull_request_review_write` method
+   `resolve_thread` (`threadId: <PRRT_… node id>`; `owner`/`repo`/`pullNumber` are
+   ignored for this method). Resolving an already-resolved thread is a no-op.
 
 6. Record the thread ID and topic signature in the ledger.
 

--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -7,7 +7,11 @@ description: Watch the current branch's PR — reply to and resolve review threa
 
 Watch the open pull request for the current branch: handle review conversations,
 fix failing status checks, and — when asked — merge once everything is green.
-Repo is `adamayoung/TMDb`; `gh` is authenticated.
+Repo is `adamayoung/TMDb`. GitHub reads/writes (PR state, checks, branch update,
+merge) use the **GitHub MCP** (`mcp__github__*`, owner/repo from the `origin` remote);
+`gh` is kept for the **blocking CI wait** (`gh pr checks --watch`, which the MCP has
+no equivalent for). If an MCP write fails with **401/403** (PAT expired or missing
+scope), fall back to the equivalent `gh` command.
 
 **Mode** — check the arguments passed to this skill (shown at the end). If they
 include `merge` (e.g. `/watch-pr merge` or "merge when ready"), enable
@@ -20,16 +24,20 @@ wait loop.
 
 ## 0. Find the PR
 
-```bash
-gh pr view --json number,url,state,headRefName,mergeStateStatus,statusCheckRollup,reviewDecision
-```
+Find the open PR for the current branch with `mcp__github__list_pull_requests`
+(owner/repo from the `origin` remote, `head: <owner>:<branch>`, `state: open`), then
+read its details with `mcp__github__pull_request_read` method `get` — `number`,
+`html_url`, `state`,
+`head.ref`, and **`mergeable_state`** (the REST merge state: lowercase
+`clean`/`blocked`/`behind`/`unstable`/`dirty`/`unknown`/`draft` — **not** `gh`'s
+uppercase `mergeStateStatus`). Read the check runs separately with method
+`get_check_runs` (§3).
 
 - No PR for the current branch → stop and tell the user (suggest `/pr`).
-- State not `OPEN` → stop and report.
-- **`reviewThreads` is not a valid `gh pr view --json` field** — adding it causes
-  `gh` to error silently (empty stdout), which breaks any JSON parsing downstream.
-  Thread data must come from `gh api graphql`; delegate to `/review-pr-threads`
-  which already does this correctly.
+- State not `open` → stop and report.
+- **Thread data is a separate call** — `pull_request_read` method `get` does not
+  return review threads. Fetch them with method `get_review_comments` (delegated to
+  `/review-pr-threads`); never expect thread data on the PR `get`.
 
 Keep a **run ledger** in your working notes: resolved thread IDs, a topic
 signature per handled thread (`path:line` + short gist), and a fix-attempt
@@ -75,21 +83,23 @@ the failing check — most often a **live integration test** — is broken or fl
 muddy the PR's scope and leave the test broken for everyone else. Triage before
 fixing here:
 
-1. **Is the failing test in this PR's diff?**
-   `gh pr diff <number> --name-only` — if the failing test's file is **not** in
+1. **Is the failing test in this PR's diff?** `mcp__github__pull_request_read`
+   method `get_files` (`pullNumber: <n>`) — if the failing test's file is **not** in
    that list, this PR did not cause it.
 
-2. **Transient or deterministic?** Re-run the failed jobs once
-   (`gh run rerun <run-id> --failed`) and watch. Passes on re-run → a transient
-   live-API flake; note it and continue. Fails again **and** not in this PR's diff
-   → a **pre-existing** problem (e.g. a brittle live-data assertion).
+2. **Transient or deterministic?** Re-run the failed jobs once with
+   `mcp__github__actions_run_trigger` method `rerun_failed_jobs` (`run_id: <id>`),
+   then watch the re-run (the loop's `gh pr checks --watch`, §1b). Passes on re-run →
+   a transient live-API flake; note it and continue. Fails again **and** not in this
+   PR's diff → a **pre-existing** problem (e.g. a brittle live-data assertion).
 
 3. **A pre-existing failure is a `main` problem — hand it to
    `/fix-integration-failures`**, which fixes it on its own branch off `main`,
    runs `make ci`, and opens/merges a PR (never on this feature branch). Tell the
    user you're opening a **second** PR to unblock this one; if they'd rather you
    stop, report and stop. Once that fix is on `main`, bring this PR's branch up to
-   date (`gh pr update-branch <number>`) and re-watch — the check now passes.
+   date (`mcp__github__update_pull_request_branch`, `pullNumber: <n>`) and re-watch —
+   the check now passes.
 
 ## 2. Loop guard (do not get stuck)
 
@@ -127,26 +137,26 @@ The PR is **ready** when every review thread is resolved, no check is failing or
 pending, AND the branch is **up to date with `main`** (the `main` ruleset requires
 it before merge).
 
-**Verify check completeness explicitly — a running check is not a pass.** "No check
-failing" is **not** the same as "all checks passed": a check still `IN_PROGRESS` /
-`QUEUED` has **no conclusion yet**, so a filter like `select(.conclusion!="SUCCESS")`
-or "are there any failures?" reports it as *absent*, not *pending* — reading as green
-when it isn't. Confirm readiness positively: **every required check has
-`status == COMPLETED` and `conclusion == SUCCESS` on the current tip.** Concretely,
-assert `[.statusCheckRollup[] | select(.status!="COMPLETED")]` is **empty** before
-calling it green, and **dedup stale duplicate entries** (the rollup keeps a row per
-run, so an earlier tip's passed "Build and Test" can sit alongside the current tip's
-`IN_PROGRESS` one — key on the latest run per check name). Do **not** infer green
-from a `gh pr checks --watch` exit alone; re-read the rollup. And when
-`mergeStateStatus` is `BLOCKED`, **rule out a pending required check first** (it is
-the common cause) before attributing the block to a review/policy rule like
-code-owner review. (Bit #361: a still-running "Build and Test" was misread as green
-and `BLOCKED` was wrongly pinned on code-owner review.)
+**Verify check completeness explicitly — a running check is not a pass.** Read the
+checks with `mcp__github__pull_request_read` method `get_check_runs` (owner/repo from
+`origin`, `pullNumber: <n>`). "No check failing" is **not** the same as "all checks
+passed": a run still `in_progress` / `queued` has **no `conclusion` yet**, so a filter
+like "any conclusion != success?" reports it as *absent*, not *pending* — reading as
+green when it isn't. Confirm readiness **positively**: every check run has
+`status == "completed"` **and** `conclusion == "success"` on the current head commit.
+`get_check_runs` is scoped to the head commit, but a re-run can still leave duplicate
+rows for a check name — key on the latest run per name. Do **not** infer green from a
+`gh pr checks --watch` exit alone; re-read the check runs. And when `mergeable_state`
+is `blocked`, **rule out a pending required check first** (it is the common cause)
+before attributing the block to a review/policy rule like code-owner review.
+(Bit #361: a still-running "Build and Test" was misread as green and the block was
+wrongly pinned on code-owner review.)
 
 **Rebase before declaring ready, never after.** `main` advances while you watch
 (other PRs merge), leaving the branch `BEHIND`. The moment the PR is otherwise
-green, bring it up to date — `gh pr update-branch <number>` (a merge of `main`; no
-force-push) — and wait for the re-triggered CI to go green again *before* you call
+green, bring it up to date — `mcp__github__update_pull_request_branch`
+(`pullNumber: <n>`; a merge of `main`, no force-push) — and wait for the re-triggered
+CI to go green again *before* you call
 it ready. "Ready" must mean "mergeable right now": never surface a `BEHIND` PR as
 ready and leave the user waiting on a rebase + re-run. Update **once** at the ready
 point, not eagerly on every `main` advance — each update re-runs the full ~4–7 min
@@ -155,11 +165,17 @@ CI matrix.
 - **Watch-only**: report "PR is ready" with a short summary (threads handled,
   checks green, branch up to date) and stop — wait for the user's explicit
   go-ahead before merging.
-- **Merge-when-ready**: on ready, merge and clean up, then report the result:
+- **Merge-when-ready**: on ready, **capture the head branch name first** (you need it
+  to delete the remote branch — `merge_pull_request` has no delete-branch option),
+  merge with `mcp__github__merge_pull_request` (owner/repo from `origin`,
+  `pullNumber: <n>`, `merge_method: squash`), **then** delete the remote branch, and
+  report the result:
 
   ```bash
-  gh pr merge --squash --delete-branch
+  git push origin --delete <branch>   # only after the squash-merge has landed
   ```
+
+  On a 401/403, fall back to `gh pr merge --squash --delete-branch`.
 
 **Several PRs queued?** Merge in dependency order. Stack one on another (base the
 later PR on the earlier branch) **only** when they genuinely depend on each other

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -601,6 +601,42 @@ Use a descriptive branch name with a conventional prefix
 > `make ci` → review → push → open), and **`/deliver`** runs it as the final step
 > of the feature pipeline. The manual steps below are the fallback / reference.
 
+### GitHub access — MCP first
+
+The PR/CI skills (`/pr`, `/watch-pr`, `/review-pr-threads`, `/fix-pr-checks`,
+`/fix-integration-failures`, the `/diagnose-*` skills) drive GitHub through the
+**GitHub MCP** (`mcp__github__*`) rather than the `gh` CLI. `gh` is kept only where
+the MCP has no equivalent:
+
+- the **blocking CI wait** — `gh pr checks --watch` / `gh run watch`;
+- the review-thread **reply** — `gh api graphql addPullRequestReviewThreadReply`
+  (the MCP reply tool needs a numeric REST comment id that the thread read doesn't
+  expose; resolving threads *is* on the MCP);
+- **headless GitHub Actions workflows** (`claude.yml`, `integration-failure.yml`),
+  where the user-scoped MCP isn't mounted — those stay on `git`/`gh`.
+
+So `gh` **remains a prerequisite**. The MCP is a **user-scoped** server, registered
+once per contributor (it is intentionally *not* in `.mcp.json`, to avoid
+double-registration and committing a token):
+
+```bash
+claude mcp add -s user --transport http github \
+  https://api.githubcopilot.com/mcp/x/all -H "Authorization: Bearer <PAT>"
+```
+
+The `/x/all` path mounts the default toolsets **and** the opt-in `actions` toolset
+(workflow runs/logs/rerun); the bare `/mcp` or a single `/x/<toolset>` path would
+drop the others. The PAT needs `repo` + `actions:write` (rerun is a write op). See
+[ADR-0009](knowledge/decisions/0009-github-mcp-over-gh-cli.md).
+
+**Owner/repo derive from the `origin` remote** — one source, fork-safe — and are
+passed to every MCP/`gh` call:
+
+```bash
+read -r OWNER REPO < <(git remote get-url origin \
+  | sed -E 's#\.git$##; s#.*[:/]([^/]+)/([^/]+)$#\1 \2#')   # adamayoung TMDb
+```
+
 **CRITICAL: You MUST run `make ci` and ensure it passes before pushing
 and creating a PR.** This is a hard requirement - no exceptions.
 
@@ -626,7 +662,12 @@ git log --oneline main..HEAD
 git push -u origin <branch-name>
 ```
 
-### 4. Create PR with gh CLI
+### 4. Create the PR (GitHub MCP)
+
+Open the PR with the **GitHub MCP** — `mcp__github__create_pull_request`
+(owner/repo from the `origin` remote — see *GitHub access* above — `base: main`,
+`head: <branch-name>`, `title`, `body`). `gh pr create` is the fallback when the MCP
+is unavailable (or returns 401/403):
 
 ```bash
 gh pr create --base main --head <branch-name> \
@@ -677,6 +718,9 @@ Use appropriate **gitmoji** from [gitmoji.dev](https://gitmoji.dev):
 ```
 
 ### 7. Example
+
+The `gh` form below shows the title/body shape; the primary path is
+`mcp__github__create_pull_request` with the same `title`/`body` (§4).
 
 ```bash
 gh pr create --base main --head feature/my-feature \

--- a/knowledge/decisions/0009-github-mcp-over-gh-cli.md
+++ b/knowledge/decisions/0009-github-mcp-over-gh-cli.md
@@ -1,0 +1,88 @@
+# ADR-0009: Use the GitHub MCP (not the `gh` CLI) in the local skills
+
+- **Status:** Accepted
+- **Date:** 2026-06-25
+- **Deciders:** Adam Young, Claude
+
+## Context
+
+The project's Claude Code skills (`/pr`, `/watch-pr`, `/review-pr-threads`,
+`/fix-pr-checks`, `/fix-integration-failures`, `/diagnose-ci-failure`,
+`/diagnose-integration-failure`, and `/deliver`) drove every GitHub interaction by
+shelling out to the `gh` CLI and parsing its output. The GitHub **MCP** server
+(`mcp__github__*`) exposes the same operations as typed, structured tool calls —
+better for an agent than scraping CLI text — so we migrated the skills to it.
+
+The MCP's capability boundary shaped the decision (verified against
+`github/github-mcp-server` and the live tool set):
+
+- **Covered:** `create_pull_request`; `pull_request_read` methods `get` /
+  `get_diff` / `get_files` / `get_check_runs` / `get_review_comments`;
+  `merge_pull_request`; `update_pull_request_branch`;
+  `pull_request_review_write` method `resolve_thread`; and the **opt-in** `actions`
+  toolset — `actions_list` / `actions_get` / `get_job_logs` (`failed_only`) /
+  `actions_run_trigger` (`rerun_failed_jobs`).
+- **Not covered → `gh` retained:**
+  1. **Blocking CI wait** — there is no equivalent of `gh pr checks --watch` /
+     `gh run watch` (the MCP can only poll). Polling burns turns, so the blocking
+     wait stays on `gh`.
+  2. **Review-thread reply** — `add_reply_to_pull_request_comment` needs a numeric
+     REST comment id, but `get_review_comments` returns only GraphQL node ids (a
+     type mismatch). The reply stays on `gh api graphql
+     addPullRequestReviewThreadReply`, which takes the thread node id we already
+     have. (Resolving threads *is* on the MCP.)
+  3. **Headless GitHub Actions workflows** (`claude.yml`,
+     `integration-failure.yml`) run on CI runners where the **user-scoped** MCP
+     isn't mounted, so they stay on `git`/`gh`.
+
+Two facts learned during the work and worth recording:
+
+- The hosted endpoint's `/x/<toolset>` paths are **exclusive**, not additive:
+  registering `…/mcp/x/actions` mounts *only* the actions toolset and **drops** the
+  default PR/issue toolset. Use `…/mcp/x/all` to get the defaults **plus** actions
+  under one `mcp__github__*` namespace.
+- The MCP's `pull_request_read get` returns the REST **`mergeable_state`**
+  (lowercase `clean`/`blocked`/`behind`/`unstable`/`dirty`/`unknown`/`draft`), not
+  `gh`'s GraphQL `mergeStateStatus` (uppercase). The `/watch-pr` merge-readiness
+  logic (and the known BLOCKED→CLEAN lag) key off the REST field/values.
+
+## Decision
+
+Migrate the local skills to `mcp__github__*` for all PR / review-thread-read +
+resolve / workflow-run operations, keeping `gh` only for the three gaps above. The
+MCP server is **user-scoped** and intentionally **not** added to `.mcp.json` —
+committing it there would double-register against the per-user server and would
+commit a token. Each contributor registers it once:
+
+```bash
+claude mcp add -s user --transport http github \
+  https://api.githubcopilot.com/mcp/x/all -H "Authorization: Bearer <PAT>"
+```
+
+The PAT needs `repo` + fine-grained `actions:write` (the rerun-failed-jobs path is a
+write op). The `mcp__github__*` permission lives in the **gitignored**
+`.claude/settings.local.json`, so it too is per-machine.
+
+`owner`/`repo` for every call **derive from the `origin` remote** (one source,
+fork-safe) rather than being hardcoded:
+
+```bash
+read -r OWNER REPO < <(git remote get-url origin \
+  | sed -E 's#\.git$##; s#.*[:/]([^/]+)/([^/]+)$#\1 \2#')   # adamayoung TMDb
+```
+
+## Consequences
+
+- The skills get typed, structured GitHub access instead of CLI text-scraping, and
+  the `actions` toolset gives workflow-run listing, failed-job logs, and
+  rerun-failed without `gh`.
+- **`gh` remains a prerequisite** (blocking wait, thread reply, headless), so the
+  migration narrows — not removes — the `gh` dependency.
+- The setup is a **hidden dependency**: nothing in the repo wires up the user-scoped
+  server or the gitignored permission, so a fresh machine / new contributor must run
+  the `claude mcp add` above and add `mcp__github__*` to their own
+  `settings.local.json`, or the skills hard-fail (an expired/read-only PAT fails
+  opaquely, with no graceful degradation). This ADR + the *GitHub access* note in
+  `CLAUDE.md` are the onboarding breadcrumb.
+- All team skills now hinge on **one user's PAT** — a single point of failure the
+  `gh`-per-developer model didn't have.

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -10,6 +10,42 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-06-25 — 🔧 Use the GitHub MCP instead of the gh CLI in the skills (#366) · lite
+
+- **Phases / skills:** phases 0–6; `pr, watch-pr` (both dogfooded the new MCP path).
+  Skipped `/review-plan` as a *skill* (the plan already got a 3-critic adversarial
+  pass earlier in the session, pre-`/deliver`); skipped `/implement-plan` (markdown
+  only — no TDD list); skipped code review (no Swift) and the automated
+  `/security-review` (diff is 100% markdown — `.md` is excluded; the only
+  security-relevant artifact, the `mcp__github__*` permission, is gitignored and out
+  of the PR — reviewed by reasoning instead, parity with `Bash(gh:*)`, ADR-0009).
+- **Worked:** the migration was **dogfooded end-to-end** — PR opened via
+  `mcp__github__create_pull_request`, readiness verified positively via
+  `get`/`get_check_runs`/`get_review_comments`, and the blocking wait used the
+  *retained* `gh pr checks --watch`. The pre-implementation 3-critic plan review paid
+  off: it caught two **BLOCKERs** before any edit — the review-reply mapping gap
+  (`add_reply_to_pull_request_comment` needs a REST comment id `get_review_comments`
+  doesn't expose → reply stays on `gh`) and the wrong method name (`rerun_failed_jobs`,
+  not "rerun-failed"). Path-aware CI resolved the docs-only PR in ~1 min.
+- **Friction — the MCP registration detour cost real time.** Enabling the `actions`
+  toolset, the user repointed the single `github` server to `…/mcp/x/actions`, whose
+  **exclusive** path silently dropped the default PR toolset — `pull_request_read`
+  etc. vanished mid-implementation, needing diagnosis + two reconnect cycles before
+  `…/mcp/x/all` fixed it. Now an ADR + `gotchas.md` entry.
+- **Deviations:** (1) the owner/repo "single source" decision surfaced *mid-edit*
+  from a user question, not in the plan — it should have been a planned design point
+  (it forced re-touching four already-edited files). (2) Captured knowledge **inline**
+  (ADR-0009 + gotchas) rather than invoking `/capture-knowledge`, since the ADR was
+  written during implementation. (3) This PR **supersedes** #365's
+  `reviewThreads`/`gh pr view --json` gotcha — watch-pr §0 no longer calls
+  `gh pr view` at all, so that guard was adapted to the MCP (`get_review_comments`).
+- **One improvement:** when a delivery edits the *very skills the pipeline runs*
+  (`/pr`, `/watch-pr`, `/deliver`), `/deliver` should note up front that the skill
+  **registry loads from the main checkout**, so the in-session skills keep the *old*
+  behaviour until merge — the change can only be dogfooded by the conductor acting
+  manually, not by the sub-skills. Flagging this avoids confusion when `/pr` visibly
+  runs `gh pr create` while the diff says otherwise.
+
 ## 2026-06-24 — 🔧 Add entry/exit criteria and auto-start to /deliver (#365) · lite
 
 - **Phases / skills:** phases 0–6; `pr, watch-pr`. Skipped `/review-plan` (lite +

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -6,6 +6,26 @@ out of it.
 
 ## Tooling
 
+### GitHub MCP: `/x/<toolset>` paths are exclusive, and `mergeable_state` ≠ `mergeStateStatus`
+
+*2026-06-25.* When wiring the skills to the GitHub MCP ([ADR-0009](decisions/0009-github-mcp-over-gh-cli.md)):
+
+- The hosted endpoint's `/x/<toolset>` paths are **exclusive, not additive**.
+  Registering `https://api.githubcopilot.com/mcp/x/actions` mounts *only* the
+  `actions` toolset and **drops** the default PR/issue toolset — so
+  `pull_request_read`, `create_pull_request`, etc. silently disappear while
+  `actions_*` work. Use `…/mcp/x/all` to get the defaults **plus** `actions` under
+  one `mcp__github__*` namespace. (`/mcp` alone = defaults only, no `actions`.)
+- `pull_request_read` method `get` returns the **REST** `mergeable_state`
+  (lowercase `clean`/`blocked`/`behind`/`unstable`/`dirty`/`unknown`/`draft`), **not**
+  `gh`'s GraphQL `mergeStateStatus` (uppercase `CLEAN`/`BLOCKED`/…). Any logic ported
+  from `gh pr view --json mergeStateStatus` (e.g. `/watch-pr` merge-readiness, the
+  BLOCKED→CLEAN lag) must key off the REST field and lowercase values.
+- The MCP reply tool (`add_reply_to_pull_request_comment`) needs a numeric REST
+  comment id, but `get_review_comments` returns only GraphQL node ids — so posting a
+  thread **reply** stays on `gh api graphql` even though resolving threads is on the
+  MCP.
+
 ### A `Write` of a Markdown/DocC file can leak `</content>`/`</invoke>` into the file tail
 
 *2026-06-24.* When creating a `.md` file with the `Write` tool, trailing


### PR DESCRIPTION
## Summary

Drive the project's PR / CI / review-thread operations in the Claude Code skills
through the **GitHub MCP** (`mcp__github__*`) instead of shelling out to the `gh`
CLI, so the tools interact with GitHub via structured, typed calls rather than
scraping CLI text. `gh` is **narrowed, not removed** — it stays where the MCP has
no equivalent.

This PR was itself delivered through the migrated pipeline (the PR was opened via
`mcp__github__create_pull_request`).

## Changes

**Skills migrated to `mcp__github__*`:**
- 🔧 `pr` — `create_pull_request`
- 🔧 `watch-pr` — `pull_request_read` (`get`/`get_files`/`get_check_runs`),
  `update_pull_request_branch`, `merge_pull_request` (+ `git push origin --delete`)
- 🔧 `review-pr-threads` — `get_review_comments` (fetch) + `resolve_thread`
- 🔧 `fix-pr-checks` — `get_check_runs`
- 🔧 `fix-integration-failures`, `diagnose-ci-failure` (+`references/_index.md`),
  `diagnose-integration-failure` — `actions_list` / `actions_get` /
  `get_job_logs` / `actions_run_trigger` (`rerun_failed_jobs`)
- 🔧 `deliver` — Phase 0.5 GC, branch-update, and teardown merge-checks via MCP

**`gh` deliberately retained** (no MCP equivalent):
- the **blocking CI wait** — `gh pr checks --watch` / `gh run watch`
- the review-thread **reply** — `gh api graphql addPullRequestReviewThreadReply`
  (the MCP reply tool needs a numeric REST comment id `get_review_comments`
  doesn't expose; *resolving* threads is on the MCP)
- **headless GitHub Actions workflows** (`claude.yml`, `integration-failure.yml`),
  where the user-scoped MCP isn't mounted — those stay on `git`/`gh`

**owner/repo:**
- ♻️ Derive from the `origin` remote (one source, fork-safe) instead of hardcoding
  `adamayoung/TMDb`; pre-existing literals swept in the touched skills.

**Docs:**
- 📝 `CLAUDE.md` — new "GitHub access — MCP first" convention (the `claude mcp add`
  onboarding, the `/x/all` registration, PAT scopes, and the owner/repo one-liner)
- 📝 ADR-0009 — the decision, the two MCP gaps, and the single-PAT / hidden-dependency risks
- 📝 `gotchas.md` — `/x/<toolset>` paths are exclusive (use `/x/all`); MCP
  `mergeable_state` (REST, lowercase) ≠ `gh`'s `mergeStateStatus`

## Notes for the reviewer

- The `mcp__github__*` permission lives in **gitignored** `.claude/settings.local.json`,
  so it's **not** in this diff — it's a per-machine setup step (documented in the ADR).
  The MCP server is user-scoped and intentionally not added to `.mcp.json`.
- Diff is **docs/config-only** (all Markdown) — no Swift, so code review and the
  test/build legs of the gate don't apply; local gate run: `make lint` (0 violations)
  + `make lint-markdown` (clean).
- The wildcard `mcp__github__*` permission auto-approves write tools (merge/rerun) —
  a deliberate **parity** with the existing `Bash(gh:*)` grant, noted in the ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)