### PR TITLE
🔧 Harden & extend the /deliver pipeline (audit P1–P5)

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -70,7 +70,12 @@ These are non-negotiable. Do them by default, without being reminded.
    Track it in a **`TaskCreate` task list — one task per phase** (Phase 0.5 →
    Phase 6), set `in_progress`/`completed` as you go, and record the branch name,
    PR number, and the delivery weight on the relevant tasks. A task list survives
-   compaction better than prose working-notes, so you can resume cleanly.
+   compaction better than prose working-notes, so you can resume cleanly. For a
+   **template→replicate** full delivery, the ledger also carries the
+   **`Phase 3a — reference-unit review`** gate task (Phase 3), which **blocks
+   Phase 4** until the reference unit has been reviewed and converged. For a
+   **multi-deliverable** plan, keep **one ledger sub-tree per deliverable** (its
+   own branch / PR / weight) — see *Multi-deliverable plans*.
 7. **Jot knowledge candidates as you go.** Keep a running **knowledge-candidates**
    list (in the ledger) and append to it the *moment* a learning occurs during
    Phases 2–3 — a thing you had to look up or web-search, a gotcha or dead-end, a
@@ -117,6 +122,34 @@ to the panel.)
 Each decision point below marks its **Auto:** branch. In the default (attended)
 mode those branches do not apply — the pipeline stops and asks, as written.
 
+## Async / queued invocation
+
+`/deliver` can be **queued to run unattended**, not just driven from an
+interactive session — the worktree isolation, the `TaskCreate` ledger, the
+Phase 0.5 GC sweep, and `auto` mode (the panel) are exactly what an unattended run
+needs. Two existing entry points already do this: a **CCR trigger**
+(`create_trigger` with `create_new_session_on_fire`, or the `/schedule` skill)
+fires a fresh session whose prompt is `/deliver auto …`, and
+`integration-failure.yml` runs a skill **headless** on a runner.
+
+If you queue a `/deliver`, mind two things:
+
+- **Inline the whole plan + acceptance criteria in the trigger prompt.** A fresh
+  session has no conversation history, and Phase 0's entry gate **requires ACs** —
+  so the plan text and its ACs must travel *in* the prompt, or the run stops at
+  the gate immediately.
+- **User-scoped MCP may be absent** (`mcp__github__*`, `wiki`). The `gh` fallbacks
+  in `/pr` and `/watch-pr` cover GitHub; the wiki step degrades silently. A
+  headless GitHub-Actions run has no user MCP at all (it uses `git`/`gh`); a
+  CCR-spawned session in your own environment usually keeps them.
+
+**Recommendation — don't routinise async *feature* delivery here.** This is a
+single-maintainer package with public API surface, where the **ready-to-merge
+human gate is deliberate** — every change is a compatibility call worth a human's
+eyes. Async earns its place for the *occasional* away-from-keyboard run and for
+the **self-healing integration cron** (which already opens a PR for review, never
+merges) — not as the default path.
+
 ## Delivery weight — auto-scale to risk (lite vs full)
 
 `/deliver` sizes its machinery to the change, automatically — no flag. Judge the
@@ -135,6 +168,52 @@ weight from the plan up front, and re-confirm from the actual diff after Phase 2
 
 When unsure, prefer **full** — the heavier review is cheap insurance against the
 changes that actually bite. Record the chosen weight in the ledger.
