### PR TITLE
♻️ Collapse conditional query-item assignment via subscript(ifPresent:)

### DIFF
--- a/Sources/TMDb/Domain/APIClient/APIRequestQueryItem.swift
+++ b/Sources/TMDb/Domain/APIClient/APIRequestQueryItem.swift
@@ -101,6 +101,22 @@ extension APIRequestQueryItem.Name {
 
 extension APIRequestQueryItems {
 
+    /// Sets the query item for `key` to `newValue`, treating `nil` as a no-op.
+    ///
+    /// Unlike the raw `Dictionary` subscript — where assigning `nil` removes the key —
+    /// assigning `nil` here leaves the collection unchanged. This lets an optional value
+    /// be applied in a single line without an `if let` guard, and without an incoming
+    /// `nil` clearing a value that was set earlier.
+    subscript(ifPresent key: Key) -> Value? {
+        get { self[key] }
+        set {
+            guard let newValue else {
+                return
+            }
+            self[key] = newValue
+        }
+    }
+
     static func idsQueryItemValue(for ids: [Int]) -> String {
         ids.map(\.description).joined(separator: ",")
     }

--- a/Sources/TMDb/Domain/Services/Account/Requests/AccountListsRequest.swift
+++ b/Sources/TMDb/Domain/Services/Account/Requests/AccountListsRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(page: Int?, sessionID: String) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
         self[.sessionID] = sessionID
     }

--- a/Sources/TMDb/Domain/Services/Account/Requests/FavouriteMoviesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Account/Requests/FavouriteMoviesRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(sortedBy: FavouriteSort?, page: Int?, sessionID: String) {
         self.init()
 
-        if let sortedBy {
-            self[.sortBy] = sortedBy
-        }
+        self[ifPresent: .sortBy] = sortedBy
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
         self[.sessionID] = sessionID
     }

--- a/Sources/TMDb/Domain/Services/Account/Requests/FavouriteTVSeriesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Account/Requests/FavouriteTVSeriesRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(sortedBy: FavouriteSort?, page: Int?, sessionID: String) {
         self.init()
 
-        if let sortedBy {
-            self[.sortBy] = sortedBy
-        }
+        self[ifPresent: .sortBy] = sortedBy
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
         self[.sessionID] = sessionID
     }

--- a/Sources/TMDb/Domain/Services/Account/Requests/MovieWatchlistRequest.swift
+++ b/Sources/TMDb/Domain/Services/Account/Requests/MovieWatchlistRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(sortedBy: WatchlistSort?, page: Int?, sessionID: String) {
         self.init()
 
-        if let sortedBy {
-            self[.sortBy] = sortedBy
-        }
+        self[ifPresent: .sortBy] = sortedBy
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
         self[.sessionID] = sessionID
     }

--- a/Sources/TMDb/Domain/Services/Account/Requests/RatedMoviesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Account/Requests/RatedMoviesRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(sortedBy: RatedSort?, page: Int?, sessionID: String) {
         self.init()
 
-        if let sortedBy {
-            self[.sortBy] = sortedBy
-        }
+        self[ifPresent: .sortBy] = sortedBy
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
         self[.sessionID] = sessionID
     }

--- a/Sources/TMDb/Domain/Services/Account/Requests/RatedTVEpisodesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Account/Requests/RatedTVEpisodesRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(sortedBy: RatedSort?, page: Int?, sessionID: String) {
         self.init()
 
-        if let sortedBy {
-            self[.sortBy] = sortedBy
-        }
+        self[ifPresent: .sortBy] = sortedBy
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
         self[.sessionID] = sessionID
     }

--- a/Sources/TMDb/Domain/Services/Account/Requests/RatedTVSeriesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Account/Requests/RatedTVSeriesRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(sortedBy: RatedSort?, page: Int?, sessionID: String) {
         self.init()
 
-        if let sortedBy {
-            self[.sortBy] = sortedBy
-        }
+        self[ifPresent: .sortBy] = sortedBy
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
         self[.sessionID] = sessionID
     }

--- a/Sources/TMDb/Domain/Services/Account/Requests/TVSeriesWatchlistRequest.swift
+++ b/Sources/TMDb/Domain/Services/Account/Requests/TVSeriesWatchlistRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(sortedBy: WatchlistSort?, page: Int?, sessionID: String) {
         self.init()
 
-        if let sortedBy {
-            self[.sortBy] = sortedBy
-        }
+        self[ifPresent: .sortBy] = sortedBy
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
         self[.sessionID] = sessionID
     }

--- a/Sources/TMDb/Domain/Services/Collections/Requests/CollectionRequest.swift
+++ b/Sources/TMDb/Domain/Services/Collections/Requests/CollectionRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Configuration/Requests/CountriesConfigurationRequest.swift
+++ b/Sources/TMDb/Domain/Services/Configuration/Requests/CountriesConfigurationRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Discover/Requests/DiscoverMoviesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Requests/DiscoverMoviesRequest.swift
@@ -22,17 +22,9 @@ final class DiscoverMoviesRequest: DecodableAPIRequest<MoviePageableList> {
             queryItems.apply(filter)
         }
 
-        if let sortedBy {
-            queryItems[.sortBy] = sortedBy
-        }
-
-        if let page {
-            queryItems[.page] = page
-        }
-
-        if let language {
-            queryItems[.language] = language
-        }
+        queryItems[ifPresent: .sortBy] = sortedBy
+        queryItems[ifPresent: .page] = page
+        queryItems[ifPresent: .language] = language
 
         super.init(path: path, queryItems: queryItems)
     }
