### PR TITLE
📝 Reconcile docs/config honesty gaps flagged by external review

### DIFF
--- a/.claude/skills/build-for-testing/SKILL.md
+++ b/.claude/skills/build-for-testing/SKILL.md
@@ -24,6 +24,13 @@ Build the TMDb Swift package and all test targets, then report concisely.
   `mkdir -p .build && make build-tests > .build/last-build-tests.log 2>&1`,
   check the exit status for pass/fail (the Makefile sets `pipefail`), and
   summarise from that log file.
+  **Trust the exit status, not xcsift's toon summary.** Outside a docs build,
+  SwiftPM emits a benign `found N file(s) which are unhandled … *.docc` warning
+  (the DocC plugin loads only under `SWIFTCI_DOCC=1`); xcsift lists it under
+  `errors[]` with `null,null` coordinates and may print `status: failed`, yet the
+  build still **exits 0**. A 0 exit whose only errors are these `.docc`
+  unhandled-file entries is a **PASS** — report succeeded and exclude them from
+  the error count.
 
 Report back ONLY:
 - Status: succeeded or failed

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -21,6 +21,13 @@ Build the TMDb Swift package and report the result concisely.
 - Otherwise run `mkdir -p .build && make build > .build/last-build.log 2>&1`,
   check the exit status for pass/fail (the Makefile sets `pipefail`, so a compile
   failure propagates through the xcsift pipe), and summarise from that log file.
+  **Trust the exit status, not xcsift's toon summary.** Outside a docs build,
+  SwiftPM emits a benign `found N file(s) which are unhandled … *.docc` warning
+  (the DocC plugin loads only under `SWIFTCI_DOCC=1`); xcsift lists it under
+  `errors[]` with `null,null` coordinates and may print `status: failed`, yet the
+  build still **exits 0**. A 0 exit whose only errors are these `.docc`
+  unhandled-file entries is a **PASS** — report succeeded and exclude them from
+  the error count.
 
 Report back ONLY:
 - Status: succeeded or failed

--- a/.claude/skills/integration-test/SKILL.md
+++ b/.claude/skills/integration-test/SKILL.md
@@ -20,6 +20,12 @@ Run the TMDb integration tests against the live API and report concisely.
 - Otherwise run
   `mkdir -p .build && make integration-test > .build/last-integration-test.log 2>&1`,
   check the exit status for pass/fail, and summarise from that log file.
