### PR TITLE
🐛 Decode Network with an empty homepage instead of throwing

### DIFF
--- a/Sources/TMDb/Domain/Models/Network.swift
+++ b/Sources/TMDb/Domain/Models/Network.swift
@@ -72,3 +72,50 @@ public struct Network: Identifiable, Codable, Equatable, Hashable, Sendable {
     }
 
 }
+
+extension Network {
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case logoPath
+        case originCountry
+        case headquarters
+        case homepage
+    }
+
+    ///
+    /// Creates a new instance by decoding from the given decoder.
+    ///
+    /// This initializer throws an error if reading from the decoder fails, or
+    /// if the data read is corrupted or otherwise invalid.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    ///
+    /// - Throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested
+    /// type.
+    /// - Throws: `DecodingError.keyNotFound` if self does not have an entry for the given key.
+    /// - Throws: `DecodingError.valueNotFound` if self has a null entry for the given key.
+    ///
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let container2 = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.id = try container.decode(Int.self, forKey: .id)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.logoPath = try container.decodeIfPresent(URL.self, forKey: .logoPath)
+        self.originCountry = try container.decodeIfPresent(String.self, forKey: .originCountry)
+        self.headquarters = try container.decodeIfPresent(String.self, forKey: .headquarters)
+
+        // Need to deal with empty strings - URL decoding will fail with an empty string
+        let homepageString = try container.decodeIfPresent(String.self, forKey: .homepage)
+        self.homepage = try {
+            guard let homepageString, !homepageString.isEmpty else {
+                return nil
+            }
+
+            return try container2.decodeIfPresent(URL.self, forKey: .homepage)
+        }()
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Models/NetworkTests.swift
+++ b/Tests/TMDbTests/Domain/Models/NetworkTests.swift
@@ -20,13 +20,27 @@ struct NetworkTests {
         #expect(result.name == network.name)
         #expect(result.logoPath == network.logoPath)
         #expect(result.originCountry == network.originCountry)
+        #expect(result.headquarters == network.headquarters)
+        #expect(result.homepage == network.homepage)
+    }
+
+    @Test("JSON decoding of Network when homepage is empty string", .tags(.decoding))
+    func decodeWhenHomepageIsEmptyStringReturnsNetwork() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            Network.self, fromResource: "network-blank-homepage"
+        )
+
+        #expect(result.homepage == nil)
+        #expect(result.id == network.id)
     }
 
     private let network = Network(
         id: 49,
         name: "HBO",
         logoPath: URL(string: "/tuomPhY2UtuPTqqFnKMVHvSb724.png"),
-        originCountry: "US"
+        originCountry: "US",
+        headquarters: "New York City, New York",
+        homepage: URL(string: "https://www.hbo.com")
     )
 
 }

--- a/Tests/TMDbTests/Resources/json/network-blank-homepage.json
+++ b/Tests/TMDbTests/Resources/json/network-blank-homepage.json
@@ -1,0 +1,8 @@
+{
+    "headquarters": "New York City, New York",
+    "homepage": "",
+    "id": 49,
+    "logo_path": "/tuomPhY2UtuPTqqFnKMVHvSb724.png",
+    "name": "HBO",
+    "origin_country": "US"
+}


### PR DESCRIPTION
## Summary

Audit Delivery C — a latent decode-failure fix. `Network` used the synthesized
`Codable`, so a `"homepage": ""` from the API made the **whole `Network` decode
throw** (`DecodingError: Invalid URL string`). Since `Network` is embedded in
`TVEpisodeGroup`, `TVSeason`, and `TVSeries`, that took those responses down too.
**Non-breaking** — public API unchanged.

## Changes

- 🐛 **Custom `Network.init(from:)`** that maps an empty `homepage` string to `nil`,
  mirroring the guard `Person`/`Company` already have. Decoding only becomes more
  tolerant; all other fields decode exactly as before.
- `Network` keeps its **`homepage`** property name — renaming it to `homepageURL`
  (to match `Company`) would be a breaking public-API change, so it's deliberately
  not done (see `knowledge/tmdb-api-notes.md`).

## Tests (canon-TDD — reproduced the bug first)

- ✅ New `network-blank-homepage.json` fixture (`"homepage": ""`) +
  `decodeWhenHomepageIsEmptyStringReturnsNetwork` → `homepage == nil` (failed
  before the fix with "Invalid URL string", passes after).
- ✅ The existing decode test now also asserts `homepage`/`headquarters` (covers
  the present-value branch of the new decoder).
- ✅ `make ci` green: unit + integration **289**, release build, docs.

## Benefits

- **Robustness** — a logo-less / homepage-less network (or any embedding response)
  no longer fails to decode on an empty homepage string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)