@@ -46,9 +38,7 @@ private extension APIRequestQueryItems {
             self[.withPeople] = Self.idsQueryItemValue(for: people)
         }
 
-        if let originalLanguage = filter.originalLanguage {
-            self[.withOriginalLanguage] = originalLanguage
-        }
+        self[ifPresent: .withOriginalLanguage] = filter.originalLanguage
 
         if let genres = filter.genres {
             self[.withGenres] = (filter.genresJoin ?? .and)
@@ -63,12 +53,8 @@ private extension APIRequestQueryItems {
 
         if let primaryReleaseYear = filter.primaryReleaseYear {
             let bounds = primaryReleaseYear.dateBounds()
-            if let lte = bounds.lte {
-                self[.primaryReleaseDateLessThan] = lte
-            }
-            if let gte = bounds.gte {
-                self[.primaryReleaseDateGreaterThan] = gte
-            }
+            self[ifPresent: .primaryReleaseDateLessThan] = bounds.lte
+            self[ifPresent: .primaryReleaseDateGreaterThan] = bounds.gte
         }
 
         if let releaseDateMin = filter.releaseDateMin {
@@ -86,21 +72,10 @@ private extension APIRequestQueryItems {
     mutating func applyVoteAndRuntimeFilters(
         from filter: DiscoverMovieFilter
     ) {
-        if let voteAverageMin = filter.voteAverageMin {
-            self[.voteAverageGreaterThan] = voteAverageMin
-        }
-
-        if let voteAverageMax = filter.voteAverageMax {
-            self[.voteAverageLessThan] = voteAverageMax
-        }
-
-        if let voteCountMin = filter.voteCountMin {
-            self[.voteCountGreaterThan] = voteCountMin
-        }
-
-        if let voteCountMax = filter.voteCountMax {
-            self[.voteCountLessThan] = voteCountMax
-        }
+        self[ifPresent: .voteAverageGreaterThan] = filter.voteAverageMin
+        self[ifPresent: .voteAverageLessThan] = filter.voteAverageMax
+        self[ifPresent: .voteCountGreaterThan] = filter.voteCountMin
+        self[ifPresent: .voteCountLessThan] = filter.voteCountMax
 
         if let companies = filter.companies {
             self[.withCompanies] = Self.idsQueryItemValue(for: companies)
@@ -117,25 +92,15 @@ private extension APIRequestQueryItems {
             )
         }
 
-        if let runtimeMin = filter.runtimeMin {
-            self[.withRuntimeGreaterThan] = runtimeMin
-        }
-
-        if let runtimeMax = filter.runtimeMax {
-            self[.withRuntimeLessThan] = runtimeMax
-        }
+        self[ifPresent: .withRuntimeGreaterThan] = filter.runtimeMin
+        self[ifPresent: .withRuntimeLessThan] = filter.runtimeMax
     }
 
     mutating func applyContentAndProviderFilters(
         from filter: DiscoverMovieFilter
     ) {
-        if let includeAdult = filter.includeAdult {
-            self[.includeAdult] = includeAdult
-        }
-
-        if let includeVideo = filter.includeVideo {
-            self[.includeVideo] = includeVideo
-        }
+        self[ifPresent: .includeAdult] = filter.includeAdult
+        self[ifPresent: .includeVideo] = filter.includeVideo
 
         if let watchProviders = filter.watchProviders {
             self[.withWatchProviders] = Self.idsQueryItemValue(
@@ -149,9 +114,7 @@ private extension APIRequestQueryItems {
             )
         }
 
-        if let watchRegion = filter.watchRegion {
-            self[.watchRegion] = watchRegion
-        }
+        self[ifPresent: .watchRegion] = filter.watchRegion
 
         applyCertificationAndExtendedFilters(from: filter)
     }
@@ -159,21 +122,10 @@ private extension APIRequestQueryItems {
     mutating func applyCertificationAndExtendedFilters(
         from filter: DiscoverMovieFilter
     ) {
-        if let certification = filter.certification {
-            self[.certification] = certification
-        }
-
-        if let certificationMin = filter.certificationMin {
-            self[.certificationMin] = certificationMin
-        }
-
-        if let certificationMax = filter.certificationMax {
-            self[.certificationMax] = certificationMax
-        }
-
-        if let certificationCountry = filter.certificationCountry {
-            self[.certificationCountry] = certificationCountry
-        }
+        self[ifPresent: .certification] = filter.certification
+        self[ifPresent: .certificationMin] = filter.certificationMin
+        self[ifPresent: .certificationMax] = filter.certificationMax
+        self[ifPresent: .certificationCountry] = filter.certificationCountry
 
         if let releaseTypes = filter.releaseTypes {
             self[.withReleaseType] = releaseTypes
@@ -189,9 +141,7 @@ private extension APIRequestQueryItems {
             self[.withCrew] = Self.idsQueryItemValue(for: withCrew)
         }
 
-        if let withOriginCountry = filter.withOriginCountry {
-            self[.withOriginCountry] = withOriginCountry
-        }
+        self[ifPresent: .withOriginCountry] = filter.withOriginCountry
 
         if let withoutCompanies = filter.withoutCompanies {
             self[.withoutCompanies] = Self.idsQueryItemValue(

--- a/Sources/TMDb/Domain/Services/Discover/Requests/DiscoverTVSeriesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Requests/DiscoverTVSeriesRequest.swift
@@ -22,17 +22,9 @@ final class DiscoverTVSeriesRequest: DecodableAPIRequest<TVSeriesPageableList> {
             queryItems.apply(filter)
         }
 
-        if let sortedBy {
-            queryItems[.sortBy] = sortedBy
-        }
-
-        if let page {
-            queryItems[.page] = page
-        }
-
-        if let language {
-            queryItems[.language] = language
-        }
+        queryItems[ifPresent: .sortBy] = sortedBy
+        queryItems[ifPresent: .page] = page
+        queryItems[ifPresent: .language] = language
 
         super.init(path: path, queryItems: queryItems)
     }
@@ -42,9 +34,7 @@ final class DiscoverTVSeriesRequest: DecodableAPIRequest<TVSeriesPageableList> {
 private extension APIRequestQueryItems {
 
     mutating func apply(_ filter: DiscoverTVSeriesFilter) {
-        if let originalLanguage = filter.originalLanguage {
-            self[.withOriginalLanguage] = originalLanguage
-        }
+        self[ifPresent: .withOriginalLanguage] = filter.originalLanguage
 
         if let genres = filter.genres {
             self[.withGenres] = (filter.genresJoin ?? .and)
@@ -55,9 +45,7 @@ private extension APIRequestQueryItems {
             self[.withoutGenres] = Self.idsQueryItemValue(for: withoutGenres)
         }
 
-        if let firstAirDateYear = filter.firstAirDateYear {
-            self[.firstAirDateYear] = firstAirDateYear
-        }
+        self[ifPresent: .firstAirDateYear] = filter.firstAirDateYear
 
         applyDateFilters(from: filter)
         applyVoteAndEntityFilters(from: filter)
@@ -89,21 +77,10 @@ private extension APIRequestQueryItems {
     mutating func applyVoteAndEntityFilters(
         from filter: DiscoverTVSeriesFilter
     ) {
-        if let voteAverageMin = filter.voteAverageMin {
-            self[.voteAverageGreaterThan] = voteAverageMin
-        }
-
-        if let voteAverageMax = filter.voteAverageMax {
-            self[.voteAverageLessThan] = voteAverageMax
-        }
-
-        if let voteCountMin = filter.voteCountMin {
-            self[.voteCountGreaterThan] = voteCountMin
-        }
-
-        if let voteCountMax = filter.voteCountMax {
-            self[.voteCountLessThan] = voteCountMax
-        }
+        self[ifPresent: .voteAverageGreaterThan] = filter.voteAverageMin
+        self[ifPresent: .voteAverageLessThan] = filter.voteAverageMax
+        self[ifPresent: .voteCountGreaterThan] = filter.voteCountMin
+        self[ifPresent: .voteCountLessThan] = filter.voteCountMax
 
         if let networks = filter.networks {
             self[.withNetworks] = Self.idsQueryItemValue(for: networks)
@@ -128,17 +105,9 @@ private extension APIRequestQueryItems {
     mutating func applyContentAndProviderFilters(
         from filter: DiscoverTVSeriesFilter
     ) {
-        if let runtimeMin = filter.runtimeMin {
-            self[.withRuntimeGreaterThan] = runtimeMin
-        }
-
-        if let runtimeMax = filter.runtimeMax {
-            self[.withRuntimeLessThan] = runtimeMax
-        }
-
-        if let includeAdult = filter.includeAdult {
-            self[.includeAdult] = includeAdult
-        }
+        self[ifPresent: .withRuntimeGreaterThan] = filter.runtimeMin
+        self[ifPresent: .withRuntimeLessThan] = filter.runtimeMax
+        self[ifPresent: .includeAdult] = filter.includeAdult
 
         if let watchProviders = filter.watchProviders {
             self[.withWatchProviders] = Self.idsQueryItemValue(
@@ -152,13 +121,8 @@ private extension APIRequestQueryItems {
             )
         }
 
-        if let watchRegion = filter.watchRegion {
-            self[.watchRegion] = watchRegion
-        }
-
-        if let includeNullFirstAirDates = filter.includeNullFirstAirDates {
-            self[.includeNullFirstAirDates] = includeNullFirstAirDates
-        }
+        self[ifPresent: .watchRegion] = filter.watchRegion
+        self[ifPresent: .includeNullFirstAirDates] = filter.includeNullFirstAirDates
 
         applyExtendedFilters(from: filter)
     }
@@ -166,9 +130,7 @@ private extension APIRequestQueryItems {
     mutating func applyExtendedFilters(
         from filter: DiscoverTVSeriesFilter
     ) {
-        if let withOriginCountry = filter.withOriginCountry {
-            self[.withOriginCountry] = withOriginCountry
-        }
+        self[ifPresent: .withOriginCountry] = filter.withOriginCountry
 
         if let withStatus = filter.withStatus {
             self[.withStatus] = withStatus
@@ -194,9 +156,7 @@ private extension APIRequestQueryItems {
                 .joined(separator: "|")
         }
 
-        if let screenedTheatrically = filter.screenedTheatrically {
-            self[.screenedTheatrically] = screenedTheatrically
-        }
+        self[ifPresent: .screenedTheatrically] = filter.screenedTheatrically
 
         if let withPeople = filter.withPeople {
             self[.withPeople] = Self.idsQueryItemValue(

--- a/Sources/TMDb/Domain/Services/Find/Requests/FindByIDRequest.swift
+++ b/Sources/TMDb/Domain/Services/Find/Requests/FindByIDRequest.swift
@@ -35,9 +35,7 @@ private extension APIRequestQueryItems {
 
         self[.externalSource] = externalSource.rawValue
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Genres/Requests/MovieGenresRequest.swift
+++ b/Sources/TMDb/Domain/Services/Genres/Requests/MovieGenresRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Genres/Requests/TVSeriesGenresRequest.swift
+++ b/Sources/TMDb/Domain/Services/Genres/Requests/TVSeriesGenresRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/GuestSessions/Requests/GuestSessionRatedMoviesRequest.swift
+++ b/Sources/TMDb/Domain/Services/GuestSessions/Requests/GuestSessionRatedMoviesRequest.swift
@@ -31,13 +31,9 @@ private extension APIRequestQueryItems {
     init(sortedBy: RatedSort?, page: Int?) {
         self.init()
 
-        if let sortedBy {
-            self[.sortBy] = sortedBy
-        }
+        self[ifPresent: .sortBy] = sortedBy
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
     }
 
 }

--- a/Sources/TMDb/Domain/Services/GuestSessions/Requests/GuestSessionRatedTVEpisodesRequest.swift
+++ b/Sources/TMDb/Domain/Services/GuestSessions/Requests/GuestSessionRatedTVEpisodesRequest.swift
@@ -31,13 +31,9 @@ private extension APIRequestQueryItems {
     init(sortedBy: RatedSort?, page: Int?) {
         self.init()
 
-        if let sortedBy {
-            self[.sortBy] = sortedBy
-        }
+        self[ifPresent: .sortBy] = sortedBy
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
     }
 
 }

--- a/Sources/TMDb/Domain/Services/GuestSessions/Requests/GuestSessionRatedTVSeriesRequest.swift
+++ b/Sources/TMDb/Domain/Services/GuestSessions/Requests/GuestSessionRatedTVSeriesRequest.swift
@@ -31,13 +31,9 @@ private extension APIRequestQueryItems {
     init(sortedBy: RatedSort?, page: Int?) {
         self.init()
 
-        if let sortedBy {
-            self[.sortBy] = sortedBy
-        }
+        self[ifPresent: .sortBy] = sortedBy
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Keywords/Requests/KeywordMoviesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Keywords/Requests/KeywordMoviesRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(page: Int?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Lists/Requests/ListRequest.swift
+++ b/Sources/TMDb/Domain/Services/Lists/Requests/ListRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(page: Int?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Movies/Requests/MovieAlternativeTitlesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Movies/Requests/MovieAlternativeTitlesRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(country: String?, language: String?) {
         self.init()
 
-        if let country {
-            self[.country] = country
-        }
+        self[ifPresent: .country] = country
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Movies/Requests/MovieChangesListRequest.swift
+++ b/Sources/TMDb/Domain/Services/Movies/Requests/MovieChangesListRequest.swift
@@ -23,17 +23,11 @@ private extension APIRequestQueryItems {
     init(startDate: Date?, endDate: Date?, page: Int?) {
         self.init()
 
-        if let startDate {
-            self[.startDate] = startDate
-        }
+        self[ifPresent: .startDate] = startDate
 
-        if let endDate {
-            self[.endDate] = endDate
-        }
+        self[ifPresent: .endDate] = endDate
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Movies/Requests/MovieChangesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Movies/Requests/MovieChangesRequest.swift
@@ -23,17 +23,11 @@ private extension APIRequestQueryItems {
     init(startDate: Date?, endDate: Date?, page: Int?) {
         self.init()
 
-        if let startDate {
-            self[.startDate] = startDate
-        }
+        self[ifPresent: .startDate] = startDate
 
-        if let endDate {
-            self[.endDate] = endDate
-        }
+        self[ifPresent: .endDate] = endDate
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Movies/Requests/MovieCreditsRequest.swift
+++ b/Sources/TMDb/Domain/Services/Movies/Requests/MovieCreditsRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Movies/Requests/MovieDetailsAppendRequest.swift
+++ b/Sources/TMDb/Domain/Services/Movies/Requests/MovieDetailsAppendRequest.swift
@@ -38,9 +38,7 @@ private extension APIRequestQueryItems {
             self[.appendToResponse] = appendToResponse.queryValue
         }
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Movies/Requests/MovieListsRequest.swift
+++ b/Sources/TMDb/Domain/Services/Movies/Requests/MovieListsRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(page: Int?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Movies/Requests/MovieRecommendationsRequest.swift
+++ b/Sources/TMDb/Domain/Services/Movies/Requests/MovieRecommendationsRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(page: Int?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Movies/Requests/MovieRequest.swift
+++ b/Sources/TMDb/Domain/Services/Movies/Requests/MovieRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Movies/Requests/MovieReviewsRequest.swift
+++ b/Sources/TMDb/Domain/Services/Movies/Requests/MovieReviewsRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(page: Int?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Movies/Requests/MoviesNowPlayingRequest.swift
+++ b/Sources/TMDb/Domain/Services/Movies/Requests/MoviesNowPlayingRequest.swift
@@ -23,17 +23,11 @@ private extension APIRequestQueryItems {
     init(page: Int?, country: String?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let country {
-            self[.region] = country
-        }
+        self[ifPresent: .region] = country
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Movies/Requests/PopularMoviesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Movies/Requests/PopularMoviesRequest.swift
@@ -23,17 +23,11 @@ private extension APIRequestQueryItems {
     init(page: Int?, country: String?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let country {
-            self[.region] = country
-        }
+        self[ifPresent: .region] = country
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Movies/Requests/SimilarMoviesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Movies/Requests/SimilarMoviesRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(page: Int?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Movies/Requests/TopRatedMoviesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Movies/Requests/TopRatedMoviesRequest.swift
@@ -23,17 +23,11 @@ private extension APIRequestQueryItems {
     init(page: Int?, country: String?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let country {
-            self[.region] = country
-        }
+        self[ifPresent: .region] = country
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Movies/Requests/UpcomingMoviesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Movies/Requests/UpcomingMoviesRequest.swift
@@ -23,17 +23,11 @@ private extension APIRequestQueryItems {
     init(page: Int?, country: String?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let country {
-            self[.region] = country
-        }
+        self[ifPresent: .region] = country
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/People/Requests/PersonChangesListRequest.swift
+++ b/Sources/TMDb/Domain/Services/People/Requests/PersonChangesListRequest.swift
@@ -42,9 +42,7 @@ private extension APIRequestQueryItems {
             self[Self.endDate] = DateFormatter.theMovieDatabase.string(from: endDate)
         }
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
     }
 
 }

--- a/Sources/TMDb/Domain/Services/People/Requests/PersonChangesRequest.swift
+++ b/Sources/TMDb/Domain/Services/People/Requests/PersonChangesRequest.swift
@@ -43,9 +43,7 @@ private extension APIRequestQueryItems {
             self[Self.endDate] = DateFormatter.theMovieDatabase.string(from: endDate)
         }
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
     }
 
 }

--- a/Sources/TMDb/Domain/Services/People/Requests/PersonCombinedCreditsRequest.swift
+++ b/Sources/TMDb/Domain/Services/People/Requests/PersonCombinedCreditsRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/People/Requests/PersonDetailsAppendRequest.swift
+++ b/Sources/TMDb/Domain/Services/People/Requests/PersonDetailsAppendRequest.swift
@@ -38,9 +38,7 @@ private extension APIRequestQueryItems {
             self[.appendToResponse] = appendToResponse.queryValue
         }
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/People/Requests/PersonMovieCreditsRequest.swift
+++ b/Sources/TMDb/Domain/Services/People/Requests/PersonMovieCreditsRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/People/Requests/PersonRequest.swift
+++ b/Sources/TMDb/Domain/Services/People/Requests/PersonRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/People/Requests/PersonTVSeriesCreditsRequest.swift
+++ b/Sources/TMDb/Domain/Services/People/Requests/PersonTVSeriesCreditsRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/People/Requests/PersonTaggedImagesRequest.swift
+++ b/Sources/TMDb/Domain/Services/People/Requests/PersonTaggedImagesRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(page: Int?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
     }
 
 }

--- a/Sources/TMDb/Domain/Services/People/Requests/PopularPeopleRequest.swift
+++ b/Sources/TMDb/Domain/Services/People/Requests/PopularPeopleRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(page: Int?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Search/Requests/CollectionSearchRequest.swift
+++ b/Sources/TMDb/Domain/Services/Search/Requests/CollectionSearchRequest.swift
@@ -33,13 +33,9 @@ private extension APIRequestQueryItems {
 
         self[.query] = query
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Search/Requests/CompanySearchRequest.swift
+++ b/Sources/TMDb/Domain/Services/Search/Requests/CompanySearchRequest.swift
@@ -31,9 +31,7 @@ private extension APIRequestQueryItems {
 
         self[.query] = query
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Search/Requests/KeywordSearchRequest.swift
+++ b/Sources/TMDb/Domain/Services/Search/Requests/KeywordSearchRequest.swift
@@ -31,9 +31,7 @@ private extension APIRequestQueryItems {
 
         self[.query] = query
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Search/Requests/MovieSearchRequest.swift
+++ b/Sources/TMDb/Domain/Services/Search/Requests/MovieSearchRequest.swift
@@ -50,29 +50,17 @@ private extension APIRequestQueryItems {
 
         self[.query] = query
 
-        if let primaryReleaseYear {
-            self[.primaryReleaseYear] = primaryReleaseYear
-        }
+        self[ifPresent: .primaryReleaseYear] = primaryReleaseYear
 
-        if let year {
-            self[.year] = year
-        }
+        self[ifPresent: .year] = year
 
-        if let country {
-            self[.region] = country
-        }
+        self[ifPresent: .region] = country
 
-        if let includeAdult {
-            self[.includeAdult] = includeAdult
-        }
+        self[ifPresent: .includeAdult] = includeAdult
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Search/Requests/MultiSearchRequest.swift
+++ b/Sources/TMDb/Domain/Services/Search/Requests/MultiSearchRequest.swift
@@ -40,17 +40,11 @@ private extension APIRequestQueryItems {
 
         self[.query] = query
 
-        if let includeAdult {
-            self[.includeAdult] = includeAdult
-        }
+        self[ifPresent: .includeAdult] = includeAdult
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Search/Requests/PersonSearchRequest.swift
+++ b/Sources/TMDb/Domain/Services/Search/Requests/PersonSearchRequest.swift
@@ -40,17 +40,11 @@ private extension APIRequestQueryItems {
 
         self[.query] = query
 
-        if let includeAdult {
-            self[.includeAdult] = includeAdult
-        }
+        self[ifPresent: .includeAdult] = includeAdult
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Search/Requests/TVSeriesSearchRequest.swift
+++ b/Sources/TMDb/Domain/Services/Search/Requests/TVSeriesSearchRequest.swift
@@ -46,25 +46,15 @@ private extension APIRequestQueryItems {
 
         self[.query] = query
 
-        if let firstAirDateYear {
-            self[.firstAirDateYear] = firstAirDateYear
-        }
+        self[ifPresent: .firstAirDateYear] = firstAirDateYear
 
-        if let year {
-            self[.year] = year
-        }
+        self[ifPresent: .year] = year
 
-        if let includeAdult {
-            self[.includeAdult] = includeAdult
-        }
+        self[ifPresent: .includeAdult] = includeAdult
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVEpisodes/Requests/TVEpisodeChangesRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVEpisodes/Requests/TVEpisodeChangesRequest.swift
@@ -44,9 +44,7 @@ private extension APIRequestQueryItems {
             self[Self.endDate] = DateFormatter.theMovieDatabase.string(from: endDate)
         }
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVEpisodes/Requests/TVEpisodeCreditsRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVEpisodes/Requests/TVEpisodeCreditsRequest.swift
@@ -28,9 +28,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVEpisodes/Requests/TVEpisodeDetailsAppendRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVEpisodes/Requests/TVEpisodeDetailsAppendRequest.swift
@@ -42,9 +42,7 @@ private extension APIRequestQueryItems {
             self[.appendToResponse] = appendToResponse.queryValue
         }
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVEpisodes/Requests/TVEpisodeRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVEpisodes/Requests/TVEpisodeRequest.swift
@@ -28,9 +28,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeasons/Requests/TVSeasonAggregateCreditsRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeasons/Requests/TVSeasonAggregateCreditsRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeasons/Requests/TVSeasonChangesRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeasons/Requests/TVSeasonChangesRequest.swift
@@ -44,9 +44,7 @@ private extension APIRequestQueryItems {
             self[Self.endDate] = DateFormatter.theMovieDatabase.string(from: endDate)
         }
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeasons/Requests/TVSeasonCreditsRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeasons/Requests/TVSeasonCreditsRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeasons/Requests/TVSeasonDetailsAppendRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeasons/Requests/TVSeasonDetailsAppendRequest.swift
@@ -39,9 +39,7 @@ private extension APIRequestQueryItems {
             self[.appendToResponse] = appendToResponse.queryValue
         }
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeasons/Requests/TVSeasonRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeasons/Requests/TVSeasonRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/PopularTVSeriesRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/PopularTVSeriesRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(page: Int?, language: String? = nil) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/SimilarTVSeriesRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/SimilarTVSeriesRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(page: Int?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesAggregateCreditsRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesAggregateCreditsRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesAiringTodayRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesAiringTodayRequest.swift
@@ -23,17 +23,11 @@ private extension APIRequestQueryItems {
     init(page: Int?, timezone: String?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let timezone {
-            self[.timezone] = timezone
-        }
+        self[ifPresent: .timezone] = timezone
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesChangesListRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesChangesListRequest.swift
@@ -34,9 +34,7 @@ private extension APIRequestQueryItems {
             self[Self.endDate] = DateFormatter.theMovieDatabase.string(from: endDate)
         }
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesChangesRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesChangesRequest.swift
@@ -34,9 +34,7 @@ private extension APIRequestQueryItems {
             self[Self.endDate] = DateFormatter.theMovieDatabase.string(from: endDate)
         }
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesCreditsRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesCreditsRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesDetailsAppendRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesDetailsAppendRequest.swift
@@ -38,9 +38,7 @@ private extension APIRequestQueryItems {
             self[.appendToResponse] = appendToResponse.queryValue
         }
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesListsRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesListsRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(page: Int?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesOnTheAirRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesOnTheAirRequest.swift
@@ -23,17 +23,11 @@ private extension APIRequestQueryItems {
     init(page: Int?, timezone: String?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let timezone {
-            self[.timezone] = timezone
-        }
+        self[ifPresent: .timezone] = timezone
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesRecommendationsRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesRecommendationsRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(page: Int?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesReviewsRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/TVSeriesReviewsRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(page: Int?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/TVSeries/Requests/TopRatedTVSeriesRequest.swift
+++ b/Sources/TMDb/Domain/Services/TVSeries/Requests/TopRatedTVSeriesRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(page: Int?, language: String? = nil) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Trending/Requests/TrendingAllRequest.swift
+++ b/Sources/TMDb/Domain/Services/Trending/Requests/TrendingAllRequest.swift
@@ -27,13 +27,9 @@ private extension APIRequestQueryItems {
     init(page: Int?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Trending/Requests/TrendingMoviesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Trending/Requests/TrendingMoviesRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(page: Int?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Trending/Requests/TrendingPeopleRequest.swift
+++ b/Sources/TMDb/Domain/Services/Trending/Requests/TrendingPeopleRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(page: Int?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/Trending/Requests/TrendingTVSeriesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Trending/Requests/TrendingTVSeriesRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(page: Int?, language: String?) {
         self.init()
 
-        if let page {
-            self[.page] = page
-        }
+        self[ifPresent: .page] = page
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/WatchProviders/Requests/WatchProviderRegionsRequest.swift
+++ b/Sources/TMDb/Domain/Services/WatchProviders/Requests/WatchProviderRegionsRequest.swift
@@ -23,9 +23,7 @@ private extension APIRequestQueryItems {
     init(language: String?) {
         self.init()
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/WatchProviders/Requests/WatchProvidersForMoviesRequest.swift
+++ b/Sources/TMDb/Domain/Services/WatchProviders/Requests/WatchProvidersForMoviesRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(country: String?, language: String?) {
         self.init()
 
-        if let country {
-            self[.watchRegion] = country
-        }
+        self[ifPresent: .watchRegion] = country
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Sources/TMDb/Domain/Services/WatchProviders/Requests/WatchProvidersForTVSeriesRequest.swift
+++ b/Sources/TMDb/Domain/Services/WatchProviders/Requests/WatchProvidersForTVSeriesRequest.swift
@@ -23,13 +23,9 @@ private extension APIRequestQueryItems {
     init(country: String?, language: String?) {
         self.init()
 
-        if let country {
-            self[.watchRegion] = country
-        }
+        self[ifPresent: .watchRegion] = country
 
-        if let language {
-            self[.language] = language
-        }
+        self[ifPresent: .language] = language
     }
 
 }

--- a/Tests/TMDbTests/Domain/APIClient/APIRequestQueryItemsTests.swift
+++ b/Tests/TMDbTests/Domain/APIClient/APIRequestQueryItemsTests.swift
@@ -1,0 +1,55 @@
+//
+//  APIRequestQueryItemsTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.apiClient, .domain))
+struct APIRequestQueryItemsTests {
+
+    @Test("subscript(ifPresent:) sets the key when the value is present")
+    func ifPresentSubscriptSetsPresentValue() {
+        var queryItems = APIRequestQueryItems()
+        let page: Int? = 3
+
+        queryItems[ifPresent: .page] = page
+
+        #expect(queryItems.count == 1)
+        #expect(queryItems[.page]?.description == "3")
+    }
+
+    @Test("subscript(ifPresent:) is a no-op when the value is nil")
+    func ifPresentSubscriptIgnoresNilValue() {
+        var queryItems = APIRequestQueryItems()
+        let page: Int? = nil
+
+        queryItems[ifPresent: .page] = page
+
+        #expect(queryItems.isEmpty)
+    }
+
+    @Test("subscript(ifPresent:) does not clear an existing value when set to nil")
+    func ifPresentSubscriptDoesNotClearExistingValue() {
+        var queryItems = APIRequestQueryItems()
+        queryItems[ifPresent: .page] = 3
+        let missing: Int? = nil
+
+        queryItems[ifPresent: .page] = missing
+
+        #expect(queryItems[.page]?.description == "3")
+    }
+
+    @Test("subscript(ifPresent:) getter returns the stored value")
+    func ifPresentSubscriptGetterReturnsStoredValue() {
+        var queryItems = APIRequestQueryItems()
+        queryItems[.language] = "en"
+
+        #expect(queryItems[ifPresent: .language]?.description == "en")
+    }
+
+}


### PR DESCRIPTION
## Summary

Tier 4 Codable-consolidation refactor **F4** — removes the repeated
`if let x { self[.x] = x }` ceremony in the request builders.

- Adds an internal `subscript(ifPresent:)` on `APIRequestQueryItems` where a
  **nil assignment is a no-op** — unlike the raw `Dictionary` subscript, whose
  `nil` *removes* the key. This lets an optional query value be applied in one
  line without an `if let` guard, and without an incoming `nil` clearing a value
  set earlier.
- Collapses `if let x { self[.x] = x }` → `self[ifPresent: .x] = x` across the
  request files (137 blocks via a fan-out sweep of 78 files, plus the two
  `Discover*Request` filter builders by hand).
- **Left as-is:** blocks whose right-hand side *transforms* the bound value
  (e.g. `Self.idsQueryItemValue(for:)`, date formatting, `.joined(...)`,
  `.queryValue(...)`) — they don't fit the direct-assignment shape.

Net **−293 lines** across 82 files. All request types are internal, so the
change is fully contained.

## Why

The `*AppendOption` / non-empty-decode consolidations (#378, #379) shrank the
most-duplicated model code; this does the same for the request builders — the
single most repeated boilerplate on the request side.

## Testing

- Behaviour-preserving: the existing per-request query-item tests (which assert
  the **exact** built query dictionaries) are the regression guard and pass
  unchanged.
- Adds `APIRequestQueryItemsTests` covering the new subscript's branches: value
  set, `nil` no-op, `nil` does not clear an existing value, and the getter.
- `make ci` green — lint, markdown lint, unit tests (2853), live integration
  tests, build-release, build-docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiQ5SMgbUZsJ82Y6Hb3MXa