+  **Trust the exit status and `failed_tests` count, not xcsift's `status:`
+  field.** Outside a docs build, SwiftPM emits a benign `found N file(s) which
+  are unhandled … *.docc` warning that xcsift lists under `errors[]` (with
+  `null,null` coordinates) and that can make it print `status: failed` even when
+  the run succeeded and `failed_tests: 0`. Treat a 0 exit with `failed_tests: 0`
+  as **passed** regardless of that `.docc` entry.
 
 These require TMDB_API_KEY, TMDB_USERNAME, and TMDB_PASSWORD, which are injected
 via the env block in .claude/settings.local.json — no sourcing is needed. `make

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -22,6 +22,12 @@ Run the TMDb unit tests and report concisely.
 - Otherwise run `mkdir -p .build && make test > .build/last-test.log 2>&1`,
   check the exit status for pass/fail (the Makefile sets `pipefail`), and
   summarise from that log file.
+  **Trust the exit status and `failed_tests` count, not xcsift's `status:`
+  field.** Outside a docs build, SwiftPM emits a benign `found N file(s) which
+  are unhandled … *.docc` warning that xcsift lists under `errors[]` (with
+  `null,null` coordinates) and that can make it print `status: failed` even when
+  the run succeeded and `failed_tests: 0`. Treat a 0 exit with `failed_tests: 0`
+  as **passed** regardless of that `.docc` entry.
 
 Report back ONLY:
 - Status: passed or failed

--- a/.github/CODE_REVIEW.md
+++ b/.github/CODE_REVIEW.md
@@ -56,7 +56,7 @@ inflate nitpicks to Critical.
 
 - A **library** (not an app) — no UI frameworks. Swift 6.0+ strict concurrency.
   No external dependencies (stdlib + Foundation only).
-- Platforms: iOS 16+, macOS 13+, watchOS 9+, tvOS 16+, visionOS 1+, Linux, Windows.
+- Platforms: iOS 16+, macOS 13+, watchOS 9+, tvOS 16+, visionOS 1+, Linux.
 - **26 services** behind `TMDbClient`, each a public `protocol` + an internal
   `TMDb`-prefixed implementation; the `naturalLanguageSearch` service is Apple-only.
 - **Networking decorator chain:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [18.0.0] - Unreleased
+## [18.1.0] - 2026-06-18
+
+### Added
+
+- `AuthenticatedSession` wrapper for `AccountService`, simplifying calls
+  that operate on an authenticated user session.
+- Auto-pagination for the Account, GuestSession, Keyword, and Changes
+  services.
+- Opt-in next-page prefetch for auto-pagination.
+
+### Changed
+
+- `URLSessionHTTPClientAdapter` now declares explicit `Sendable`
+  conformance.
+- Standardised `details(...)` parameter labels to `<entity>ID` across
+  services for consistency.
+
+### Fixed
+
+- `Retry-After` sleep is now capped to `maxDelay`.
+- `RetryHTTPClient` now retries transient transport errors.
+- Search queries and degenerate `Discover` filter inputs are now
+  validated.
+- Query items are sorted by name to produce a canonical cache key.
+- Unknown `Status` and `media_type` values now decode resiliently
+  instead of failing.
+
+## [18.0.1] - 2026-06-11
+
+### Fixed
+
+- Missing `genre_ids` in search list items now decode as an empty array
+  instead of failing.
+
+## [18.0.0] - 2026-06-10
 
 ### Breaking
 
@@ -49,4 +83,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `PersonService.personChanges(startDate:endDate:page:)` — use
   `PersonService.changes(startDate:endDate:page:)` instead.
 
+[18.1.0]: https://github.com/adamayoung/TMDb/releases/tag/18.1.0
+[18.0.1]: https://github.com/adamayoung/TMDb/releases/tag/18.0.1
 [18.0.0]: https://github.com/adamayoung/TMDb/releases/tag/18.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,8 +112,9 @@ through a `LanguageModelSession`. It is gated by
 `#if canImport(FoundationModels) && !os(tvOS)` and annotated
 `@available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)`.
 
-Seven tools are exposed: `search`, `movieDetails`, `tvSeriesDetails`,
-`personFilmography`, `trending`, `watchProviders`, and `discoverMovies`. They
+Eight tools are exposed: `search`, `movieDetails`, `movieCredits`,
+`tvSeriesDetails`, `personFilmography`, `trending`, `watchProviders`, and
+`discoverMovies`. They
 are reachable from `TMDbClient` via `languageModelTools` (shorthand for
 `TMDbToolbox(client:).all`) and individual `*Tool` accessors (`searchTool`,
 `movieDetailsTool`, …). Each tool returns compact text whose every line leads

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ WATCHOS_DESTINATION = 'platform=watchOS Simulator,name=Apple Watch Series 11 (46
 TVOS_DESTINATION = 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.2'
 VISIONOS_DESTINATION = 'platform=visionOS Simulator,name=Apple Vision Pro,OS=26.2'
 
