### PR TITLE
✨ Route confidently non-English NL-search prompts to the multilingual fallback

### DIFF
--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchPlanGenerator.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchPlanGenerator.swift
@@ -21,13 +21,26 @@ struct NaturalLanguageSearchPlanGenerator: DeterministicSearchPlanning {
 
     private let classifier: any IntentClassifying
     private let personExtractor: any PersonNameExtracting
+    private let languageDetector: any PromptLanguageDetecting
 
-    init(classifier: some IntentClassifying, personExtractor: some PersonNameExtracting) {
+    init(
+        classifier: some IntentClassifying,
+        personExtractor: some PersonNameExtracting,
+        languageDetector: some PromptLanguageDetecting
+    ) {
         self.classifier = classifier
         self.personExtractor = personExtractor
+        self.languageDetector = languageDetector
     }
 
     func confidentPlan(for prompt: String) -> SearchPlan? {
+        // The classifier and lexicon are English-only. A confidently non-English
+        // prompt would be mis-parsed and silently emitted as a literal `find`, so
+        // abstain and let the multilingual fallback (or a plain search) handle it.
+        guard !languageDetector.isConfidentlyNonEnglish(prompt) else {
+            return nil
+        }
+
         let normalized = SearchPlanLexicon.normalize(prompt)
         guard let intent = classifier.classify(normalized) else {
             return nil

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/PromptLanguageDetecting.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/PromptLanguageDetecting.swift
@@ -1,0 +1,85 @@
+//
+//  PromptLanguageDetecting.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// Detects whether a prompt is written in a language the deterministic planner
+/// cannot interpret.
+///
+/// The rule-based planner and its lexicon are English-only, so a confidently
+/// non-English prompt should not be forced through them (it would be
+/// mis-parsed and silently emitted as a literal `find`). Instead the planner
+/// abstains, letting the language-model fallback — which is multilingual — take
+/// over, or, failing that, run a plain text search.
+///
+protocol PromptLanguageDetecting: Sendable {
+
+    ///
+    /// Whether the prompt is confidently in a language other than English.
+    ///
+    /// Implementations should be conservative: short prompts (typically bare,
+    /// often foreign, titles such as `"Amélie"`) must not be judged non-English,
+    /// since they are legitimate `find` queries and language detection is
+    /// unreliable on little text.
+    ///
+    /// - Parameter prompt: The natural-language prompt.
+    ///
+    /// - Returns: `true` only when the dominant language is confidently not
+    ///   English; `false` when English, undetermined, or too short to judge.
+    ///
+    func isConfidentlyNonEnglish(_ prompt: String) -> Bool
+
+}
+
+#if canImport(NaturalLanguage)
+    import NaturalLanguage
+
+    ///
+    /// A ``PromptLanguageDetecting`` backed by `NLLanguageRecognizer`.
+    ///
+    /// A fresh `NLLanguageRecognizer` is created per call (it is stateful and not
+    /// `Sendable`), keeping this type a safe `Sendable` value.
+    ///
+    @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+    struct NLLanguageRecognizerPromptDetector: PromptLanguageDetecting {
+
+        /// Prompts with fewer words than this are never judged non-English: they
+        /// are usually bare titles (often foreign) that must stay valid `find`
+        /// queries, and `NLLanguageRecognizer` is unreliable on very short text.
+        private let minimumWordCount: Int
+
+        /// The minimum dominant-language probability required to abstain, so only
+        /// a confident non-English reading routes away from the English planner.
+        private let minimumConfidence: Double
+
+        init(minimumWordCount: Int = 3, minimumConfidence: Double = 0.85) {
+            self.minimumWordCount = minimumWordCount
+            self.minimumConfidence = minimumConfidence
+        }
+
+        func isConfidentlyNonEnglish(_ prompt: String) -> Bool {
+            let wordCount = prompt.split(whereSeparator: \.isWhitespace).count
+            guard wordCount >= minimumWordCount else {
+                return false
+            }
+
+            let recognizer = NLLanguageRecognizer()
+            recognizer.processString(prompt)
+
+            guard let (language, confidence) = recognizer
+                .languageHypotheses(withMaximum: 1)
+                .max(by: { $0.value < $1.value })
+            else {
+                return false
+            }
+
+            return language != .english && confidence >= minimumConfidence
+        }
+
+    }
+#endif

--- a/Sources/TMDb/TMDbClient.swift
+++ b/Sources/TMDb/TMDbClient.swift
@@ -296,7 +296,8 @@ public final class TMDbClient: Sendable {
 
             let deterministic = NaturalLanguageSearchPlanGenerator(
                 classifier: RuleBasedIntentClassifier(),
-                personExtractor: NLTaggerPersonNameExtractor()
+                personExtractor: NLTaggerPersonNameExtractor(),
+                languageDetector: NLLanguageRecognizerPromptDetector()
             )
 
             // Foundation Models is an optional fallback for the fuzzy tail, only on

--- a/Tests/TMDbIntegrationTests/NaturalLanguageSearchEndToEndIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/NaturalLanguageSearchEndToEndIntegrationTests.swift
@@ -76,5 +76,17 @@
             #expect(!result.movies.isEmpty)
         }
 
+        @Test("a non-English prompt degrades gracefully instead of throwing")
+        func nonEnglishPrompt() async throws {
+            // CI runners have no Apple Intelligence, so the multilingual language-model
+            // fallback is unavailable. A confidently non-English prompt must therefore
+            // abstain to a plain literal search — not be mis-parsed by the English
+            // planner, and not throw `.unsupportedLanguage`. (The FM-backed multilingual
+            // interpretation only runs on capable devices, which CI cannot exercise.)
+            await #expect(throws: Never.self) {
+                _ = try await search.search(matching: "films policiers français des années quatre-vingt-dix")
+            }
+        }
+
     }
 #endif

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/Mocks/NaturalLanguagePlannerMocks.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/Mocks/NaturalLanguagePlannerMocks.swift
@@ -15,6 +15,15 @@ final class MockPersonNameExtractor: PersonNameExtracting, @unchecked Sendable {
     }
 }
 
+final class MockPromptLanguageDetector: PromptLanguageDetecting, @unchecked Sendable {
+    var isNonEnglish = false
+    private(set) var calls: [String] = []
+    func isConfidentlyNonEnglish(_ prompt: String) -> Bool {
+        calls.append(prompt)
+        return isNonEnglish
+    }
+}
+
 final class MockIntentClassifier: IntentClassifying, @unchecked Sendable {
     var intent: SearchPlan.Intent?
     func classify(_ prompt: String) -> SearchPlan.Intent? {

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/NLLanguageRecognizerPromptDetectorTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/NLLanguageRecognizerPromptDetectorTests.swift
@@ -1,0 +1,55 @@
+//
+//  NLLanguageRecognizerPromptDetectorTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+#if canImport(NaturalLanguage)
+    import Foundation
+    import Testing
+    @testable import TMDb
+
+    ///
+    /// Coverage for the production language detector. `NLLanguageRecognizer` is a
+    /// built-in identifier (no downloadable model), so these assertions run
+    /// directly on the host rather than under `withKnownIssue`.
+    ///
+    @Suite("NLLanguageRecognizerPromptDetector")
+    struct NLLanguageRecognizerPromptDetectorTests {
+
+        private let detector = NLLanguageRecognizerPromptDetector()
+
+        @Test("flags a clearly non-English sentence")
+        func flagsNonEnglish() {
+            #expect(detector.isConfidentlyNonEnglish("un film policier français avec une intrigue captivante"))
+        }
+
+        @Test("does not flag a clearly English sentence")
+        func allowsEnglish() {
+            #expect(!detector.isConfidentlyNonEnglish("a gripping crime movie with a great cast"))
+        }
+
+        @Test("does not flag a short, possibly foreign, title")
+        func allowsShortTitle() {
+            // Bare titles are legitimate `find` queries and are too short to judge.
+            #expect(!detector.isConfidentlyNonEnglish("Amélie"))
+            #expect(!detector.isConfidentlyNonEnglish("La Haine"))
+        }
+
+        @Test("does not flag an empty or whitespace-only prompt")
+        func allowsEmpty() {
+            #expect(!detector.isConfidentlyNonEnglish(""))
+            #expect(!detector.isConfidentlyNonEnglish("   "))
+        }
+
+        @Test("respects the confidence threshold")
+        func respectsConfidenceThreshold() {
+            // An unreachable confidence bar means even a clearly non-English
+            // sentence is not flagged — exercising the confidence gate directly.
+            let strict = NLLanguageRecognizerPromptDetector(minimumConfidence: 1.0)
+            #expect(!strict.isConfidentlyNonEnglish("un film policier français avec une intrigue captivante"))
+        }
+
+    }
+#endif

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchPlanGeneratorTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/NaturalLanguageSearchPlanGeneratorTests.swift
@@ -13,11 +13,13 @@ import Testing
 struct NaturalLanguageSearchPlanGeneratorTests {
 
     private let people = MockPersonNameExtractor()
+    private let language = MockPromptLanguageDetector()
 
     private func make() -> NaturalLanguageSearchPlanGenerator {
         NaturalLanguageSearchPlanGenerator(
             classifier: RuleBasedIntentClassifier(),
-            personExtractor: people
+            personExtractor: people,
+            languageDetector: language
         )
     }
 
@@ -28,6 +30,21 @@ struct NaturalLanguageSearchPlanGeneratorTests {
         #expect(plan?.title == "Fight Club")
         #expect(plan?.people.isEmpty == true)
         #expect(plan?.isInScope == true)
+    }
+
+    @Test("abstains on a confidently non-English prompt")
+    func nonEnglishPromptAbstains() {
+        language.isNonEnglish = true
+        // Without the language gate this would classify as a literal `find`.
+        let plan = make().confidentPlan(for: "un bon film avec de grands acteurs")
+        #expect(plan == nil)
+        #expect(language.calls == ["un bon film avec de grands acteurs"])
+    }
+
+    @Test("does not abstain when the prompt is English")
+    func englishPromptDoesNotAbstain() {
+        language.isNonEnglish = false
+        #expect(make().confidentPlan(for: "trending shows")?.intent == .list)
     }
 
     @Test("list extracts kind and media type")


### PR DESCRIPTION
## Summary

Fixes the **silently English-only** deterministic planner in on-device NaturalLanguageSearch (finding **F7** — Tier 2).

The rule-based classifier and its lexicon are English-only, but the classifier returns `.find` as a last resort. So a **non-English prompt** (e.g. a French sentence) was forced through the English planner, emitted as a **literal `.find`**, and returned as the *confident* plan — which **pre-empts** the multilingual Foundation Models fallback in `GatedSearchPlanGenerator` and never surfaces the existing `.unsupportedLanguage` signal. A French query just ran a degenerate literal text search with no degradation.

## Approach

Add a `PromptLanguageDetecting` seam (backed by `NLLanguageRecognizer`), mirroring the existing `PersonNameExtracting` / `NLTaggerPersonNameExtractor` family, and gate `confidentPlan`:

```
confidentPlan(prompt):
    if languageDetector.isConfidentlyNonEnglish(prompt) { return nil }   // abstain
    … existing classify/extract …
```

Abstaining routes the prompt through `GatedSearchPlanGenerator` to:
- the **FM fallback** where available (multilingual — interprets it, or reports `.unsupportedLanguage`), or
- a **plain literal search** where FM is unavailable.

## Why it's low-risk

- **Conservative detection.** Only a **confidently** non-English reading abstains: a `minimumConfidence` gate (0.85) **and** a `minimumWordCount` (3) short-string guard. Bare titles — usually short, often foreign (`"Amélie"`, `"La Haine"`) — are **never** judged non-English, so foreign-title `.find` queries keep working.
- **Never a hard throw** from this code — abstain only.
- **No behaviour change on non-FM devices.** Without FM, an abstained prompt falls through to `SearchPlan(intent: .find, title: prompt)` — byte-identical to the previous literal `.find`. Only FM-capable devices gain the multilingual path.
- **All new types are internal** — no public API surface, no DocC/README change.

## Changes

- `PromptLanguageDetecting.swift` (new) — `Sendable` protocol + `#if canImport(NaturalLanguage)` `NLLanguageRecognizerPromptDetector` (fresh recognizer per call, documented thresholds).
- `NaturalLanguageSearchPlanGenerator` — inject the detector; abstain gate at the top of `confidentPlan`.
- `TMDbClient` — wire the real detector alongside the sibling NL types.

## Tests

- **Unit:** the planner abstains via a mock detector (and passes the raw prompt); the real `NLLanguageRecognizer` detector flags French, allows English, ignores short/empty prompts, and respects the confidence threshold.
- **Integration:** a non-English prompt **degrades gracefully** (`#expect(throws: Never.self)`) end-to-end against the live API — robust on CI (no Apple Intelligence → literal-search path).
- ✅ `make ci` green — **2845** unit + **290** integration tests, release build, docs build.

## Review status

- Code review (`.github/CODE_REVIEW.md`): **0 Critical / High / Medium**. Two advisory Lows: an acknowledged, narrow, acceptable tradeoff for *long* foreign titles on FM-capable devices (they route to FM, which maps a bare title to `.find`; only an FM-unsupported language surfaces `.unsupportedLanguage` — the intended signal); and a confidence-threshold branch — **test added** in this PR.
- Security: no new attack surface (read-only language identification; input validation at the public boundary unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)