### PR TITLE
🔧 Fix three /deliver pipeline issues from the #368 retro scan

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -362,6 +362,12 @@ by whatever spawned the subshell — **not** this file; check the environment fi
 Record the worktree path and branch name in the ledger. The branch is what the PR
 and all later phases (`git diff origin/main...HEAD`, `/pr`, `/watch-pr`) operate on.
 
+**(Re-)create the ledger here, inside the worktree.** The `TaskCreate` ledger is
+**CWD-scoped and cleared by `EnterWorktree`** (and can be reset mid-run by an MCP
+reconnect or a plan-mode exit), so open the Contract §6 ledger *after* entering
+the worktree — and if a later phase finds it empty, **re-create it from the phase
+list** rather than treating it as lost work. (Bit #364 and #368.)
+
 **Edit via worktree paths, and verify your diff landed there — not on `main`.** A
 file `Read` *before* `EnterWorktree` (e.g. source you scoped in Phase 0) yields a
 **main-checkout** absolute path; continuing to `Edit` that exact path after entering

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -10,10 +10,10 @@ I'll create a pull request for the current branch by following these steps. If a
 **Mode** — check the arguments passed to this skill (shown at the end). If they
 include `reviewed` (or `skip-review`), an upstream step already ran the
 `code-reviewer` and fixed its findings (e.g. `/deliver`'s code-review phase), so
-**skip steps 4–6** to avoid reviewing identical code twice. Otherwise (standalone
+**skip steps 5–7** to avoid reviewing identical code twice. Otherwise (standalone
 `/pr`), run the internal review as normal.
 
-**Also skip steps 4–6 when the branch changes no Swift** — code review is for
+**Also skip steps 5–7 when the branch changes no Swift** — code review is for
 Swift, so a docs-only / config-only PR needs none:
 
 ```bash
@@ -35,11 +35,11 @@ git diff --name-only origin/main...HEAD | grep -qE '\.swift$' || echo "no-swift 
     - Already branched off an up-to-date `origin/main` with nothing to replay → this is a fast no-op.
 4. Run the pre-PR gate — **MANDATORY; it must pass before going further.** Run it directly (do not delegate). If it fails, stop and fix — **commit the fixes** — then re-run; never open a PR on a red gate. Scale the gate to the diff:
     - **Default — full `make ci`.** The gate CLAUDE.md requires before any PR: lint, markdown lint, unit tests, integration tests, the release build, and the docs build. Use this whenever **any** code or build-affecting file changed.
-    - **Docs/config-only fast gate.** When the diff touches **no build- or test-affecting files** — i.e. no `*.swift` **and** none of `Makefile`, `Package.swift`, `Package.resolved`, `*.xctestplan`, or `.github/**` — the test/release-build legs of `make ci` have nothing to exercise. Run only the meaningful checks instead: `make lint && make lint-markdown && make build-docs` (drop `build-docs` if no `*.docc/**` changed). Detect this with:
+    - **Docs/config-only fast gate.** When the diff touches **no build- or test-affecting files** — i.e. no `*.swift` **and** none of `Makefile`, `Package.swift`, `Package.resolved`, `*.xctestplan`, or `.github/workflows/**` — the test/release-build legs of `make ci` have nothing to exercise. Run only the meaningful checks instead: `make lint && make lint-markdown && make build-docs` (drop `build-docs` if no `*.docc/**` changed). Detect this with:
 
         ```bash
         git diff --name-only origin/main...HEAD \
-          | grep -qE '\.swift$|^Makefile$|^Package\.(swift|resolved)$|\.xctestplan$|^\.github/' \
+          | grep -qE '\.swift$|^Makefile$|^Package\.(swift|resolved)$|\.xctestplan$|^\.github/workflows/' \
           && echo "code/build touched → full make ci" \
           || echo "docs/config-only → fast gate"
         ```

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,58 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-06-30 — Ledger fragility recurred (#364, #368): re-create it inside the worktree · applied
+
+- **Pattern:** the `TaskCreate` phase ledger (Contract §6) is CWD-scoped and is
+  cleared by `EnterWorktree` (and, in #368, reset again mid-run by an MCP
+  reconnect / plan-mode exit), so the durable phase ledger keeps getting lost —
+  #364 (lost on EnterWorktree) and #368 (lost twice).
+- **Decision:** **applied** (user-approved, from the #368 Phase 6 scan). Took the
+  **lightweight** path the deferred *2026-06-18 file-based ledger* entry called
+  for, not a new state machine: `/deliver` Phase 0.5 now says to (re-)create the
+  ledger *inside* the worktree after entering, and to re-create it from the phase
+  list if a later phase finds it empty. Landed in `.claude/skills/deliver/SKILL.md`
+  Phase 0.5.
+- **Rationale:** matches that entry's "reconsider when interruptions actually bite
+  — prefer the lighter fix"; a re-create instruction costs nothing and stops a
+  reset ledger being mistaken for lost work. The heavy committed-JSON option stays
+  rejected.
+- **Reconsider when:** the re-create instruction proves insufficient (resets lose
+  in-flight decisions not reconstructable from the phase list) — then revisit
+  "checkpoint the ledger into the PR description".
+
+### 2026-06-30 — Fast-gate over-matched `.github/`: narrow to `.github/workflows/` · applied
+
+- **Pattern:** the `/pr` docs/config fast-gate detector treated **any** `.github/`
+  change as build/CI-affecting (`^\.github/`), so a pure docs change under
+  `.github/` — e.g. `.github/CODE_REVIEW.md` in #368 — forced the **full** `make
+  ci` (live integration suite included) for a markdown-only diff. The "full gate
+  for a no-logic change" friction recurred across #340/#343/#344/#363 and #368.
+- **Decision:** **applied** (user-approved). Narrowed the detector's `^\.github/`
+  → `^\.github/workflows/` (and the prose `.github/**` → `.github/workflows/**`)
+  in `.claude/skills/pr/SKILL.md` step 4 — only workflow files affect CI. Safe
+  because the PR's own CI always runs the full matrix regardless; the fast gate
+  only trims the *local* run.
+- **Rationale:** `.github/CODE_REVIEW.md` and issue/PR templates don't affect
+  `swift build`/`test`/docs, so they shouldn't trip the full gate; an obscure
+  CI-affecting change is still caught by the PR's own CI.
+- **Reconsider when:** the repo adds composite actions under `.github/actions/`
+  the local gate should exercise — then widen the pattern to include them.
+
+### 2026-06-30 — `/pr` "skip steps 4–6" off-by-one would skip the mandatory gate · applied
+
+- **Pattern:** `/pr`'s mode preamble said `reviewed`/no-Swift should "**skip steps
+  4–6**", but **step 4 is the mandatory `make ci` gate**; the skippable review
+  steps are 5–7 (and are correctly annotated as such per-step). Taken literally
+  the preamble would skip the gate CLAUDE.md mandates before every PR. Found during
+  #368 — a single occurrence, but a correctness bug, so logged despite being below
+  the recurring-scan ≥2 bar.
+- **Decision:** **applied** (user-approved). Changed both "skip steps 4–6"
+  occurrences to "skip steps 5–7" in `.claude/skills/pr/SKILL.md`.
+- **Rationale:** the gate is never optional; the preamble must agree with the
+  per-step annotations so a future literal reading can't skip `make ci`.
+- **Reconsider when:** n/a (applied).
+
 ### 2026-06-30 — Phase 3 per-unit review: replace the blanket rule with a template→replicate reference-unit gate · applied
 
 - **Pattern:** Phase 3's "Full / multi-unit → review per cohesive unit,


### PR DESCRIPTION
## Summary

Three small pipeline fixes surfaced by PR #368's Phase 6 recurring-pattern scan
and approved for action. **Markdown only** — `.claude/skills/` + `knowledge/`; no
Swift, no public-API change. Each is recorded in `knowledge/skill-improvement-log.md`.

## Changes

- 🔧 **Ledger fragility (recurring #364 + #368).** The `TaskCreate` phase ledger is
  CWD-scoped and is cleared by `EnterWorktree` (and reset mid-run by an MCP
  reconnect / plan-mode exit). `/deliver` Phase 0.5 now says to **(re-)create the
  ledger inside the worktree** after entering, and to rebuild it from the phase
  list if a later phase finds it empty — the lightweight mitigation the deferred
  *file-based ledger* decision called for (no new state machine).
- 🔧 **Fast-gate over-match.** `/pr`'s docs/config fast-gate detector treated **any**
  `.github/` change as build/CI-affecting (`^\.github/`), so a docs change like
  `.github/CODE_REVIEW.md` forced the full `make ci`. Narrowed to
  `^\.github/workflows/` (only workflow files affect CI); the PR's own CI still
  runs the full matrix, so this only trims the local gate.
- 🔧 **`/pr` off-by-one.** The `reviewed`/no-Swift mode preamble said "skip steps
  **4–6**", but **step 4 is the mandatory `make ci` gate** — corrected to "skip
  steps **5–7**" (the review steps, matching the per-step annotations). Prevents a
  literal reading from skipping the gate.

## Benefits

- **Resilient ledger** — a reset ledger is rebuilt, not mistaken for lost work.
- **Cheaper docs PRs** — a review-spec/template change no longer pays the full
  live-integration matrix locally.
- **The gate can't be skipped** — the `/pr` preamble now agrees that `make ci` is
  always run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)