### PR TITLE
🔧 Write the /deliver retro pre-PR so the ready gate is never re-opened

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -14,8 +14,9 @@ keeps going across the long session until the PR is ready.
 ```text
 you approve the plan ─▶ /deliver ─▶ entry gate (ACs?) ─▶ worktree ─▶ [review-plan] ─▶
   implement ─▶ code-review + fix ─▶ security-review + fix ─▶ capture ─▶
-  rubric check (ACs met?) ─▶ /pr reviewed ─▶ /watch-pr ─▶ GATE: ready-to-merge ─▶ retro
-                                                            ▲ the only hard stop
+  rubric check (ACs met?) ─▶ retro (pre-PR) ─▶ /pr reviewed ─▶ /watch-pr ─▶
+  GATE: ready-to-merge ─▶ wrap-up (wiki + recurring-pattern scan)
+  ▲ the only hard stop
   … then, when the PR actually merges (maybe a later session): teardown (Phase 7)
 ```
 
@@ -31,7 +32,8 @@ teardown).
 there it runs **autonomously** to a single hard stop — **ready-to-merge** — pausing
 mid-run only for a genuine blocker (a plan-review blocker, or a red gate it cannot
 triage). It **auto-scales** the machinery to the change's risk (see *Delivery
-weight*), and ends with a short **retrospective** so the workflow keeps improving.
+weight*), and writes a short **retrospective** that rides the delivery's own PR
+(Phase 3.7) so the workflow keeps improving.
 
 The plan itself is **not** part of this skill — create it first with `/plan` (or
 plan mode). `/deliver` picks up from there.
@@ -42,8 +44,8 @@ These are non-negotiable. Do them by default, without being reminded.
 
 1. **Invoking `/deliver` is plan approval — then run autonomously to the one
    gate.** Do not stop for a second "is the plan ok?" confirmation. Proceed through
-   branch → (review-plan) → implement → code-review/fix → capture → pr → watch-pr
-   to the single hard stop, **Gate: ready-to-merge** (Phase 5). The only legitimate
+   branch → (review-plan) → implement → code-review/fix → capture → retro →
+   pr → watch-pr to the single hard stop, **Gate: ready-to-merge** (Phase 5). The only legitimate
    mid-run pauses are: a **blocker** raised by `/review-plan` (Phase 1), or a **red
    gate you cannot triage** (Contract §4).
 2. **Delegate to the existing skills — don't reinvent them.** Invoke
@@ -627,6 +629,44 @@ takes seconds. Only gaps trigger work.
 The rubric answers a different question than CI: *"did we build what the plan
 said?"* not *"did the build pass?"*
 
+## Phase 3.7 — Write the retrospective (pre-PR)
+
+Write the delivery's retrospective **now — before the PR opens — so it rides the
+PR itself** and the ready-to-merge gate is never re-opened by a routine retro
+push (every post-gate push re-triggers `claude-review` and the CI matrix; see
+Phase 6). This is mandatory, not optional. Reflect on the delivery so far
+(Phases 0–4) and write a dated entry to
+[`knowledge/delivery-retros.md`](../../../knowledge/delivery-retros.md):
+
+- **Feature / branch**, date, and delivery weight (lite/full). The PR number
+  doesn't exist yet — head the entry with the branch name; Phase 4 backfills
+  the number right after the PR is created.
+- **Phases completed / Skills invoked** — a compact one-liner each (e.g. phases
+  `0–4`; skills `review-plan, implement-plan, review-changes, security-review,
+  capture-knowledge`). This is telemetry for the recurring-pattern scan: over
+  time it shows which skills fire, which phases get skipped, and where
+  deliveries stop.
+- **What worked** — one or two things the pipeline did well.
+- **Friction** — where it was rough, slow, or stopped unnecessarily.
+- **Deviations** — anywhere you had to depart from this skill to do the right
+  thing (a strong signal the skill has a gap).
+- **One improvement** — the single highest-value change to `/deliver` (or a
+  sub-skill) suggested by this run.
+- **`watch:`** — omit it now. This optional line is added only as a
+  **post-gate amendment** when Phase 5 produces a noteworthy event (see
+  Phase 6); an uneventful watch adds nothing.
+
+Keep it to a handful of bullets — a log, not a ceremony. **Commit the entry on
+the PR branch** so it travels with the delivery (the GitHub reviewer ignores
+`**/*.md`, so it adds no review noise).
+
+**Keep the file windowed.** After adding the entry, if `delivery-retros.md` holds
+more than **~12 full entries**, distil the oldest into its one-line archive table
+(`date · PR · weight · one-line outcome`) and drop the prose — per
+[`knowledge/README.md`](../../../knowledge/README.md) → *Maintenance & retention*.
+An old retro's lesson already lives in the skills and `skill-improvement-log.md`;
+the table preserves the telemetry without the bulk.
+
 ## Phase 4 — Create the PR
 
 **Gate check (template→replicate deliveries):** before anything else, confirm the