+
+## Multi-deliverable plans — one run, several PRs
+
+A plan is sometimes a **program of independent deliverables**, not one change
+(e.g. "extract a shared validation helper" + "fix the mis-applied test tags" +
+"harden a decoder" — three cohesive changes that don't touch each other). Forcing
+those into one PR couples unrelated review and risk; running them as wholly
+separate invocations loses the shared plan context. So `/deliver` **decomposes a
+multi-deliverable plan into one PR per deliverable**, runs the independent ones in
+the same session, and **only serialises the ones that are obviously dependent**.
+
+**Decompose up front (Phase 0).** List the deliverables and build a **dependency
+graph**:
+
+- **Dependent** = one deliverable consumes a type, API, helper, or file that
+  another *introduces or substantially changes* (e.g. "B calls the shared helper A
+  extracts"). Dependent deliverables are **sequenced** — the dependent one
+  branches off its dependency (or waits for it to merge).
+- **Independent** = no such coupling → each gets its **own worktree + branch +
+  PR**.
+- **When unsure, treat as dependent and sequence** — the safe default. Split into
+  concurrent PRs only when independence is *obvious*.
+
+**Execution — serial implement, concurrent watch.** A single conductor can only
+drive one inline `/implement-plan` loop at a time (the implement phase is
+deliberately visible — *Context & isolation*), so each deliverable's
+**implementation runs serially**, one worktree at a time, through Phases 0.5 → 4
+(its own worktree, code review, security review, rubric, PR). What runs
+**concurrently is Phase 5**: once a deliverable's PR is open, start its
+`/watch-pr` **in the background** and move on to implement the next independent
+deliverable — so CI churns on the open PRs while the conductor keeps building.
+
+> The honest win is **N PRs from one run + their CI watched in parallel**, not
+> parallel compilation — builds stay serial within the single-threaded conductor
+> (cross-worktree `.build` dirs are separate, but the conductor is not). For
+> genuinely parallel *implementation*, launch a separate `/deliver` per
+> deliverable in its own session (see *Async / queued invocation*).
+
+**The gate becomes a batch.** Phase 5's ready-to-merge gate reports **all** the
+deliverables' PRs and their states together (PR A ready · PR B ready · PR C
+waiting on PR A) and hands the batch to the user. Each worktree is torn down
+(Phase 7) as **its** PR merges, independently; a stuck PR in the batch never
+blocks reporting the others as ready. Per-deliverable, nothing else changes —
+each PR still runs the full single-deliverable pipeline (weight scaling, review,
+security, capture, rubric); multi-deliverable mode only adds the decomposition,
+the dependency ordering, and the batched gate.
 
 ## Context & isolation (by design)
 
@@ -186,6 +265,10 @@ it never bloats or biases the main window:
   block the pipeline on it.
 - **Judge the delivery weight** (lite vs full) from the plan, and open the
   `TaskCreate` ledger (Contract §6).
+- **Decompose a multi-deliverable plan.** If the plan is a *program* of more than
+  one cohesive deliverable, decompose it now and build the **dependency graph**
+  (see *Multi-deliverable plans*) — this decides whether the run opens **one PR or
+  several**, and in what order. A single-deliverable plan skips this.
 - **Entry gate — acceptance criteria required.** Plans are expected in the form
   *"As a \<user-type\> I want \<feature\> so that \<reason\>"* followed by
   acceptance criteria and any elaboration. Locate the acceptance criteria in the
@@ -390,13 +473,26 @@ refactor-on-green.
 
 - **Lite / single-unit** (one method, one model) → review **once**, on the full
   diff after Phase 2. `/review-changes` takes its single-`code-reviewer` path.
-- **Full / multi-unit** (several new models/methods, or risky concurrency/
-  networking) → review **per cohesive unit** as each completes (a finished model;
-  a service method + its tests), rather than one large end-diff. Smaller diffs
-  review more accurately, and a wrong foundational pattern is caught before later
-  units build on it. Do not drop to per-test-list-item — per *unit*, not per
-  *item*. Here Phases 2 and 3 **interleave**: review a unit as Phase 2 finishes it
-  (and fix per the loop below) before moving on.
+- **Full, template→replicate** (one pattern applied across **N≥3 cohesive
+  units** — e.g. 25 sibling mocks, "validate every public String input", one
+  method mirrored across services; the shape Phase 2's *"enumerate ALL sites up
+  front"* blockquote already flags) → **review the reference unit before the rest
+  are generated.** This is a **hard ledger gate**, not advice: add a
+  `Phase 3a — reference-unit review @ <sha>` task to the ledger, have
+  `/implement-plan` commit the first unit on its own, run `/review-changes` scoped
+  to that commit (`git diff origin/main...<sha>`), converge its Critical/High per
+  the loop below, and only then let Phase 2 replicate the pattern across the
+  remaining units. **Phase 4 must not start while this task is open.** A wrong
+  foundational pattern caught here is one *not* baked into all N units (the #359
+  "reference-first" win: a cross-module DocC break caught in `MockGenreService`
+  before it replicated into 25 mocks).
+- **Full, otherwise** (multi-unit but *not* template-replicate — several distinct
+  models/methods, parallel-similar work, risky concurrency/networking) → review
+  **once**, on the full diff after Phase 2, via the fan-out + adversarial-verify
+  `/review-changes`. A single end-diff fan-out is the right tool here; do **not**
+  interleave per unit — the units don't build on each other, so per-unit review
+  only adds churn, and the fan-out's per-dimension adversarial pass already covers
+  the whole diff.
 
 Run the review via **`/review-changes`**, which scales the machinery to the diff
 itself: a single `code-reviewer` agent for a small change, or a fan-out Workflow
@@ -526,6 +622,12 @@ The rubric answers a different question than CI: *"did we build what the plan
 said?"* not *"did the build pass?"*
 
 ## Phase 4 — Create the PR
+
+**Gate check (template→replicate deliveries):** before anything else, confirm the
+ledger's `Phase 3a — reference-unit review` task is **`completed`**. If it is
+still open, the reference unit was never reviewed — **go back to Phase 3** and run
+it before opening the PR. (Other deliveries have no Phase 3a task; this is a
+no-op for them.)
 
 Invoke **`/pr reviewed`** — the `reviewed` argument tells `/pr` to **skip its
 internal `code-reviewer` pass**, because Phase 3 already reviewed and converged

--- a/.claude/skills/implement-plan/SKILL.md
+++ b/.claude/skills/implement-plan/SKILL.md
@@ -94,6 +94,18 @@ Test list — <plan goal>
 It is a living list — you will add cases as implementation reveals them. Confirm
 it with the user (or state it explicitly) before proceeding.
 
+**Mirror the family — probe the nearest siblings first.** When an item adds a
+*sibling* to an existing family (another service method, another model, another
+`addRating`-style guarded method, another `@Suite` test), **read the 1–2 closest
+existing siblings before writing the test**, and capture the conventions they
+share as explicit test-list items: input validation (does the sibling guard
+empty/degenerate input?), the error case it throws (`.badRequest` vs a dedicated
+`TMDbError` case), the model conformance set and decode strategy (synthesised vs
+custom `init(from:)`), and the test-suite tag/structure. New code should match
+its family's pattern by default; a deliberate divergence is fine, but it should
+be a *choice*, not an accident. This is the prevent-half of the
+convention-conformance check `.github/CODE_REVIEW.md` enforces at review time.
+
 ## Step 2 — Set the finishing goal
 
 The completion condition for this whole effort is: **the test list is empty** —

--- a/.claude/skills/review-changes/SKILL.md
+++ b/.claude/skills/review-changes/SKILL.md
@@ -87,8 +87,8 @@ const SPEC = '.github/CODE_REVIEW.md'
 const DIMENSIONS = [
   { key: 'correctness', focus: 'correctness & safety — logic bugs, behavioural regressions, force unwraps / try!, and input validation at system boundaries' },
   { key: 'concurrency', focus: 'Swift 6 concurrency — async/await, actor isolation, Sendable conformance, no blanket @MainActor, and justified @preconcurrency / @unchecked Sendable' },
-  { key: 'architecture', focus: 'architecture — protocol + TMDb-prefixed implementation, service-layer boundaries, new API exposed on TMDbClient and wired in TMDbFactory, required model conformances' },
-  { key: 'testing', focus: 'tests — both unit and integration present, fixtures exercise EVERY decoder branch, edge cases (boundaries / empty / nil), request-pattern correctness, and #require over force-unwrap' },
+  { key: 'architecture', focus: 'architecture — protocol + TMDb-prefixed implementation, service-layer boundaries, new API exposed on TMDbClient and wired in TMDbFactory, required model conformances, AND sibling-convention conformance: a newly-added member of an existing family (service method, model, guarded method) must match its siblings — same input validation, same error case, same conformance set / decode strategy — or the divergence is flagged' },
+  { key: 'testing', focus: 'tests — both unit and integration present, fixtures exercise EVERY decoder branch, edge cases (boundaries / empty / nil), request-pattern correctness, #require over force-unwrap, AND test-suite convention conformance: a new @Suite matches its siblings (same tags / construction pattern) or the divergence is flagged' },
   { key: 'api-docs', focus: 'model<->API alignment (verify properties/optionality/types/CodingKeys via mcp__tmdb__* and the OpenAPI spec) and public-API docs + DocC catalog + README sync' },
 ]
 

--- a/.github/CODE_REVIEW.md
+++ b/.github/CODE_REVIEW.md
@@ -98,8 +98,16 @@ inflate nitpicks to Critical.
   optionality, and types match the TMDb API; `CodingKeys` map correctly; fixtures
   match real responses. Verify via `mcp__tmdb__*` and the OpenAPI spec; **skip if
   you lack those tools.**
-- **Consistency of repeated fixes** — a textual fix applied in one place (e.g. a
-  protocol doc) is applied to all (its `public extension` twin, sibling methods).
+- **Consistency with siblings** — two checks: (1) a textual fix applied in one
+  place (e.g. a protocol doc) is applied to all (its `public extension` twin,
+  sibling methods); and (2) a **newly-added** member of an existing family — a
+  service method, a model, an `addRating`-style guarded method, a test `@Suite` —
+  **matches the conventions of its siblings**: the same input validation, the
+  same error case (`.badRequest` vs a dedicated `TMDbError` case), the same model
+  conformance set / decode strategy, the same test-suite tag. Flag a silent
+  divergence (a sibling validates but the new one doesn't; a new model drops
+  `Sendable`; a service suite tagged `.requests` not `.services`) — it is how
+  standardization debt enters.
 
 ## Out of scope / ignore
 
@@ -123,6 +131,13 @@ reporting it. This is the filter that keeps the review honest and quiet:
    there context that invalidates it?
 4. **Confirm scope** — does it relate to code changed in this diff, not a
    pre-existing concern?
+5. **Verify any sibling-claim before dropping on it.** If you downgrade or drop a
+   finding on a factual claim about *other* code — "siblings don't do this
+   either", "handled elsewhere", "the convention is X" — **check that claim
+   against the tree first** (list the directory, read the sibling). An unverified
+   sibling-claim is **not** grounds to drop: a real "missing integration test"
+   High was once dropped because "no sibling has one" when the integration dir
+   was never opened. Verify, then drop.
 
 **Only findings that survive this pass are reported.** Drop the rest silently.
 

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -10,6 +10,42 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-06-30 — 🔧 Harden & extend the /deliver pipeline (audit P1–P5) (#368) · lite
+
+- **Phases / skills:** phases 0–6; `pr, watch-pr`. Skipped `/review-plan` (the
+  proposals came from an adversarial audit earlier this session; `/deliver`
+  invocation was approval); skipped `/implement-plan` (markdown-only — no Canon
+  TDD list); skipped code review + `/security-review` (no Swift, and the diff
+  touches none of the security triggers — `.github/CODE_REVIEW.md` and
+  `.claude/skills/**` are not `.github/workflows/` or `.claude/settings*`).
+  Knowledge captured **inline** (skill-improvement-log + tmdb-api-notes), not via
+  a separate `/capture-knowledge`.
+- **Worked:** the audit→plan→deliver chain held end-to-end for a *meta* change
+  (editing the pipeline's own skills). Full `make ci` clean first try (unit 2824,
+  integration 289 — no flake); the PR's path-aware CI resolved in ~1 min. Scoping
+  the run to **Part 1** (skills) up front and deferring codebase fixes A/B/C to
+  follow-on runs kept it cohesive. Absorbed two mid-run asks (P5 multi-PR; the
+  durable `Company.logoPath` note) without losing the thread.
+- **Friction:** (1) **the `TaskCreate` ledger reset twice** mid-run (after the MCP
+  reconnect / plan-mode exit) — phases tracked inline instead. **Second** delivery
+  to lose the ledger (cf. #364 "CWD-scoped, lost on EnterWorktree"). (2) **The
+  markdownlint `--fix` hook corrupted a paragraph** — an inline `#A` token was
+  rewritten into a real `# A")` H1 (MD025), caught by `make lint-markdown`; fixed
+  by rewording to "PR A/B/C". (3) **Docs fast-gate over-matched** — a review-spec
+  doc (`.github/CODE_REVIEW.md`) trips `^\.github/` → full `make ci` though it's
+  not build/test-affecting.
+- **Deviations:** none material — knowledge captured inline (as in #366) since it
+  was authored during implementation. The retro file is over its ~12 window;
+  archive-distil deferred to next cycle.
+- **Bug found in `/pr`:** the mode preamble says reviewed mode should "**skip steps
+  4–6**", but **step 4 is the mandatory `make ci` gate** — the per-step
+  annotations correctly mark 5–7 as the skippable review steps. Taken literally it
+  would skip the gate; I ran it regardless. Candidate fix (separate PR).
+- **One improvement:** ledger fragility now has **two** occurrences — resurface
+  the deferred `2026-06-18 file-based ledger` decision (its "reconsider when
+  interruptions actually bite" condition now holds), or have `/deliver` re-create
+  the ledger after an `EnterWorktree`/reconnect.
+
 ## 2026-06-25 — 🔧 Use the GitHub MCP instead of the gh CLI in the skills (#366) · lite
 
 - **Phases / skills:** phases 0–6; `pr, watch-pr` (both dogfooded the new MCP path).

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,157 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-06-30 — Phase 3 per-unit review: replace the blanket rule with a template→replicate reference-unit gate · applied
+
+- **Pattern:** Phase 3's "Full / multi-unit → review per cohesive unit,
+  interleaving Phases 2 and 3" rule was **never executed as written** across any
+  full delivery (#335, #337, #346, #349, #359) and flagged as a deviation in none
+  — it structurally fights `/implement-plan`'s drive-to-empty-test-list loop. Its
+  valuable core (catch a wrong foundational pattern before it replicates) was
+  followed only in the one template→replicate case (#359's informal
+  "reference-first" review of `MockGenreService`); parallel-similar fulls used a
+  single end-diff fan-out, which worked.
+- **Decision:** **applied** (2026-06-30 standardization audit, user-approved).
+  `/deliver` Phase 3 now splits the full case: **template→replicate** (one pattern
+  across N≥3 units) gets a **hard ledger gate** — a `Phase 3a — reference-unit
+  review` task that reviews the first unit's commit before the rest are generated
+  and **blocks Phase 4** until done (Contract §6 records the task);
+  **full-otherwise** explicitly uses the single end-diff fan-out, with the
+  per-unit interleave language removed. Landed in `.claude/skills/deliver/SKILL.md`
+  Phase 3 + Contract §6.
+- **Rationale:** narrows the gate to the only shape where a foundational defect
+  actually fans out (and makes it enforceable via the ledger), instead of
+  demanding a per-unit interleave that doesn't happen and isn't worth forcing on
+  parallel-similar work.
+- **Reconsider when:** a *non-template* multi-unit delivery ships a foundational
+  defect an earlier per-unit review would have caught — then widen the trigger.
+
+### 2026-06-30 — Sibling-convention conformance: Phase 2 prevent-probe + review-time detect-lens · applied
+
+- **Pattern:** new code diverges from its existing family because conventions are
+  implicit/copy-paste, not enforced — verified in the audit: the empty-input guard
+  copy-pasted across 7+ services with no shared helper (the #364 straggler root
+  cause); `Movie.addRating` missing the rating guard its TV siblings have;
+  `Company` vs `Network` decoding the same field oppositely; service test suites
+  mis-tagged `.requests` vs `.services` within a folder.
+- **Decision:** **applied** (audit, user-approved). **Prevent:** `/implement-plan`
+  Step 1 now says — when an item adds a sibling to an existing family, read the
+  1–2 nearest siblings first and capture their shared conventions (validation,
+  error case, conformance set, decode strategy, suite tag) as explicit test-list
+  items. **Detect:** `.github/CODE_REVIEW.md`'s "Consistency of repeated fixes"
+  broadened to "Consistency with siblings" (a new family member must match its
+  siblings or the divergence is flagged), with matching cues added to the
+  `architecture`/`testing` dimensions in `review-changes`. Shared spec → the
+  GitHub bot inherits the lens.
+- **Rationale:** the "standardization is the substrate" lesson at this scale —
+  prevent divergence at authoring time and catch it pre-PR, closing the class
+  instead of finding stragglers one review pass at a time.
+- **Reconsider when:** the underlying conventions are unified in code (e.g. a
+  shared validation helper lands) so the lens can point at the helper rather than
+  "the nearest sibling".
+
+### 2026-06-30 — Adversarial-drop hardening: verify any sibling-claim before dropping a finding · applied
+
+- **Pattern:** the local reviewer's *trustworthiness* has failed by dropping a
+  **real** finding on a false premise about siblings — #357 dropped a real
+  "missing integration test" High reasoning "no sibling toolbox tool has one" (it
+  only checked the unit-test dir), and the PR bot caught it after the local review
+  had cleared it. The #357 retro proposed the fix but, as a single occurrence
+  below the recurring-scan ≥2 bar, it was never logged or applied — it fell
+  through the crack.
+- **Decision:** **applied** (audit, user-approved despite being single-occurrence).
+  Added rule 5 to `.github/CODE_REVIEW.md`'s adversarial re-evaluation: a finding
+  may not be downgraded/dropped on a factual claim about other code ("siblings
+  don't", "handled elsewhere", "the convention is X") without **verifying that
+  claim against the tree** (list the dir, read the sibling) first. Applies to both
+  reviewers.
+- **Rationale:** a verifier that confidently drops real findings on unchecked
+  assumptions is the failure mode that keeps unsupervised success low; cheapest
+  high-leverage reliability fix, and shares a root cause with the
+  sibling-convention work above.
+- **Reconsider when:** n/a (applied; additive and low-cost).
+
+### 2026-06-30 — Document /deliver's async/queued capability; recommend against routinising it · applied
+
+- **Pattern:** queued/headless `/deliver` is ~90% built (`auto` panel, worktree
+  isolation, Phase 0.5 GC, the `TaskCreate` ledger, the CCR `create_trigger` +
+  `integration-failure.yml` precedent) but undocumented; a naive fresh-session
+  trigger would die at Phase 0's AC gate (no conversation history) or stall on an
+  absent user-scoped MCP.
+- **Decision:** **applied** (audit, user-approved). Added an "Async / queued
+  invocation" section to `/deliver`: possible via `/deliver auto` from a CCR
+  trigger / `/schedule`; the **full plan + ACs must be inlined in the trigger
+  prompt**; user-scoped MCP (`github`/`wiki`) may be absent (the `gh` fallbacks
+  cover GitHub, wiki degrades silently); and **routine async feature delivery is
+  explicitly not recommended** for this single-maintainer public-API package — the
+  human merge gate is deliberate.
+- **Rationale:** captures the real capability and its sharp edges in one place
+  while recording the deliberate decision *not* to chase a fully-autonomous-to-PR
+  model that's fleet-survival elsewhere and merely convenience here.
+- **Reconsider when:** the contributor count grows beyond one, or repetitive
+  cross-cutting migrations become common — then build a real async entry point.
+
+### 2026-06-30 — Multi-deliverable plans: one /deliver run, several PRs (serial impl, concurrent watch) · applied
+
+- **Pattern:** `/deliver` assumed one plan → one PR, so a plan that's a *program*
+  of independent deliverables had to be force-fit into one PR (coupling unrelated
+  review/risk) or split into separate manual invocations (losing shared plan
+  context). Surfaced this session: the standardization-audit plan decomposed into
+  one pipeline-hardening PR + three independent codebase fixes.
+- **Decision:** **applied** (user-requested this session). Added a
+  "Multi-deliverable plans — one run, several PRs" section + a Phase 0
+  decomposition bullet: decompose into deliverables + a dependency graph (dependent
+  = consumes a type/API/helper/file another introduces → sequenced; independent →
+  own worktree/branch/PR; **unsure → sequence**). Execution is **serial implement**
+  (one inline `/implement-plan` at a time), **concurrent watch** (background
+  `/watch-pr` per open PR); the ready-to-merge gate reports the **batch**.
+  Per-deliverable pipeline unchanged. Landed in `.claude/skills/deliver/SKILL.md`.
+- **Rationale:** respects the single-threaded-conductor reality and the "implement
+  is inline/visible" principle (so it doesn't fan out to silent subagents) while
+  still giving N PRs per run + parallel CI — the honest win without pretending to
+  parallelise compilation. Dependency-aware so it never opens a PR that can't stand
+  alone.
+- **Reconsider when:** the serial-implement bottleneck actually bites (many
+  independent deliverables per run) — then revisit a "fan out to background
+  `/deliver` sub-sessions" model (true parallel implementation, at the cost of
+  inline visibility).
+
+### 2026-06-30 — Error-idiom unification (`.invalidRating` → `.badRequest`) · rejected
+
+- **Pattern:** the audit flagged two idioms for "caller passed an invalid
+  argument" — string validators throw `.badRequest("…")`, rating validators throw
+  the dedicated `.invalidRating` — and considered unifying them.
+- **Decision:** **rejected** (audit). `.invalidRating` is a **public**,
+  non-`@frozen` `TMDbError` case (documented in `HandlingErrors.md`, mapped in
+  `ToolErrorMapper`, asserted in 6 test sites); merging it into
+  `.badRequest(String? = nil)` is a **breaking** public-API change **and** trades a
+  precise typed case for a stringly-typed one — net-negative. The cosmetic
+  `throw TMDbError.X` vs `throw .X` style is left to SwiftFormat.
+- **Rationale:** a breaking change that makes the API *worse* is not worth doing;
+  the dedicated case is arguably the better pattern, so the "debt" framing was
+  wrong.
+- **Reconsider when:** a deliberate major-version bump is on the table for other
+  reasons — then reconsider as part of a broader `TMDbError` review, never alone.
+
+### 2026-06-30 — Align `Network` to `Company` (rename `homepage`, force `logoPath` non-optional) · rejected
+
+- **Pattern:** the audit flagged `Company` and `Network` decoding the same
+  homepage-URL / logo-path fields differently and considered making them identical.
+- **Decision:** **rejected** for the *aligning* direction; the **non-breaking
+  robustness subset is kept** as a separate codebase delivery. Renaming
+  `Network.homepage`→`homepageURL` and forcing `Network.logoPath` non-optional are
+  both **breaking**, and the `logoPath` change is **wrong-directional** —
+  `Network.logoPath` is correctly `URL?` because the API omits it; forcing
+  non-optional would make decoding throw. The valuable, non-breaking piece (give
+  `Network.homepage` the empty-string→nil guard `Company` already has) is split
+  into its own delivery. The opposite latent issue — `Company.logoPath` is a
+  *required* decode that throws if `logo_path` is absent — is captured in
+  `knowledge/tmdb-api-notes.md` and deferred (fixing it is breaking).
+- **Rationale:** "make them consistent" would break public API and degrade decode
+  resilience; only the non-breaking robustness improvement is worth doing now.
+- **Reconsider when:** a major-version bump lets `Company.logoPath` become optional
+  and the two models can be aligned deliberately.
+
 ### 2026-06-24 — "Fix every instance of X" deliveries: enumerate all sites up front · applied
 
 - **Pattern:** for a delivery whose goal is "apply change C to every occurrence of

--- a/knowledge/tmdb-api-notes.md
+++ b/knowledge/tmdb-api-notes.md
@@ -89,6 +89,23 @@ status code alone proves nothing.
   before deciding — the docs aren't always accurate about which fields are
   guaranteed.
 
+### `Company.logoPath` is a required decode — latent throw if `logo_path` is absent
+
+*2026-06-30, `/3/company/{company_id}`.* `Company.logoPath` is non-optional
+(`public let logoPath: URL`) and decoded with a **required**
+`try container.decode(URL.self, forKey: .logoPath)`
+(`Sources/TMDb/Domain/Models/Company.swift`), so an absent, `null`, or empty
+`logo_path` makes the **whole `Company` decode throw**. TMDb does return
+logo-less production companies, so this is a real latent failure, not theoretical.
+Note the asymmetry in the *same* decoder: `homepageURL` **is** guarded (empty
+string → `nil`, with the comment "URL decoding will fail with an empty string"),
+and the sibling `Network.logoPath` is correctly `URL?` — only `Company.logoPath`
+is unguarded. **Fixing it means making `logoPath` optional (`URL?`), a breaking
+public-API change** (property type + `init` parameter), so it is deferred to a
+deliberate major version rather than patched ad hoc. Until then, treat a company
+with no logo as a known decode-failure risk. (Surfaced in the 2026-06-30
+standardization audit.)
+
 ## Changes endpoints
 
 ### `changes/movie|tv|person` list responses are large and carry an unmodelled `softcore` field


### PR DESCRIPTION
## Summary

A meta-improvement pass on the autonomous `/deliver` pipeline, applying five
proposals (P1–P5) from a standardization audit of the pipeline (benchmarked
against Spotify's "Honk" background-agent lessons), plus durable capture of a
latent-decode finding. **Markdown only** — skills, the shared review spec, and
`knowledge/`; no Swift, no public-API change. Every pipeline change is recorded
in `knowledge/skill-improvement-log.md`.

## Changes

**Pipeline / skill hardening** (`.claude/skills/`, `.github/CODE_REVIEW.md`):

- 🔧 **P1 — Phase 3 reference-unit gate.** Replaces the never-executed "review per
  cohesive unit" rule with a detectable, ledger-enforced gate: a *template→replicate*
  delivery (one pattern across N≥3 units) reviews the **reference unit before the
  rest are generated** (`Phase 3a` blocks Phase 4); other multi-unit full changes
  explicitly use the single end-diff fan-out.
- 🔧 **P2 — sibling-convention conformance.** A *prevent-probe* in `/implement-plan`
  Step 1 (read the nearest siblings, mirror their conventions) **and** a
  *detect-lens* in `CODE_REVIEW.md` ("Consistency with siblings") + the
  `review-changes` architecture/testing dimensions.
- 🔧 **P3 — adversarial-drop hardening.** A reviewer may not drop a finding on an
  **unverified claim about sibling code** (`CODE_REVIEW.md` adversarial rule 5).
- 🔧 **P4 — async/queued invocation.** Documents that `/deliver auto` can be queued
  (CCR trigger / `/schedule`), its requirements (inline plan + ACs; `gh`/wiki
  fallbacks), and an explicit recommendation **against** routinising async feature
  delivery for this single-maintainer public-API package.
- 🔧 **P5 — multi-deliverable plans.** `/deliver` can now decompose a
  multi-deliverable plan into **one PR per independent deliverable**
  (dependency-graph aware): serial implement + concurrent background watch, with a
  batched ready-to-merge gate.

**Knowledge** (`knowledge/`):

- 📝 **`Company.logoPath` latent-decode risk** in `tmdb-api-notes.md` — a required,
  non-optional `URL` decode that throws if the API omits `logo_path` (unlike the
  guarded `homepageURL` beside it, and the correctly-optional `Network.logoPath`).
  Fixing it is breaking, so it's deferred to a major version.
- 📝 **7 `skill-improvement-log.md` entries** — P1–P5 **applied**; error-idiom
  unification and `Network`↔`Company` field alignment **rejected** (breaking /
  net-negative), each with rationale + reconsider-when.

**Tests / build:** none required — Markdown only. `make ci` green (unit **2824**,
integration **289**, release build, docs build).

## Benefits

- **Catches standardization debt before the PR** — the prevent-probe + detect-lens
  close the recurring "new code silently diverges from its family" class.
- **A review gate that actually fires** — P1 swaps an unenforced rule for a
  ledger-blocked checkpoint on the one shape where a foundational defect fans out.
- **More trustworthy verifier** — P3 stops real findings being dropped on
  unchecked sibling-claims.
- **Multiple PRs per run** — P5 produces several independent PRs from one
  `/deliver` instead of coupling unrelated work or running many manual sessions.
- **Durable findings** — the `Company.logoPath` risk and every accept/reject
  decision now live in the repo, not a transient plan.

> Note: this PR edits the very skills the pipeline runs; the skill registry loads
> from the main checkout, so the new behaviour takes effect only **after merge**
> (it could not be dogfooded within this run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)