### PR TITLE
🐛 Validate Movie.addRating + extract shared input-validation helpers

### DIFF
--- a/Sources/TMDb/Domain/Services/Authentication/TMDbAuthenticationService.swift
+++ b/Sources/TMDb/Domain/Services/Authentication/TMDbAuthenticationService.swift
@@ -88,19 +88,12 @@ final class TMDbAuthenticationService: AuthenticationService {
 extension TMDbAuthenticationService {
 
     private static func validate(accessToken: String) throws(TMDbError) {
-        guard !accessToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw .badRequest("Access token must not be empty")
-        }
+        try accessToken.validateNotEmpty(message: "Access token must not be empty")
     }
 
     private static func validate(credential: Credential) throws(TMDbError) {
-        guard !credential.username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw .badRequest("Username must not be empty")
-        }
-
-        guard !credential.password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw .badRequest("Password must not be empty")
-        }
+        try credential.username.validateNotEmpty(message: "Username must not be empty")
+        try credential.password.validateNotEmpty(message: "Password must not be empty")
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Credits/TMDbCreditService.swift
+++ b/Sources/TMDb/Domain/Services/Credits/TMDbCreditService.swift
@@ -29,9 +29,7 @@ final class TMDbCreditService: CreditService {
 extension TMDbCreditService {
 
     private static func validate(id: Credit.ID) throws(TMDbError) {
-        guard !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw .badRequest("Credit ID must not be empty")
-        }
+        try id.validateNotEmpty(message: "Credit ID must not be empty")
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Find/TMDbFindService.swift
+++ b/Sources/TMDb/Domain/Services/Find/TMDbFindService.swift
@@ -40,9 +40,7 @@ final class TMDbFindService: FindService {
 extension TMDbFindService {
 
     private static func validate(externalID: String) throws(TMDbError) {
-        guard !externalID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw .badRequest("External ID must not be empty")
-        }
+        try externalID.validateNotEmpty(message: "External ID must not be empty")
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Lists/TMDbListService.swift
+++ b/Sources/TMDb/Domain/Services/Lists/TMDbListService.swift
@@ -102,9 +102,7 @@ final class TMDbListService: ListService {
 extension TMDbListService {
 
     private static func validate(name: String) throws(TMDbError) {
-        guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw .badRequest("List name must not be empty")
-        }
+        try name.validateNotEmpty(message: "List name must not be empty")
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Movies/TMDbMovieService.swift
+++ b/Sources/TMDb/Domain/Services/Movies/TMDbMovieService.swift
@@ -195,6 +195,8 @@ final class TMDbMovieService: MovieService {
         toMovie movieID: Movie.ID,
         session: Session
     ) async throws(TMDbError) {
+        try rating.validateAsRating()
+
         let request = AddMovieRatingRequest(rating: rating, movieID: movieID, sessionID: session.sessionID)
 
         _ = try await apiClient.perform(request)

--- a/Sources/TMDb/Domain/Services/Reviews/TMDbReviewService.swift
+++ b/Sources/TMDb/Domain/Services/Reviews/TMDbReviewService.swift
@@ -31,9 +31,7 @@ final class TMDbReviewService: ReviewService {
 extension TMDbReviewService {
 
     private static func validate(id: Review.ID) throws(TMDbError) {
-        guard !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw .badRequest("Review ID must not be empty")
-        }
+        try id.validateNotEmpty(message: "Review ID must not be empty")
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Search/TMDbSearchService.swift
+++ b/Sources/TMDb/Domain/Services/Search/TMDbSearchService.swift
@@ -143,9 +143,7 @@ final class TMDbSearchService: SearchService {
 extension TMDbSearchService {
 
     private static func validate(query: String) throws(TMDbError) {
-        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw .badRequest("Search query must not be empty")
-        }
+        try query.validateNotEmpty(message: "Search query must not be empty")
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVEpisodeGroups/TMDbTVEpisodeGroupService.swift
+++ b/Sources/TMDb/Domain/Services/TVEpisodeGroups/TMDbTVEpisodeGroupService.swift
@@ -31,9 +31,7 @@ final class TMDbTVEpisodeGroupService: TVEpisodeGroupService {
 extension TMDbTVEpisodeGroupService {
 
     private static func validate(id: TVEpisodeGroup.ID) throws(TMDbError) {
-        guard !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw .badRequest("TV episode group ID must not be empty")
-        }
+        try id.validateNotEmpty(message: "TV episode group ID must not be empty")
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVEpisodes/TMDbTVEpisodeService+Account.swift
+++ b/Sources/TMDb/Domain/Services/TVEpisodes/TMDbTVEpisodeService+Account.swift
@@ -33,12 +33,7 @@ extension TMDbTVEpisodeService {
         inTVSeries tvSeriesID: TVSeries.ID,
         session: Session
     ) async throws(TMDbError) {
-        guard
-            (0.5 ... 10.0).contains(rating),
-            rating.truncatingRemainder(dividingBy: 0.5) == 0
-        else {
-            throw TMDbError.invalidRating
-        }
+        try rating.validateAsRating()
 
         let request = TVEpisodeAddRatingRequest(
             rating: rating,

--- a/Sources/TMDb/Domain/Services/TVSeries/TMDbTVSeriesService+Account.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/TMDbTVSeriesService+Account.swift
@@ -22,9 +22,7 @@ extension TMDbTVSeriesService {
         toTVSeries tvSeriesID: TVSeries.ID,
         session: Session
     ) async throws(TMDbError) {
-        guard (0.5 ... 10.0).contains(rating), rating.truncatingRemainder(dividingBy: 0.5) == 0 else {
-            throw TMDbError.invalidRating
-        }
+        try rating.validateAsRating()
 
         let request = TVSeriesAddRatingRequest(
             rating: rating,

--- a/Sources/TMDb/Extensions/Double+Rating.swift
+++ b/Sources/TMDb/Extensions/Double+Rating.swift
@@ -1,0 +1,28 @@
+//
+//  Double+Rating.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+extension Double {
+
+    ///
+    /// Validates that the value is a valid TMDb rating — within the range
+    /// `0.5...10.0` and a multiple of `0.5`.
+    ///
+    /// Use this to guard a public `addRating` boundary against an out-of-range or
+    /// off-step rating before a request is built.
+    ///
+    /// - Throws: ``TMDbError/invalidRating`` if the value is outside `0.5...10.0`
+    ///   or not a multiple of `0.5`.
+    ///
+    func validateAsRating() throws(TMDbError) {
+        guard (0.5 ... 10.0).contains(self), truncatingRemainder(dividingBy: 0.5) == 0 else {
+            throw .invalidRating
+        }
+    }
+
+}

--- a/Sources/TMDb/Extensions/String+Validation.swift
+++ b/Sources/TMDb/Extensions/String+Validation.swift
@@ -1,0 +1,31 @@
+//
+//  String+Validation.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+extension String {
+
+    ///
+    /// Validates that the string is not empty once leading and trailing
+    /// whitespace and newlines are trimmed.
+    ///
+    /// Use this to guard a public API boundary that takes a `String` (or a
+    /// `String`-backed identifier) against empty or whitespace-only input, so the
+    /// degenerate value is rejected before a request is built.
+    ///
+    /// - Parameter message: The message for the thrown ``TMDbError/badRequest(_:)``.
+    ///
+    /// - Throws: ``TMDbError/badRequest(_:)`` if the string is empty or contains
+    ///   only whitespace.
+    ///
+    func validateNotEmpty(message: String) throws(TMDbError) {
+        guard !trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw .badRequest(message)
+        }
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Movies/TMDbMovieServiceRatingTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Movies/TMDbMovieServiceRatingTests.swift
@@ -1,0 +1,83 @@
+//
+//  TMDbMovieServiceRatingTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.services, .movie))
+struct TMDbMovieServiceRatingTests {
+
+    var service: TMDbMovieService!
+    var apiClient: MockAPIClient!
+
+    init() {
+        self.apiClient = MockAPIClient()
+        self.service = TMDbMovieService(apiClient: apiClient)
+    }
+
+    @Test("addRating with valid rating succeeds")
+    func addRatingWithValidRatingSucceeds() async throws {
+        let movieID = 1
+        let session = Session.mock()
+        let rating = 8.5
+        apiClient.addResponse(.success(SuccessResult(success: true)))
+        let expectedRequest = AddMovieRatingRequest(
+            rating: rating,
+            movieID: movieID,
+            sessionID: session.sessionID
+        )
+
+        try await service.addRating(rating, toMovie: movieID, session: session)
+
+        #expect(apiClient.lastRequest as? AddMovieRatingRequest == expectedRequest)
+    }
+
+    @Test("addRating with rating too low throws invalidRating and performs no request")
+    func addRatingTooLowThrowsInvalidRating() async throws {
+        let session = Session.mock()
+
+        await #expect(throws: TMDbError.invalidRating) {
+            try await service.addRating(0.0, toMovie: 1, session: session)
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
+    @Test("addRating with rating too high throws invalidRating and performs no request")
+    func addRatingTooHighThrowsInvalidRating() async throws {
+        let session = Session.mock()
+
+        await #expect(throws: TMDbError.invalidRating) {
+            try await service.addRating(10.5, toMovie: 1, session: session)
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
+    @Test("addRating with rating not a multiple of 0.5 throws invalidRating and performs no request")
+    func addRatingOffStepThrowsInvalidRating() async throws {
+        let session = Session.mock()
+
+        await #expect(throws: TMDbError.invalidRating) {
+            try await service.addRating(8.3, toMovie: 1, session: session)
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
+    @Test("addRating when errors throws error")
+    func addRatingWhenErrorsThrowsError() async throws {
+        let session = Session.mock()
+        apiClient.addResponse(.failure(.unknown))
+
+        await #expect(throws: TMDbError.unknown) {
+            try await service.addRating(8.5, toMovie: 1, session: session)
+        }
+    }
+
+}

--- a/Tests/TMDbTests/Extensions/Double+RatingTests.swift
+++ b/Tests/TMDbTests/Extensions/Double+RatingTests.swift
@@ -1,0 +1,40 @@
+//
+//  Double+RatingTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+struct DoubleRatingTests {
+
+    @Test("valid ratings pass", arguments: [0.5, 1.0, 5.5, 8.5, 10.0])
+    func validRatingsPass(_ rating: Double) throws {
+        try rating.validateAsRating()
+    }
+
+    @Test("ratings below 0.5 throw invalidRating", arguments: [0.0, 0.4, -1.0])
+    func tooLowRatingsThrow(_ rating: Double) {
+        #expect(throws: TMDbError.invalidRating) {
+            try rating.validateAsRating()
+        }
+    }
+
+    @Test("ratings above 10.0 throw invalidRating", arguments: [10.5, 11.0, 100.0])
+    func tooHighRatingsThrow(_ rating: Double) {
+        #expect(throws: TMDbError.invalidRating) {
+            try rating.validateAsRating()
+        }
+    }
+
+    @Test("ratings not a multiple of 0.5 throw invalidRating", arguments: [0.7, 5.3, 8.25])
+    func offStepRatingsThrow(_ rating: Double) {
+        #expect(throws: TMDbError.invalidRating) {
+            try rating.validateAsRating()
+        }
+    }
+
+}

--- a/Tests/TMDbTests/Extensions/String+ValidationTests.swift
+++ b/Tests/TMDbTests/Extensions/String+ValidationTests.swift
@@ -1,0 +1,38 @@
+//
+//  String+ValidationTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+struct StringValidationTests {
+
+    @Test("non-empty string passes validation")
+    func nonEmptyStringPasses() throws {
+        try "hello".validateNotEmpty(message: "must not be empty")
+    }
+
+    @Test("string with surrounding whitespace but real content passes")
+    func paddedContentPasses() throws {
+        try "  hello  ".validateNotEmpty(message: "must not be empty")
+    }
+
+    @Test("empty string throws badRequest with the message")
+    func emptyStringThrowsBadRequest() {
+        #expect(throws: TMDbError.badRequest("must not be empty")) {
+            try "".validateNotEmpty(message: "must not be empty")
+        }
+    }
+
+    @Test("whitespace-only string throws badRequest with the message")
+    func whitespaceStringThrowsBadRequest() {
+        #expect(throws: TMDbError.badRequest("must not be empty")) {
+            try "  \t\n ".validateNotEmpty(message: "must not be empty")
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

Standardizes input validation across the services (audit Delivery A): one shared
helper instead of a copy-pasted guard, and a genuine missing-guard **bug fix** on
`Movie.addRating`. No public-API change.

## Changes

**Bug fix:**
- 🐛 **`MovieService.addRating` now validates the rating.** It previously passed the
  `Double` straight to the API, while its `TVSeries`/`TVEpisode` siblings guard it
  — so an out-of-range or off-step movie rating was sent unchecked. Now guarded
  (throws `.invalidRating`), matching the siblings.

**Refactor (behaviour-preserving):**
- ♻️ New `String.validateNotEmpty(message:)` and `Double.validateAsRating()` in
  `Sources/TMDb/Extensions/`.
- ♻️ Routed the **8** duplicated empty-string `validate(...)` funcs
  (Search/List/Find/Credit/Review/TVEpisodeGroup/Authentication) and the
  TVSeries/TVEpisode rating guards through the shared helpers — one source of the
  rule instead of copy-paste, so a future `String`/rating boundary has one obvious
  thing to call (closes the recurring "straggler" class).

**Tests:**
- ✅ `StringValidationTests`, `DoubleRatingTests` (helper units).
- ✅ `TMDbMovieServiceRatingTests` — valid / too-low / too-high / non-half-step /
  error cases (the bug-fix coverage, mirroring `TMDbTVSeriesServiceAccountTests`).
- ✅ `make ci` green: unit **2837**, integration **289**, release build, docs.

> No new integration test: **no `addRating` method has one** (Movie or TV) — a
> live-write rating test isn't an established sibling pattern, so the guard is
> covered by unit tests, consistent with the family.

## Benefits

- **Correctness** — invalid movie ratings are rejected client-side instead of
  reaching the API.
- **One validation idiom** — removes 11 copy-pasted guards; new boundaries call
  the shared helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)