@@ -660,6 +700,12 @@ then push the branch and open the PR with a gitmoji title and structured body.
    Don't patch an unrelated test onto this feature branch, and don't hard-stop on it.
 
 Record the PR number/URL in the ledger.
+
+**Backfill the retro heading.** Phase 3.7 headed the fresh `delivery-retros.md`
+entry with the branch name (no PR number existed yet). Now that the PR is open,
+replace it with the PR number, commit, and push immediately. This is
+**pre-gate** — CI has only just started on the opening push, and the superseded
+run is cancelled by the workflow's concurrency group — so nothing is re-opened.
 
 ## Phase 5 — Watch to ready  → GATE: ready-to-merge
 
@@ -695,64 +741,44 @@ work can be resumed.
 > the gate becomes "report the merge" instead of stopping. Default is watch-only.
 > Either way, a confirmed merge triggers **Phase 7 teardown**.
 
-## Phase 6 — Retrospective (continuous improvement)
+## Phase 6 — Wrap-up (wiki, pattern scan, exceptional retro amendment)
 
-After the gate (PR ready, or merged in `merge` mode), run a **brief, honest
-retrospective** so the workflow keeps improving — this is mandatory, not optional.
-Reflect on *this* delivery and write a dated entry to
-[`knowledge/delivery-retros.md`](../../../knowledge/delivery-retros.md):
+The retrospective is already on the PR (Phase 3.7). After the gate (PR ready, or
+merged in `merge` mode), finish with the wrap-up below — **the default path
+pushes nothing after the gate**; that is the point of writing the retro pre-PR.
+Then **scan recent entries** for recurring friction or deviations — the
+recurring-pattern scan below formalizes this.
 
-- **Feature / PR**, date, and delivery weight (lite/full).
-- **Phases completed / Skills invoked** — a compact one-liner each (e.g. phases
-  `0–6`; skills `review-plan, implement-plan, review-changes, security-review,
-  capture-knowledge, pr, watch-pr`). This is telemetry for the recurring-pattern
-  scan: over time it shows which skills fire, which phases get skipped, and where
-  deliveries stop.
-- **What worked** — one or two things the pipeline did well.
-- **Friction** — where it was rough, slow, or stopped unnecessarily.
-- **Deviations** — anywhere you had to depart from this skill to do the right
-  thing (a strong signal the skill has a gap).
-- **One improvement** — the single highest-value change to `/deliver` (or a
-  sub-skill) suggested by this run.
+**Amend the retro only for a noteworthy watch phase.** If Phase 5 was uneventful
+(checks went green, threads resolved without surprises), the retro is complete —
+do not touch it. If the watch phase produced something the next
+recurring-pattern scan should see — a stuck check, a new Critical/High review
+thread, a flake routed to `/fix-integration-failures`, a wrong readiness call —
+append a one-line **`watch:`** bullet to the entry, commit, and push. Two cases:
 
-Keep it to a handful of bullets — a log, not a ceremony. Then **scan recent
-entries** for recurring friction or deviations — the recurring-pattern scan below
-formalizes this.
+- **Watch-only (PR still open)** — commit the amendment on the PR branch and
+  push it, so it rides the open PR.
+- **`merge`/auto mode (branch already merged + deleted in Phase 5)** — the PR
+  branch is gone, so commit it on a **fresh branch off `origin/main`** and open
+  a small follow-up PR; the same applies to any skill edits the auto
+  recurring-pattern scan commits. Do this **before** Phase 7 teardown, and
+  confirm it's pushed — otherwise teardown's `discard_changes` drops it.
 
