### PR TITLE
♻️ Consolidate empty-string date/URL decoding into shared container helpers

### DIFF
--- a/Sources/TMDb/Domain/Models/Company.swift
+++ b/Sources/TMDb/Domain/Models/Company.swift
@@ -117,21 +117,12 @@ extension Company {
     ///
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let container2 = try decoder.container(keyedBy: CodingKeys.self)
 
         self.id = try container.decode(Int.self, forKey: .id)
         self.name = try container.decode(String.self, forKey: .name)
         self.description = try container.decode(String.self, forKey: .description)
         self.headquarters = try container.decode(String.self, forKey: .headquarters)
-        // Need to deal with empty strings - URL decoding will fail with an empty string
-        let homepageURLString = try container.decodeIfPresent(String.self, forKey: .homepageURL)
-        self.homepageURL = try {
-            guard let homepageURLString, !homepageURLString.isEmpty else {
-                return nil
-            }
-
-            return try container2.decodeIfPresent(URL.self, forKey: .homepageURL)
-        }()
+        self.homepageURL = try container.decodeNonEmptyURLIfPresent(forKey: .homepageURL)
         self.logoPath = try container.decode(URL.self, forKey: .logoPath)
         self.originCountry = try container.decode(String.self, forKey: .originCountry)
         self.parentCompany = try container.decodeIfPresent(Parent.self, forKey: .parentCompany)

--- a/Sources/TMDb/Domain/Models/Movie.swift
+++ b/Sources/TMDb/Domain/Models/Movie.swift
@@ -279,9 +279,8 @@ extension Movie {
     /// - Throws: `DecodingError.keyNotFound` if self does not have an entry for the given key.
     /// - Throws: `DecodingError.valueNotFound` if self has a null entry for the given key.
     ///
-    public init(from decoder: Decoder) throws { // swiftlint:disable:this function_body_length
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let container2 = try decoder.container(keyedBy: CodingKeys.self)
 
         self.id = try container.decode(Int.self, forKey: .id)
         self.title = try container.decode(String.self, forKey: .title)
@@ -296,32 +295,12 @@ extension Movie {
         self.overview = try container.decodeIfPresent(String.self, forKey: .overview)
         self.runtime = try container.decodeIfPresent(Int.self, forKey: .runtime)
         self.genres = try container.decodeIfPresent([Genre].self, forKey: .genres)
-
-        // Need to deal with empty strings - date decoding will fail with an empty string
-        let releaseDateString = try container.decodeIfPresent(String.self, forKey: .releaseDate)
-        self.releaseDate = try {
-            guard let releaseDateString, !releaseDateString.isEmpty else {
-                return nil
-            }
-
-            return try container2.decodeIfPresent(Date.self, forKey: .releaseDate)
-        }()
-
+        self.releaseDate = try container.decodeNonEmptyDateIfPresent(forKey: .releaseDate)
         self.posterPath = try container.decodeIfPresent(URL.self, forKey: .posterPath)
         self.backdropPath = try container.decodeIfPresent(URL.self, forKey: .backdropPath)
         self.budget = try container.decodeIfPresent(Double.self, forKey: .budget)
         self.revenue = try container.decodeIfPresent(Double.self, forKey: .revenue)
-
-        // Need to deal with empty strings - URL decoding will fail with an empty string
-        let homepageURLString = try container.decodeIfPresent(String.self, forKey: .homepageURL)
-        self.homepageURL = try {
-            guard let homepageURLString, !homepageURLString.isEmpty else {
-                return nil
-            }
-
-            return try container2.decodeIfPresent(URL.self, forKey: .homepageURL)
-        }()
-
+        self.homepageURL = try container.decodeNonEmptyURLIfPresent(forKey: .homepageURL)
         self.imdbID = try container.decodeIfPresent(String.self, forKey: .imdbID)
         self.status = try container.decodeIfPresent(Status.self, forKey: .status)
         self.productionCompanies = try container.decodeIfPresent(

--- a/Sources/TMDb/Domain/Models/MovieCastCredit.swift
+++ b/Sources/TMDb/Domain/Models/MovieCastCredit.swift
@@ -205,7 +205,6 @@ extension MovieCastCredit {
     ///
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let container2 = try decoder.container(keyedBy: CodingKeys.self)
 
         self.id = try container.decode(Int.self, forKey: .id)
         self.title = try container.decode(String.self, forKey: .title)
@@ -213,17 +212,7 @@ extension MovieCastCredit {
         self.originalLanguage = try container.decode(String.self, forKey: .originalLanguage)
         self.overview = try container.decode(String.self, forKey: .overview)
         self.genreIDs = try container.decode([Genre.ID].self, forKey: .genreIDs)
-
-        // Need to deal with empty strings - date decoding will fail with an empty string
-        let releaseDateString = try container.decodeIfPresent(String.self, forKey: .releaseDate)
-        self.releaseDate = try {
-            guard let releaseDateString, !releaseDateString.isEmpty else {
-                return nil
-            }
-
-            return try container2.decodeIfPresent(Date.self, forKey: .releaseDate)
-        }()
-
+        self.releaseDate = try container.decodeNonEmptyDateIfPresent(forKey: .releaseDate)
         self.posterPath = try container.decodeIfPresent(URL.self, forKey: .posterPath)
         self.backdropPath = try container.decodeIfPresent(URL.self, forKey: .backdropPath)
         self.popularity = try container.decodeIfPresent(Double.self, forKey: .popularity)

--- a/Sources/TMDb/Domain/Models/MovieCrewCredit.swift
+++ b/Sources/TMDb/Domain/Models/MovieCrewCredit.swift
@@ -205,7 +205,6 @@ extension MovieCrewCredit {
     ///
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let container2 = try decoder.container(keyedBy: CodingKeys.self)
 
         self.id = try container.decode(Int.self, forKey: .id)
         self.title = try container.decode(String.self, forKey: .title)
@@ -213,17 +212,7 @@ extension MovieCrewCredit {
         self.originalLanguage = try container.decode(String.self, forKey: .originalLanguage)
         self.overview = try container.decode(String.self, forKey: .overview)
         self.genreIDs = try container.decode([Genre.ID].self, forKey: .genreIDs)
-
-        // Need to deal with empty strings - date decoding will fail with an empty string
-        let releaseDateString = try container.decodeIfPresent(String.self, forKey: .releaseDate)
-        self.releaseDate = try {
-            guard let releaseDateString, !releaseDateString.isEmpty else {
-                return nil
-            }
-
-            return try container2.decodeIfPresent(Date.self, forKey: .releaseDate)
-        }()
-
+        self.releaseDate = try container.decodeNonEmptyDateIfPresent(forKey: .releaseDate)
         self.posterPath = try container.decodeIfPresent(URL.self, forKey: .posterPath)
         self.backdropPath = try container.decodeIfPresent(URL.self, forKey: .backdropPath)
         self.popularity = try container.decodeIfPresent(Double.self, forKey: .popularity)

--- a/Sources/TMDb/Domain/Models/MovieListItem.swift
+++ b/Sources/TMDb/Domain/Models/MovieListItem.swift
@@ -182,7 +182,6 @@ extension MovieListItem {
     ///
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let container2 = try decoder.container(keyedBy: CodingKeys.self)
 
         self.id = try container.decode(Int.self, forKey: .id)
         self.title = try container.decode(String.self, forKey: .title)
@@ -195,17 +194,7 @@ extension MovieListItem {
         // Collection entries interleaved into `/search/movie` results omit
         // `genre_ids` entirely; default to an empty array rather than failing.
         self.genreIDs = try container.decodeIfPresent([Genre.ID].self, forKey: .genreIDs) ?? []
-
-        // Need to deal with empty strings - date decoding will fail with an empty string
-        let releaseDateString = try container.decodeIfPresent(String.self, forKey: .releaseDate)
-        self.releaseDate = try {
-            guard let releaseDateString, !releaseDateString.isEmpty else {
-                return nil
-            }
-
-            return try container2.decodeIfPresent(Date.self, forKey: .releaseDate)
-        }()
-
+        self.releaseDate = try container.decodeNonEmptyDateIfPresent(forKey: .releaseDate)
         self.posterPath = try container.decodeIfPresent(URL.self, forKey: .posterPath)
         self.backdropPath = try container.decodeIfPresent(URL.self, forKey: .backdropPath)
         self.popularity = try container.decodeIfPresent(Double.self, forKey: .popularity)

--- a/Sources/TMDb/Domain/Models/Network.swift
+++ b/Sources/TMDb/Domain/Models/Network.swift
@@ -99,23 +99,13 @@ extension Network {
     ///
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let container2 = try decoder.container(keyedBy: CodingKeys.self)
 
         self.id = try container.decode(Int.self, forKey: .id)
         self.name = try container.decode(String.self, forKey: .name)
         self.logoPath = try container.decodeIfPresent(URL.self, forKey: .logoPath)
         self.originCountry = try container.decodeIfPresent(String.self, forKey: .originCountry)
         self.headquarters = try container.decodeIfPresent(String.self, forKey: .headquarters)
-
-        // Need to deal with empty strings - URL decoding will fail with an empty string
-        let homepageString = try container.decodeIfPresent(String.self, forKey: .homepage)
-        self.homepage = try {
-            guard let homepageString, !homepageString.isEmpty else {
-                return nil
-            }
-
-            return try container2.decodeIfPresent(URL.self, forKey: .homepage)
-        }()
+        self.homepage = try container.decodeNonEmptyURLIfPresent(forKey: .homepage)
     }
 
 }

--- a/Sources/TMDb/Domain/Models/Person.swift
+++ b/Sources/TMDb/Domain/Models/Person.swift
@@ -171,7 +171,6 @@ extension Person {
     ///
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let container2 = try decoder.container(keyedBy: CodingKeys.self)
 
         self.id = try container.decode(Int.self, forKey: .id)
         self.name = try container.decode(String.self, forKey: .name)
@@ -187,17 +186,7 @@ extension Person {
         self.profilePath = try container.decodeIfPresent(URL.self, forKey: .profilePath)
         self.popularity = try container.decodeIfPresent(Double.self, forKey: .popularity)
         self.imdbID = try container.decodeIfPresent(String.self, forKey: .imdbID)
-
-        // Need to deal with empty strings - URL decoding will fail with an empty string
-        let homepageURLString = try container.decodeIfPresent(String.self, forKey: .homepageURL)
-        self.homepageURL = try {
-            guard let homepageURLString, !homepageURLString.isEmpty else {
-                return nil
-            }
-
-            return try container2.decodeIfPresent(URL.self, forKey: .homepageURL)
-        }()
-
+        self.homepageURL = try container.decodeNonEmptyURLIfPresent(forKey: .homepageURL)
         self.isAdultOnly = try container.decodeIfPresent(
             Bool.self, forKey: .isAdultOnly
         )

--- a/Sources/TMDb/Domain/Models/TVEpisode.swift
+++ b/Sources/TMDb/Domain/Models/TVEpisode.swift
@@ -178,24 +178,13 @@ extension TVEpisode {
     /// - Throws: `DecodingError.valueNotFound` if self has a null entry for the given key.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let container2 = try decoder.container(keyedBy: CodingKeys.self)
 
         self.id = try container.decode(Int.self, forKey: .id)
         self.name = try container.decode(String.self, forKey: .name)
         self.episodeNumber = try container.decode(Int.self, forKey: .episodeNumber)
         self.seasonNumber = try container.decode(Int.self, forKey: .seasonNumber)
         self.overview = try container.decodeIfPresent(String.self, forKey: .overview)
-
-        // Need to deal with empty strings - date decoding will fail with an empty string
-        let airDateString = try container.decodeIfPresent(String.self, forKey: .airDate)
-        self.airDate = try {
-            guard let airDateString, !airDateString.isEmpty else {
-                return nil
-            }
-
-            return try container2.decodeIfPresent(Date.self, forKey: .airDate)
-        }()
-
+        self.airDate = try container.decodeNonEmptyDateIfPresent(forKey: .airDate)
         self.episodeType = try container.decodeIfPresent(String.self, forKey: .episodeType)
         self.runtime = try container.decodeIfPresent(Int.self, forKey: .runtime)
         self.showID = try container.decodeIfPresent(Int.self, forKey: .showID)

--- a/Sources/TMDb/Domain/Models/TVEpisodeAirDate.swift
+++ b/Sources/TMDb/Domain/Models/TVEpisodeAirDate.swift
@@ -165,24 +165,13 @@ extension TVEpisodeAirDate {
     ///
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let container2 = try decoder.container(keyedBy: CodingKeys.self)
 
         self.id = try container.decode(Int.self, forKey: .id)
         self.name = try container.decode(String.self, forKey: .name)
         self.episodeNumber = try container.decode(Int.self, forKey: .episodeNumber)
         self.seasonNumber = try container.decode(Int.self, forKey: .seasonNumber)
         self.overview = try container.decodeIfPresent(String.self, forKey: .overview)
-
-        // Need to deal with empty strings - date decoding will fail with an empty string
-        let airDateString = try container.decodeIfPresent(String.self, forKey: .airDate)
-        self.airDate = try {
-            guard let airDateString, !airDateString.isEmpty else {
-                return nil
-            }
-
-            return try container2.decodeIfPresent(Date.self, forKey: .airDate)
-        }()
-
+        self.airDate = try container.decodeNonEmptyDateIfPresent(forKey: .airDate)
         self.episodeType = try container.decodeIfPresent(String.self, forKey: .episodeType)
         self.runtime = try container.decodeIfPresent(Int.self, forKey: .runtime)
         self.showID = try container.decodeIfPresent(Int.self, forKey: .showID)

--- a/Sources/TMDb/Domain/Models/TVSeason.swift
+++ b/Sources/TMDb/Domain/Models/TVSeason.swift
@@ -133,23 +133,12 @@ extension TVSeason {
     /// - Throws: `DecodingError.valueNotFound` if self has a null entry for the given key.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let container2 = try decoder.container(keyedBy: CodingKeys.self)
 
         self.id = try container.decode(Int.self, forKey: .id)
         self.name = try container.decode(String.self, forKey: .name)
         self.seasonNumber = try container.decode(Int.self, forKey: .seasonNumber)
         self.overview = try container.decodeIfPresent(String.self, forKey: .overview)
-
-        // Need to deal with empty strings - date decoding will fail with an empty string
-        let airDateString = try container.decodeIfPresent(String.self, forKey: .airDate)
-        self.airDate = try {
-            guard let airDateString, !airDateString.isEmpty else {
-                return nil
-            }
-
-            return try container2.decodeIfPresent(Date.self, forKey: .airDate)
-        }()
-
+        self.airDate = try container.decodeNonEmptyDateIfPresent(forKey: .airDate)
         self.posterPath = try container.decodeIfPresent(URL.self, forKey: .posterPath)
         self.voteAverage = try container.decodeIfPresent(Double.self, forKey: .voteAverage)
         self.episodeCount = try container.decodeIfPresent(

--- a/Sources/TMDb/Domain/Models/TVSeries.swift
+++ b/Sources/TMDb/Domain/Models/TVSeries.swift
@@ -5,8 +5,6 @@
 //  Copyright © 2026 Adam Young.
 //
 
-// swiftlint:disable file_length
-
 import Foundation
 
 ///
@@ -337,9 +335,8 @@ extension TVSeries {
     /// type.
     /// - Throws: `DecodingError.keyNotFound` if self does not have an entry for the given key.
     /// - Throws: `DecodingError.valueNotFound` if self has a null entry for the given key.
-    public init(from decoder: Decoder) throws { // swiftlint:disable:this function_body_length
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let container2 = try decoder.container(keyedBy: CodingKeys.self)
 
         self.id = try container.decode(Int.self, forKey: .id)
         self.name = try container.decode(String.self, forKey: .name)
@@ -355,43 +352,14 @@ extension TVSeries {
         self.seasons = try container.decodeIfPresent([TVSeason].self, forKey: .seasons)
         self.createdBy = try container.decodeIfPresent([Creator].self, forKey: .createdBy)
         self.genres = try container.decodeIfPresent([Genre].self, forKey: .genres)
-
-        // Need to deal with empty strings - date decoding will fail with an empty string
-        let firstAirDateString = try container.decodeIfPresent(String.self, forKey: .firstAirDate)
-        self.firstAirDate = try {
-            guard let firstAirDateString, !firstAirDateString.isEmpty else {
-                return nil
-            }
-
-            return try container2.decodeIfPresent(Date.self, forKey: .firstAirDate)
-        }()
-
+        self.firstAirDate = try container.decodeNonEmptyDateIfPresent(forKey: .firstAirDate)
         self.originCountry = try container.decodeIfPresent([String].self, forKey: .originCountry)
         self.posterPath = try container.decodeIfPresent(URL.self, forKey: .posterPath)
         self.backdropPath = try container.decodeIfPresent(URL.self, forKey: .backdropPath)
-
-        // Need to deal with empty strings - URL decoding will fail with an empty string
-        let homepageURLString = try container.decodeIfPresent(String.self, forKey: .homepageURL)
-        self.homepageURL = try {
-            guard let homepageURLString, !homepageURLString.isEmpty else {
-                return nil
-            }
-
-            return try container2.decodeIfPresent(URL.self, forKey: .homepageURL)
-        }()
-
+        self.homepageURL = try container.decodeNonEmptyURLIfPresent(forKey: .homepageURL)
         self.isInProduction = try container.decodeIfPresent(Bool.self, forKey: .isInProduction)
         self.languages = try container.decodeIfPresent([String].self, forKey: .languages)
-
-        // Need to deal with empty strings - date decoding will fail with an empty string
-        let lastAirDateString = try container.decodeIfPresent(String.self, forKey: .lastAirDate)
-        self.lastAirDate = try {
-            guard let lastAirDateString, !lastAirDateString.isEmpty else {
-                return nil
-            }
-
-            return try container2.decodeIfPresent(Date.self, forKey: .lastAirDate)
-        }()
+        self.lastAirDate = try container.decodeNonEmptyDateIfPresent(forKey: .lastAirDate)
         self.lastEpisodeToAir = try container.decodeIfPresent(
             TVEpisodeAirDate.self, forKey: .lastEpisodeToAir
         )

--- a/Sources/TMDb/Domain/Models/TVSeriesCastCredit.swift
+++ b/Sources/TMDb/Domain/Models/TVSeriesCastCredit.swift
@@ -205,7 +205,6 @@ extension TVSeriesCastCredit {
     ///
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let container2 = try decoder.container(keyedBy: CodingKeys.self)
 
         self.id = try container.decode(Int.self, forKey: .id)
         self.name = try container.decode(String.self, forKey: .name)
@@ -213,17 +212,7 @@ extension TVSeriesCastCredit {
         self.originalLanguage = try container.decode(String.self, forKey: .originalLanguage)
         self.overview = try container.decode(String.self, forKey: .overview)
         self.genreIDs = try container.decode([Genre.ID].self, forKey: .genreIDs)
-
-        // Need to deal with empty strings - date decoding will fail with an empty string
-        let firstAirDateString = try container.decodeIfPresent(String.self, forKey: .firstAirDate)
-        self.firstAirDate = try {
-            guard let firstAirDateString, !firstAirDateString.isEmpty else {
-                return nil
-            }
-
-            return try container2.decodeIfPresent(Date.self, forKey: .firstAirDate)
-        }()
-
+        self.firstAirDate = try container.decodeNonEmptyDateIfPresent(forKey: .firstAirDate)
         self.originCountries = try container.decode([String].self, forKey: .originCountries)
         self.posterPath = try container.decodeIfPresent(URL.self, forKey: .posterPath)
         self.backdropPath = try container.decodeIfPresent(URL.self, forKey: .backdropPath)

--- a/Sources/TMDb/Domain/Models/TVSeriesCrewCredit.swift
+++ b/Sources/TMDb/Domain/Models/TVSeriesCrewCredit.swift
@@ -214,7 +214,6 @@ extension TVSeriesCrewCredit {
     ///
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let container2 = try decoder.container(keyedBy: CodingKeys.self)
 
         self.id = try container.decode(Int.self, forKey: .id)
         self.name = try container.decode(String.self, forKey: .name)
@@ -222,17 +221,7 @@ extension TVSeriesCrewCredit {
         self.originalLanguage = try container.decode(String.self, forKey: .originalLanguage)
         self.overview = try container.decode(String.self, forKey: .overview)
         self.genreIDs = try container.decode([Genre.ID].self, forKey: .genreIDs)
-
-        // Need to deal with empty strings - date decoding will fail with an empty string
-        let firstAirDateString = try container.decodeIfPresent(String.self, forKey: .firstAirDate)
-        self.firstAirDate = try {
-            guard let firstAirDateString, !firstAirDateString.isEmpty else {
-                return nil
-            }
-
-            return try container2.decodeIfPresent(Date.self, forKey: .firstAirDate)
-        }()
-
+        self.firstAirDate = try container.decodeNonEmptyDateIfPresent(forKey: .firstAirDate)
         self.originCountries = try container.decode([String].self, forKey: .originCountries)
         self.posterPath = try container.decodeIfPresent(URL.self, forKey: .posterPath)
         self.backdropPath = try container.decodeIfPresent(URL.self, forKey: .backdropPath)

--- a/Sources/TMDb/Domain/Models/TVSeriesListItem.swift
+++ b/Sources/TMDb/Domain/Models/TVSeriesListItem.swift
@@ -173,7 +173,6 @@ extension TVSeriesListItem {
     ///
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let container2 = try decoder.container(keyedBy: CodingKeys.self)
 
         self.id = try container.decode(Int.self, forKey: .id)
         self.name = try container.decode(String.self, forKey: .name)
@@ -183,17 +182,7 @@ extension TVSeriesListItem {
         // Some search results omit `genre_ids` entirely; default to an empty
         // array rather than failing to decode the whole page.
         self.genreIDs = try container.decodeIfPresent([Genre.ID].self, forKey: .genreIDs) ?? []
-
-        // Need to deal with empty strings - date decoding will fail with an empty string
-        let firstAirDateString = try container.decodeIfPresent(String.self, forKey: .firstAirDate)
-        self.firstAirDate = try {
-            guard let firstAirDateString, !firstAirDateString.isEmpty else {
-                return nil
-            }
-
-            return try container2.decodeIfPresent(Date.self, forKey: .firstAirDate)
-        }()
-
+        self.firstAirDate = try container.decodeNonEmptyDateIfPresent(forKey: .firstAirDate)
         self.originCountries = try container.decode([String].self, forKey: .originCountries)
         self.posterPath = try container.decodeIfPresent(URL.self, forKey: .posterPath)
         self.backdropPath = try container.decodeIfPresent(URL.self, forKey: .backdropPath)

--- a/Sources/TMDb/Extensions/KeyedDecodingContainer+NonEmpty.swift
+++ b/Sources/TMDb/Extensions/KeyedDecodingContainer+NonEmpty.swift
@@ -1,0 +1,63 @@
+//
+//  KeyedDecodingContainer+NonEmpty.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+extension KeyedDecodingContainer {
+
+    ///
+    /// Decodes a `Date` value for the given key, treating an empty string as `nil`.
+    ///
+    /// Some TMDb endpoints represent an absent date as an empty string rather than
+    /// omitting the key or using `null`. Decoding an empty string directly as a `Date`
+    /// would fail, so this first peeks at the raw string and short-circuits to `nil`
+    /// when it is empty, before decoding the `Date` (applying the decoder's configured
+    /// date decoding strategy) for a non-empty value.
+    ///
+    /// - Parameter key: The key to decode the date for.
+    ///
+    /// - Returns: The decoded `Date`, or `nil` if the key is absent, its value is
+    /// `null`, or its value is an empty string.
+    ///
+    /// - Throws: `DecodingError` if the value is present, non-empty and fails to
+    /// decode as a `Date`.
+    ///
+    func decodeNonEmptyDateIfPresent(forKey key: Key) throws -> Date? {
+        guard let stringValue = try decodeIfPresent(String.self, forKey: key), !stringValue.isEmpty
+        else {
+            return nil
+        }
+
+        return try decodeIfPresent(Date.self, forKey: key)
+    }
+
+    ///
+    /// Decodes a `URL` value for the given key, treating an empty string as `nil`.
+    ///
+    /// Some TMDb endpoints represent an absent URL as an empty string rather than
+    /// omitting the key or using `null`. Decoding an empty string directly as a `URL`
+    /// would fail, so this first peeks at the raw string and short-circuits to `nil`
+    /// when it is empty, before decoding the `URL` for a non-empty value.
+    ///
+    /// - Parameter key: The key to decode the URL for.
+    ///
+    /// - Returns: The decoded `URL`, or `nil` if the key is absent, its value is
+    /// `null`, or its value is an empty string.
+    ///
+    /// - Throws: `DecodingError` if the value is present, non-empty and fails to
+    /// decode as a `URL`.
+    ///
+    func decodeNonEmptyURLIfPresent(forKey key: Key) throws -> URL? {
+        guard let stringValue = try decodeIfPresent(String.self, forKey: key), !stringValue.isEmpty
+        else {
+            return nil
+        }
+
+        return try decodeIfPresent(URL.self, forKey: key)
+    }
+
+}


### PR DESCRIPTION
## Summary

A behaviour-preserving refactor (finding **F1** — Tier 4 Codable consolidation).

Fourteen model decoders each created a **redundant second keyed container** (`container2`) purely to re-decode a date/URL key as an empty-string→nil workaround, with the guard logic duplicated inline (17 sites). TMDb represents an absent date/URL as an empty string, which fails a direct `Date`/`URL` decode — hence the workaround.

## Change

Add a `KeyedDecodingContainer` extension with two helpers:

```swift
func decodeNonEmptyDateIfPresent(forKey key: Key) throws -> Date? {
    guard let s = try decodeIfPresent(String.self, forKey: key), !s.isEmpty else { return nil }
    return try decodeIfPresent(Date.self, forKey: key)   // still applies the decoder's date strategy
}
// … decodeNonEmptyURLIfPresent twin
```

- Replace the inline empty-string blocks across all **14** files (Movie, TVSeries, Person, Network, Company, TVEpisode, TVEpisodeAirDate, TVSeason, MovieListItem, TVSeriesListItem, MovieCastCredit, MovieCrewCredit, TVSeriesCastCredit, TVSeriesCrewCredit).
- Delete every `container2` (`grep container2` now returns nothing).
- `Movie.init` also shed its `function_body_length` swiftlint pragma now that the body is smaller.

**−201 / +82 lines.**

## Why it's safe

- **Behaviour-preserving** — the helpers are byte-equivalent to the removed inline blocks (peek string → empty→nil → `decodeIfPresent(Date/URL)`); the `Date` path still applies the decoder-level custom date strategy.
- **No public API change** — the helpers are internal; model initializers keep their signatures.
- The existing **JSON decode fixtures** (empty-string + present + missing cases per model) are the regression guard.

## Verification

- ✅ `make ci` green — **2849** unit + **291** integration tests (unchanged counts — pure refactor), release build, docs build.
- `grep -rn container2 Sources/TMDb/Domain/Models` → nothing.

## Note

This was implemented by a fresh-context agent and is being reviewed before merge (0-findings target); it is **not** auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)