### PR TITLE
♻️ Consolidate *AppendOption query serialisation into a shared protocol

### DIFF
--- a/Sources/TMDb/Domain/Models/AppendToResponseOption.swift
+++ b/Sources/TMDb/Domain/Models/AppendToResponseOption.swift
@@ -1,0 +1,36 @@
+//
+//  AppendToResponseOption.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// An `append_to_response` option set whose selected members serialise to the
+/// comma-separated query value TMDb expects.
+///
+/// Each conforming type supplies only its ``mapping`` (option → TMDb token);
+/// the ``queryValue`` serialisation is shared, since it is identical for every
+/// append-to-response family.
+///
+protocol AppendToResponseOption: OptionSet where Element == Self {
+
+    /// Maps each individual option to its TMDb `append_to_response` token,
+    /// in the order it should appear in the query value.
+    static var mapping: [(Self, String)] { get }
+
+}
+
+extension AppendToResponseOption {
+
+    /// The selected options as a comma-separated `append_to_response` value.
+    var queryValue: String {
+        Self.mapping
+            .filter { contains($0.0) }
+            .map(\.1)
+            .joined(separator: ",")
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/MovieAppendOption.swift
+++ b/Sources/TMDb/Domain/Models/MovieAppendOption.swift
@@ -72,9 +72,9 @@ public struct MovieAppendOption: OptionSet, Hashable, Sendable {
 
 }
 
-extension MovieAppendOption {
+extension MovieAppendOption: AppendToResponseOption {
 
-    private static let mapping: [(MovieAppendOption, String)] = [
+    static let mapping: [(MovieAppendOption, String)] = [
         (.credits, "credits"),
         (.images, "images"),
         (.videos, "videos"),
@@ -90,12 +90,5 @@ extension MovieAppendOption {
         (.lists, "lists"),
         (.changes, "changes")
     ]
-
-    var queryValue: String {
-        Self.mapping
-            .filter { contains($0.0) }
-            .map(\.1)
-            .joined(separator: ",")
-    }
 
 }

--- a/Sources/TMDb/Domain/Models/PersonAppendOption.swift
+++ b/Sources/TMDb/Domain/Models/PersonAppendOption.swift
@@ -54,9 +54,9 @@ public struct PersonAppendOption: OptionSet, Hashable, Sendable {
 
 }
 
-extension PersonAppendOption {
+extension PersonAppendOption: AppendToResponseOption {
 
-    private static let mapping: [(PersonAppendOption, String)] = [
+    static let mapping: [(PersonAppendOption, String)] = [
         (.movieCredits, "movie_credits"),
         (.tvCredits, "tv_credits"),
         (.combinedCredits, "combined_credits"),
@@ -66,12 +66,5 @@ extension PersonAppendOption {
         (.externalIDs, "external_ids"),
         (.changes, "changes")
     ]
-
-    var queryValue: String {
-        Self.mapping
-            .filter { contains($0.0) }
-            .map(\.1)
-            .joined(separator: ",")
-    }
 
 }

--- a/Sources/TMDb/Domain/Models/TVEpisodeAppendOption.swift
+++ b/Sources/TMDb/Domain/Models/TVEpisodeAppendOption.swift
@@ -48,21 +48,14 @@ public struct TVEpisodeAppendOption: OptionSet, Hashable, Sendable {
 
 }
 
-extension TVEpisodeAppendOption {
+extension TVEpisodeAppendOption: AppendToResponseOption {
 
-    private static let mapping: [(TVEpisodeAppendOption, String)] = [
+    static let mapping: [(TVEpisodeAppendOption, String)] = [
         (.credits, "credits"),
         (.images, "images"),
         (.videos, "videos"),
         (.translations, "translations"),
         (.externalIDs, "external_ids")
     ]
-
-    var queryValue: String {
-        Self.mapping
-            .filter { contains($0.0) }
-            .map(\.1)
-            .joined(separator: ",")
-    }
 
 }

--- a/Sources/TMDb/Domain/Models/TVSeasonAppendOption.swift
+++ b/Sources/TMDb/Domain/Models/TVSeasonAppendOption.swift
@@ -53,9 +53,9 @@ public struct TVSeasonAppendOption: OptionSet, Hashable, Sendable {
 
 }
 
-extension TVSeasonAppendOption {
+extension TVSeasonAppendOption: AppendToResponseOption {
 
-    private static let mapping: [(TVSeasonAppendOption, String)] = [
+    static let mapping: [(TVSeasonAppendOption, String)] = [
         (.credits, "credits"),
         (.aggregateCredits, "aggregate_credits"),
         (.images, "images"),
@@ -64,12 +64,5 @@ extension TVSeasonAppendOption {
         (.watchProviders, "watch/providers"),
         (.externalIDs, "external_ids")
     ]
-
-    var queryValue: String {
-        Self.mapping
-            .filter { contains($0.0) }
-            .map(\.1)
-            .joined(separator: ",")
-    }
 
 }

--- a/Sources/TMDb/Domain/Models/TVSeriesAppendOption.swift
+++ b/Sources/TMDb/Domain/Models/TVSeriesAppendOption.swift
@@ -82,9 +82,9 @@ public struct TVSeriesAppendOption: OptionSet, Hashable, Sendable {
 
 }
 
-extension TVSeriesAppendOption {
+extension TVSeriesAppendOption: AppendToResponseOption {
 
-    private static let mapping: [(TVSeriesAppendOption, String)] = [
+    static let mapping: [(TVSeriesAppendOption, String)] = [
         (.credits, "credits"),
         (.aggregateCredits, "aggregate_credits"),
         (.images, "images"),
@@ -103,12 +103,5 @@ extension TVSeriesAppendOption {
         (.lists, "lists"),
         (.changes, "changes")
     ]
-
-    var queryValue: String {
-        Self.mapping
-            .filter { contains($0.0) }
-            .map(\.1)
-            .joined(separator: ",")
-    }
 
 }


### PR DESCRIPTION
## Summary

A behaviour-preserving refactor (finding **F5** — the first, smallest piece of the Tier 4 Codable consolidation).

The five `*AppendOption` OptionSets — `Movie` / `Person` / `TVEpisode` / `TVSeason` / `TVSeries` — each carried a **byte-identical** `queryValue` serialiser, differing only in their per-type `mapping` table:

```swift
var queryValue: String {
    Self.mapping.filter { contains($0.0) }.map(\.1).joined(separator: ",")
}
```

## Change

Introduce an internal protocol and share the serialiser as a default:

```swift
protocol AppendToResponseOption: OptionSet where Element == Self {
    static var mapping: [(Self, String)] { get }
}

extension AppendToResponseOption {
    var queryValue: String { Self.mapping.filter { contains($0.0) }.map(\.1).joined(separator: ",") }
}
```

- Conform all five types (internal conformance).
- Promote each `mapping` from `private static let` → internal `static let` (to satisfy the requirement).
- Delete the five duplicated `queryValue` bodies (~30 lines of exact duplication gone).

The `where Element == Self` constraint is what lets the shared default call `contains(_:)` (which takes `Self`); every `OptionSet` here satisfies it via the default `Element = Self`.

## Why it's safe

- **Behaviour-preserving** — the shared default is byte-for-byte the removed bodies; `mapping` order is unchanged, so serialised token order can't change.
- **No public API change** — the protocol and conformances are internal; `rawValue` / `init(rawValue:)` / the static option members stay public and untouched; `queryValue` and `mapping` were already internal.
- **Full coverage** — every changed line is exercised by the existing **61** `*AppendOptionTests` (per-option, multi-option, all-options), which now drive the shared default and each `mapping`. No codecov/patch gap.

## Verification

- ✅ `make ci` green — 2846 unit + 290 integration tests, release build, docs build.
- Code review (`.github/CODE_REVIEW.md`): **0 findings** — clean DRY extraction, adversarial pass clean.
- Security: N/A (pure internal refactor, no attack surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)