-**Commit *and push* the retro before teardown — never leave it as a worktree-only
-commit.** Phase 7's teardown discards the worktree, so an unpushed retro commit is
-lost. Two cases:
-
-- **Watch-only (PR still open)** — commit the retro on the PR branch and **push it**
-  (`git push`), so it rides the open PR. (This is the common path.)
-- **`merge`/auto mode (branch already merged + deleted in Phase 5)** — the PR branch
-  is gone, so commit the retro on a **fresh branch off `origin/main`** and open a
-  small follow-up PR (or push straight if policy allows); the same applies to any
-  skill edits the auto recurring-pattern scan commits. Do this **before** Phase 7,
-  and confirm it's pushed — otherwise teardown's `discard_changes` drops it.
-
-**Pushing the retro re-opens the gate — re-watch before merge.** In watch-only mode
-the retro / knowledge / skill commits are pushed to the **PR branch after** the
-ready gate, and **every push re-triggers `claude-review` and the CI matrix** — which
-can post a **new blocking thread** (the `main` ruleset requires thread resolution)
-or restart checks. So after the **last** post-gate push, **return to the `/watch-pr`
+**Any post-gate push re-opens the gate — re-watch before merge.** This governs
+the *exceptions* above (a retro amendment, an approved skill edit from the
+scan): every push re-triggers `claude-review` and the CI matrix, which can post
+a **new blocking thread** (the `main` ruleset requires thread resolution) or
+restart checks. After the **last** post-gate push, **return to the `/watch-pr`
 loop once more**: re-sweep unresolved threads and re-confirm checks green before
-treating the PR as merge-ready or merging. "Ready" is only ever true of the *current*
-branch tip — never a tip you have since pushed past. (Bit `/deliver` on #361: a
-"ready, 0 threads" call made before the retro+skill pushes, whose re-reviews then
-raised a High thread that blocked the merge.)
+treating the PR as merge-ready or merging. "Ready" is only ever true of the
+*current* branch tip — never a tip you have since pushed past. (Bit `/deliver`
+on #361, back when the retro itself was a routine post-gate push — the
+sequencing Phase 3.7 now avoids.)
 
-**Keep the file windowed.** After adding the entry, if `delivery-retros.md` holds
-more than **~12 full entries**, distil the oldest into its one-line archive table
-(`date · PR · weight · one-line outcome`) and drop the prose — per
-[`knowledge/README.md`](../../../knowledge/README.md) → *Maintenance & retention*.
-An old retro's lesson already lives in the skills and `skill-improvement-log.md`;
-the table preserves the telemetry without the bulk.
+### Update the personal wiki (at wrap-up)
 
