### PR TITLE
✅ Fix mis-applied test-suite tags on Search/People service suites

### DIFF
--- a/Tests/TMDbTests/Domain/Services/People/TMDbPersonServiceChangesTests.swift
+++ b/Tests/TMDbTests/Domain/Services/People/TMDbPersonServiceChangesTests.swift
@@ -9,7 +9,7 @@ import Foundation
 import Testing
 @testable import TMDb
 
-@Suite(.tags(.requests, .people))
+@Suite(.tags(.services, .people))
 struct TMDbPersonServiceChangesTests {
 
     var service: TMDbPersonService!

--- a/Tests/TMDbTests/Domain/Services/People/TMDbPersonServiceTaggedImagesTests.swift
+++ b/Tests/TMDbTests/Domain/Services/People/TMDbPersonServiceTaggedImagesTests.swift
@@ -9,7 +9,7 @@ import Foundation
 import Testing
 @testable import TMDb
 
-@Suite(.tags(.requests, .people))
+@Suite(.tags(.services, .people))
 struct TMDbPersonServiceTaggedImagesTests {
 
     var service: TMDbPersonService!

--- a/Tests/TMDbTests/Domain/Services/People/TMDbPersonServiceTests.swift
+++ b/Tests/TMDbTests/Domain/Services/People/TMDbPersonServiceTests.swift
@@ -9,7 +9,7 @@ import Foundation
 import Testing
 @testable import TMDb
 
-@Suite(.tags(.requests, .people))
+@Suite(.tags(.services, .people))
 struct TMDbPersonServiceTests {
 
     var service: TMDbPersonService!

--- a/Tests/TMDbTests/Domain/Services/People/TMDbPersonServiceTranslationsTests.swift
+++ b/Tests/TMDbTests/Domain/Services/People/TMDbPersonServiceTranslationsTests.swift
@@ -9,7 +9,7 @@ import Foundation
 import Testing
 @testable import TMDb
 
-@Suite(.tags(.requests, .people))
+@Suite(.tags(.services, .people))
 struct TMDbPersonServiceTranslationsTests {
 
     var service: TMDbPersonService!

--- a/Tests/TMDbTests/Domain/Services/Search/TMDbSearchServiceCollectionsTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Search/TMDbSearchServiceCollectionsTests.swift
@@ -9,7 +9,7 @@ import Foundation
 import Testing
 @testable import TMDb
 
-@Suite(.tags(.requests, .search))
+@Suite(.tags(.services, .search))
 struct TMDbSearchServiceCollectionsTests {
 
     var service: TMDbSearchService!

--- a/Tests/TMDbTests/Domain/Services/Search/TMDbSearchServiceCompaniesTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Search/TMDbSearchServiceCompaniesTests.swift
@@ -9,7 +9,7 @@ import Foundation
 import Testing
 @testable import TMDb
 
-@Suite(.tags(.requests, .search))
+@Suite(.tags(.services, .search))
 struct TMDbSearchServiceCompaniesTests {
 
     var service: TMDbSearchService!

--- a/Tests/TMDbTests/Domain/Services/Search/TMDbSearchServiceKeywordsTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Search/TMDbSearchServiceKeywordsTests.swift
@@ -9,7 +9,7 @@ import Foundation
 import Testing
 @testable import TMDb
 
-@Suite(.tags(.requests, .search))
+@Suite(.tags(.services, .search))
 struct TMDbSearchServiceKeywordsTests {
 
     var service: TMDbSearchService!

--- a/Tests/TMDbTests/Domain/Services/Search/TMDbSearchServiceTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Search/TMDbSearchServiceTests.swift
@@ -9,7 +9,7 @@ import Foundation
 import Testing
 @testable import TMDb
 
-@Suite(.tags(.requests, .search))
+@Suite(.tags(.services, .search))
 struct TMDbSearchServiceTests {
 
     var service: TMDbSearchService!

--- a/Tests/TMDbTests/Domain/Services/Search/TMDbSearchServiceValidationTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Search/TMDbSearchServiceValidationTests.swift
@@ -9,7 +9,7 @@ import Foundation
 import Testing
 @testable import TMDb
 
-@Suite(.tags(.requests, .search))
+@Suite(.tags(.services, .search))
 struct TMDbSearchServiceValidationTests {
 
     var service: TMDbSearchService!


### PR DESCRIPTION
## Summary

Audit Delivery B. Nine **service-behaviour** test suites were tagged `.requests`
instead of `.services`, inconsistent with their own siblings (e.g.
`TMDbSearchServicePaginationTests`, `TMDbPersonServicePaginationTests`) and every
other service-test folder. Test-only; no logic change.

## Changes

- ✅ Flipped `@Suite(.tags(.requests, .<area>))` → `.tags(.services, .<area>)` on:
  - **People** — `TMDbPersonServiceTests`, `…ChangesTests`, `…TaggedImagesTests`,
    `…TranslationsTests`
  - **Search** — `TMDbSearchServiceTests`, `…CollectionsTests`, `…CompaniesTests`,
    `…KeywordsTests`, `…ValidationTests`
- The genuine **Requests DTO** suites under `*/Requests/` correctly keep
  `.requests` and are untouched.

## Benefits

- `swift test --filter`-by-tag now selects these service suites under `services`,
  consistent with the rest of the suite — removes a standardization seam an agent
  (or contributor) would otherwise copy.

✅ `make ci` green (unit + integration **289**, release build, docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)