### PR TITLE
✨ Add v4 bearer-token authentication (TMDbClient(bearerToken:))

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,14 @@ let movie = try await movieService.details(forMovie: 550)
 Create an API key from The Movie Database web site
 [https://www.themoviedb.org/documentation/api](https://www.themoviedb.org/documentation/api).
 
+Alternatively, use the v4 **API Read Access Token** from the same settings
+page. It is sent as an `Authorization: Bearer` header rather than in the URL,
+keeping the credential out of logs, proxies, and cache keys:
+
+```swift
+let tmdbClient = TMDbClient(bearerToken: "<your-access-token>")
+```
+
 ### Quick Start
 
 ```swift

--- a/Sources/TMDb/Networking/APICredential.swift
+++ b/Sources/TMDb/Networking/APICredential.swift
@@ -1,0 +1,27 @@
+//
+//  APICredential.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// The credential a ``TMDbClient`` uses to authenticate API requests.
+///
+/// TMDb accepts either a v3 API key (as a query item) or a v4 access token (as
+/// an `Authorization: Bearer` header) on its v3 endpoints. This internal type
+/// lets the client carry either while the request-building logic stays in one
+/// place.
+///
+enum APICredential: Equatable {
+
+    /// A TMDb v3 API key, sent as the `api_key` query item on every request.
+    case apiKey(String)
+
+    /// A TMDb v4 access token, sent as an `Authorization: Bearer` header,
+    /// keeping the credential out of the request URL.
+    case bearerToken(String)
+
+}

--- a/Sources/TMDb/Networking/TMDbAPIClient.swift
+++ b/Sources/TMDb/Networking/TMDbAPIClient.swift
@@ -13,18 +13,18 @@ import Foundation
 
 final class TMDbAPIClient: UnmappedAPIClient {
 
-    private let apiKey: String
+    private let credential: APICredential
     private let baseURL: URL
     private let serialiser: any Serialiser
     private let httpClient: any HTTPClient
 
     init(
-        apiKey: String,
+        credential: APICredential,
         baseURL: URL,
         serialiser: some Serialiser,
         httpClient: some HTTPClient
     ) {
-        self.apiKey = apiKey
+        self.credential = credential
         self.baseURL = baseURL
         self.serialiser = serialiser
         self.httpClient = httpClient
@@ -66,13 +66,19 @@ extension TMDbAPIClient {
         }
 
         var queryItems = request.queryItems
-        queryItems["api_key"] = apiKey
+        var headers = request.headers
+
+        switch credential {
+        case .apiKey(let apiKey):
+            queryItems["api_key"] = apiKey
+        case .bearerToken(let token):
+            headers["Authorization"] = "Bearer \(token)"
+        }
 
         let url = urlFromPath(path, queryItems: queryItems)
 
         let method = Self.method(from: request.method)
 
-        var headers = request.headers
         headers["Accept"] = serialiser.mimeType
 
         var data: Data?

--- a/Sources/TMDb/TMDb.docc/Extensions/TMDbClient.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/TMDbClient.md
@@ -6,6 +6,8 @@
 
 - ``init(apiKey:configuration:)``
 - ``init(apiKey:httpClient:configuration:)``
+- ``init(bearerToken:configuration:)``
+- ``init(bearerToken:httpClient:configuration:)``
 
 ### Configuration
 

--- a/Sources/TMDb/TMDbClient.swift
+++ b/Sources/TMDb/TMDbClient.swift
@@ -211,7 +211,58 @@ public final class TMDbClient: Sendable {
         configuration: TMDbConfiguration = .system
     ) {
         let dependencies = TMDbFactory.makeServiceDependencies(
-            apiKey: apiKey,
+            credential: .apiKey(apiKey),
+            httpClient: httpClient,
+            configuration: configuration
+        )
+
+        self.init(dependencies: dependencies, configuration: configuration)
+    }
+
+    ///
+    /// Creates a TMDb client authenticated with a v4 access token, using
+    /// `URLSession` as the `HTTPClient`.
+    ///
+    /// The token is sent as an `Authorization: Bearer` header rather than an
+    /// `api_key` query item, keeping the credential out of request URLs (and
+    /// therefore out of logs, proxies, and cache keys). Use the **API Read
+    /// Access Token** from your TMDb account's API settings.
+    ///
+    /// - Parameters:
+    ///   - bearerToken: The TMDb v4 access token to authenticate requests with.
+    ///   - configuration: The configuration for the client. Defaults to ``TMDbConfiguration/system``.
+    ///
+    public convenience init(
+        bearerToken: String,
+        configuration: TMDbConfiguration = .system
+    ) {
+        self.init(
+            bearerToken: bearerToken,
+            httpClient: TMDbFactory.defaultHTTPClientAdapter(),
+            configuration: configuration
+        )
+    }
+
+    ///
+    /// Creates a TMDb client authenticated with a v4 access token.
+    ///
+    /// The token is sent as an `Authorization: Bearer` header rather than an
+    /// `api_key` query item, keeping the credential out of request URLs (and
+    /// therefore out of logs, proxies, and cache keys). Use the **API Read
+    /// Access Token** from your TMDb account's API settings.
+    ///
+    /// - Parameters:
+    ///   - bearerToken: The TMDb v4 access token to authenticate requests with.
+    ///   - httpClient: A custom HTTP client adapter for making HTTP requests.
+    ///   - configuration: The configuration for the client. Defaults to ``TMDbConfiguration/system``.
+    ///
+    public convenience init(
+        bearerToken: String,
+        httpClient: some HTTPClient,
+        configuration: TMDbConfiguration = .system
+    ) {
+        let dependencies = TMDbFactory.makeServiceDependencies(
+            credential: .bearerToken(bearerToken),
             httpClient: httpClient,
             configuration: configuration
         )

--- a/Sources/TMDb/TMDbFactory.swift
+++ b/Sources/TMDb/TMDbFactory.swift
@@ -23,10 +23,10 @@ final class TMDbFactory {
 
 extension TMDbFactory {
 
-    static func apiClient(apiKey: String, httpClient: some HTTPClient) -> some APIClient {
+    static func apiClient(credential: APICredential, httpClient: some HTTPClient) -> some APIClient {
         ErrorMappingAPIClient(
             apiClient: TMDbAPIClient(
-                apiKey: apiKey,
+                credential: credential,
                 baseURL: tmdbAPIBaseURL,
                 serialiser: serialiser(),
                 httpClient: httpClient
@@ -34,10 +34,10 @@ extension TMDbFactory {
         )
     }
 
-    static func authAPIClient(apiKey: String, httpClient: some HTTPClient) -> some APIClient {
+    static func authAPIClient(credential: APICredential, httpClient: some HTTPClient) -> some APIClient {
         ErrorMappingAPIClient(
             apiClient: TMDbAPIClient(
-                apiKey: apiKey,
+                credential: credential,
                 baseURL: .tmdbAPIBase,
                 serialiser: authSerialiser(),
                 httpClient: httpClient
@@ -50,7 +50,7 @@ extension TMDbFactory {
     }
 
     static func makeServiceDependencies(
-        apiKey: String,
+        credential: APICredential,
         httpClient: some HTTPClient,
         configuration: TMDbConfiguration
     ) -> TMDbServiceDependencies {
@@ -61,8 +61,8 @@ extension TMDbFactory {
         )
 
         return TMDbServiceDependencies(
-            apiClient: apiClient(apiKey: apiKey, httpClient: wrappedHTTPClient),
-            authAPIClient: authAPIClient(apiKey: apiKey, httpClient: wrappedHTTPClient),
+            apiClient: apiClient(credential: credential, httpClient: wrappedHTTPClient),
+            authAPIClient: authAPIClient(credential: credential, httpClient: wrappedHTTPClient),
             authenticateURLBuilder: authenticateURLBuilder()
         )
     }

--- a/Tests/TMDbIntegrationTests/BearerTokenAuthIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/BearerTokenAuthIntegrationTests.swift
@@ -1,0 +1,41 @@
+//
+//  BearerTokenAuthIntegrationTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+///
+/// Verifies that a client configured with a v4 access token authenticates live
+/// v3 requests via the `Authorization: Bearer` header.
+///
+/// Gated on `TMDB_ACCESS_TOKEN` (a TMDb API Read Access Token). It is skipped
+/// when that variable is absent — including on CI, which provides only the v3
+/// `TMDB_API_KEY` — so it runs only where a v4 token is supplied. The header vs
+/// query-item behaviour itself is fully covered by `TMDbAPIClientCredentialTests`.
+///
+@Suite(
+    .integrationGate,
+    .serialized,
+    .tags(.authentication),
+    .enabled(if: CredentialHelper.shared.hasAccessToken)
+)
+struct BearerTokenAuthIntegrationTests {
+
+    @Test("a bearer-token client authenticates a v3 request")
+    func bearerTokenAuthenticatesRequest() async throws {
+        let client = TMDbClient(
+            bearerToken: CredentialHelper.shared.tmdbAccessToken,
+            configuration: TMDbConfiguration(retry: .default)
+        )
+
+        let movie = try await client.movies.details(forMovie: 550, language: nil)
+
+        #expect(movie.title.localizedCaseInsensitiveContains("Fight Club"))
+    }
+
+}

--- a/Tests/TMDbIntegrationTests/Utility/CredentialHelper.swift
+++ b/Tests/TMDbIntegrationTests/Utility/CredentialHelper.swift
@@ -14,6 +14,7 @@ final class CredentialHelper: Sendable {
 
     let tmdbCredential: Credential
     let tmdbAPIKey: String
+    let tmdbAccessToken: String
 
     var hasCredential: Bool {
         !tmdbCredential.username.isEmpty && !tmdbCredential.password.isEmpty
@@ -21,6 +22,10 @@ final class CredentialHelper: Sendable {
 
     var hasAPIKey: Bool {
         !tmdbAPIKey.isEmpty
+    }
+
+    var hasAccessToken: Bool {
+        !tmdbAccessToken.isEmpty
     }
 
     /// Returns a `TMDbClient` configured with the integration-test API key
@@ -41,6 +46,7 @@ final class CredentialHelper: Sendable {
         self.tmdbCredential = Credential(username: username, password: password)
 
         self.tmdbAPIKey = processInfo.environment["TMDB_API_KEY"] ?? ""
+        self.tmdbAccessToken = processInfo.environment["TMDB_ACCESS_TOKEN"] ?? ""
     }
 
 }

--- a/Tests/TMDbTests/Networking/TMDbAPIClientCredentialTests.swift
+++ b/Tests/TMDbTests/Networking/TMDbAPIClientCredentialTests.swift
@@ -1,0 +1,66 @@
+//
+//  TMDbAPIClientCredentialTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.networking))
+struct TMDbAPIClientCredentialTests {
+
+    var baseURL: URL!
+    var serialiser: TMDbJSONSerialiser!
+    var httpClient: HTTPMockClient!
+
+    init() async {
+        self.baseURL = URL(string: "https://some.domain.com/path")
+        self.serialiser = TMDbJSONSerialiser()
+        self.httpClient = await HTTPMockClient()
+    }
+
+    private func apiClient(credential: APICredential) -> TMDbAPIClient {
+        TMDbAPIClient(
+            credential: credential,
+            baseURL: baseURL,
+            serialiser: serialiser,
+            httpClient: httpClient
+        )
+    }
+
+    @Test("an API key credential sends api_key and no Authorization header")
+    @MainActor
+    func apiKeyCredentialSendsAPIKeyQueryItem() async throws {
+        let client = apiClient(credential: .apiKey("abc123"))
+        let stubRequest = APIStubRequest<String, String>(path: "/endpoint")
+        httpClient.result = .success(HTTPResponse())
+
+        _ = try? await client.perform(stubRequest)
+
+        let request = try #require(httpClient.lastRequest)
+        let components = try #require(URLComponents(url: request.url, resolvingAgainstBaseURL: false))
+        let apiKeyItem = components.queryItems?.first { $0.name == "api_key" }
+        #expect(apiKeyItem?.value == "abc123")
+        #expect(request.headers["Authorization"] == nil)
+    }
+
+    @Test("a bearer token credential sends an Authorization header and no api_key")
+    @MainActor
+    func bearerTokenCredentialSendsAuthorizationHeader() async throws {
+        let client = apiClient(credential: .bearerToken("v4-access-token"))
+        let stubRequest = APIStubRequest<String, String>(path: "/endpoint")
+        httpClient.result = .success(HTTPResponse())
+
+        _ = try? await client.perform(stubRequest)
+
+        let request = try #require(httpClient.lastRequest)
+        #expect(request.headers["Authorization"] == "Bearer v4-access-token")
+        let components = try #require(URLComponents(url: request.url, resolvingAgainstBaseURL: false))
+        let hasAPIKey = components.queryItems?.contains { $0.name == "api_key" } ?? false
+        #expect(hasAPIKey == false)
+    }
+
+}

--- a/Tests/TMDbTests/Networking/TMDbAPIClientTests.swift
+++ b/Tests/TMDbTests/Networking/TMDbAPIClientTests.swift
@@ -30,7 +30,7 @@ struct TMDbAPIClientTests {
         configuration.protocolClasses = [MockURLProtocol.self]
         self.httpClient = await HTTPMockClient()
         self.apiClient = TMDbAPIClient(
-            apiKey: apiKey,
+            credential: .apiKey(apiKey),
             baseURL: baseURL,
             serialiser: serialiser,
             httpClient: httpClient

--- a/Tests/TMDbTests/TMDbClientTests.swift
+++ b/Tests/TMDbTests/TMDbClientTests.swift
@@ -24,6 +24,13 @@ struct TMDbClientTests {
         #expect(client.account is TMDbAccountService)
     }
 
+    @Test("init with bearer token creates account service")
+    func initWithBearerTokenCreatesAccountService() {
+        let client = TMDbClient(bearerToken: "v4-access-token")
+
+        #expect(client.account is TMDbAccountService)
+    }
+
     @Test("init with API key creates authentication service")
     func initWithAPIKeyCreatesAuthenticationService() {
         let client = TMDbClient(apiKey: apiKey)

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -263,6 +263,22 @@ breaking; it isn't.) See [ADR-0004](decisions/0004-service-parameter-name-conven
 
 ## Networking
 
+### Bearer-token clients share one credential-free `URLCache` key space
+
+- `TMDbClient(bearerToken:)` (v4 auth) sends the token as an
+  `Authorization: Bearer` header, so — unlike `api_key` mode — the credential is
+  **not** in the request URL. That's the point (keys stay out of logs/proxies),
+  but it means the process-wide default `URLCache` (and the opt-in
+  `CacheHTTPClient`, which keys on `request.url.absoluteString`) no longer
+  partitions cache entries by credential. Two bearer clients with **different**
+  tokens in one process can therefore serve each other cache hits.
+- This is **benign today**: the affected v3 `GET` endpoints return app-level
+  public data identical across tokens, and user-specific requests carry
+  `session_id` in the URL (distinct cache keys, and `CacheHTTPClient` bypasses
+  session requests entirely). It would only matter if TMDb started returning
+  token-specific data on an otherwise-public GET — worth remembering before
+  relying on per-token cache isolation.
+
 ### `URLComponents` path round-trip in `TMDbAPIClient.urlFromPath` decodes `%2F`
 
 *2026-06-24.* `TMDbAPIClient.urlFromPath` rebuilds the request URL by reading and


### PR DESCRIPTION
## Summary

Adds v4 **bearer-token authentication** (finding **F12** — Tier 3), the security-recommended TMDb auth mode.

TMDb v3 endpoints accept **either** a v3 API key (as an `api_key` **query item**) **or** a v4 access token (as an `Authorization: Bearer` **header**). Until now the client only supported the former, baking the credential into every request URL — and therefore into logs, proxies, and in-memory cache keys.

## API (your chosen shape)

A new bearer-only initializer, mirroring the `apiKey` pair — the existing `TMDbClient(apiKey:)` is unchanged:

```swift
// existing, unchanged
let client = TMDbClient(apiKey: "<v3-api-key>")

// new
let client = TMDbClient(bearerToken: "<v4-access-token>")
// → Authorization: Bearer <token>, and NO api_key in the URL
```

## How it works

- An **internal** `APICredential` enum (`.apiKey` / `.bearerToken`) is threaded through `TMDbFactory` into `TMDbAPIClient`, which branches **once** in `buildHTTPRequest`: `.apiKey` sets the `api_key` query item; `.bearerToken` sets the `Authorization: Bearer` header. Mutually exclusive — neither path emits both.
- **No new public type** (`APICredential` is internal); the only new public surface is the two `bearerToken:` inits.

## Why it's safe

- **Purely additive / non-breaking** — the `.apiKey` branch is byte-identical to the previous behaviour; existing inits just map to `.apiKey`.
- **Security posture improves** — the bearer token never touches the URL, so it stays out of logs, proxies, and the `URLCache`/`CacheHTTPClient` key (which derive from the URL). Confirmed no logging in the networking layer.

## Tests

- **Unit** (`TMDbAPIClientCredentialTests`): the bearer credential sets `Authorization: Bearer` and omits `api_key`; the api-key credential does the reverse (both positive **and** negative assertions). `TMDbClientTests` covers the new init end-to-end through the factory.
- **Integration** (`BearerTokenAuthIntegrationTests`): authenticates a real v3 request with a bearer token — **gated on `TMDB_ACCESS_TOKEN`**, so it's skipped on CI (which has only the v3 key) and runs where a v4 token is supplied.
- ✅ `make ci` green — **2849** unit + **291** integration tests, release build, docs build. Every changed **source** line is covered by a unit test.

## Docs

- `///` on both new inits, added to the DocC catalog (`TMDbClient.md`) and the README auth section. Captured a `knowledge/gotchas.md` note on the (benign) shared-`URLCache` behaviour for bearer clients.

## Review status

- Code review (`.github/CODE_REVIEW.md`): **0 Critical / High / Medium**; two Lows fixed (a doc-comment reference; the shared-cache note).
- Security review: **no vulnerabilities** — credential routing is mutually exclusive, no injection/logging/leakage, net-positive posture.

## Note

To verify bearer auth against the **live** API, set `TMDB_ACCESS_TOKEN` (your TMDb *API Read Access Token*) in the env — otherwise that one integration test is skipped. The unit tests fully cover the client-side header/query behaviour regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)