-### Update the personal wiki (after the retro)
-
-The retro distils this delivery's durable learnings, so it is the natural moment
-to feed the **personal `wiki`** (Adam's cross-project engineering knowledge, via
+The retro (Phase 3.7) distils this delivery's durable learnings, so wrap-up is
+the natural moment to feed the **personal `wiki`** (Adam's cross-project engineering knowledge, via
 the `wiki` MCP). The retro/`knowledge/` base is *project-specific*; the wiki is
 for **generalizable, reusable opinions, heuristics, and patterns** — the things
 that would apply on the next project too (a design stance, a concurrency or
@@ -770,10 +796,10 @@ testing heuristic, a tooling gotcha that isn't TMDb-specific).
   that's only project-specific (that already lives in `knowledge/`) or already in
   the wiki. Capturing nothing is a valid outcome.
 
-### Recurring-pattern scan (after committing the retro)
+### Recurring-pattern scan (at wrap-up)
 
-Once the retro entry is committed, do a structured cross-delivery scan — this is
-what turns one-off retros into reviewed skill improvements:
+With the retro already on the PR (Phase 3.7), do a structured cross-delivery
+scan — this is what turns one-off retros into reviewed skill improvements:
 
 1. **Read the recent window + the log.** Read the **~last 12** entries of
    [`knowledge/delivery-retros.md`](../../../knowledge/delivery-retros.md) (the
@@ -846,7 +872,8 @@ worktree down once the PR is merged** — this reclaims both the worktree **and*
    (owner/repo from the `origin` remote, `pullNumber: <n>`) → `merged: true`.
 2. **The worktree has no unsaved work beyond what's merged** — `MERGED` only
    guarantees the *pushed* feature commits are on `main`; it says nothing about a
-   commit made (or a file edited) **after** the last push, e.g. the retro. Verify
+   commit made (or a file edited) **after** the last push, e.g. an exceptional
+   retro amendment (Phase 6). Verify
    the tree is clean **and** fully pushed before discarding:
 
    ```bash

--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -117,8 +117,9 @@ fixing here:
   severity-gated topic reappears across pushes, treat it as noise per the rule
   above (reply with the earlier SHA, resolve, don't re-edit).
 - **Re-sweep after every push — "ready" is only true of the current tip.** Any push
-  to the branch (a check fix, *and* a caller's post-gate commit such as a `/deliver`
-  retro or skill edit) re-triggers `claude-review`, which can post a fresh
+  to the branch (a check fix, *and* a caller's exceptional post-gate commit such as
+  an approved skill edit or a `/deliver` retro amendment) re-triggers
+  `claude-review`, which can post a fresh
   Critical/High thread that **blocks the merge** (`required_review_thread_resolution`).
   Never declare ready off a thread/check snapshot taken *before* the latest push:
   after the last push settles, run one more full pass (thread sweep + check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,12 +165,13 @@ itself the plan-approval gate** — it then runs autonomously to a single hard s
 **ready-to-merge**, pausing only for a plan-review blocker or a red gate it can't
 triage. It **auto-scales** its review machinery to the change's risk (lite vs
 full), **triages** an unrelated red CI gate to `/fix-integration-failures` rather
-than stalling, and ends each delivery with a short retrospective into
-[`knowledge/delivery-retros.md`](knowledge/delivery-retros.md):
+than stalling, and records each delivery's short retrospective into
+[`knowledge/delivery-retros.md`](knowledge/delivery-retros.md) **before the PR
+opens**, so it rides the delivery's own PR:
 
 branch → (`/review-plan` for risky/large changes) → `/implement-plan` →
 `/review-changes` (+ fix) → `/security-review` (+ fix) → `/capture-knowledge` →
-`/pr reviewed` → `/watch-pr` → retro.
+retro → `/pr reviewed` → `/watch-pr`.
 
 Key skills (the README's *Claude Code Skills* tables list them all):
 

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -13,7 +13,7 @@ this directory; the detail lives here and is read on demand.
 | [`decisions/`](decisions/) | **ADRs** — Architecture Decision Records, one per decision, numbered + dated. Use for any non-obvious design choice and its rationale. |
 | [`gotchas.md`](gotchas.md) | Implementation quirks, things that bit us, tooling traps, and anything that needed a web search / lookup to resolve. |
 | [`tmdb-api-notes.md`](tmdb-api-notes.md) | Behaviours of the **live TMDb API** discovered while implementing (nullable/absent fields, undocumented quirks, response-shape surprises). |
-| [`delivery-retros.md`](delivery-retros.md) | A short retrospective per feature delivered via `/deliver` (its Phase 6) — what worked, friction, deviations, one improvement. |
+| [`delivery-retros.md`](delivery-retros.md) | A short retrospective per feature delivered via `/deliver` (its Phase 3.7, written pre-PR so it rides the delivery's own PR) — what worked, friction, deviations, one improvement. |
 | [`skill-improvement-log.md`](skill-improvement-log.md) | Decisions on every skill-improvement proposal from `/deliver`'s Phase 6 recurring-pattern scan (applied / deferred / rejected), so the scan doesn't re-propose settled calls. |
 
 ## How to use it

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,6 +14,28 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-07-05 — 🔧 Write the /deliver retro pre-PR (chore/deliver-retro-before-pr) · lite
+
+- **Phases / skills:** phases 0–4; no sub-skills fired (markdown-only: code +
+  security review self-skipped, `/implement-plan` N/A with no Canon TDD list,
+  `/review-plan` skipped — lite + plan approved via `ExitPlanMode` after a
+  plan-mode design round). Knowledge captured **inline** (an `EnterWorktree`
+  gotcha + the skill-improvement-log entry), precedented in #366/#368/#374.
+- **Worked:** the plan came from a first-principles review of `/deliver` against
+  this file and the improvement log — the same loop the skill automates — and
+  both open design decisions (amend-only-if-noteworthy; two sequenced PRs) were
+  settled with the user via `AskUserQuestion` *before* any edit. The change is
+  **dogfooded immediately**: this entry is written pre-PR under the sequencing
+  it introduces, and the overdue archive-distil (deferred in #368 and #374) ran
+  as part of the new Phase 3.7 windowing step.
+- **Friction:** `EnterWorktree` ignored the requested name for the **branch**
+  (created `worktree-chore+…`; prior deliveries got the requested name) —
+  renamed with `git branch -m`, now a `gotchas.md` entry.
+- **Deviations:** none material — inline knowledge capture per precedent.
+- **One improvement:** deliverable B of this same run — the
+  progressive-disclosure restructure of `deliver/SKILL.md` — is the standing
+  improvement; no new one surfaced.
+
 ## 2026-07-02 — 📝 Reconcile docs/config honesty gaps from external reviews (#374) · lite
 
 - **Phases / skills:** phases 0.5–6; `review-changes, security-review,
@@ -395,138 +417,17 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
   `.claude/**` to the CI job so the two gates agree. Today a green CI can sit behind
   a red local `make ci`, which repeatedly mis-signals "your change broke the gate."
 
-## 2026-06-18 — ✨ AuthenticatedSession wrapper for AccountService (#346) · full
+## Archive (distilled)
 
-- **Worked:** the full pipeline earned its keep on the only genuinely risky change
-  of the session. `/review-plan`'s three critics **unanimously** caught three
-  blockers *before* a line was written — (1) adding methods as public-protocol
-  *requirements* would break external conformers, (2) the 16 auto-pagination
-  methods were omitted from scope, (3) deprecating the old forms would cascade
-  `--Werror` failures through the package's own internal callers — which reversed
-  the user's earlier "deprecate-and-add" choice to a clean additive design. The
-  fan-out `/review-changes` then caught real coverage gaps (9 untested pagination
-  forwards). 2,700 unit tests, ADR-0005.
-- **Friction:** local `make ci` reported lint **green**, but the PR's CI `Lint`
-  job failed on `file_length`/`type_body_length` for the two new oversized files —
-  a real local-vs-CI lint discrepancy that cost a CI round-trip. Adding the
-  `swiftlint:disable` directives (matching `AccountService+Pagination.swift`'s
-  precedent) fixed it; a fresh `make lint` then agreed with CI.
-- **Deviations:** stopped mid-Phase-1 to surface the deprecation blocker to the
-  user (legitimate per the contract — it reversed an explicit prior decision).
-- **Improvement:** the local-vs-CI lint gap is the highest-value fix. `make ci`'s
-  lint step passed locally on violations CI caught (stale SwiftLint cache, or a
-  config/path difference) — so the mandatory gate gave a false green. Recommend
-  `/pr` run a fresh `make lint` (or `swiftlint --no-cache`) as part of step 4,
-  rather than trusting `make ci`'s lint leg, so file-size violations on new files
-  surface locally.
+Older entries condensed per the rolling window (`knowledge/README.md` →
+*Maintenance & retention*); prose is in git history.
 
-## 2026-06-18 — 📝 Add error-handling How-To guide (#344) · lite (docs-only)
-
-- **Worked:** reading the real source first (`TMDbError+TMDbAPIError.swift` for the
-  status→case mapping, `RetryHTTPClient.swift` for retry semantics) meant the guide
-  documented *actual* behaviour — including the "error thrown only after retries are
-  exhausted" nuance from the dropped item 3 — rather than plausible-sounding
-  guesses. `make build-docs` (warnings-as-errors) was the real gate: it validated
-  every `` ``TMDbError/notFound(_:)`` `` enum-case link and `<doc:>` reference, so a
-  broken symbol link would have failed before the PR.
-- **Friction:** same recurring one — `make ci` ran the full unit+integration+release
-  matrix for a docs-only change; only `build-docs` + `lint-markdown` were meaningful.
-- **Deviations:** none — clean docs-only lite path (review auto-skipped, no Swift).
-- **Improvement:** reinforces the **docs/config-only fast gate** idea already logged
-  on #340/#343 — for a no-`.swift` diff, `make ci` could run just lint +
-  lint-markdown + build-docs. Three docs-only deliveries this session each paid the
-  full-matrix cost; worth implementing the fast gate in `/pr` step 4 now.
-
-## 2026-06-18 — ♻️ Explicit `Sendable` on `URLSessionHTTPClientAdapter` (#343) · lite
-
-- **Worked:** grounding the plan in the actual code first paid off again — reading
-  the adapter revealed it is `internal` and already enforced as `Sendable` via
-  `HTTPClient: Sendable`, so the change was correctly framed as
-  clarity/future-proofing rather than the bug fix the source review implied. The
-  `code-reviewer` confirmed all three safety claims and caught one honest Low (the
-  compile-time assertion guards Sendability "by any route", not the explicit
-  annotation) — applied the reword and moved on.
-- **Friction:** none of note. `make ci` again ran the full ~6-min gate for a
-  ~14-line change (same docs/low-risk fast-path gap noted on #340).
-- **Deviations:** none — clean lite path (skip critics, single reviewer).
-- **Improvement:** the compile-time `requireSendable(_:)` assertion is a nice
-  reusable idiom for pinning `Sendable` on concurrency-sensitive types; consider a
-  one-line note in `knowledge/gotchas.md` if it recurs (didn't capture yet — single
-  use so far).
-
-## 2026-06-18 — ♻️ Standardize details(...) parameter names to `<entity>ID` (#341) · lite
-
-- **Worked:** scouting the *actual* scope before planning (an `Explore` sweep over
-  all 26 services) overturned two assumptions from the source review — the change
-  was non-breaking (internal names only) and the cheap, convention-aligned
-  direction (`<entity>ID`, 7 methods) was the **opposite** of the review's
-  recommendation (`id`, 24 methods). Re-confirming the decision with the user
-  before editing avoided a 24-method diff against the grain of the codebase.
-  Single-`code-reviewer` lite path fit the mechanical diff; build/tests/lint/review
-  all clean first time.
-- **Friction:** my raw `awk` line-length check flagged ~140 lines >100 chars and
-  briefly looked like a lint failure, but `make lint` reported 0 violations (the
-  enforced threshold ignores comment/URL lines and is higher than the documented
-  100 for code). Wasted a beat reconciling the two. Lesson: trust `make lint`, not
-  a hand-rolled length check.
-- **Deviations:** had to go back to the user mid-delivery to correct my own earlier
-  framing (I'd asked about deprecation/major-bump for a change that turned out
-  non-breaking). The right move, but a sign the *up-front* questions were asked
-  before the scope was actually understood.
-- **Improvement:** when a delivery originates from a review *finding* (not a
-  user-authored plan), scope it against the code (a quick `Explore` pass) **before**
-  asking the user any strategy questions — the finding's framing may be wrong, as
-  it was here (and for the dropped retry "fix"). Treat review findings as
-  hypotheses to verify, not approved plans.
-
-## 2026-06-18 — 📝 Fix non-compiling watch-provider README examples (#340) · lite
-
-- **Worked:** lite path was exactly right for a docs-only fix — `/review-plan` and
-  `/review-changes` both auto-skipped (no Swift in the diff), so the pipeline went
-  branch → edit → `make ci` → PR → green with no wasted machinery. Verifying the
-  property against source (`WatchProvider.name`, JSON key `providerName`) before
-  editing confirmed the fix was real.
-- **Friction:** `make ci` runs the *full* gate (unit + live integration tests,
-  release build, docs build) even for a two-character README change — minutes of
-  CI for a typo. The hard "always `make ci`" rule has no docs-only fast path.
-- **Deviations:** none.
-- **Improvement:** consider a docs/config-only gate (lint + markdown-lint + docs
-  build, skipping the test/release-build legs) when `git diff --name-only
-  main...HEAD` touches no `*.swift` — the PR's own CI still runs the full matrix.
-- **Cross-cutting note:** the sibling finding "off-by-one retry semantics" (item 3
-  of the same review) turned out to be a **false positive** — the existing test
-  `429 exhausts retries and returns last response` (RetryHTTPClientTests.swift:38)
-  pins `performCount == 4` for `maxRetries: 3` (1 initial + 3 retries) as the
-  intended contract. `/deliver`'s test-first discipline caught it before any
-  change. Lesson: treat AI-review findings as *hypotheses* and confirm against the
-  contract/tests before delivering.
-
-## 2026-06-18 — ⚡️ Opt-in next-page prefetch (#337) · full
-
-- **Worked:** the full pipeline shone on the riskiest change of the effort (first
-  hand-rolled `Task` lifecycle). The fan-out `/review-changes` found a real gap
-  (page-level cancellation untested); the fix + re-review converged to 0/0/0/0.
-  Haiku-delegated build/test/TSan kept context lean.
-- **Friction:** SourceKit `<new-diagnostics>` false positives on every newly-created
-  file added narration noise (now a documented gotcha + CLAUDE.md note). The
-  cancellation-forwarding test took several iterations to make deterministic.
-- **Deviations:** skipped `/review-plan`'s critics (the plan had already converged
-  over three prior rounds) — the skill now makes this explicit (Phase 1 plan-aware).
-- **Improvement:** delivered — the autonomy/lite/triage/ledger/handoff/retro changes
-  in this very PR came out of this run.
-
-## 2026-06-18 — ✨ Auto-pagination coverage for Account/GuestSession/Keyword/Changes (#335) · full
-
-- **Worked:** mechanical, pattern-repeating change went smoothly; the two gates kept
-  the user in control without micromanaging.
-- **Friction:** the biggest rough edge of the whole session — `make ci` went red on a
-  **flaky, pre-existing, unrelated** integration test (`SearchPaginationIntegrationTests`),
-  and `/deliver` had no built-in path for "a red gate that isn't your fault." The
-  resolution (fix on a branch off `main` → merge → rebase) was entirely improvised
-  and cost several `make ci` re-runs (#334).
-- **Deviations:** skipped the critic re-run (plan already reviewed); improvised the
-  red-gate triage and built `/fix-integration-failures` mid-stream.
-- **Improvement:** **red-gate triage** is now built into Phase 4 (in-diff vs
-  pre-existing → route to `/fix-integration-failures`), so an unrelated flake no
-  longer stalls a delivery. The fan-out review was arguably overkill for this
-  mechanical change → **auto-detected lite mode** added.
+| Date | PR | Weight | Outcome |
+| --- | --- | --- | --- |
+| 2026-06-18 | #346 | full | AuthenticatedSession wrapper; 3 critics unanimously reversed deprecate-and-add to additive; local-vs-CI lint cache gap → `/pr` `--no-cache` step. |
+| 2026-06-18 | #344 | lite | Error-handling How-To guide; `make build-docs` was the real gate; reinforced the docs-only fast-gate need. |
+| 2026-06-18 | #343 | lite | Explicit `Sendable` on `URLSessionHTTPClientAdapter`; premise re-framed from bug fix to clarity. |
+| 2026-06-18 | #341 | lite | `details(...)` params → `<entity>ID`; Explore-first overturned the review's framing (non-breaking, opposite direction). |
+| 2026-06-18 | #340 | lite | README watch-provider example fix; sibling retry "bug" finding disproved (false positive). |
+| 2026-06-18 | #337 | full | Opt-in next-page prefetch; fan-out review caught untested cancellation; spawned the autonomy/lite/triage `/deliver` changes. |
+| 2026-06-18 | #335 | full | Auto-pagination coverage; unrelated flaky red gate improvised → built `/fix-integration-failures` + red-gate triage. |

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -1,12 +1,16 @@
 # Delivery Retrospectives
 
-A short, honest entry per feature delivered via `/deliver` (its Phase 6), newest
-at the top. The point is **continuous improvement**: when the same friction or
+A short, honest entry per feature delivered via `/deliver` (its Phase 3.7 —
+written **pre-PR** so the entry rides the delivery's own PR; the PR number is
+backfilled once the PR opens), newest at the top. A noteworthy watch-phase event
+is appended post-gate as an optional *watch:* line — an uneventful watch adds
+nothing. The point is **continuous improvement**: when the same friction or
 deviation recurs across entries, fold the fix into the relevant skill. Keep each
 entry to a handful of bullets — a log, not a ceremony.
 
 Format: **Feature / PR** · date · weight · *phases completed / skills invoked* ·
-*what worked* · *friction* · *deviations* · *one improvement*.
+*what worked* · *friction* · *deviations* · *one improvement* · *watch:*
+(optional, amended post-gate).
 
 ---
 

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,7 +14,7 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
-## 2026-07-05 — 🔧 Write the /deliver retro pre-PR (chore/deliver-retro-before-pr) · lite
+## 2026-07-05 — 🔧 Write the /deliver retro pre-PR (#382) · lite
 
 - **Phases / skills:** phases 0–4; no sub-skills fired (markdown-only: code +
   security review self-skipped, `/implement-plan` N/A with no Canon TDD list,

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -6,6 +6,17 @@ out of it.
 
 ## Tooling
 
+### `EnterWorktree` no longer uses the requested name as the branch name
+
+*2026-07-05.* `EnterWorktree(name: "chore/deliver-retro-before-pr")` created the
+worktree directory as `.claude/worktrees/chore+deliver-retro-before-pr/` (the
+`/` becomes `+`) but named the **branch** `worktree-chore+deliver-retro-before-pr`
+— not the requested name, as earlier deliveries observed. Since the branch is
+what the PR and the conventional-prefix rule care about, rename it right after
+entering: `git branch -m chore/deliver-retro-before-pr` (safe — nothing is
+pushed yet). Check `git branch --show-current` after every `EnterWorktree`
+rather than assuming the tool honoured the name.
+
 ### GitHub MCP: `/x/<toolset>` paths are exclusive, and `mergeable_state` ≠ `mergeStateStatus`
 
 *2026-06-25.* When wiring the skills to the GitHub MCP ([ADR-0009](decisions/0009-github-mcp-over-gh-cli.md)):

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,32 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-07-05 — Retro moved pre-PR: routine post-gate push loop eliminated · applied
+
+- **Pattern:** every delivery pushed the retro to the PR branch **after** the
+  ready-to-merge gate, re-triggering `claude-review` + the full CI matrix and
+  mandating a re-watch pass — ~5–7 min of CI plus a re-review per run to land a
+  markdown file. Bit hard on #361 (a post-gate push raised a High thread that
+  blocked the merge); paid silently on every delivery since. The applied
+  2026-06-24 "re-sweep after every push" rule treated the symptom, not the
+  sequencing.
+- **Decision:** **applied** (user-approved plan, this delivery). `/deliver` now
+  writes the retro in a new **Phase 3.7 (pre-PR)** so it rides the delivery's
+  own PR (entry headed with the branch name; the PR number is backfilled at
+  Phase 4 creation, pre-gate). Phase 6 became **wrap-up** (wiki +
+  recurring-pattern scan), with the retro **amended post-gate only for a
+  noteworthy watch-phase event** (optional `watch:` line). The re-watch rule
+  remains for the exceptions (amendments, approved skill edits). Landed in
+  `.claude/skills/deliver/SKILL.md`, `CLAUDE.md`,
+  `knowledge/delivery-retros.md` (header), `knowledge/README.md`, and
+  `.claude/skills/watch-pr/SKILL.md` §2.
+- **Rationale:** the root cause was ordering, not the re-watch rule — with the
+  retro committed pre-PR, the default path has **zero** post-gate pushes, so
+  the gate is never re-opened by the pipeline's own bookkeeping.
+- **Reconsider when:** watch-phase learnings routinely turn out noteworthy
+  enough that the amendment path fires on most deliveries — then revisit
+  deferring watch-phase learnings to the *next* delivery's retro instead.
+
 ### 2026-07-02 — Haiku build/test subagents misread xcsift toon `errors[]` as failure (#374) · applied
 
 - **Pattern:** the DocC `.docc` "unhandled file" package-load warning lands in


### PR DESCRIPTION
## Summary

`/deliver` used to commit and push its retrospective **after** the ready-to-merge gate. Every push re-triggers `claude-review` and the full CI matrix, so each delivery paid ~5–7 min of CI, a re-review, and a mandated re-watch pass just to land a markdown file — and on #361 the post-gate push raised a High thread that blocked the merge. This PR fixes the sequencing: the retro is written in a new **Phase 3.7 (pre-PR)** so it rides the delivery's own PR, and the default path pushes **nothing** after the gate.

## Changes

**`.claude/skills/deliver/SKILL.md`:**

- 🔧 New **Phase 3.7 — Write the retrospective (pre-PR)**: dated entry committed on the PR branch before `/pr`, headed with the branch name; includes the rolling-window archive step.
- 🔧 **Phase 4** backfills the PR number into the retro heading right after creation (pre-gate; the superseded CI run is cancelled by the concurrency group).
- 🔧 **Phase 6** reworked into **wrap-up** (wiki + recurring-pattern scan): the retro is amended post-gate only for a **noteworthy** watch-phase event (optional `watch:` line); the push-re-opens-the-gate → re-watch rule is kept, now scoped to those exceptions.
- 🔧 Pipeline diagram, behaviour-contract sequence, and Phase 7 references updated.

**Cross-references:**

- 📝 `CLAUDE.md` — pipeline line now reads `… /capture-knowledge → retro → /pr reviewed → /watch-pr`.
- 📝 `knowledge/delivery-retros.md` — header documents pre-PR entries, PR-number backfill, and the optional `watch:` amendment.
- 📝 `knowledge/README.md` — index row updated.
- 📝 `.claude/skills/watch-pr/SKILL.md` §2 — loop-guard wording now names the exceptional post-gate commits (skill edit / retro amendment).

**Knowledge:**

- 📚 `knowledge/skill-improvement-log.md` — applied entry recording this decision.
- 📚 `knowledge/gotchas.md` — `EnterWorktree` no longer uses the requested name as the branch name.
- 📚 Dogfooded in this very PR: its own retro entry is committed pre-PR, and the overdue archive-distil of the seven 2026-06-18/19 entries (deferred in #368 and #374) ran as part of the new windowing step.

## Benefits

- **No routine post-gate churn**: the ready-to-merge gate is reached once and stays valid — no re-triggered CI matrix, re-review, or re-watch pass for the pipeline's own bookkeeping.
- **Fewer blocked merges**: the #361 failure mode (a post-gate retro push raising a new blocking thread) can no longer occur on the default path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5GRMKxWvFUx8m9o5SF21M