### PR TITLE
♻️ Extract shared decode helpers for the *DetailsResponse decoders

### DIFF
--- a/Sources/TMDb/Domain/Models/ImageCollection.swift
+++ b/Sources/TMDb/Domain/Models/ImageCollection.swift
@@ -56,3 +56,42 @@ public struct ImageCollection: Identifiable, Codable, Equatable, Hashable, Senda
     }
 
 }
+
+extension ImageCollection {
+
+    ///
+    /// Decodes an image collection from the wrapper object at `key`.
+    ///
+    /// The image append section wraps up to three arrays — `posters`, `logos`, and
+    /// `backdrops` — each defaulting to empty when absent, so a wrapper carrying only
+    /// some of them decodes into a collection with the rest empty.
+    ///
+    /// - Parameters:
+    ///   - container: The container holding the `images` wrapper.
+    ///   - key: The wrapper key. When absent, the initializer returns `nil`.
+    ///   - id: The identifier of the owning entity.
+    ///
+    init?<Key: CodingKey>(
+        from container: KeyedDecodingContainer<Key>,
+        forKey key: Key,
+        id: Int
+    ) throws {
+        guard container.contains(key) else {
+            return nil
+        }
+
+        let nested = try container.nestedContainer(keyedBy: StringCodingKey.self, forKey: key)
+
+        func images(_ name: String) throws -> [ImageMetadata] {
+            try nested.decodeIfPresent([ImageMetadata].self, forKey: StringCodingKey(name)) ?? []
+        }
+
+        try self.init(
+            id: id,
+            posters: images("posters"),
+            logos: images("logos"),
+            backdrops: images("backdrops")
+        )
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/MovieDetailsResponse.swift
+++ b/Sources/TMDb/Domain/Models/MovieDetailsResponse.swift
@@ -165,113 +165,22 @@ extension MovieDetailsResponse: Decodable {
         case changes
     }
 
-    private enum CreditsCodingKeys: String, CodingKey {
-        case cast
-        case crew
-    }
-
-    private enum ImagesCodingKeys: String, CodingKey {
-        case backdrops
-        case logos
-        case posters
-    }
-
-    private enum VideosCodingKeys: String, CodingKey {
-        case results
-    }
-
-    private enum ResultsCodingKeys: String, CodingKey {
-        case results
-    }
-
-    private enum TitlesCodingKeys: String, CodingKey {
-        case titles
-    }
-
-    private enum TranslationsCodingKeys: String, CodingKey {
-        case translations
-    }
-
-    private enum MovieKeywordsCodingKeys: String, CodingKey {
-        case keywords
-    }
-
-    private enum ExternalIDsCodingKeys: String, CodingKey {
-        case imdbID = "imdbId"
-        case wikiDataID = "wikidataId"
-        case facebookID = "facebookId"
-        case instagramID = "instagramId"
-        case twitterID = "twitterId"
-    }
-
-    private enum WatchProvidersCodingKeys: String, CodingKey {
-        case results
-    }
-
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     public init(from decoder: Decoder) throws {
         self.movie = try Movie(from: decoder)
+        let id = movie.id
 
-        let container = try decoder.container(
-            keyedBy: CodingKeys.self
-        )
+        let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        if container.contains(.credits) {
-            let nested = try container.nestedContainer(
-                keyedBy: CreditsCodingKeys.self,
-                forKey: .credits
-            )
-            let cast = try nested.decodeIfPresent(
-                [CastMember].self, forKey: .cast
-            ) ?? []
-            let crew = try nested.decodeIfPresent(
-                [CrewMember].self, forKey: .crew
-            ) ?? []
-            self.credits = ShowCredits(
-                id: movie.id, cast: cast, crew: crew
-            )
-        } else {
-            self.credits = nil
-        }
+        self.credits = try container
+            .decodeCastAndCrewIfPresent(CastMember.self, CrewMember.self, forKey: .credits)
+            .map { ShowCredits(id: id, cast: $0.cast, crew: $0.crew) }
 
-        if container.contains(.images) {
-            let nested = try container.nestedContainer(
-                keyedBy: ImagesCodingKeys.self,
-                forKey: .images
-            )
-            let backdrops = try nested.decodeIfPresent(
-                [ImageMetadata].self, forKey: .backdrops
-            ) ?? []
-            let logos = try nested.decodeIfPresent(
-                [ImageMetadata].self, forKey: .logos
-            ) ?? []
-            let posters = try nested.decodeIfPresent(
-                [ImageMetadata].self, forKey: .posters
-            ) ?? []
-            self.images = ImageCollection(
-                id: movie.id,
-                posters: posters,
-                logos: logos,
-                backdrops: backdrops
-            )
-        } else {
-            self.images = nil
-        }
+        self.images = try ImageCollection(from: container, forKey: .images, id: id)
 
-        if container.contains(.videos) {
-            let nested = try container.nestedContainer(
-                keyedBy: VideosCodingKeys.self,
-                forKey: .videos
-            )
-            let results = try nested.decodeIfPresent(
-                [VideoMetadata].self, forKey: .results
-            ) ?? []
-            self.videos = VideoCollection(
-                id: movie.id, results: results
-            )
-        } else {
-            self.videos = nil
-        }
+        self.videos = try container
+            .decodeNestedArrayIfPresent(VideoMetadata.self, forKey: .videos, nestedKey: "results")
+            .map { VideoCollection(id: id, results: $0) }
 
         self.reviews = try container.decodeIfPresent(
             ReviewPageableList.self, forKey: .reviews
@@ -289,103 +198,33 @@ extension MovieDetailsResponse: Decodable {
             ChangeCollection.self, forKey: .changes
         )
 
-        if container.contains(.releaseDates) {
-            let nested = try container.nestedContainer(
-                keyedBy: ResultsCodingKeys.self,
-                forKey: .releaseDates
-            )
-            self.releaseDates = try nested.decodeIfPresent(
-                [MovieReleaseDatesByCountry].self,
-                forKey: .results
-            )
-        } else {
-            self.releaseDates = nil
-        }
+        self.releaseDates = try container.decodeNestedIfPresent(
+            [MovieReleaseDatesByCountry].self, forKey: .releaseDates, nestedKey: "results"
+        )
+        self.alternativeTitles = try container.decodeNestedIfPresent(
+            [AlternativeTitle].self, forKey: .alternativeTitles, nestedKey: "titles"
+        )
+        self.translations = try container.decodeNestedIfPresent(
+            [Translation<MovieTranslationData>].self, forKey: .translations, nestedKey: "translations"
+        )
+        self.keywords = try container.decodeNestedIfPresent(
+            [Keyword].self, forKey: .keywords, nestedKey: "keywords"
+        )
+        self.watchProviders = try container.decodeNestedIfPresent(
+            [String: ShowWatchProvider].self, forKey: .watchProviders, nestedKey: "results"
+        )
 
-        if container.contains(.alternativeTitles) {
-            let nested = try container.nestedContainer(
-                keyedBy: TitlesCodingKeys.self,
-                forKey: .alternativeTitles
-            )
-            self.alternativeTitles = try nested.decodeIfPresent(
-                [AlternativeTitle].self, forKey: .titles
-            )
-        } else {
-            self.alternativeTitles = nil
-        }
-
-        if container.contains(.translations) {
-            let nested = try container.nestedContainer(
-                keyedBy: TranslationsCodingKeys.self,
-                forKey: .translations
-            )
-            self.translations = try nested.decodeIfPresent(
-                [Translation<MovieTranslationData>].self,
-                forKey: .translations
-            )
-        } else {
-            self.translations = nil
-        }
-
-        if container.contains(.keywords) {
-            let nested = try container.nestedContainer(
-                keyedBy: MovieKeywordsCodingKeys.self,
-                forKey: .keywords
-            )
-            self.keywords = try nested.decodeIfPresent(
-                [Keyword].self, forKey: .keywords
-            )
-        } else {
-            self.keywords = nil
-        }
-
-        if container.contains(.watchProviders) {
-            let nested = try container.nestedContainer(
-                keyedBy: WatchProvidersCodingKeys.self,
-                forKey: .watchProviders
-            )
-            self.watchProviders = try nested.decodeIfPresent(
-                [String: ShowWatchProvider].self,
-                forKey: .results
-            )
-        } else {
-            self.watchProviders = nil
-        }
-
-        if container.contains(.externalIDs) {
-            let nested = try container.nestedContainer(
-                keyedBy: ExternalIDsCodingKeys.self,
-                forKey: .externalIDs
-            )
-            let imdbID = try nested.decodeIfPresent(
-                String.self, forKey: .imdbID
-            )
-            let wikiDataID = try nested.decodeIfPresent(
-                String.self, forKey: .wikiDataID
-            )
-            let facebookID = try nested.decodeIfPresent(
-                String.self, forKey: .facebookID
-            )
-            let instagramID = try nested.decodeIfPresent(
-                String.self, forKey: .instagramID
-            )
-            let twitterID = try nested.decodeIfPresent(
-                String.self, forKey: .twitterID
-            )
-            self.externalIDs = MovieExternalLinksCollection(
-                id: movie.id,
-                imdb: IMDbLink(imdbTitleID: imdbID),
-                wikiData: WikiDataLink(wikiDataID: wikiDataID),
-                facebook: FacebookLink(facebookID: facebookID),
-                instagram: InstagramLink(
-                    instagramID: instagramID
-                ),
-                twitter: TwitterLink(twitterID: twitterID)
-            )
-        } else {
-            self.externalIDs = nil
-        }
+        self.externalIDs = try SocialLinkIDs(from: container, forKey: .externalIDs)
+            .map {
+                MovieExternalLinksCollection(
+                    id: id,
+                    imdb: IMDbLink(imdbTitleID: $0.imdbID),
+                    wikiData: WikiDataLink(wikiDataID: $0.wikiDataID),
+                    facebook: FacebookLink(facebookID: $0.facebookID),
+                    instagram: InstagramLink(instagramID: $0.instagramID),
+                    twitter: TwitterLink(twitterID: $0.twitterID)
+                )
+            }
     }
-    // swiftlint:enable function_body_length
 
 }

--- a/Sources/TMDb/Domain/Models/PersonDetailsResponse.swift
+++ b/Sources/TMDb/Domain/Models/PersonDetailsResponse.swift
@@ -112,104 +112,33 @@ extension PersonDetailsResponse: Decodable {
         case changes
     }
 
-    private enum CreditsCodingKeys: String, CodingKey {
-        case cast
-        case crew
-    }
-
-    private enum ImagesCodingKeys: String, CodingKey {
-        case profiles
-    }
-
-    private enum TranslationsCodingKeys: String, CodingKey {
-        case translations
-    }
-
-    private enum ExternalIDsCodingKeys: String, CodingKey {
-        case imdbID = "imdbId"
-        case wikiDataID = "wikidataId"
-        case facebookID = "facebookId"
-        case instagramID = "instagramId"
-        case twitterID = "twitterId"
-        case tikTokID = "tiktokId"
-    }
-
-    // swiftlint:disable function_body_length
     public init(from decoder: Decoder) throws {
         self.person = try Person(from: decoder)
+        let id = person.id
 
-        let container = try decoder.container(
-            keyedBy: CodingKeys.self
-        )
+        let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        if container.contains(.movieCredits) {
-            let nested = try container.nestedContainer(
-                keyedBy: CreditsCodingKeys.self,
-                forKey: .movieCredits
+        self.movieCredits = try container
+            .decodeCastAndCrewIfPresent(
+                MovieCastCredit.self, MovieCrewCredit.self, forKey: .movieCredits
             )
-            let cast = try nested.decodeIfPresent(
-                [MovieCastCredit].self, forKey: .cast
-            ) ?? []
-            let crew = try nested.decodeIfPresent(
-                [MovieCrewCredit].self, forKey: .crew
-            ) ?? []
-            self.movieCredits = PersonMovieCredits(
-                id: person.id, cast: cast, crew: crew
-            )
-        } else {
-            self.movieCredits = nil
-        }
+            .map { PersonMovieCredits(id: id, cast: $0.cast, crew: $0.crew) }
 
-        if container.contains(.tvCredits) {
-            let nested = try container.nestedContainer(
-                keyedBy: CreditsCodingKeys.self,
-                forKey: .tvCredits
+        self.tvCredits = try container
+            .decodeCastAndCrewIfPresent(
+                TVSeriesCastCredit.self, TVSeriesCrewCredit.self, forKey: .tvCredits
             )
-            let cast = try nested.decodeIfPresent(
-                [TVSeriesCastCredit].self, forKey: .cast
-            ) ?? []
-            let crew = try nested.decodeIfPresent(
-                [TVSeriesCrewCredit].self, forKey: .crew
-            ) ?? []
-            self.tvCredits = PersonTVSeriesCredits(
-                id: person.id, cast: cast, crew: crew
-            )
-        } else {
-            self.tvCredits = nil
-        }
+            .map { PersonTVSeriesCredits(id: id, cast: $0.cast, crew: $0.crew) }
 
-        if container.contains(.combinedCredits) {
-            let nested = try container.nestedContainer(
-                keyedBy: CreditsCodingKeys.self,
-                forKey: .combinedCredits
+        self.combinedCredits = try container
+            .decodeCastAndCrewIfPresent(
+                ShowCastCredit.self, ShowCrewCredit.self, forKey: .combinedCredits
             )
-            let cast = try nested.decodeIfPresent(
-                [ShowCastCredit].self, forKey: .cast
-            ) ?? []
-            let crew = try nested.decodeIfPresent(
-                [ShowCrewCredit].self, forKey: .crew
-            ) ?? []
-            self.combinedCredits = PersonCombinedCredits(
-                id: person.id, cast: cast, crew: crew
-            )
-        } else {
-            self.combinedCredits = nil
-        }
+            .map { PersonCombinedCredits(id: id, cast: $0.cast, crew: $0.crew) }
 
-        if container.contains(.images) {
-            let nested = try container.nestedContainer(
-                keyedBy: ImagesCodingKeys.self,
-                forKey: .images
-            )
-            let profiles = try nested.decodeIfPresent(
-                [ImageMetadata].self, forKey: .profiles
-            ) ?? []
-            self.images = PersonImageCollection(
-                id: person.id, profiles: profiles
-            )
-        } else {
-            self.images = nil
-        }
+        self.images = try container
+            .decodeNestedArrayIfPresent(ImageMetadata.self, forKey: .images, nestedKey: "profiles")
+            .map { PersonImageCollection(id: id, profiles: $0) }
 
         self.taggedImages = try container.decodeIfPresent(
             TaggedImagePageableList.self,
@@ -219,61 +148,24 @@ extension PersonDetailsResponse: Decodable {
             ChangeCollection.self, forKey: .changes
         )
 
-        if container.contains(.translations) {
-            let nested = try container.nestedContainer(
-                keyedBy: TranslationsCodingKeys.self,
-                forKey: .translations
-            )
-            self.translations = try nested.decodeIfPresent(
-                [Translation<PersonTranslationData>].self,
-                forKey: .translations
-            )
-        } else {
-            self.translations = nil
-        }
+        self.translations = try container.decodeNestedIfPresent(
+            [Translation<PersonTranslationData>].self,
+            forKey: .translations,
+            nestedKey: "translations"
+        )
 
-        if container.contains(.externalIDs) {
-            let nested = try container.nestedContainer(
-                keyedBy: ExternalIDsCodingKeys.self,
-                forKey: .externalIDs
-            )
-            let imdbID = try nested.decodeIfPresent(
-                String.self, forKey: .imdbID
-            )
-            let wikiDataID = try nested.decodeIfPresent(
-                String.self, forKey: .wikiDataID
-            )
-            let facebookID = try nested.decodeIfPresent(
-                String.self, forKey: .facebookID
-            )
-            let instagramID = try nested.decodeIfPresent(
-                String.self, forKey: .instagramID
-            )
-            let twitterID = try nested.decodeIfPresent(
-                String.self, forKey: .twitterID
-            )
-            let tikTokID = try nested.decodeIfPresent(
-                String.self, forKey: .tikTokID
-            )
-            self.externalIDs = PersonExternalLinksCollection(
-                id: person.id,
-                imdb: IMDbLink(imdbNameID: imdbID),
-                wikiData: WikiDataLink(
-                    wikiDataID: wikiDataID
-                ),
-                facebook: FacebookLink(
-                    facebookID: facebookID
-                ),
-                instagram: InstagramLink(
-                    instagramID: instagramID
-                ),
-                twitter: TwitterLink(twitterID: twitterID),
-                tikTok: TikTokLink(tikTokID: tikTokID)
-            )
-        } else {
-            self.externalIDs = nil
-        }
+        self.externalIDs = try SocialLinkIDs(from: container, forKey: .externalIDs)
+            .map {
+                PersonExternalLinksCollection(
+                    id: id,
+                    imdb: IMDbLink(imdbNameID: $0.imdbID),
+                    wikiData: WikiDataLink(wikiDataID: $0.wikiDataID),
+                    facebook: FacebookLink(facebookID: $0.facebookID),
+                    instagram: InstagramLink(instagramID: $0.instagramID),
+                    twitter: TwitterLink(twitterID: $0.twitterID),
+                    tikTok: TikTokLink(tikTokID: $0.tikTokID)
+                )
+            }
     }
-    // swiftlint:enable function_body_length
 
 }

--- a/Sources/TMDb/Domain/Models/SocialLinkIDs.swift
+++ b/Sources/TMDb/Domain/Models/SocialLinkIDs.swift
@@ -1,0 +1,63 @@
+//
+//  SocialLinkIDs.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// The optional social-link identifiers decoded from an `external_ids` append section.
+///
+/// A shared intermediate that each `*ExternalLinksCollection` maps into its own
+/// external-links type.
+///
+struct SocialLinkIDs {
+
+    let imdbID: String?
+    let wikiDataID: String?
+    let facebookID: String?
+    let instagramID: String?
+    let twitterID: String?
+    let tikTokID: String?
+
+}
+
+extension SocialLinkIDs {
+
+    ///
+    /// Decodes the social-link identifiers from the object at `key`.
+    ///
+    /// The `external_ids` append section is a flat object of optional identifier
+    /// strings; this decodes every known identifier (each `nil` when absent).
+    ///
+    /// - Parameters:
+    ///   - container: The container holding the `external_ids` wrapper.
+    ///   - key: The wrapper key. When absent, the initializer returns `nil`.
+    ///
+    init?<Key: CodingKey>(
+        from container: KeyedDecodingContainer<Key>,
+        forKey key: Key
+    ) throws {
+        guard container.contains(key) else {
+            return nil
+        }
+
+        let nested = try container.nestedContainer(keyedBy: StringCodingKey.self, forKey: key)
+
+        func string(_ name: String) throws -> String? {
+            try nested.decodeIfPresent(String.self, forKey: StringCodingKey(name))
+        }
+
+        try self.init(
+            imdbID: string("imdbId"),
+            wikiDataID: string("wikidataId"),
+            facebookID: string("facebookId"),
+            instagramID: string("instagramId"),
+            twitterID: string("twitterId"),
+            tikTokID: string("tiktokId")
+        )
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/TVEpisodeDetailsResponse.swift
+++ b/Sources/TMDb/Domain/Models/TVEpisodeDetailsResponse.swift
@@ -87,119 +87,38 @@ extension TVEpisodeDetailsResponse: Decodable {
         case externalIDs = "externalIds"
     }
 
-    private enum CreditsCodingKeys: String, CodingKey {
-        case cast
-        case crew
-    }
-
-    private enum StillsCodingKeys: String, CodingKey {
-        case stills
-    }
-
-    private enum VideosCodingKeys: String, CodingKey {
-        case results
-    }
-
-    private enum TranslationsCodingKeys: String, CodingKey {
-        case translations
-    }
-
-    private enum ExternalIDsCodingKeys: String, CodingKey {
-        case imdbID = "imdbId"
-        case wikiDataID = "wikidataId"
-    }
-
-    // swiftlint:disable function_body_length
     public init(from decoder: Decoder) throws {
         self.episode = try TVEpisode(from: decoder)
+        let id = episode.id
 
-        let container = try decoder.container(
-            keyedBy: CodingKeys.self
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.credits = try container
+            .decodeCastAndCrewIfPresent(CastMember.self, CrewMember.self, forKey: .credits)
+            .map { ShowCredits(id: id, cast: $0.cast, crew: $0.crew) }
+
+        self.images = try container
+            .decodeNestedArrayIfPresent(ImageMetadata.self, forKey: .images, nestedKey: "stills")
+            .map { TVEpisodeImageCollection(id: id, stills: $0) }
+
+        self.videos = try container
+            .decodeNestedArrayIfPresent(VideoMetadata.self, forKey: .videos, nestedKey: "results")
+            .map { VideoCollection(id: id, results: $0) }
+
+        self.translations = try container.decodeNestedIfPresent(
+            [Translation<TVEpisodeTranslationData>].self,
+            forKey: .translations,
+            nestedKey: "translations"
         )
 
-        if container.contains(.credits) {
-            let nested = try container.nestedContainer(
-                keyedBy: CreditsCodingKeys.self,
-                forKey: .credits
-            )
-            let cast = try nested.decodeIfPresent(
-                [CastMember].self, forKey: .cast
-            ) ?? []
-            let crew = try nested.decodeIfPresent(
-                [CrewMember].self, forKey: .crew
-            ) ?? []
-            self.credits = ShowCredits(
-                id: episode.id, cast: cast, crew: crew
-            )
-        } else {
-            self.credits = nil
-        }
-
-        if container.contains(.images) {
-            let nested = try container.nestedContainer(
-                keyedBy: StillsCodingKeys.self,
-                forKey: .images
-            )
-            let stills = try nested.decodeIfPresent(
-                [ImageMetadata].self, forKey: .stills
-            ) ?? []
-            self.images = TVEpisodeImageCollection(
-                id: episode.id, stills: stills
-            )
-        } else {
-            self.images = nil
-        }
-
-        if container.contains(.videos) {
-            let nested = try container.nestedContainer(
-                keyedBy: VideosCodingKeys.self,
-                forKey: .videos
-            )
-            let results = try nested.decodeIfPresent(
-                [VideoMetadata].self, forKey: .results
-            ) ?? []
-            self.videos = VideoCollection(
-                id: episode.id, results: results
-            )
-        } else {
-            self.videos = nil
-        }
-
-        if container.contains(.translations) {
-            let nested = try container.nestedContainer(
-                keyedBy: TranslationsCodingKeys.self,
-                forKey: .translations
-            )
-            self.translations = try nested.decodeIfPresent(
-                [Translation<TVEpisodeTranslationData>].self,
-                forKey: .translations
-            )
-        } else {
-            self.translations = nil
-        }
-
-        if container.contains(.externalIDs) {
-            let nested = try container.nestedContainer(
-                keyedBy: ExternalIDsCodingKeys.self,
-                forKey: .externalIDs
-            )
-            let imdbID = try nested.decodeIfPresent(
-                String.self, forKey: .imdbID
-            )
-            let wikiDataID = try nested.decodeIfPresent(
-                String.self, forKey: .wikiDataID
-            )
-            self.externalIDs = TVEpisodeExternalLinksCollection(
-                id: episode.id,
-                imdb: IMDbLink(imdbTitleID: imdbID),
-                wikiData: WikiDataLink(
-                    wikiDataID: wikiDataID
+        self.externalIDs = try SocialLinkIDs(from: container, forKey: .externalIDs)
+            .map {
+                TVEpisodeExternalLinksCollection(
+                    id: id,
+                    imdb: IMDbLink(imdbTitleID: $0.imdbID),
+                    wikiData: WikiDataLink(wikiDataID: $0.wikiDataID)
                 )
-            )
-        } else {
-            self.externalIDs = nil
-        }
+            }
     }
-    // swiftlint:enable function_body_length
 
 }

--- a/Sources/TMDb/Domain/Models/TVSeasonDetailsResponse.swift
+++ b/Sources/TMDb/Domain/Models/TVSeasonDetailsResponse.swift
@@ -105,152 +105,42 @@ extension TVSeasonDetailsResponse: Decodable {
         case externalIDs = "externalIds"
     }
 
-    private enum CreditsCodingKeys: String, CodingKey {
-        case cast
-        case crew
-    }
-
-    private enum ImagesCodingKeys: String, CodingKey {
-        case posters
-    }
-
-    private enum VideosCodingKeys: String, CodingKey {
-        case results
-    }
-
-    private enum TranslationsCodingKeys: String, CodingKey {
-        case translations
-    }
-
-    private enum ResultsCodingKeys: String, CodingKey {
-        case results
-    }
-
-    private enum ExternalIDsCodingKeys: String, CodingKey {
-        case wikiDataID = "wikidataId"
-    }
-
-    // swiftlint:disable function_body_length
     public init(from decoder: Decoder) throws {
         self.season = try TVSeason(from: decoder)
+        let id = season.id
 
-        let container = try decoder.container(
-            keyedBy: CodingKeys.self
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.credits = try container
+            .decodeCastAndCrewIfPresent(CastMember.self, CrewMember.self, forKey: .credits)
+            .map { ShowCredits(id: id, cast: $0.cast, crew: $0.crew) }
+
+        self.aggregateCredits = try container
+            .decodeCastAndCrewIfPresent(
+                AggregateCastMember.self, AggregateCrewMember.self, forKey: .aggregateCredits
+            )
+            .map { TVSeasonAggregateCredits(id: id, cast: $0.cast, crew: $0.crew) }
+
+        self.images = try ImageCollection(from: container, forKey: .images, id: id)
+
+        self.videos = try container
+            .decodeNestedArrayIfPresent(VideoMetadata.self, forKey: .videos, nestedKey: "results")
+            .map { VideoCollection(id: id, results: $0) }
+
+        self.translations = try container.decodeNestedIfPresent(
+            [Translation<TVSeasonTranslationData>].self,
+            forKey: .translations,
+            nestedKey: "translations"
         )
 
-        if container.contains(.credits) {
-            let nested = try container.nestedContainer(
-                keyedBy: CreditsCodingKeys.self,
-                forKey: .credits
-            )
-            let cast = try nested.decodeIfPresent(
-                [CastMember].self, forKey: .cast
-            ) ?? []
-            let crew = try nested.decodeIfPresent(
-                [CrewMember].self, forKey: .crew
-            ) ?? []
-            self.credits = ShowCredits(
-                id: season.id, cast: cast, crew: crew
-            )
-        } else {
-            self.credits = nil
-        }
+        self.watchProviders = try container.decodeNestedIfPresent(
+            [String: ShowWatchProvider].self,
+            forKey: .watchProviders,
+            nestedKey: "results"
+        )
 
-        if container.contains(.aggregateCredits) {
-            let nested = try container.nestedContainer(
-                keyedBy: CreditsCodingKeys.self,
-                forKey: .aggregateCredits
-            )
-            let cast = try nested.decodeIfPresent(
-                [AggregateCastMember].self, forKey: .cast
-            ) ?? []
-            let crew = try nested.decodeIfPresent(
-                [AggregateCrewMember].self, forKey: .crew
-            ) ?? []
-            self.aggregateCredits = TVSeasonAggregateCredits(
-                id: season.id, cast: cast, crew: crew
-            )
-        } else {
-            self.aggregateCredits = nil
-        }
-
-        if container.contains(.images) {
-            let nested = try container.nestedContainer(
-                keyedBy: ImagesCodingKeys.self,
-                forKey: .images
-            )
-            let posters = try nested.decodeIfPresent(
-                [ImageMetadata].self, forKey: .posters
-            ) ?? []
-            self.images = ImageCollection(
-                id: season.id,
-                posters: posters,
-                logos: [],
-                backdrops: []
-            )
-        } else {
-            self.images = nil
-        }
-
-        if container.contains(.videos) {
-            let nested = try container.nestedContainer(
-                keyedBy: VideosCodingKeys.self,
-                forKey: .videos
-            )
-            let results = try nested.decodeIfPresent(
-                [VideoMetadata].self, forKey: .results
-            ) ?? []
-            self.videos = VideoCollection(
-                id: season.id, results: results
-            )
-        } else {
-            self.videos = nil
-        }
-
-        if container.contains(.translations) {
-            let nested = try container.nestedContainer(
-                keyedBy: TranslationsCodingKeys.self,
-                forKey: .translations
-            )
-            self.translations = try nested.decodeIfPresent(
-                [Translation<TVSeasonTranslationData>].self,
-                forKey: .translations
-            )
-        } else {
-            self.translations = nil
-        }
-
-        if container.contains(.watchProviders) {
-            let nested = try container.nestedContainer(
-                keyedBy: ResultsCodingKeys.self,
-                forKey: .watchProviders
-            )
-            self.watchProviders = try nested.decodeIfPresent(
-                [String: ShowWatchProvider].self,
-                forKey: .results
-            )
-        } else {
-            self.watchProviders = nil
-        }
-
-        if container.contains(.externalIDs) {
-            let nested = try container.nestedContainer(
-                keyedBy: ExternalIDsCodingKeys.self,
-                forKey: .externalIDs
-            )
-            let wikiDataID = try nested.decodeIfPresent(
-                String.self, forKey: .wikiDataID
-            )
-            self.externalIDs = TVSeasonExternalLinksCollection(
-                id: season.id,
-                wikiData: WikiDataLink(
-                    wikiDataID: wikiDataID
-                )
-            )
-        } else {
-            self.externalIDs = nil
-        }
+        self.externalIDs = try SocialLinkIDs(from: container, forKey: .externalIDs)
+            .map { TVSeasonExternalLinksCollection(id: id, wikiData: WikiDataLink(wikiDataID: $0.wikiDataID)) }
     }
-    // swiftlint:enable function_body_length
 
 }

--- a/Sources/TMDb/Domain/Models/TVSeriesDetailsResponse.swift
+++ b/Sources/TMDb/Domain/Models/TVSeriesDetailsResponse.swift
@@ -5,8 +5,6 @@
 //  Copyright © 2026 Adam Young.
 //
 
-// swiftlint:disable file_length
-
 import Foundation
 
 ///
@@ -197,126 +195,34 @@ extension TVSeriesDetailsResponse: Decodable {
         case changes
     }
 
-    private enum CreditsCodingKeys: String, CodingKey {
-        case cast
-        case crew
-    }
-
-    private enum ImagesCodingKeys: String, CodingKey {
-        case backdrops
-        case logos
-        case posters
-    }
-
-    private enum VideosCodingKeys: String, CodingKey {
-        case results
-    }
-
-    private enum ResultsCodingKeys: String, CodingKey {
-        case results
-    }
-
-    private enum TranslationsCodingKeys: String, CodingKey {
-        case translations
-    }
-
-    private enum ExternalIDsCodingKeys: String, CodingKey {
-        case imdbID = "imdbId"
-        case wikiDataID = "wikidataId"
-        case facebookID = "facebookId"
-        case instagramID = "instagramId"
-        case twitterID = "twitterId"
-    }
-
-    // swiftlint:disable function_body_length cyclomatic_complexity
+    // swiftlint:disable:next function_body_length
     public init(from decoder: Decoder) throws {
         self.tvSeries = try TVSeries(from: decoder)
+        let id = tvSeries.id
 
-        let container = try decoder.container(
-            keyedBy: CodingKeys.self
-        )
+        let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        if container.contains(.credits) {
-            let nested = try container.nestedContainer(
-                keyedBy: CreditsCodingKeys.self,
-                forKey: .credits
-            )
-            let cast = try nested.decodeIfPresent(
-                [CastMember].self, forKey: .cast
-            ) ?? []
-            let crew = try nested.decodeIfPresent(
-                [CrewMember].self, forKey: .crew
-            ) ?? []
-            self.credits = ShowCredits(
-                id: tvSeries.id, cast: cast, crew: crew
-            )
-        } else {
-            self.credits = nil
-        }
+        self.credits = try container
+            .decodeCastAndCrewIfPresent(CastMember.self, CrewMember.self, forKey: .credits)
+            .map { ShowCredits(id: id, cast: $0.cast, crew: $0.crew) }
 
-        if container.contains(.aggregateCredits) {
-            let nested = try container.nestedContainer(
-                keyedBy: CreditsCodingKeys.self,
-                forKey: .aggregateCredits
+        self.aggregateCredits = try container
+            .decodeCastAndCrewIfPresent(
+                AggregateCastMember.self, AggregateCrewMember.self, forKey: .aggregateCredits
             )
-            let cast = try nested.decodeIfPresent(
-                [AggregateCastMember].self, forKey: .cast
-            ) ?? []
-            let crew = try nested.decodeIfPresent(
-                [AggregateCrewMember].self, forKey: .crew
-            ) ?? []
-            self.aggregateCredits = TVSeriesAggregateCredits(
-                id: tvSeries.id, cast: cast, crew: crew
-            )
-        } else {
-            self.aggregateCredits = nil
-        }
+            .map { TVSeriesAggregateCredits(id: id, cast: $0.cast, crew: $0.crew) }
 
-        if container.contains(.images) {
-            let nested = try container.nestedContainer(
-                keyedBy: ImagesCodingKeys.self,
-                forKey: .images
-            )
-            let backdrops = try nested.decodeIfPresent(
-                [ImageMetadata].self, forKey: .backdrops
-            ) ?? []
-            let logos = try nested.decodeIfPresent(
-                [ImageMetadata].self, forKey: .logos
-            ) ?? []
-            let posters = try nested.decodeIfPresent(
-                [ImageMetadata].self, forKey: .posters
-            ) ?? []
-            self.images = ImageCollection(
-                id: tvSeries.id,
-                posters: posters,
-                logos: logos,
-                backdrops: backdrops
-            )
-        } else {
-            self.images = nil
-        }
+        self.images = try ImageCollection(from: container, forKey: .images, id: id)
 
-        if container.contains(.videos) {
-            let nested = try container.nestedContainer(
-                keyedBy: VideosCodingKeys.self,
-                forKey: .videos
-            )
-            let results = try nested.decodeIfPresent(
-                [VideoMetadata].self, forKey: .results
-            ) ?? []
-            self.videos = VideoCollection(
-                id: tvSeries.id, results: results
-            )
-        } else {
-            self.videos = nil
-        }
+        self.videos = try container
+            .decodeNestedArrayIfPresent(VideoMetadata.self, forKey: .videos, nestedKey: "results")
+            .map { VideoCollection(id: id, results: $0) }
 
         self.reviews = try container.decodeIfPresent(
             ReviewPageableList.self, forKey: .reviews
         )
         self.recommendations = try container.decodeIfPresent(
-            TVSeriesPageableList.self,
-            forKey: .recommendations
+            TVSeriesPageableList.self, forKey: .recommendations
         )
         self.similar = try container.decodeIfPresent(
             TVSeriesPageableList.self, forKey: .similar
@@ -328,132 +234,39 @@ extension TVSeriesDetailsResponse: Decodable {
             ChangeCollection.self, forKey: .changes
         )
 
-        if container.contains(.contentRatings) {
-            let nested = try container.nestedContainer(
-                keyedBy: ResultsCodingKeys.self,
-                forKey: .contentRatings
-            )
-            self.contentRatings = try nested.decodeIfPresent(
-                [ContentRating].self, forKey: .results
-            )
-        } else {
-            self.contentRatings = nil
-        }
+        self.contentRatings = try container.decodeNestedIfPresent(
+            [ContentRating].self, forKey: .contentRatings, nestedKey: "results"
+        )
+        self.alternativeTitles = try container.decodeNestedIfPresent(
+            [AlternativeTitle].self, forKey: .alternativeTitles, nestedKey: "results"
+        )
+        self.translations = try container.decodeNestedIfPresent(
+            [Translation<TVSeriesTranslationData>].self, forKey: .translations, nestedKey: "translations"
+        )
+        self.keywords = try container.decodeNestedIfPresent(
+            [Keyword].self, forKey: .keywords, nestedKey: "results"
+        )
+        self.watchProviders = try container.decodeNestedIfPresent(
+            [String: ShowWatchProvider].self, forKey: .watchProviders, nestedKey: "results"
+        )
+        self.screenedTheatrically = try container.decodeNestedIfPresent(
+            [ScreenedTheatricallyResult].self, forKey: .screenedTheatrically, nestedKey: "results"
+        )
+        self.episodeGroups = try container.decodeNestedIfPresent(
+            [TVEpisodeGroup].self, forKey: .episodeGroups, nestedKey: "results"
+        )
 
-        if container.contains(.alternativeTitles) {
-            let nested = try container.nestedContainer(
-                keyedBy: ResultsCodingKeys.self,
-                forKey: .alternativeTitles
-            )
-            self.alternativeTitles = try nested.decodeIfPresent(
-                [AlternativeTitle].self, forKey: .results
-            )
-        } else {
-            self.alternativeTitles = nil
-        }
-
-        if container.contains(.translations) {
-            let nested = try container.nestedContainer(
-                keyedBy: TranslationsCodingKeys.self,
-                forKey: .translations
-            )
-            self.translations = try nested.decodeIfPresent(
-                [Translation<TVSeriesTranslationData>].self,
-                forKey: .translations
-            )
-        } else {
-            self.translations = nil
-        }
-
-        if container.contains(.keywords) {
-            let nested = try container.nestedContainer(
-                keyedBy: ResultsCodingKeys.self,
-                forKey: .keywords
-            )
-            self.keywords = try nested.decodeIfPresent(
-                [Keyword].self, forKey: .results
-            )
-        } else {
-            self.keywords = nil
-        }
-
-        if container.contains(.watchProviders) {
-            let nested = try container.nestedContainer(
-                keyedBy: ResultsCodingKeys.self,
-                forKey: .watchProviders
-            )
-            self.watchProviders = try nested.decodeIfPresent(
-                [String: ShowWatchProvider].self,
-                forKey: .results
-            )
-        } else {
-            self.watchProviders = nil
-        }
-
-        if container.contains(.screenedTheatrically) {
-            let nested = try container.nestedContainer(
-                keyedBy: ResultsCodingKeys.self,
-                forKey: .screenedTheatrically
-            )
-            self.screenedTheatrically =
-                try nested.decodeIfPresent(
-                    [ScreenedTheatricallyResult].self,
-                    forKey: .results
+        self.externalIDs = try SocialLinkIDs(from: container, forKey: .externalIDs)
+            .map {
+                TVSeriesExternalLinksCollection(
+                    id: id,
+                    imdb: IMDbLink(imdbTitleID: $0.imdbID),
+                    wikiData: WikiDataLink(wikiDataID: $0.wikiDataID),
+                    facebook: FacebookLink(facebookID: $0.facebookID),
+                    instagram: InstagramLink(instagramID: $0.instagramID),
+                    twitter: TwitterLink(twitterID: $0.twitterID)
                 )
-        } else {
-            self.screenedTheatrically = nil
-        }
-
-        if container.contains(.episodeGroups) {
-            let nested = try container.nestedContainer(
-                keyedBy: ResultsCodingKeys.self,
-                forKey: .episodeGroups
-            )
-            self.episodeGroups = try nested.decodeIfPresent(
-                [TVEpisodeGroup].self, forKey: .results
-            )
-        } else {
-            self.episodeGroups = nil
-        }
-
-        if container.contains(.externalIDs) {
-            let nested = try container.nestedContainer(
-                keyedBy: ExternalIDsCodingKeys.self,
-                forKey: .externalIDs
-            )
-            let imdbID = try nested.decodeIfPresent(
-                String.self, forKey: .imdbID
-            )
-            let wikiDataID = try nested.decodeIfPresent(
-                String.self, forKey: .wikiDataID
-            )
-            let facebookID = try nested.decodeIfPresent(
-                String.self, forKey: .facebookID
-            )
-            let instagramID = try nested.decodeIfPresent(
-                String.self, forKey: .instagramID
-            )
-            let twitterID = try nested.decodeIfPresent(
-                String.self, forKey: .twitterID
-            )
-            self.externalIDs = TVSeriesExternalLinksCollection(
-                id: tvSeries.id,
-                imdb: IMDbLink(imdbTitleID: imdbID),
-                wikiData: WikiDataLink(
-                    wikiDataID: wikiDataID
-                ),
-                facebook: FacebookLink(
-                    facebookID: facebookID
-                ),
-                instagram: InstagramLink(
-                    instagramID: instagramID
-                ),
-                twitter: TwitterLink(twitterID: twitterID)
-            )
-        } else {
-            self.externalIDs = nil
-        }
+            }
     }
-    // swiftlint:enable function_body_length cyclomatic_complexity
 
 }

--- a/Sources/TMDb/Extensions/KeyedDecodingContainer+Nested.swift
+++ b/Sources/TMDb/Extensions/KeyedDecodingContainer+Nested.swift
@@ -1,0 +1,97 @@
+//
+//  KeyedDecodingContainer+Nested.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+extension KeyedDecodingContainer {
+
+    ///
+    /// Decodes a value nested one level under `key` at `nestedKey`.
+    ///
+    /// Many TMDb append-to-response payloads wrap the appended value in a single-key
+    /// object (e.g. `{ "results": [...] }`). This opens the wrapper object at `key` and
+    /// decodes `nestedKey` from it, short-circuiting to `nil` when `key` is absent.
+    ///
+    /// - Parameters:
+    ///   - type: The type to decode.
+    ///   - key: The wrapper key. When absent, the result is `nil`.
+    ///   - nestedKey: The key of the wrapped value inside the wrapper object.
+    ///
+    /// - Returns: The decoded value, or `nil` when `key` is absent (or the nested value is).
+    ///
+    func decodeNestedIfPresent<T: Decodable>(
+        _ type: T.Type,
+        forKey key: Key,
+        nestedKey: String
+    ) throws -> T? {
+        guard contains(key) else {
+            return nil
+        }
+
+        let nested = try nestedContainer(keyedBy: StringCodingKey.self, forKey: key)
+        return try nested.decodeIfPresent(T.self, forKey: StringCodingKey(nestedKey))
+    }
+
+    ///
+    /// Decodes an array nested one level under `key` at `nestedKey`, defaulting a
+    /// missing nested value to an empty array.
+    ///
+    /// Like ``decodeNestedIfPresent(_:forKey:nestedKey:)`` but for a wrapped array whose
+    /// absence (when the wrapper `key` *is* present) should be an empty array rather than
+    /// `nil` — matching collections that are always constructed once the wrapper exists.
+    ///
+    /// - Parameters:
+    ///   - elementType: The array element type to decode.
+    ///   - key: The wrapper key. When absent, the result is `nil`.
+    ///   - nestedKey: The key of the wrapped array inside the wrapper object.
+    ///
+    /// - Returns: The decoded array (empty if the nested value is absent), or `nil` when
+    /// `key` is absent.
+    ///
+    func decodeNestedArrayIfPresent<Element: Decodable>(
+        _ elementType: Element.Type,
+        forKey key: Key,
+        nestedKey: String
+    ) throws -> [Element]? {
+        guard contains(key) else {
+            return nil
+        }
+
+        let nested = try nestedContainer(keyedBy: StringCodingKey.self, forKey: key)
+        return try nested.decodeIfPresent([Element].self, forKey: StringCodingKey(nestedKey)) ?? []
+    }
+
+    ///
+    /// Decodes the `cast` and `crew` arrays nested under `key`.
+    ///
+    /// The credits-shaped append sections (`credits`, `aggregate_credits`, and the
+    /// person credit variants) all wrap two arrays, `{ "cast": [...], "crew": [...] }`,
+    /// each defaulting to empty. The caller maps the result into its specific credits type.
+    ///
+    /// - Parameters:
+    ///   - castType: The cast element type.
+    ///   - crewType: The crew element type.
+    ///   - key: The wrapper key. When absent, the result is `nil`.
+    ///
+    /// - Returns: The decoded cast and crew arrays, or `nil` when `key` is absent.
+    ///
+    func decodeCastAndCrewIfPresent<Cast: Decodable, Crew: Decodable>(
+        _ castType: Cast.Type,
+        _ crewType: Crew.Type,
+        forKey key: Key
+    ) throws -> (cast: [Cast], crew: [Crew])? {
+        guard contains(key) else {
+            return nil
+        }
+
+        let nested = try nestedContainer(keyedBy: StringCodingKey.self, forKey: key)
+        let cast = try nested.decodeIfPresent([Cast].self, forKey: StringCodingKey("cast")) ?? []
+        let crew = try nested.decodeIfPresent([Crew].self, forKey: StringCodingKey("crew")) ?? []
+        return (cast, crew)
+    }
+
+}

--- a/Sources/TMDb/Extensions/StringCodingKey.swift
+++ b/Sources/TMDb/Extensions/StringCodingKey.swift
@@ -1,0 +1,33 @@
+//
+//  StringCodingKey.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A dynamic coding key addressed by its string value.
+///
+/// Lets nested-container decoding address a JSON key by name without declaring a
+/// bespoke `CodingKey` enum for each wrapper object.
+///
+struct StringCodingKey: CodingKey {
+
+    let stringValue: String
+    let intValue: Int? = nil
+
+    init(_ stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    init?(intValue _: Int) {
+        nil
+    }
+
+}


### PR DESCRIPTION
## Summary

Tier 4 Codable-consolidation refactor **F2** — de-duplicates the five hand-rolled
`*DetailsResponse` append-merge decoders.

Each `init(from:)` repeated the same nested-unwrap ceremony — open a nested
container, decode a single wrapped value, else `nil` — behind a
`function_body_length` pragma (and `cyclomatic_complexity` + `file_length` on
TVSeries).

The extracted logic is **split by generality** so the shared piece stays
model-agnostic and domain decoding lives with its own type:

- **`KeyedDecodingContainer+Nested.swift`** — three *generic*, model-agnostic
  helpers only, referencing no domain type:
  - `decodeNestedIfPresent` — `{ nestedKey: value }` unwrap (returned directly)
  - `decodeNestedArrayIfPresent` — `{ nestedKey: [array] }`, missing nested value → `[]`
  - `decodeCastAndCrewIfPresent` — the `{ cast, crew }` shape (returns a plain tuple)
- **`StringCodingKey.swift`** — the shared dynamic-key utility those helpers use.
- **Domain-coupled decoding lives with its type:**
  - `ImageCollection` gains an `init?(from:forKey:id:)` (owns its `posters`/`logos`/`backdrops` decode)
  - a new `SocialLinkIDs` DTO decodes the flat `external_ids` object via its own `init?(from:forKey:)`

Each decoder now maps the helper/init result into its specific type.

**−642 lines** across the five decoders. The `cyclomatic_complexity` and
`file_length` disables are gone; `function_body_length` is removed from three of
five decoders and reduced to a single-line `disable:next` on the two largest
(Movie / TVSeries — 15 / 17 appended properties, genuinely long rather than
obscured by ceremony).

## Why

Fable's #1 maintenance finding: these five decoders were the most-duplicated
hand-written `Decodable` code in the package. Builds on F1's
`KeyedDecodingContainer+NonEmpty.swift`. Structured so the shared container
extension holds only generic utilities, keeping domain knowledge next to each model.

## Testing

- Behaviour-preserving: the per-type JSON fixtures — both "all appended present"
  (`*-details-append-response.json`) and "without appended → all `nil`" — are the
  regression guard and pass **unchanged**, exercising both the key-present and
  key-absent branch of every helper/init.
- `CollectionTranslationData` / `MediaListItem` are deliberately **not** touched
  (they use `URL(string:)` / `try? Date(strategy:)` — intentionally different).
- `make ci` green — lint (`--strict`), markdown lint, unit tests, live integration
  tests, build-release, build-docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiQ5SMgbUZsJ82Y6Hb3MXa