### PR TITLE
🐛 Align NL-search FoundationModels availability to the watchOS 27 floor

### DIFF
--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/FoundationModelsSearchPlanGenerator.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/FoundationModelsSearchPlanGenerator.swift
@@ -15,7 +15,7 @@
     /// A fresh ``LanguageModelSession`` is created for each request, so the session
     /// never needs to be stored or shared across isolation boundaries.
     ///
-    @available(iOS 26, macOS 26, visionOS 26, *)
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
     struct FoundationModelsSearchPlanGenerator: SearchPlanGenerating {
 
         private let model: SystemLanguageModel
@@ -76,7 +76,7 @@
 
     }
 
-    @available(iOS 26, macOS 26, visionOS 26, *)
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
     extension FoundationModelsSearchPlanGenerator {
 
         // swiftlint:disable:next function_body_length

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/GeneratedSearchPlan.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/GeneratedSearchPlan.swift
@@ -16,7 +16,7 @@
     /// It is mapped to the un-gated ``SearchPlan`` immediately, keeping
     /// Foundation Models out of the rest of the feature.
     ///
-    @available(iOS 26, macOS 26, visionOS 26, *)
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
     @Generable
     struct GeneratedSearchPlan {
 
@@ -74,25 +74,25 @@
 
     }
 
-    @available(iOS 26, macOS 26, visionOS 26, *)
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
     @Generable
     enum GeneratedIntent {
         case find, browse, filmography, castOf, crewRole, similar, list, mood
     }
 
-    @available(iOS 26, macOS 26, visionOS 26, *)
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
     @Generable
     enum GeneratedMediaType {
         case movie, tv, person
     }
 
-    @available(iOS 26, macOS 26, visionOS 26, *)
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
     @Generable
     enum GeneratedListKind {
         case trending, popular, topRated, nowPlaying, upcoming, airingToday
     }
 
-    @available(iOS 26, macOS 26, visionOS 26, *)
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
     @Generable
     enum GeneratedDatePhrase {
         case thisYear, recent, lastFiveYears, lastTenYears

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanMapper.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanMapper.swift
@@ -14,7 +14,7 @@
     /// The mapping is pure and deterministic, so it can be unit tested without the
     /// model.
     ///
-    @available(iOS 26, macOS 26, visionOS 26, *)
+    @available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)
     enum SearchPlanMapper {
 
         static func map(_ generated: GeneratedSearchPlan) -> SearchPlan {

--- a/Sources/TMDb/TMDbClient.swift
+++ b/Sources/TMDb/TMDbClient.swift
@@ -303,7 +303,7 @@ public final class TMDbClient: Sendable {
             // capable OS versions. The NaturalLanguage planner is always the default.
             var fallback: (any SearchPlanGenerating)?
             #if canImport(FoundationModels)
-                if #available(iOS 26, macOS 26, visionOS 26, *) {
+                if #available(iOS 26, macOS 26, visionOS 26, watchOS 27, *) {
                     fallback = FoundationModelsSearchPlanGenerator()
                 }
             #endif

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/SearchPlanMapperTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/SearchPlanMapperTests.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2026 Adam Young.
 //
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && os(macOS)
     import Foundation
     import Testing
     @testable import TMDb

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/TMDbClientNaturalLanguageSearchTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/TMDbClientNaturalLanguageSearchTests.swift
@@ -1,0 +1,26 @@
+//
+//  TMDbClientNaturalLanguageSearchTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(NaturalLanguage)
+    import Foundation
+    import Testing
+    @testable import TMDb
+
+    @Suite(.tags(.naturalLanguageSearch))
+    struct TMDbClientNaturalLanguageSearchTests {
+
+        private let client = TMDbClient(apiKey: "test-api-key")
+
+        @Test("naturalLanguageSearch constructs an available service")
+        func naturalLanguageSearchConstructsAvailableService() {
+            // Exercises the full property graph — including the availability-gated
+            // Foundation Models fallback wiring — so the accessor stays covered.
+            #expect(client.naturalLanguageSearch.availability == .available)
+        }
+
+    }
+#endif

--- a/Tests/TMDbTests/TestUtils/Tags.swift
+++ b/Tests/TMDbTests/TestUtils/Tags.swift
@@ -49,5 +49,6 @@ extension Tag {
     @Tag static var watchProvider: Self
     @Tag static var changes: Self
     @Tag static var languageModelTools: Self
+    @Tag static var naturalLanguageSearch: Self
 
 }

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -169,6 +169,26 @@ members). Every time, `swift build` / `make build-tests` reported **0 errors /
 - There is **no `GetBuildLog` tool** — for build-error detail inside Xcode use
   `mcp__xcode-tools__XcodeRefreshCodeIssuesInFile` on the flagged file(s).
 
+### FoundationModels can't build for watchOS under Xcode 27 beta 2 (CoreImage)
+
+- Building the package for a **watchOS** destination
+  (`xcodebuild -scheme TMDb -destination 'generic/platform=watchOS Simulator'`)
+  fails during module resolution:
+  `error: Unable to resolve module dependency: 'CoreImage'` inside the watchOS
+  SDK's own `FoundationModels.swiftinterface`. It is an **SDK/toolchain bug**
+  (Xcode 27.0 beta 2 / watchOS 27 beta), not a problem in this code — it fires for
+  **any** `import FoundationModels` on watchOS, including the existing
+  `LanguageModelTools`.
+- Consequence: you **cannot build- or availability-verify** watchOS-gated
+  FoundationModels code locally yet. The error aborts before type-checking, so it
+  even **masks** genuine `@available` violations (a watchOS availability bug and a
+  clean build look identical — both fail on CoreImage). Verify such changes by
+  reasoning + Apple's documented availability instead, and note the gap.
+- Apple **does** document `SystemLanguageModel` / `LanguageModelSession` as
+  `watchOS 27.0+ (Beta)`, so `watchOS 27` is the correct availability floor; the
+  build failure is transient beta breakage, expected to clear in a later toolchain.
+- `make ci` is unaffected — it builds the macOS host only, never watchOS.
+
 ## Testing
 
 ### Model-decode equality tests: build the expected value directly, not from an over-populated mock


### PR DESCRIPTION
## Summary

Fixes a latent **watchOS availability violation** in the on-device NaturalLanguageSearch feature (finding **F8** from the external-review worklist — Tier 2, shipped on its own).

The FoundationModels-backed planner gated its **9** availability sites at `iOS 26, macOS 26, visionOS 26, *` — **omitting watchOS**. With `*` and no explicit watchOS, the guard resolved to the package deployment floor (**watchOS 9**), while the code constructs `SystemLanguageModel` / `LanguageModelSession`, which Apple documents as **`watchOS 27.0+`**. So on watchOS the availability contract was wrong, and it disagreed with:

- the sibling **`LanguageModelTools`**, already gated at `watchOS 27` (16 sites), and
- the **DocC / README** contract, which already states `watchOS 27`.

## Changes

**Production (`♻️` availability):**
- Widened all 9 sites to `iOS 26, macOS 26, visionOS 26, watchOS 27, *`:
  - `TMDbClient.swift` (the `#available` fallback guard)
  - `FoundationModelsSearchPlanGenerator.swift` (×2)
  - `GeneratedSearchPlan.swift` (×5)
  - `SearchPlanMapper.swift` (×1)
- The two package-floor annotations on the **NLTagger** path (`LiveNaturalLanguageSearchDataSource`, `PersonNameExtracting`) are correctly left at `watchOS 9` — they don't touch FoundationModels.

**Tests (`✅`):**
- Guarded `SearchPlanMapperTests` with `#if canImport(FoundationModels) && os(macOS)`, matching its **11 sibling** FoundationModels test files. Without it, the test's `@available` annotations (still `visionOS 26, *`) would mismatch the now-`watchOS 27` source types on a watchOS test compile.

**Docs (`📝`):**
- Captured a `knowledge/gotchas.md` entry: FoundationModels can't build for watchOS under Xcode 27 beta 2 (an SDK-level `CoreImage` resolution bug).

## Why this is safe

- **Purely additive** to each `@available` list — the iOS/macOS/visionOS floors are unchanged, and Linux/tvOS are excluded by `#if canImport(FoundationModels)`. It only tightens watchOS from the erroneous package floor to the true `27`.
- The `#available` call site and the `@available` on the type it constructs are now identical, so the constructor can never be reached on a version where the type is unavailable.

## Verification

- ✅ `make ci` green — 2838 unit + 289 integration tests, release build, docs build.
- ✅ Floor confirmed against **Apple's documented** `SystemLanguageModel` availability (`watchOS 27.0+`).
- ⚠️ A full **watchOS build** can't verify this locally: the Xcode 27 beta 2 watchOS SDK's `FoundationModels.swiftinterface` fails to resolve `CoreImage`, aborting before the availability check (affects *any* FoundationModels use on watchOS, not this change). Fix rests on Apple's documented availability + sibling/DocC consistency; a watchOS CI destination is a sensible future follow-up once the SDK bug clears.

## Review status

- Code review (`.github/CODE_REVIEW.md`): 0 Critical / 0 High; 1 Medium (the test-guard mismatch this diff created) — **fixed** in this PR.
- Security review: no attack surface (availability metadata + a test-compilation guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)