-SWIFT_CONTAINER_IMAGE = swift:6.0.3-jammy
+SWIFT_CONTAINER_IMAGE = swift:6.1-jammy
 
 # SwiftPM scratch (build) directory — the swift-build equivalent of Xcode's
 # DerivedData. Override to isolate concurrent builds across git worktrees, e.g.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Documentation](https://github.com/adamayoung/TMDb/actions/workflows/documentation.yml/badge.svg)](https://github.com/adamayoung/TMDb/actions/workflows/documentation.yml)
 [![codecov](https://codecov.io/gh/adamayoung/TMDb/graph/badge.svg?token=TICHRASF6F)](https://codecov.io/gh/adamayoung/TMDb)
 [![Swift 6.0+](https://img.shields.io/badge/Swift-6.0+-orange.svg)](https://swift.org)
-[![Platforms](https://img.shields.io/badge/Platforms-iOS%20|%20macOS%20|%20watchOS%20|%20tvOS%20|%20visionOS%20|%20Linux%20|%20Windows-blue.svg)](https://github.com/adamayoung/TMDb)
+[![Platforms](https://img.shields.io/badge/Platforms-iOS%20|%20macOS%20|%20watchOS%20|%20tvOS%20|%20visionOS%20|%20Linux-blue.svg)](https://github.com/adamayoung/TMDb)
 [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](LICENSE)
 
 A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
@@ -33,7 +33,7 @@ A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
   and vote averages as percentages (e.g. `"85%"` in English locales)
 * **Swift 6 Ready**: Full strict concurrency support with Sendable types
 * **Cross-Platform**: iOS 16+, macOS 13+, watchOS 9+, tvOS 16+,
-  visionOS 1+, Linux, Windows
+  visionOS 1+, Linux
 * **Automatic Retry**: Opt-in retry with exponential backoff for rate
   limits (HTTP 429) and server errors (HTTP 5xx)
 * **Response Caching**: On-disk HTTP caching by default on Apple platforms
@@ -95,7 +95,6 @@ for detailed usage.
   * watchOS 9+
   * tvOS 16+
   * visionOS 1+
-  * Windows
   * Linux
 
 ## Installation
@@ -270,7 +269,7 @@ requests are served from disk (and persist across launches) with no
 configuration. To tune or disable it, supply your own `HTTPClient` backed by a
 `URLSession` you configure.
 
-For an additional in-memory layer (or for caching on Linux/Windows, where
+For an additional in-memory layer (or for caching on Linux, where
 `URLCache` is not installed), enable in-memory response caching:
 
 ```swift

--- a/Tests/TMDbIntegrationTests/Utility/TMDbSessionHelper.swift
+++ b/Tests/TMDbIntegrationTests/Utility/TMDbSessionHelper.swift
@@ -14,42 +14,9 @@ actor TMDbSessionHelper {
 
     private let credentialHelper: CredentialHelper
 
-    private var sessionCache: CacheEntry?
-
     private init(credentialHelper: CredentialHelper = .shared) {
         self.credentialHelper = credentialHelper
     }
-
-    //    func session() async throws -> Session {
-    //        if let sessionCache {
-    //            switch sessionCache {
-    //            case .ready(let session):
-    //                return session
-    //
-    //            case .inProgress(let task):
-    //                return try await task.value
-    //            }
-    //        }
-    //
-    //        let apiKey = CredentialHelper.shared.tmdbAPIKey
-    //        let tmdbClient = TMDbClient(apiKey: apiKey)
-    //        let credential = credentialHelper.tmdbCredential
-    //
-    //        let task = Task {
-    //            try await tmdbClient.authentication.createSession(withCredential: credential)
-    //        }
-    //
-    //        sessionCache = .inProgress(task)
-    //
-    //        do {
-    //            let session = try await task.value
-    //            sessionCache = .ready(session)
-    //            return session
-    //        } catch {
-    //            sessionCache = nil
-    //            throw error
-    //        }
-    //    }
 
     func createSession() async throws -> Session {
         let apiKey = CredentialHelper.shared.tmdbAPIKey
@@ -64,15 +31,6 @@ actor TMDbSessionHelper {
         let tmdbClient = TMDbClient(apiKey: apiKey)
 
         try await tmdbClient.authentication.deleteSession(session)
-    }
-
-}
-
-extension TMDbSessionHelper {
-
-    private enum CacheEntry {
-        case inProgress(Task<Session, Error>)
-        case ready(Session)
     }
 
 }

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -10,6 +10,54 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-07-02 — 📝 Reconcile docs/config honesty gaps from external reviews (#374) · lite
+
+- **Phases / skills:** phases 0.5–6; `review-changes, security-review,
+  build-for-testing, pr`. Skipped `/review-plan` (lite + the worklist was approved
+  via `ExitPlanMode` this session, and its findings were already adversarially
+  *verified* by an 18-agent read-only workflow beforehand); skipped
+  `/implement-plan` (no Canon TDD list — docs/config edits + a dead-code deletion).
+  Knowledge captured **inline** (a gotcha + the skill-improvement-log entry), not
+  via a separate `/capture-knowledge`.
+- **Worked:** the standout was **verifying the reviews before acting on them.** Two
+  external reviews (Fable + Codex) were turned into a de-risked worklist by an
+  18-agent workflow that opened/grepped/counted every claim in-repo — which caught
+  real overstatements before any edit (tool count is *eight* not "seven"; the
+  `*DetailsResponse` decoders are 90–225 lines not "~180"; 84 request files not
+  "~95"; `.unsupportedLanguage` is actually reachable, not dead). Only the
+  **verified, softened** Tier-1 subset was delivered. `make ci` green first try
+  (2838 unit + 289 integration); the single `code-reviewer` returned **0 findings**
+  and independently re-checked the docs claims (tool count, CHANGELOG dates vs the
+  actual tags).
+- **Friction — the standout:** the Haiku `/build-for-testing` subagent reported the
+  build **failed** when `swift build` had **exited 0**. Cause: the benign DocC
+  `.docc` "unhandled file" package-load warning lands in xcsift's toon `errors[]`
+  array (with `null,null` coords) and flips its `status:` field to `failed`; the
+  agent trusted that field over the exit code. The same artifact reappeared in
+  `make ci`'s toon (`status: failed` with `failed_tests: 0`). Cost a diagnostic
+  cycle to prove it benign. **Fixed this run** (user-requested): a gotcha in
+  `gotchas.md` + a "trust the exit status, not xcsift's toon summary" caveat added
+  to all four build/test skill prompts (`/build`, `/build-for-testing`, `/test`,
+  `/integration-test`).
+- **Deviations:** (1) the delivery is **one tier of a 5-batch verified worklist**
+  (user green-lit Tiers 1–4 + F7 via `AskUserQuestion`), so the "plan" is the
+  worklist doc, not a single-feature plan. (2) **Bundled** the build/test
+  skill-prompt fix + its gotcha + skill-improvement-log entry into this honesty PR
+  rather than a separate one — the diagnosis gotcha was already committed here, so
+  splitting diagnosis from remediation would be worse; a mild scope-broadening,
+  flagged to the user. (3) Ran `/security-review` on a zero-attack-surface change
+  (docs + a version string + a dead-code deletion) because the Swift-touched gate
+  triggered — returned clean, as expected.
+- **One improvement:** the DocC-warning false-failure is patched at the prompt
+  level, but the deeper fix is to give the Haiku build subagents an **unambiguous**
+  pass/fail signal instead of asking them to interpret xcsift's toon fields — e.g.
+  have the `make build*/test*` targets append the real exit code to the log
+  (`echo "EXIT=$?"`) so the subagent parses one authoritative line. Worth a
+  follow-up if the toon-interpretation ambiguity bites again.
+- **Housekeeping:** this file is ~2 cycles over its ~12-entry window (archive-distil
+  of the 2026-06-18 cluster was deferred in #368 too) — an archive pass is overdue
+  next cycle.
+
 ## 2026-06-30 — 🔧 Harden & extend the /deliver pipeline (audit P1–P5) (#368) · lite
 
 - **Phases / skills:** phases 0–6; `pr, watch-pr`. Skipped `/review-plan` (the

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -144,6 +144,17 @@ members). Every time, `swift build` / `make build-tests` reported **0 errors /
   format); CI builds use `xcsift -f github-actions` (GitHub annotations).
 - Build targets pass `--Werror` (warnings-as-errors) and `2>&1` (compiler
   diagnostics are emitted on stderr). **Linux/Docker targets do not use xcsift.**
+- **The `.docc` "unhandled file" warning is a false alarm — trust the exit code,
+  not the toon `errors[]` array.** `swift build`/`make build-tests` emit
+  `'<pkg>': found 1 file(s) which are unhandled … Sources/TMDb/TMDb.docc` (and the
+  `TMDbTesting.docc` twin) because the DocC plugin only loads under
+  `SWIFTCI_DOCC=1` (see `Package.swift`), so outside a docs build SwiftPM sees the
+  catalogs as unhandled. It is a **package-load warning, not a compile error**, so
+  `--Werror` does **not** promote it and the build **exits 0** ("Build complete!").
+  But xcsift's `-f toon` output lists it under `errors[…]{file,line,message}` with
+  `null,null` coordinates, so a Haiku `/build-for-testing` subagent that keys off
+  that array (instead of the exit status) will wrongly report the build as
+  **failed**. Re-check the actual exit code before believing it.
 
 ### The `xcode-tools` MCP only exists inside Xcode
 

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,27 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-07-02 — Haiku build/test subagents misread xcsift toon `errors[]` as failure (#374) · applied
+
+- **Pattern:** the DocC `.docc` "unhandled file" package-load warning lands in
+  xcsift's toon `errors[]` array (with `null,null` coordinates) and makes it print
+  `status: failed`, even though `swift build`/`swift test` **exit 0** (the DocC
+  plugin only loads under `SWIFTCI_DOCC=1`). During the #374 delivery a Haiku
+  `/build-for-testing` subagent keyed off that array and reported the build
+  **failed** — a false negative that cost a diagnostic cycle. First occurrence,
+  surfaced and fixed the same run at the user's direct request (not via the
+  recurring-pattern scan).
+- **Decision:** **applied** — added a "trust the exit status, not xcsift's toon
+  summary / `status:` field" caveat to all four build/test skill prompts
+  (`/build`, `/build-for-testing`, `/test`, `/integration-test`) in #374, naming
+  the benign `.docc` unhandled-file entry explicitly. Root cause also captured as a
+  gotcha (`knowledge/gotchas.md`, same PR).
+- **Rationale:** the prompts already said "check the exit status" but never warned
+  that xcsift's structured error list can carry a benign package-load warning, so
+  the agent trusted the list over the exit code. Naming the specific false-alarm
+  removes the ambiguity without weakening real-failure detection.
+- **Reconsider when:** n/a (applied).
+
 ### 2026-06-30 — Ledger fragility recurred (#364, #368): re-create it inside the worktree · applied
 
 - **Pattern:** the `TaskCreate` phase ledger (Contract §6) is CWD-scoped and is


### PR DESCRIPTION
## Summary

Independently-verified fixes for the "claims vs reality" gaps surfaced by two external reviews (Fable + Codex). This is **Tier 1** of a verified review worklist — the low-risk honesty/docs batch. Every claim was re-checked against the actual codebase (an 18-agent read-only verification pass) before acting; several reviewer claims were softened where they overstated (see notes below).

Docs/config/test-util only — **no production source or public-API change**.

## Changes

**Documentation:**
- 📝 **CHANGELOG**: the sole heading was `[18.0.0] - Unreleased` while `18.0.0`, `18.0.1`, and `18.1.0` are all tagged. Dated the `18.0.0` section (2026-06-10) and added `18.0.1` (2026-06-11) and `18.1.0` (2026-06-18) sections, reconstructed from git history between the tags, with matching link references.
- 📝 **README + `.github/CODE_REVIEW.md`**: removed the **Windows** platform claim (badge, cross-platform list, requirements, caching note) — it was advertised but no CI job builds Windows. **Linux stays** — it *is* built and verified in CI.
- 📝 **CLAUDE.md**: corrected the language-model tool count from **seven → eight** and added `movieCredits` (shipped in #357) to the enumerated list. (DocC and README already listed all eight.)

**Configuration:**
- 🔧 **Makefile**: aligned the local Docker image `swift:6.0.3-jammy` → `swift:6.1-jammy` so the local Linux build matches CI's authoritative merge gate.

**Test utility:**
- 🔥 Removed the dead commented-out `session()` cache from `TMDbSessionHelper`, plus its now-unused `sessionCache` property and `CacheEntry` enum (verified unreferenced elsewhere).

**Tooling (build/test skills):**
- 🔧 The `.docc` "unhandled file" package-load warning lands in xcsift's toon `errors[]` array and flips its `status:` field to `failed` even though `swift build`/`swift test` exit 0 — a Haiku `/build-for-testing` subagent misread this as a build failure during this very delivery. Added a "trust the exit status, not xcsift's toon summary" caveat (naming the benign `.docc` entry) to all four build/test skill prompts (`/build`, `/build-for-testing`, `/test`, `/integration-test`), plus a `knowledge/gotchas.md` entry, the Phase 6 retro, and a skill-improvement-log record. *(Bundled here because its diagnosing gotcha was already committed in this PR.)*

## Benefits

- **Trust**: the README, CHANGELOG, and CLAUDE.md now match what CI actually verifies and what the code actually ships.
- **Reproducibility**: local Linux builds now use the same Swift toolchain as CI.
- **Hygiene**: dead code removed; a real tooling gotcha recorded and fixed at the source.

## Notes on reviewer accuracy (verified)

- "Windows" claim: confirmed advertised-but-unbuilt. Chose to soften the docs (Option A) rather than add a Windows CI job (tracked as possible follow-up).
- CHANGELOG dates cross-checked against the actual git tags; the `18.1.0`/`18.0.1` bullets were reconstructed from library-facing commits only (dev-tooling/process commits excluded).

## Review status

- Code review (`.github/CODE_REVIEW.md`): **Ready to merge, zero findings**.
- Security review: **no vulnerabilities** (docs + version string + dead-code deletion; no attack surface).
- Local `make ci`: green — 2838 unit + 289 integration tests, release build, docs build. (The build/test skill fix + retro are markdown-only, added after the gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)