### PR TITLE
♻️ Restructure /deliver for progressive disclosure (343-line core + references/)

### DIFF
--- a/.claude/skills/capture-knowledge/SKILL.md
+++ b/.claude/skills/capture-knowledge/SKILL.md
@@ -7,7 +7,7 @@ description: Capture durable, project-specific learnings from the work just done
 
 Fold what you just learned into the committed knowledge base at `knowledge/`, so a
 future session (or contributor) doesn't have to re-learn or re-discover it. Run
-this **before a PR** — in `/deliver` it runs automatically as Phase 3.5, so the
+this **before a PR** — in `/deliver` it runs automatically pre-PR, so the
 notes land in the same PR as the change.
 
 ## What to capture (be selective)

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -55,9 +55,9 @@ Non-negotiable. Do these by default, without being reminded.
    review`** gate task, which **blocks Phase 9**. A multi-deliverable plan
    keeps one ledger sub-tree per deliverable.
 7. **Jot knowledge candidates the moment a learning occurs** (a lookup, a
-   gotcha, a live-API surprise, a non-obvious decision) — one line each, in
-   the ledger. Phase 6 curates them; reconstruction later loses the best
-   material.
+   gotcha, a live-API surprise, a non-obvious decision) — one line each
+   (`<category>: <gist> [where]`), in the ledger. Phase 6 curates them;
+   reconstruction later loses the best material.
 8. **Auto-start after plan-mode approval.** `ExitPlanMode` approval IS the
    start signal — invoke `/deliver` immediately; pause first only if
    Phase 0's entry gate fires.
@@ -88,7 +88,8 @@ single-reviewer path. **Full** — anything risky or large ⇒ the three-critic
 
 A plan that is a *program* of cohesive deliverables becomes **one PR per
 deliverable**. Decompose in Phase 0 with a dependency graph: **dependent**
-(consumes a type/API/helper/file another introduces) → **sequence** it
+(consumes a type/API/helper/file another introduces *or substantially
+changes*) → **sequence** it
 (branch off its dependency, or wait for its merge); **independent** → own
 worktree + branch + PR; **unsure → treat as dependent**. Execution is
 **serial implement, concurrent watch**: one deliverable at a time through
@@ -108,7 +109,8 @@ implementation = separate `/deliver` sessions.)
 - **The gate stays in the main agent**; phases hand off via git / disk / the
   PR, not context.
 - Separate worktrees get separate `.build` dirs; run builds sequentially
-  *within* one worktree.
+  *within* one worktree. No `SCRATCH_PATH` override is needed — that flag is
+  only for multiple agents sharing one working directory.
 
 ## Phase 0 — Preconditions
 
@@ -121,7 +123,9 @@ implementation = separate `/deliver` sessions.)
   silently if the `wiki` MCP is absent.
 - **Decompose a multi-deliverable plan** (rules above); single-deliverable
   plans skip this.
-- **Entry gate — acceptance criteria required.** Extract the ACs verbatim as
+- **Entry gate — acceptance criteria required.** Plans are expected as
+  *"As a \<user-type\> I want \<feature\> so that \<reason\>"* + acceptance
+  criteria. Extract the ACs verbatim as
   the **delivery rubric** (consumed in Phase 7) into the ledger. Absent →
   stop and ask for them ("Given X, when Y, then Z") — don't enter the
   worktree. **Auto:** panel — proceed rubric-less (Phase 7 no-ops) vs stop.
@@ -144,8 +148,9 @@ Procedures and traps:
 3. **Copy `.claude/settings.local.json` in** from the main checkout (the
    permission allowlist; credentials come from the process env).
 4. **Record worktree + branch in the ledger, and (re-)create the ledger
-   here** — it is CWD-scoped and cleared by `EnterWorktree`/MCP reconnects;
-   found empty later → re-create from the phase list, it isn't lost work.
+   here** — it is CWD-scoped and cleared by `EnterWorktree`, an MCP
+   reconnect, or a plan-mode exit; found empty later → re-create from the
+   phase list, it isn't lost work.
 5. **Edit via worktree paths**: re-`Read` anything read before entering, and
    **verify `git status` shows your diff in the worktree before trusting the
    first green build** (empty diff + baseline counts = edits went to `main`).
@@ -157,7 +162,8 @@ enter, proceed.
 
 **Lite, or already reviewed this session** (a converged `/review-plan`, or
 `ExitPlanMode` approval) → skip the critics. **Full with an unreviewed plan**
-→ invoke `/review-plan`, present the revised plan as an **FYI**, keep going —
+→ invoke `/review-plan`, present the revised plan + a one-line change log
+(applied / rejected) as an **FYI**, keep going —
 except a **blocker** (wrong approach, breaking, data-loss), which stops the
 run. **Auto:** data-loss/breaking = hard stop (never delegated); other
 blockers → panel.
@@ -233,7 +239,8 @@ a valid outcome.
 Take the rubric (Phase 0 ACs) from the ledger; none extracted → skip. Verify
 each AC against the committed diff — behaviour by diff-scan or a targeted
 test (`swift test --filter …`), coverage by the test + assertion existing,
-integration by the integration test existing. Satisfied → mark off. Not →
+integration by the integration test existing (the live run already passed in
+Phase 3 — no re-run needed). Satisfied → mark off. Not →
 fix test-first, commit, re-verify; a gap needing a plan change is noted in
 the PR description. Lightweight, inline — *"did we build what the plan
 said?"*, not *"did the build pass?"*.
@@ -294,7 +301,8 @@ after the gate**. Guidance:
   Critical/High thread, routed flake, wrong readiness call): append a
   one-line `watch:` bullet, commit, push — on the PR branch (watch-only), or
   a fresh branch off `origin/main` as a small follow-up PR (`merge`/auto
-  mode, before teardown). Uneventful watch → don't touch it.
+  mode, before teardown; the same routing applies to any skill edits the auto
+  scan commits). Uneventful watch → don't touch it.
 - **Any post-gate push re-opens the gate** — after the last exceptional push
   (amendment or approved skill edit), run the `/watch-pr` loop once more on
   the new tip before merge.

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -6,10 +6,15 @@ description: Take the current plan all the way to a ready-to-merge pull request 
 # Deliver
 
 Drive the **current plan** through the whole feature pipeline to a PR that is
-green and ready to merge — without you hand-running each step. This skill is an
-**orchestrator**: it does not re-implement review, TDD, or PR logic; it sequences
-the existing skills and the `code-reviewer` agent, adds the safety gates, and
-keeps going across the long session until the PR is ready.
+green and ready to merge. This skill is an **orchestrator** — it sequences the
+existing skills and adds the safety gates; the expertise lives in the pieces
+it invokes. It runs **autonomously** from invocation (which is itself plan
+approval) to a single hard stop — **ready-to-merge** — auto-scaling its
+machinery to the change's risk, and writing a short **retrospective** that
+rides the delivery's own PR. Every run happens in its **own git worktree**
+(Phase 1; torn down on merge, Phase 12) so the user's main checkout stays
+free. The plan is created first with `/plan` (or plan mode) — `/deliver`
+picks up from there.
 
 ```text
 you approve the plan ─▶ /deliver ─▶ entry gate (ACs?) ─▶ worktree ─▶ [review-plan] ─▶
@@ -17,899 +22,314 @@ you approve the plan ─▶ /deliver ─▶ entry gate (ACs?) ─▶ worktree �
   rubric check (ACs met?) ─▶ retro (pre-PR) ─▶ /pr reviewed ─▶ /watch-pr ─▶
   GATE: ready-to-merge ─▶ wrap-up (wiki + recurring-pattern scan)
   ▲ the only hard stop
-  … then, when the PR actually merges (maybe a later session): teardown (Phase 7)
+  … then, when the PR actually merges (maybe a later session): teardown (Phase 12)
 ```
 
-Every `/deliver` runs in its **own git worktree** (Phase 0.5), so your **main
-checkout on disk stays free** — a second Claude session, Xcode, or a manual build
-can use it while this delivery runs (and you can launch a second `/deliver` in
-another session), with no fighting over the working tree or `.build`. (This very
-session is busy delivering; what's freed is the checkout, for *other* tools and
-sessions.) The worktree and its `.build` are **torn down on merge** (Phase 7
-teardown).
-
-**Invoking `/deliver` on an approved plan is itself the plan-approval gate.** From
-there it runs **autonomously** to a single hard stop — **ready-to-merge** — pausing
-mid-run only for a genuine blocker (a plan-review blocker, or a red gate it cannot
-triage). It **auto-scales** the machinery to the change's risk (see *Delivery
-weight*), and writes a short **retrospective** that rides the delivery's own PR
-(Phase 3.7) so the workflow keeps improving.
-
-The plan itself is **not** part of this skill — create it first with `/plan` (or
-plan mode). `/deliver` picks up from there.
+**Detail on demand:** procedures, traps, and incident history live in
+[`references/`](references/) — read the named file when its phase arrives,
+not up front.
 
 ## Agent Behaviour Contract
 
-These are non-negotiable. Do them by default, without being reminded.
+Non-negotiable. Do these by default, without being reminded.
 
-1. **Invoking `/deliver` is plan approval — then run autonomously to the one
-   gate.** Do not stop for a second "is the plan ok?" confirmation. Proceed through
-   branch → (review-plan) → implement → code-review/fix → capture → retro →
-   pr → watch-pr to the single hard stop, **Gate: ready-to-merge** (Phase 5). The only legitimate
-   mid-run pauses are: a **blocker** raised by `/review-plan` (Phase 1), or a **red
-   gate you cannot triage** (Contract §4).
-2. **Delegate to the existing skills — don't reinvent them.** Invoke
-   `/review-plan`, `/implement-plan`, `/review-changes`, `/security-review`,
-   `/capture-knowledge`, `/pr`, `/watch-pr`, and `/fix-integration-failures`
-   (`/review-changes` is what spawns the `code-reviewer` agent or the review
-   Workflow). This skill only sequences and gates; the expertise lives in those
-   pieces.
-3. **Never work on `main` — always in a fresh worktree.** Phase 0.5 enters a
-   dedicated git worktree (a new branch off `origin/main`) **before** `/review-plan`
-   or any file edit, and all work happens there — so the user's main checkout is
-   never touched and stays free for concurrent work. `CLAUDE.md` forbids editing
-   `main`; the worktree guarantees it. On merge, tear the worktree down (Phase 7).
-4. **A red gate triages before it stops.** If `make ci` or a check fails, first
-   classify **in-diff vs pre-existing** (Phase 4). A failure your diff caused → fix
-   test-first and re-run; only **stop** if it can't converge in the cap. A
-   **pre-existing / unrelated** failure (typically a flaky live integration test
-   not in your diff) → route it to `/fix-integration-failures` (fix off `main`,
-   merge, update this branch) and re-run — **don't** hard-stop on someone else's
-   flake. Only a genuine, in-diff, unfixable break stops the pipeline.
-5. **Test-first all the way.** Every fix in the code-review loop follows
-   `canon-tdd` — reproduce with a failing test, then fix. No untested patches.
-6. **Keep a durable phase ledger.** This is a long session that may be summarised.
-   Track it in a **`TaskCreate` task list — one task per phase** (Phase 0.5 →
-   Phase 6), set `in_progress`/`completed` as you go, and record the branch name,
-   PR number, and the delivery weight on the relevant tasks. A task list survives
-   compaction better than prose working-notes, so you can resume cleanly. For a
-   **template→replicate** full delivery, the ledger also carries the
-   **`Phase 3a — reference-unit review`** gate task (Phase 3), which **blocks
-   Phase 4** until the reference unit has been reviewed and converged. For a
-   **multi-deliverable** plan, keep **one ledger sub-tree per deliverable** (its
-   own branch / PR / weight) — see *Multi-deliverable plans*.
-7. **Jot knowledge candidates as you go.** Keep a running **knowledge-candidates**
-   list (in the ledger) and append to it the *moment* a learning occurs during
-   Phases 2–3 — a thing you had to look up or web-search, a gotcha or dead-end, a
-   surprising live-API behaviour, or a non-obvious decision. One line each
-   (`<category>: <gist> [where]`). Phase 3.5 curates this list; reconstructing it
-   at the end loses the best material (and may not survive compaction).
-8. **Auto-start after plan-mode approval.** When a plan has just been approved via
-   `ExitPlanMode` in this session, invoke `/deliver` immediately — **do not ask
-   "shall I start?" or "ready to proceed?"**. The plan-mode approval IS the start
-   signal. The only legitimate reason to pause before starting is if Phase 0's
-   entry gate fires (missing acceptance criteria) — that is a plan problem, not a
-   confirmation prompt.
+1. **Invoking `/deliver` is plan approval — run autonomously to the one
+   gate** (the diagram above), with no second "is the plan ok?" prompt. The
+   only legitimate mid-run pauses: a **blocker** from `/review-plan`
+   (Phase 2), or a **red gate you cannot triage** (§4).
+2. **Delegate to the existing skills — don't reinvent them**: `/review-plan`,
+   `/implement-plan`, `/review-changes`, `/security-review`,
+   `/capture-knowledge`, `/pr`, `/watch-pr`, `/fix-integration-failures`.
+3. **Never work on `main` — always in a fresh worktree**, entered **before**
+   `/review-plan` or any file edit (`CLAUDE.md` forbids editing `main`).
+4. **A red gate triages before it stops.** In-diff failure → fix test-first
+   and re-run. Pre-existing/unrelated (typically a flaky live integration
+   test) → route to `/fix-integration-failures` and re-run — never hard-stop
+   on someone else's flake. Only a genuine, in-diff, unfixable break stops
+   the pipeline.
+5. **Test-first all the way.** Every review-loop fix follows `canon-tdd` —
+   failing test first. No untested patches.
+6. **Keep a durable phase ledger** — a `TaskCreate` list, one task per phase,
+   statuses current, recording branch, PR number, and weight. A
+   template→replicate delivery adds the **`Phase 4a — reference-unit
+   review`** gate task, which **blocks Phase 9**. A multi-deliverable plan
+   keeps one ledger sub-tree per deliverable.
+7. **Jot knowledge candidates the moment a learning occurs** (a lookup, a
+   gotcha, a live-API surprise, a non-obvious decision) — one line each, in
+   the ledger. Phase 6 curates them; reconstruction later loses the best
+   material.
+8. **Auto-start after plan-mode approval.** `ExitPlanMode` approval IS the
+   start signal — invoke `/deliver` immediately; pause first only if
+   Phase 0's entry gate fires.
 
-## Auto mode (unattended)
+## Auto mode & async invocation
 
-`/deliver auto` runs the **entire** pipeline with **no human interaction** — every
-mid-run decision that would normally stop and ask the user is instead resolved by
-an **adversarial panel** of three Opus subagents, and the conductor acts on their
-majority verdict and keeps going through Phase 6.
+`/deliver auto` replaces every stop-and-ask decision with an **adversarial
+panel** of three Opus subagents (majority verdict, ledger audit trail);
+decision points are marked **Auto:** below. Never delegated: a **data-loss or
+breaking-change plan blocker is a hard stop even in auto**. `/deliver` can
+also be queued headless (the plan + ACs must travel in the trigger prompt).
+Panel procedure and queuing caveats:
+[`references/auto-and-async.md`](references/auto-and-async.md). In attended
+mode the **Auto:** branches do not apply — stop and ask, as written.
 
-**The panel.** At each decision point, convene three subagents in parallel, each
-given the same context (the decision, the evidence, the options):
+## Delivery weight — auto-scale to risk
 
-- **Proceed** — argues the case for continuing the pipeline.
-- **Stop** — argues the case for halting and handing back to the user.
-- **Devil's advocate** — attacks whichever way looks easiest, so the other two
-  can't converge on a comfortable answer unchallenged.
-
-Each returns a one-line verdict (`proceed` / `stop`) and its reasoning. **Majority
-wins.** The conductor records the outcome in the ledger and continues — `proceed`
-resumes the pipeline; `stop` ends the run with the usual status summary.
-
-**Audit trail.** For **every** panel convened, write a ledger entry recording: the
-**decision point**, the **three subagent verdicts**, the **majority outcome**, and
-a **one-line rationale**. The point of `auto` is autonomy *with* a full record of
-why each call was made — a run that went unattended must still be reviewable.
-
-**The one exception — never delegated.** A Phase 1 `blocker` where the plan would
-cause **data loss** or a **breaking change** is **always a hard stop**, even in
-`auto`. It is too consequential to hand to a panel: surface it to the user and
-wait. (Every other decision point — including all *other* Phase 1 blockers — goes
-to the panel.)
-
-Each decision point below marks its **Auto:** branch. In the default (attended)
-mode those branches do not apply — the pipeline stops and asks, as written.
-
-## Async / queued invocation
-
-`/deliver` can be **queued to run unattended**, not just driven from an
-interactive session — the worktree isolation, the `TaskCreate` ledger, the
-Phase 0.5 GC sweep, and `auto` mode (the panel) are exactly what an unattended run
-needs. Two existing entry points already do this: a **CCR trigger**
-(`create_trigger` with `create_new_session_on_fire`, or the `/schedule` skill)
-fires a fresh session whose prompt is `/deliver auto …`, and
-`integration-failure.yml` runs a skill **headless** on a runner.
-
-If you queue a `/deliver`, mind two things:
-
-- **Inline the whole plan + acceptance criteria in the trigger prompt.** A fresh
-  session has no conversation history, and Phase 0's entry gate **requires ACs** —
-  so the plan text and its ACs must travel *in* the prompt, or the run stops at
-  the gate immediately.
-- **User-scoped MCP may be absent** (`mcp__github__*`, `wiki`). The `gh` fallbacks
-  in `/pr` and `/watch-pr` cover GitHub; the wiki step degrades silently. A
-  headless GitHub-Actions run has no user MCP at all (it uses `git`/`gh`); a
-  CCR-spawned session in your own environment usually keeps them.
-
-**Recommendation — don't routinise async *feature* delivery here.** This is a
-single-maintainer package with public API surface, where the **ready-to-merge
-human gate is deliberate** — every change is a compatibility call worth a human's
-eyes. Async earns its place for the *occasional* away-from-keyboard run and for
-the **self-healing integration cron** (which already opens a PR for review, never
-merges) — not as the default path.
-
-## Delivery weight — auto-scale to risk (lite vs full)
-
-`/deliver` sizes its machinery to the change, automatically — no flag. Judge the
-weight from the plan up front, and re-confirm from the actual diff after Phase 2:
-
-- **Lite** — a small, mechanical, single-unit change that touches **no risky
-  surface**: no concurrency (`Task`/actor/`Sendable`), no networking/`HTTPClient`
-  layer, no model `Decodable`/`CodingKeys` changes, and no new public API beyond a
-  simple additive method; roughly **under a few hundred changed lines**. Lite ⇒
-  **skip `/review-plan`'s three-critic pass** (Phase 1) and let `/review-changes`
-  take its **single-reviewer** path (Phase 3) — it already self-scales.
-- **Full** — anything risky or large: new concurrency, networking, models/decoders,
-  a new service or public-API surface, multi-unit work, or a big diff. Full ⇒ the
-  **three-critic `/review-plan`** and the **fan-out + adversarial-verify**
-  `/review-changes`.
-
-When unsure, prefer **full** — the heavier review is cheap insurance against the
-changes that actually bite. Record the chosen weight in the ledger.
+Judge from the plan; re-confirm from the diff after Phase 3; record in the
+ledger. **Lite** — small, mechanical, single-unit, no risky surface (no
+concurrency, networking/`HTTPClient`, or `Decodable`/`CodingKeys` changes; no
+new public API beyond a simple additive method; under a few hundred changed
+lines) ⇒ skip `/review-plan`'s critics; `/review-changes` takes its
+single-reviewer path. **Full** — anything risky or large ⇒ the three-critic
+`/review-plan` and the fan-out + adversarial-verify `/review-changes`.
+**When unsure, prefer full.**
 
 ## Multi-deliverable plans — one run, several PRs
 
-A plan is sometimes a **program of independent deliverables**, not one change
-(e.g. "extract a shared validation helper" + "fix the mis-applied test tags" +
-"harden a decoder" — three cohesive changes that don't touch each other). Forcing
-those into one PR couples unrelated review and risk; running them as wholly
-separate invocations loses the shared plan context. So `/deliver` **decomposes a
-multi-deliverable plan into one PR per deliverable**, runs the independent ones in
-the same session, and **only serialises the ones that are obviously dependent**.
-
-**Decompose up front (Phase 0).** List the deliverables and build a **dependency
-graph**:
-
-- **Dependent** = one deliverable consumes a type, API, helper, or file that
-  another *introduces or substantially changes* (e.g. "B calls the shared helper A
-  extracts"). Dependent deliverables are **sequenced** — the dependent one
-  branches off its dependency (or waits for it to merge).
-- **Independent** = no such coupling → each gets its **own worktree + branch +
-  PR**.
-- **When unsure, treat as dependent and sequence** — the safe default. Split into
-  concurrent PRs only when independence is *obvious*.
-
-**Execution — serial implement, concurrent watch.** A single conductor can only
-drive one inline `/implement-plan` loop at a time (the implement phase is
-deliberately visible — *Context & isolation*), so each deliverable's
-**implementation runs serially**, one worktree at a time, through Phases 0.5 → 4
-(its own worktree, code review, security review, rubric, PR). What runs
-**concurrently is Phase 5**: once a deliverable's PR is open, start its
-`/watch-pr` **in the background** and move on to implement the next independent
-deliverable — so CI churns on the open PRs while the conductor keeps building.
-
-> The honest win is **N PRs from one run + their CI watched in parallel**, not
-> parallel compilation — builds stay serial within the single-threaded conductor
-> (cross-worktree `.build` dirs are separate, but the conductor is not). For
-> genuinely parallel *implementation*, launch a separate `/deliver` per
-> deliverable in its own session (see *Async / queued invocation*).
-
-**The gate becomes a batch.** Phase 5's ready-to-merge gate reports **all** the
-deliverables' PRs and their states together (PR A ready · PR B ready · PR C
-waiting on PR A) and hands the batch to the user. Each worktree is torn down
-(Phase 7) as **its** PR merges, independently; a stuck PR in the batch never
-blocks reporting the others as ready. Per-deliverable, nothing else changes —
-each PR still runs the full single-deliverable pipeline (weight scaling, review,
-security, capture, rubric); multi-deliverable mode only adds the decomposition,
-the dependency ordering, and the batched gate.
+A plan that is a *program* of cohesive deliverables becomes **one PR per
+deliverable**. Decompose in Phase 0 with a dependency graph: **dependent**
+(consumes a type/API/helper/file another introduces) → **sequence** it
+(branch off its dependency, or wait for its merge); **independent** → own
+worktree + branch + PR; **unsure → treat as dependent**. Execution is
+**serial implement, concurrent watch**: one deliverable at a time through
+Phases 1→9, but once its PR is open, start its `/watch-pr` **in the
+background** and move to the next. The gate reports the **batch**; each
+worktree is torn down as *its* PR merges; a stuck PR never blocks the others.
+The full per-deliverable pipeline applies unchanged. (Genuinely parallel
+implementation = separate `/deliver` sessions.)
 
 ## Context & isolation (by design)
 
-`/deliver` is a **lean main-context conductor** — it should hold only the plan
-reference, the phase ledger, the one gate interaction, and a short summary returned
-from each phase. The heavy or independent-judgment work is deliberately isolated so
-it never bloats or biases the main window:
-
-- **Already isolated — keep it that way.** `/review-plan` runs its three Opus
-  critics in a separate Workflow (only verdicts return); the `code-reviewer`
-  agent reads the diff, OpenAPI spec, and MCP in its own context; and `/test`,
-  `/build`, `/integration-test`, `/lint` delegate their logs to Haiku subagents.
-- **Implement runs inline — on purpose.** `/implement-plan` stays in the main
-  context so the Canon TDD test list and each red/green step are **visible** to
-  the user, and so it can pause for any mid-implementation decision. Its noisy
-  output (test/build logs) is already delegated to Haiku, so the inline cost is
-  mostly the edits themselves. **Do not** convert this phase to a silent subagent
-  — that would trade away the visibility the workflow is built around.
-- **The gate stays in the main agent.** Subagents are non-interactive; the
-  ready-to-merge gate is handed to the user, so the conductor — not a subagent —
-  owns it. Phases hand off via **git / disk / the PR**, not via context.
-- **The work happens in a worktree, the session stays put.** The conductor
-  `EnterWorktree`s in Phase 0.5 so the delivery's branch and its multi-GB `.build`
-  live in `.claude/worktrees/<branch>/`, isolated from the user's main checkout.
-  This is what lets a second `/deliver` (or hand work) run concurrently — separate
-  worktrees get separate `.build` directories automatically (the scratch path is
-  CWD-relative), so their builds don't collide. No `SCRATCH_PATH` override is needed
-  for this; that flag is only for *multiple agents sharing one* working directory.
+- The conductor stays **lean** (plan reference, ledger, gate, short per-phase
+  summaries); heavy work is already isolated in Workflows/subagents — keep it
+  that way.
+- **Implement runs inline — on purpose** (the TDD list stays visible). Do
+  **not** convert it to a silent subagent.
+- **The gate stays in the main agent**; phases hand off via git / disk / the
+  PR, not context.
+- Separate worktrees get separate `.build` dirs; run builds sequentially
+  *within* one worktree.
 
 ## Phase 0 — Preconditions
 
-- **A plan must exist.** Locate it the way `/review-plan` does (named target →
-  plan-mode plan → most recent plan in the conversation). If there is no plan,
-  stop and tell the user to run `/plan` first — do not invent one.
-- **If the plan originates from a review finding, verify it first.** When the
-  delivery comes from a code-review / source-review *finding* rather than a
-  user-authored plan, treat the finding as a **hypothesis, not an approved
-  plan**: do a quick `Explore` pass to confirm it against the actual code (Is it
-  real? Is the framing right? Breaking or not?) **before** drafting the plan or
-  asking the user any strategy questions. Review findings have repeatedly been
-  mis-framed — a non-breaking change mistaken for breaking, a false-positive
-  "bug", a "fix" that was really a clarity tweak.
-- **State the goal** in a sentence so every downstream phase is anchored to it.
-- **Pull relevant context from the wiki** (best-effort). If the personal `wiki`
-  MCP is available, call `get_context` on the goal to surface any of Adam's
-  durable preferences, prior decisions, or conventions that bear on the approach,
-  and let them calibrate the plan and the review emphasis. **Degrade silently** if
-  the wiki MCP is absent (a contributor's machine, a headless/cron run) — never
-  block the pipeline on it.
-- **Judge the delivery weight** (lite vs full) from the plan, and open the
-  `TaskCreate` ledger (Contract §6).
-- **Decompose a multi-deliverable plan.** If the plan is a *program* of more than
-  one cohesive deliverable, decompose it now and build the **dependency graph**
-  (see *Multi-deliverable plans*) — this decides whether the run opens **one PR or
-  several**, and in what order. A single-deliverable plan skips this.
-- **Entry gate — acceptance criteria required.** Plans are expected in the form
-  *"As a \<user-type\> I want \<feature\> so that \<reason\>"* followed by
-  acceptance criteria and any elaboration. Locate the acceptance criteria in the
-  plan:
-  - **If acceptance criteria are present:** extract them verbatim as the **delivery
-    rubric** and record them in the ledger. Proceed silently.
-  - **If acceptance criteria are absent:** stop and ask the user to add them before
-    proceeding — do not enter the worktree or begin implementation. Be specific:
-    *"The plan has no acceptance criteria. Please add them so there is a clear
-    definition of done (e.g. 'Given X, when Y, then Z')."*
-  - **Auto:** convene the panel on a missing-AC stop. **Proceed** majority → note
-    the gap in the ledger, continue without a rubric (Phase 3.6 becomes a no-op).
-    **Stop** majority → surface to the user.
-
-  The delivery rubric (extracted ACs) travels through the run and is consumed in
-  Phase 3.6.
-
-- **Read the plan's content into context now — before the worktree.** Phase 0.5's
-  `EnterWorktree` switches the working directory and **clears the CWD-scoped plans
-  cache**, so the active plan reference can be lost after the switch. Locate and
-  **read the plan file fully here** (its content travels with the conversation),
-  so Phase 1+ can work from it inside the worktree without re-finding it.
-
-## Phase 0.5 — Enter an isolated worktree (before any edit)
-
-Do this **before** Phase 1 — `/review-plan` applies its consensus by editing the
-plan, and all of implementation happens next; none of it may touch `main` or the
-user's main checkout (`CLAUDE.md` forbids editing `main`; Contract §3). **Every
-`/deliver` runs in its own git worktree** so the user's checkout stays free for
-concurrent work.
-
-**First, GC any stale worktree from a prior delivery** (this run is the garbage
-collector for the *previous* one's deferred merge — Phase 7 only fires on an
-in-session merge, and the common path is "merged later, elsewhere"). Sweep the
-worktree dirs and reclaim any whose PR has since merged. Get every PR's state in
-**one** call — `mcp__github__list_pull_requests` (owner/repo from the `origin` remote,
-`state: all`, `perPage: 100`) — and build a `head.ref → merged?` map (a merged PR
-reports `state: closed` + `merged: true`). Then, for each worktree branch the map
-marks **merged**, remove it:
-
-```bash
-# For each $wt under .claude/worktrees/ whose branch ($br) the map marks merged:
-git worktree remove --force "$wt" && git branch -D "$br" 2>/dev/null
-```
-
-(The branch→merged map comes from the MCP call above; the shell step only does the
-removal — tool calls can't run inside a bash loop. Get branches with
-`git -C "$wt" rev-parse --abbrev-ref HEAD`.)
-
-This keeps `.claude/worktrees/` (each carrying a multi-GB `.build`) from
-accumulating across deliveries the user merged in the GitHub UI or a later session.
-
-**Enter the worktree** with the harness's `EnterWorktree` tool, naming it from the
-plan with a conventional prefix — `feature/<slug>` for new work, `fix/<slug>` for a
-bug fix, etc.:
-
-- `EnterWorktree(name: "feature/<slug>")` creates `.claude/worktrees/feature/<slug>/`
-  and switches the session into it. By default (`worktree.baseRef: fresh`) the branch
-  is cut from **`origin/main`**; if the user has set `worktree.baseRef: head`, it's
-  cut from local HEAD instead — so don't assume `origin/main` unconditionally. This
-  is the sanctioned auto-use of `EnterWorktree` for `/deliver` (Contract §3 +
-  memory) — do it without asking. **Note the `fresh` consequence:** the worktree is
-  cut from `origin/main`, so any **uncommitted or local-only** state (including the
-  on-disk plan file, if it isn't committed) is **absent** — which is why Phase 0
-  reads the plan's content into the conversation first.
-- **Already in a worktree?** (e.g. the user entered one manually.) Don't nest — use
-  the current worktree and just create the branch in it (`git checkout -b
-  feature/<slug>`). `EnterWorktree` refuses to nest anyway.
-
-**Restore the local permission allowlist in the worktree.** Credentials are **not**
-the concern — `TMDB_API_KEY` / `USERNAME` / `PASSWORD` are injected into the
-session's **process environment** at startup (CWD-independent), and `make ci` /
-`make integration-test` read them straight from the environment, so a subshell in
-the worktree inherits them regardless. What a fresh worktree lacks is the
-**gitignored `.claude/settings.local.json`**, which also holds the **permission
-allowlist** — and whether the harness re-reads it from the new CWD is unverified, so
-without it an autonomous run could stall on permission prompts. Copy it in as cheap
-insurance:
-
-```bash
-# CWD is the worktree; the main checkout is the first entry of `git worktree list`.
-main_root=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
-mkdir -p .claude
-cp "$main_root/.claude/settings.local.json" .claude/settings.local.json 2>/dev/null || true
-```
-
-It stays gitignored in the worktree, so it won't be committed. If `make ci`'s
-integration leg fails on **credentials**, the cause is the *env* not being inherited
-by whatever spawned the subshell — **not** this file; check the environment first.
-
-Record the worktree path and branch name in the ledger. The branch is what the PR
-and all later phases (`git diff origin/main...HEAD`, `/pr`, `/watch-pr`) operate on.
-
-**(Re-)create the ledger here, inside the worktree.** The `TaskCreate` ledger is
-**CWD-scoped and cleared by `EnterWorktree`** (and can be reset mid-run by an MCP
-reconnect or a plan-mode exit), so open the Contract §6 ledger *after* entering
-the worktree — and if a later phase finds it empty, **re-create it from the phase
-list** rather than treating it as lost work. (Bit #364 and #368.)
-
-**Edit via worktree paths, and verify your diff landed there — not on `main`.** A
-file `Read` *before* `EnterWorktree` (e.g. source you scoped in Phase 0) yields a
-**main-checkout** absolute path; continuing to `Edit` that exact path after entering
-writes to **`main`**, not the worktree (they share `.git` but have **separate
-working dirs**). The trap is self-concealing: the build/test then runs against the
-still-pristine worktree and returns **baseline** counts, so a green run "confirms"
-work that never landed. So: after entering, **re-`Read` source files before editing
-them**, and **before trusting the first green build, verify `git status` shows your
-diff in the worktree** (an empty diff + baseline test counts = edits went to `main`).
-Rescue stranded edits with a shared stash: `git -C <main-checkout> stash` then
-`git stash pop` in the worktree. (Same root cause as the fanned-out-subagent variant
-in `knowledge/gotchas.md` → *Edits can land in the main checkout*.)
-
-**Invoked from plan mode?** If you reach `/deliver` while in plan mode with an
-approved plan, that approval *is* Gate-1: exit plan mode (the plan file is your
-input — already read into context in Phase 0), enter the worktree, and proceed —
-there's no separate `ExitPlanMode`-then-approve dance, and no second "is the plan
-ok?" prompt.
-
-## Phase 1 — Harden the plan (no separate approval stop)
-
-The plan is already approved (Contract §1), so this phase only **hardens** it; it
-does not re-ask for approval.
-
-- **Lite change, or a plan already reviewed this session** (a recent `/review-plan`
-  that converged, or a plan approved via `ExitPlanMode`) → **skip the critics** and
-  proceed straight to Phase 2. Re-running three Opus critics on a settled or trivial
-  plan is wasted work.
-- **Full change with an unreviewed plan** → invoke **`/review-plan`** (three
-  adversarial Opus critics → consensus → applied to the plan). Then:
-  - Present the **revised** plan + a one-line change log (applied / rejected) as an
-    **FYI**, and **keep going** — do not wait for re-approval.
-  - **Exception — a `blocker`:** if a critic raises a blocker (the approach is
-    wrong, a breaking change, data-loss, etc.), **stop and surface it** before
-    implementing. A blocker means the approved plan would do harm; that's worth the
-    interruption. Improvements/`major`/`minor` are folded in and you proceed.
-    - **Auto:** a **data-loss or breaking-change** blocker is **always a hard
-      stop** (the never-delegated exception). For **any other** blocker, convene
-      the panel to decide proceed vs stop and act on the majority verdict.
-
-## Phase 2 — Implement the plan
-
-Invoke **`/implement-plan`**. It derives the Canon TDD test list (shown before any
-code), drives the Red-Green-Refactor loop one test at a time, and finishes only
-when the **test list is empty** and the suites are green, and expects the
-lint/format PostToolUse hook to reshape files after writes.
-
-> **"Fix every instance of pattern X" → enumerate ALL sites up front.** When the
-> plan's goal is to apply one change across every occurrence of a pattern (encode
-> every path interpolation, validate every public String input, rename every call
-> site), do a single **type-driven sweep first** and list the sites in the test
-> list before implementing — don't discover them piecemeal. Piecemeal discovery is
-> a recurring miss: a grep keyed on the wrong signal finds a subset, and the
-> stragglers surface one at a time across code review / security review / the
-> `claude-review` bot (PR #364 found a 4th encode site in review and three more
-> unvalidated methods from the bot, after both the plan sweep and `/security-review`
-> had each missed a different subset). Sweep by **type**, not by eyeballing: e.g.
-> `grep 'path = "/.*\('` for String-into-path interpolations *and* scan public
-> service signatures for `String`/`*.ID` params — `Int` IDs are injection-safe and
-> need nothing. Confirm the full list, then implement against it.
->
-> ---
->
-> **Consult the specialist skills — don't hand-roll their domains (mandatory).**
-> `/implement-plan`'s contract §4 already requires this, but it is easy to skip
-> under delivery momentum, so treat it as a hard checkpoint here too — including
-> when implementation work is fanned out to subagents/Workflows (give them the
-> same instruction). The trigger is the *topic*, not whether you feel stuck:
->
-> - **`swift-concurrency`** — invoke the moment the change touches `actor`s,
->   `@MainActor`, `Sendable`/`@unchecked Sendable`, locks (`NSLock`/`Mutex`),
->   `Task`/`async let`/task groups, or any data-race/isolation question. Use it to
->   *design* the approach, not just to debug a diagnostic. (This run hand-rolled an
->   `NSLock`/`@unchecked Sendable` mock design and only consulted the skill when the
->   user prompted — at which point it both validated the choice and caught a missing
->   `@unchecked Sendable` removal-plan. See `delivery-retros.md` 2026-06-23 #359.)
-> - **`swift-testing-expert`** — invoke when writing or structuring tests
->   (`@Test`/`#expect`/`#require`, suites, traits/tags, parameterised tests, async
->   waiting), not after hand-writing them.
->
-> The same applies in **Phase 3**: when the diff is concurrency-sensitive, run the
-> finding through `swift-concurrency` before accepting or dismissing it.
-
-It also **commits at logical checkpoints** as it goes — each commit a coherent,
-green, lint-clean increment (`/implement-plan`'s *Commit at logical points*). This
-matters for the pipeline: Phase 3 reviews **committed** history (`git diff
-origin/main...HEAD`), so committing as you implement means the review sees the real
-change rather than an empty diff.
-
-Do not advance until `/implement-plan` reports an empty test list with `/test`
-**and** `/integration-test` passing, and the work committed. Re-confirm the
-delivery weight from the actual diff now (a "lite" plan that ballooned is `full`).
-
-## Phase 3 — Code review + fix loop
-
-**Skip this phase entirely if the change has no Swift source.** `/review-changes`
-self-gates (it returns immediately when `git diff origin/main...HEAD` touches no
-`*.swift`), so a docs-only / config-only delivery sails straight to Phase 3.5
-with no review. Code review is for Swift.
-
-Review **stable** code, not work in progress. Code review is an independent,
-adversarial lens — apply it once the design has settled, not after every Canon TDD
-item (the test list is deliberately emergent; early items are reshaped by later
-ones, so per-item review just flags churn). The per-item quality gate already
-lives in Phase 2 — the passing test, the inline docs, the lint hook, and
-refactor-on-green.
-
-**Granularity by delivery weight:**
-
-- **Lite / single-unit** (one method, one model) → review **once**, on the full
-  diff after Phase 2. `/review-changes` takes its single-`code-reviewer` path.
-- **Full, template→replicate** (one pattern applied across **N≥3 cohesive
-  units** — e.g. 25 sibling mocks, "validate every public String input", one
-  method mirrored across services; the shape Phase 2's *"enumerate ALL sites up
-  front"* blockquote already flags) → **review the reference unit before the rest
-  are generated.** This is a **hard ledger gate**, not advice: add a
-  `Phase 3a — reference-unit review @ <sha>` task to the ledger, have
-  `/implement-plan` commit the first unit on its own, run `/review-changes` scoped
-  to that commit (`git diff origin/main...<sha>`), converge its Critical/High per
-  the loop below, and only then let Phase 2 replicate the pattern across the
-  remaining units. **Phase 4 must not start while this task is open.** A wrong
-  foundational pattern caught here is one *not* baked into all N units (the #359
-  "reference-first" win: a cross-module DocC break caught in `MockGenreService`
-  before it replicated into 25 mocks).
-- **Full, otherwise** (multi-unit but *not* template-replicate — several distinct
-  models/methods, parallel-similar work, risky concurrency/networking) → review
-  **once**, on the full diff after Phase 2, via the fan-out + adversarial-verify
-  `/review-changes`. A single end-diff fan-out is the right tool here; do **not**
-  interleave per unit — the units don't build on each other, so per-unit review
-  only adds churn, and the fan-out's per-dimension adversarial pass already covers
-  the whole diff.
-
-Run the review via **`/review-changes`**, which scales the machinery to the diff
-itself: a single `code-reviewer` agent for a small change, or a fan-out Workflow
-(one reviewer per dimension → adversarial verification of each Critical/High →
-reconcile) for a large/multi-unit one. Then converge:
-
-1. Read its severity-graded report (it follows `.github/CODE_REVIEW.md`, including
-   the adversarial pass — on the large path, Critical/High are independently
-   verified, so they're high-confidence).
-2. **If there are Critical or High findings**, fix each one **test-first** via
-   `canon-tdd` — failing test that captures the defect, then the fix — then re-run
-   `/test` (+ `/integration-test` if behaviour changed) and **commit the fix**.
-   The commit is required: `/review-changes` diffs **committed** history
-   (`origin/main...HEAD`), so an uncommitted fix would re-review as still-broken and never
-   converge.
-3. **Re-invoke `/review-changes`** on the updated (committed) diff. Repeat until no
-   Critical/High findings remain.
-4. **Cap at 3 iterations.** If Critical/High issues persist after three rounds,
-   stop and surface them to the user — don't loop forever or paper over them.
-   - **Auto:** convene the panel. **Proceed** → note the unresolved Critical/High
-     findings in the PR description and continue; **stop** → surface to the user.
-
-Medium/Low findings: apply the cheap, clearly-correct ones; note the rest in the
-PR description rather than blocking on them.
-
-This is the **single substantive review** of the change — it converges Critical/
-High here so the pipeline doesn't stall. `/pr` is therefore invoked in `reviewed`
-mode (Phase 4) so it won't deep-review the identical code again.
-
-## Phase 3.4 — Security review + fix loop
-
-Once code review has converged (Phase 3), run a **security-focused** pass over the
-same committed diff. Code review and security review are different lenses —
-correctness / concurrency / architecture versus **attack surface** — and an
-unattended `/deliver` (especially `auto`) opens PRs without a human reading every
-line, so the security lens earns its place before the PR.
-
-**Skip this phase entirely if the change has no security-relevant surface.** Run it
-when `git diff --name-only origin/main...HEAD` touches **Swift source**,
-**dependency manifests** (`Package.swift` / `Package.resolved`), **CI / workflow**
-(`.github/workflows/`), or **permission / credential config** (`.claude/settings*`).
-A pure docs / markdown delivery has no attack surface — sail straight to Phase 3.5.
-This phase does **not** scale down on a `lite` change: if the surface is touched, it
-runs (a `lite` change is a single pass anyway).
-
-Run the review via **`/security-review`** — it reviews the pending changes on the
-branch and returns findings graded **High / Medium / Low** (no "Critical" tier; it
-filters out anything below confidence 8 and excludes documentation files, so a
-docs-only diff returns nothing). It produces findings; it does **not** fix — the
-conductor applies fixes, symmetric with Phase 3. For this library the
-surfaces that actually bite: the `HTTPClient` / networking layer, `api_key` and
-session / credential handling, URL and query construction, `Decodable` paths over
-untrusted API data, anything that logs, and dependency / permission changes. Then
-converge with the same loop as Phase 3:
-
-1. Read the severity-graded findings.
-2. **For each High finding** (and any Medium with a concrete attack path), fix it —
-   **test-first via `canon-tdd` where the defect is reproducible** (input validation
-   at a public boundary, a decoding guard), or by the minimal direct change where it
-   is not (removing a secret-leaking log line, tightening a permission). Re-run
-   `/test` (+ `/integration-test` if behaviour changed) and **commit the fix** — the
-   commit is required so the re-review diffs committed history and converges (as in
-   Phase 3).
-3. **Re-invoke `/security-review`** on the updated (committed) diff. Repeat until no
-   High findings remain.
-4. **Cap at 3 iterations.** If High findings persist after three rounds,
-   stop and surface them to the user — never loop forever or ship a known
-   vulnerability silently.
-   - **Auto:** convene the panel. **Proceed** → note the unresolved finding in the
-     PR description and continue; **stop** → surface to the user. A finding that
-     **leaks credentials or opens a clear exploit** is the security analogue of the
-     never-delegated data-loss blocker — treat it as a **hard stop even in `auto`**.
-
-Medium/Low findings: apply the cheap, clearly-correct ones; note the rest in the PR
-description rather than blocking on them.
-
-Phase 4's `make ci` is a **correctness** gate (lint, tests, build, docs) — there is
-no SAST step in CI — so this phase is the pipeline's **only** security gate. Don't
-skip it on a change that touches the surfaces above.
-
-## Phase 3.5 — Capture learnings
-
-Invoke **`/capture-knowledge`**, **passing the knowledge-candidates list you kept
-in the ledger (Contract §7) as the skill argument** (`$ARGUMENTS`) — paste the
-list lines into the invocation rather than assuming the skill can still see the
-ledger in context. The ledger may have been summarised away by now; the argument
-travels with the call, so the candidates reach the skill even after compaction.
-Its job here is to **curate** that list — filter to the durable, non-obvious,
-reusable items, dedup against existing `knowledge/` entries, and write them into
-the right file (gotchas / API notes / a new ADR for
-decisions). Starting from the running list is the whole point — it captures the
-learnings you'd have forgotten by now.
-
-Do this **before** `/pr` so the notes are committed in the **same PR** as the
-change. Capturing nothing is a valid outcome — don't manufacture entries. The
-`knowledge/` files are Markdown, so they add no review noise (the GitHub reviewer
-ignores `**/*.md`); keep entries tidy by hand.
-
-## Phase 3.6 — Rubric verification (exit gate)
-
-Retrieve the delivery rubric (the acceptance criteria extracted in Phase 0) from
-the ledger. If none were extracted — the plan lacked ACs and the auto panel chose
-to proceed — **skip this phase entirely**.
-
-For each AC, verify the committed diff satisfies it:
-
-- **A behaviour criterion** (decoding, error handling, an API call shape) → scan
-  the diff (`git diff origin/main...HEAD`) for the relevant code path, or run a
-  targeted test (`swift test --filter …`) if one covers it directly.
-- **A test-coverage criterion** → confirm the test file and assertion exist in
-  the diff.
-- **An integration criterion** → confirm the integration test exists; the live
-  run already passed in Phase 2, so no re-run is needed.
-
-**For each criterion:**
-
-- **Satisfied** → mark it off in the ledger, no action.
-- **Not satisfied** → fix it test-first (`canon-tdd`), commit, and re-verify. If
-  a gap cannot be closed without a plan change, note it in the PR description with
-  the reason.
-
-This check is lightweight — reading a diff against a short list, not a full review.
-Do it inline (no subagent needed). If every item passes in a quick scan, this phase
-takes seconds. Only gaps trigger work.
-
-The rubric answers a different question than CI: *"did we build what the plan
-said?"* not *"did the build pass?"*
-
-## Phase 3.7 — Write the retrospective (pre-PR)
-
-Write the delivery's retrospective **now — before the PR opens — so it rides the
-PR itself** and the ready-to-merge gate is never re-opened by a routine retro
-push (every post-gate push re-triggers `claude-review` and the CI matrix; see
-Phase 6). This is mandatory, not optional. Reflect on the delivery so far
-(Phases 0–4) and write a dated entry to
-[`knowledge/delivery-retros.md`](../../../knowledge/delivery-retros.md):
-
-- **Feature / branch**, date, and delivery weight (lite/full). The PR number
-  doesn't exist yet — head the entry with the branch name; Phase 4 backfills
-  the number right after the PR is created.
-- **Phases completed / Skills invoked** — a compact one-liner each (e.g. phases
-  `0–4`; skills `review-plan, implement-plan, review-changes, security-review,
-  capture-knowledge`). This is telemetry for the recurring-pattern scan: over
-  time it shows which skills fire, which phases get skipped, and where
-  deliveries stop.
-- **What worked** — one or two things the pipeline did well.
-- **Friction** — where it was rough, slow, or stopped unnecessarily.
-- **Deviations** — anywhere you had to depart from this skill to do the right
-  thing (a strong signal the skill has a gap).
-- **One improvement** — the single highest-value change to `/deliver` (or a
-  sub-skill) suggested by this run.
-- **`watch:`** — omit it now. This optional line is added only as a
-  **post-gate amendment** when Phase 5 produces a noteworthy event (see
-  Phase 6); an uneventful watch adds nothing.
-
-Keep it to a handful of bullets — a log, not a ceremony. **Commit the entry on
-the PR branch** so it travels with the delivery (the GitHub reviewer ignores
-`**/*.md`, so it adds no review noise).
-
-**Keep the file windowed.** After adding the entry, if `delivery-retros.md` holds
-more than **~12 full entries**, distil the oldest into its one-line archive table
-(`date · PR · weight · one-line outcome`) and drop the prose — per
-[`knowledge/README.md`](../../../knowledge/README.md) → *Maintenance & retention*.
-An old retro's lesson already lives in the skills and `skill-improvement-log.md`;
-the table preserves the telemetry without the bulk.
-
-## Phase 4 — Create the PR
-
-**Gate check (template→replicate deliveries):** before anything else, confirm the
-ledger's `Phase 3a — reference-unit review` task is **`completed`**. If it is
-still open, the reference unit was never reviewed — **go back to Phase 3** and run
-it before opening the PR. (Other deliveries have no Phase 3a task; this is a
-no-op for them.)
-
-Invoke **`/pr reviewed`** — the `reviewed` argument tells `/pr` to **skip its
-internal `code-reviewer` pass**, because Phase 3 already reviewed and converged
-this exact code; re-running the deep review on identical code is wasted work (and
-its stop-to-ask gate would interrupt the autonomous run). `/pr` will then: run
-`/format` (committing any formatting changes), run `make ci` (the **mandatory**
-full gate — lint, markdown, unit + integration tests, release build, docs build),
-then push the branch and open the PR with a gitmoji title and structured body.
-
-**If `make ci` fails, triage before you stop** (Contract §4):
-
-1. **Which check, and is it in your diff?** Read the failure. Compare the failing
-   test/file against `git diff --name-only origin/main...HEAD`.
-2. **In-diff genuine failure** → it's yours: fix it (test-first), commit, re-run
-   `make ci`. Only **stop and report** if it can't converge.
-   - **Auto:** when it can't converge, convene the panel. **Proceed** → open the
-     PR with the known-failing check noted in its description; **stop** → report.
-3. **Pre-existing / unrelated** — the failing test isn't in your diff and (for a
-   live integration test) often passes in isolation / on a re-run → it's a `main`
-   problem, not yours. Hand it to **`/fix-integration-failures`** (it fixes the
-   flake on its own branch off `main`, runs `make ci`, and merges), then bring this
-   branch up to date (`git merge main` / `mcp__github__update_pull_request_branch`)
-   and re-run the gate.
-   Don't patch an unrelated test onto this feature branch, and don't hard-stop on it.
-
-Record the PR number/URL in the ledger.
-
-**Backfill the retro heading.** Phase 3.7 headed the fresh `delivery-retros.md`
-entry with the branch name (no PR number existed yet). Now that the PR is open,
-replace it with the PR number, commit, and push immediately. This is
-**pre-gate** — CI has only just started on the opening push, and the superseded
-run is cancelled by the workflow's concurrency group — so nothing is re-opened.
-
-## Phase 5 — Watch to ready  → GATE: ready-to-merge
-
-Invoke **`/watch-pr`** in **watch-only** mode (do not pass `merge`), and **run it in
-the background** so the user can keep interacting while CI churns. It resolves
-review threads and fixes failing checks (its §1c routes a pre-existing/unrelated
-integration failure to `/fix-integration-failures`, per Contract §4), looping until
-the PR is **ready** (green checks, threads resolved) or **stuck**.
-
-**Ready means mergeable *now*.** Before the gate, `/watch-pr` brings the branch up
-to date with `main` (`mcp__github__update_pull_request_branch`) and waits for the
-re-run, so a PR
-reported ready isn't `BEHIND` and waiting on a rebase — the user can merge straight
-away. (See `/watch-pr` §3.)
-
-**THE GATE — hard stop at ready-to-merge.** When the PR is ready, **stop and hand
-it to the user for the final merge** — `/deliver` does not merge by default. Report
-the PR URL and its ready state, then run Phase 6. The **worktree stays in place**
-at the gate (the PR branch lives there); it's torn down only on merge (Phase 7). If
-`/watch-pr` reports the PR is **stuck** (a check it can't fix, or a human-decision
-review thread), stop and summarise what's blocking — **keep the worktree** so the
-work can be resumed.
-
-> **Auto:** on a stuck PR, convene the panel to decide **wait-and-retry vs stop**.
-> **Proceed** (majority to keep trying) → schedule a later re-check with
-> `ScheduleWakeup` and resume `/watch-pr` when it fires; **stop** (majority) → end
-> the run and report what's blocking. The ready-to-merge gate itself is **not** a
-> panel decision: in `auto` it behaves exactly as the `merge` opt-in below — once
-> the PR is ready, proceed to Phase 6 (and merge if `merge` was passed).
->
-> **Opt-in auto-merge:** if the user explicitly passes `merge` to `/deliver`,
-> forward it to `/watch-pr` (`/watch-pr merge`) so it squash-merges once ready, and
-> the gate becomes "report the merge" instead of stopping. Default is watch-only.
-> Either way, a confirmed merge triggers **Phase 7 teardown**.
-
-## Phase 6 — Wrap-up (wiki, pattern scan, exceptional retro amendment)
-
-The retrospective is already on the PR (Phase 3.7). After the gate (PR ready, or
-merged in `merge` mode), finish with the wrap-up below — **the default path
-pushes nothing after the gate**; that is the point of writing the retro pre-PR.
-Then **scan recent entries** for recurring friction or deviations — the
-recurring-pattern scan below formalizes this.
-
-**Amend the retro only for a noteworthy watch phase.** If Phase 5 was uneventful
-(checks went green, threads resolved without surprises), the retro is complete —
-do not touch it. If the watch phase produced something the next
-recurring-pattern scan should see — a stuck check, a new Critical/High review
-thread, a flake routed to `/fix-integration-failures`, a wrong readiness call —
-append a one-line **`watch:`** bullet to the entry, commit, and push. Two cases:
-
-- **Watch-only (PR still open)** — commit the amendment on the PR branch and
-  push it, so it rides the open PR.
-- **`merge`/auto mode (branch already merged + deleted in Phase 5)** — the PR
-  branch is gone, so commit it on a **fresh branch off `origin/main`** and open
-  a small follow-up PR; the same applies to any skill edits the auto
-  recurring-pattern scan commits. Do this **before** Phase 7 teardown, and
-  confirm it's pushed — otherwise teardown's `discard_changes` drops it.
-
-**Any post-gate push re-opens the gate — re-watch before merge.** This governs
-the *exceptions* above (a retro amendment, an approved skill edit from the
-scan): every push re-triggers `claude-review` and the CI matrix, which can post
-a **new blocking thread** (the `main` ruleset requires thread resolution) or
-restart checks. After the **last** post-gate push, **return to the `/watch-pr`
-loop once more**: re-sweep unresolved threads and re-confirm checks green before
-treating the PR as merge-ready or merging. "Ready" is only ever true of the
-*current* branch tip — never a tip you have since pushed past. (Bit `/deliver`
-on #361, back when the retro itself was a routine post-gate push — the
-sequencing Phase 3.7 now avoids.)
-
-### Update the personal wiki (at wrap-up)
-
-The retro (Phase 3.7) distils this delivery's durable learnings, so wrap-up is
-the natural moment to feed the **personal `wiki`** (Adam's cross-project engineering knowledge, via
-the `wiki` MCP). The retro/`knowledge/` base is *project-specific*; the wiki is
-for **generalizable, reusable opinions, heuristics, and patterns** — the things
-that would apply on the next project too (a design stance, a concurrency or
-testing heuristic, a tooling gotcha that isn't TMDb-specific).
-
-- **Degrade silently if the `wiki` MCP is absent** (a contributor's machine, a
-  headless/cron run) — never block on it.
-- **Search first** (`search_wiki`/`search_entries`) and prefer **updating** a
-  near-match over creating a duplicate.
-- **Propose, don't autonomously save.** The wiki tooling reserves `add_entry`/
-  `update_entry` for Adam's explicit approval — use **`propose_entry`** to render
-  each candidate for review, and only `add_entry`/`update_entry` once Adam
-  approves. Cite the wiki when an answer later draws on it.
-- **Be selective** — one or two high-signal entries beat a dump; skip anything
-  that's only project-specific (that already lives in `knowledge/`) or already in
-  the wiki. Capturing nothing is a valid outcome.
-
-### Recurring-pattern scan (at wrap-up)
-
-With the retro already on the PR (Phase 3.7), do a structured cross-delivery
-scan — this is what turns one-off retros into reviewed skill improvements:
-
-1. **Read the recent window + the log.** Read the **~last 12** entries of
-   [`knowledge/delivery-retros.md`](../../../knowledge/delivery-retros.md) (the
-   rolling window — older deliveries are archived to one-liners, so this is the
-   whole live history anyway), **all** of
-   [`knowledge/skill-improvement-log.md`](../../../knowledge/skill-improvement-log.md),
-   and **every** `SKILL.md` under `.claude/skills/` (including the sub-skills those
-   skills reference). The bounded retro read keeps the scan's cost flat as history
-   grows: a recurrence worth acting on shows up in the recent window, and anything
-   already settled lives in the log.
-2. **Find what recurs.** For any friction, deviation, or improvement suggestion
-   that appears in **more than one** retro entry, write a numbered proposal in
-   this exact format:
-
-   Pattern: [what keeps happening]
-   Seen in: [retro dates / feature names]
-   Skill: [relative path to SKILL.md]
-   Current text: [exact existing wording, or "missing"]
-   Proposed change: [exact new wording and location]
-   Rationale: [one sentence on why this eliminates the pattern]
-
-   **Skip any pattern already decided in `skill-improvement-log.md`** — one
-   already **applied** (the fix is in the skill), or **deferred/rejected** (don't
-   re-propose a settled *no*; only resurface it if its recorded "reconsider when…"
-   condition now holds).
-3. **Stop and ask.** **Do not edit any skill files.** Present the proposals and
-   wait for **explicit approval on each one** before changing anything. If no
-   *new* pattern recurs across multiple entries, **say so and stop** — emit no
-   proposals.
-   - **Auto:** don't wait for the user. The panel reviews **each** proposal and
-     **applies approved ones directly** (edit the skill, commit). Rejected
-     proposals are still recorded in `skill-improvement-log.md` with the panel's
-     rationale (step 4).
-4. **Record every decision in the log.** For each proposal you presented, append
-   an entry to
-   [`knowledge/skill-improvement-log.md`](../../../knowledge/skill-improvement-log.md)
-   **in the five-field format documented at the top of that file** (date · title ·
-   status; Pattern / Decision / Rationale / Reconsider when) — **applied** (with
-   the skill + commit it landed in), **deferred**, or **rejected**. The **Decision**
-   (status) and **Reconsider when** fields are exactly what step 2's dedup keys on,
-   so keep them on every entry; this is what stops the scan re-proposing a settled
-   call next time.
-
-## Phase 7 — Teardown on merge (reclaim the worktree)
-
-A delivery's worktree carries a full `.build` (here **~3 GB** after the CI gate, on
-top of the source). Leaving one per delivery accumulates fast, so **tear the
-worktree down once the PR is merged** — this reclaims both the worktree **and** its
-`.build` in one step.
-
-**The trigger is the merge, and only the merge:**
-
-- **`merge` mode** — `/watch-pr merge` squash-merged the PR. Tear down immediately
-  after.
-- **Watch-only (default)** — the worktree **stays** at the gate (Phase 5). When the
-  merge happens *within this session* (the user says "merge" and you do it, or a
-  later turn confirms the PR is `MERGED`), tear down **then**. If the session ends
-  with the PR still open, **leave the worktree** — the work must survive until it's
-  merged. Interactive sessions get a harness keep/remove prompt at exit; **headless /
-  `auto` runs have no one to answer it**, so a merged-later worktree is reclaimed not
-  here but by the **Phase 0.5 GC sweep at the start of the *next* delivery** (it
-  removes any worktree whose PR has since merged). That sweep is the backstop that
-  keeps unattended runs from leaking disk.
-- **Stuck / blocked / abandoned** — **never** tear down. Keep the worktree so the
-  work can be resumed.
-
-**How to tear down** — two preconditions, both required:
-
-1. **The PR is actually merged** — `mcp__github__pull_request_read` method `get`
-   (owner/repo from the `origin` remote, `pullNumber: <n>`) → `merged: true`.
-2. **The worktree has no unsaved work beyond what's merged** — `MERGED` only
-   guarantees the *pushed* feature commits are on `main`; it says nothing about a
-   commit made (or a file edited) **after** the last push, e.g. an exceptional
-   retro amendment (Phase 6). Verify
-   the tree is clean **and** fully pushed before discarding:
-
-   ```bash
-   git status --porcelain                                  # must be empty (no uncommitted work)
-   test "$(git rev-parse HEAD)" = "$(git rev-parse @{u})"  # HEAD must equal its pushed upstream
-   ```
-
-   If either check fails, there is worktree-only work not yet on `main` — **stop**,
-   land it (push it / move it to a follow-up off `origin/main`, per Phase 6), and
-   only then tear down. Do **not** discard it.
-
-Then:
-
-```text
-ExitWorktree(action: "remove", discard_changes: true)
-```
-
-- `remove` deletes the worktree directory (which **is** its `.build` — the multi-GB
-  reclaim) and the local branch, then returns the session to the main checkout.
-- `discard_changes: true` is needed only because a **squash**-merge lands the work
-  as a *new* commit on `main`, so the branch's pushed-and-merged commits aren't
-  *literally* on `main` and `ExitWorktree` would otherwise refuse. It is safe
-  **only because** precondition 2 proved there's nothing un-merged left to lose —
-  not merely because the PR is `MERGED`. Never pass it on an unverified tree.
-
-After teardown, the session is back in the main checkout — **leave it as you found
-it**. Do *not* auto-`merge --ff-only` it: the user may be actively working there
-(the whole point of the worktree) with uncommitted or diverged state, and the FF
-would fail noisily or fight their work. Only if it is **clean and on `main`**
-(`git status --porcelain` empty) may you fast-forward it (`git fetch origin &&
-git merge --ff-only origin/main`); otherwise just note "main checkout left as-is
-(N commits behind)". Report the reclaimed worktree in the final summary.
+- **A plan must exist** (named target → plan-mode plan → most recent in
+  conversation). None → stop; point at `/plan`. Never invent one.
+- **A plan born from a review finding is a hypothesis** — verify against the
+  code (quick `Explore`) *before* planning or asking strategy questions.
+- **State the goal** in a sentence; **judge the weight**; open the ledger.
+- **Pull wiki context** best-effort (`get_context` on the goal); degrade
+  silently if the `wiki` MCP is absent.
+- **Decompose a multi-deliverable plan** (rules above); single-deliverable
+  plans skip this.
+- **Entry gate — acceptance criteria required.** Extract the ACs verbatim as
+  the **delivery rubric** (consumed in Phase 7) into the ledger. Absent →
+  stop and ask for them ("Given X, when Y, then Z") — don't enter the
+  worktree. **Auto:** panel — proceed rubric-less (Phase 7 no-ops) vs stop.
+- **Read the plan's content into context now** — `EnterWorktree` switches CWD
+  (clearing the plans cache), and a fresh worktree lacks uncommitted local
+  files; the plan must travel in the conversation.
+
+## Phase 1 — Enter an isolated worktree (before any edit)
+
+Procedures and traps:
+[`references/worktree-lifecycle.md`](references/worktree-lifecycle.md).
+
+1. **GC first**: reclaim prior worktrees whose PRs have since merged (one
+   `list_pull_requests` call → branch→merged map → remove) — this sweep keeps
+   unattended runs from leaking disk.
+2. **Enter** with `EnterWorktree(name: "<prefix>/<slug>")` (`feature/`,
+   `fix/`, `chore/`, …) — sanctioned auto-use, don't ask. **Verify the branch
+   name afterwards** (`git branch --show-current`; `git branch -m` if the
+   tool renamed it). Already in a worktree? Don't nest — branch there.
+3. **Copy `.claude/settings.local.json` in** from the main checkout (the
+   permission allowlist; credentials come from the process env).
+4. **Record worktree + branch in the ledger, and (re-)create the ledger
+   here** — it is CWD-scoped and cleared by `EnterWorktree`/MCP reconnects;
+   found empty later → re-create from the phase list, it isn't lost work.
+5. **Edit via worktree paths**: re-`Read` anything read before entering, and
+   **verify `git status` shows your diff in the worktree before trusting the
+   first green build** (empty diff + baseline counts = edits went to `main`).
+
+Invoked from plan mode? That approval *is* the start signal — exit plan mode,
+enter, proceed.
+
+## Phase 2 — Harden the plan (no approval stop)
+
+**Lite, or already reviewed this session** (a converged `/review-plan`, or
+`ExitPlanMode` approval) → skip the critics. **Full with an unreviewed plan**
+→ invoke `/review-plan`, present the revised plan as an **FYI**, keep going —
+except a **blocker** (wrong approach, breaking, data-loss), which stops the
+run. **Auto:** data-loss/breaking = hard stop (never delegated); other
+blockers → panel.
+
+## Phase 3 — Implement the plan
+
+Invoke **`/implement-plan`** (Canon TDD: list shown first, one failing test
+at a time, done only when the list is empty and both suites green). It
+commits at logical checkpoints — required: Phase 4 reviews **committed**
+history. Don't advance until `/test` **and** `/integration-test` pass and the
+work is committed; re-confirm the weight from the diff. Two hard checkpoints:
+
+- **"Fix every instance of pattern X" → enumerate ALL sites up front** with a
+  single **type-driven sweep**, listed in the test list before implementing —
+  piecemeal discovery ships subsets (incidents:
+  [`references/review-loops.md`](references/review-loops.md)).
+- **Consult the specialist skills — mandatory, topic-triggered, including for
+  fanned-out subagents.** `swift-concurrency` the moment actors,
+  `@MainActor`, `Sendable`/`@unchecked Sendable`, locks, `Task`/task groups,
+  or any data-race question appears — to *design*, not just debug;
+  `swift-testing-expert` when writing or structuring tests. Same in Phase 4:
+  run concurrency-sensitive findings through `swift-concurrency` before
+  accepting or dismissing them.
+
+## Phase 4 — Code review + fix loop
+
+**Skip entirely if the diff has no Swift source** (`/review-changes`
+self-gates). Review **stable** code once the design settles — not per TDD
+item. Granularity by weight:
+
+- **Lite / single-unit** → one review of the full diff (single-reviewer
+  path).
+- **Full, template→replicate** (one pattern across N≥3 cohesive units) →
+  **review the reference unit before the rest are generated**: the hard
+  `Phase 4a — reference-unit review @ <sha>` ledger task **blocks Phase 9**
+  (procedure: [`references/review-loops.md`](references/review-loops.md)).
+- **Full, otherwise** → one review of the full end diff via the fan-out
+  path; do **not** interleave per unit.
+
+Converge via **`/review-changes`**: read the severity-graded report; fix each
+**Critical/High** test-first, re-run `/test` (+ `/integration-test` if
+behaviour changed), **commit the fix** (an uncommitted fix re-reviews as
+still-broken); re-invoke; repeat until none remain. **Cap at 3 iterations**,
+then stop and surface. **Auto:** panel — proceed (note unresolved findings in
+the PR description) vs stop. Medium/Low: apply the cheap, clearly-correct
+ones; note the rest in the PR description. This is the **single substantive
+review** — `/pr` therefore runs in `reviewed` mode (Phase 9).
+
+## Phase 5 — Security review + fix loop
+
+**Run only when the diff touches a security-relevant surface**: Swift source,
+`Package.swift`/`Package.resolved`, `.github/workflows/`, or
+`.claude/settings*`. Pure docs/markdown → skip. No scale-down on lite.
+Invoke **`/security-review`** (findings only — the conductor fixes) and
+converge with the Phase 4 loop: fix each **High** (and any Medium with a
+concrete attack path) test-first where reproducible, commit, re-invoke, cap
+at 3. **Auto:** panel — but a **credential leak or clear exploit is a hard
+stop even in auto**. This is the pipeline's **only** security gate (CI has no
+SAST). Surfaces that bite:
+[`references/review-loops.md`](references/review-loops.md).
+
+## Phase 6 — Capture learnings
+
+Invoke **`/capture-knowledge`**, passing the ledger's knowledge-candidates
+list as the skill argument (`$ARGUMENTS` — it travels with the call even
+after compaction). It curates: durable, non-obvious, reusable items only,
+deduped against `knowledge/`, written to the right file (gotchas / API notes
+/ an ADR). Before `/pr`, so the notes ride the same PR. Capturing nothing is
+a valid outcome.
+
+## Phase 7 — Rubric verification (exit gate)
+
+Take the rubric (Phase 0 ACs) from the ledger; none extracted → skip. Verify
+each AC against the committed diff — behaviour by diff-scan or a targeted
+test (`swift test --filter …`), coverage by the test + assertion existing,
+integration by the integration test existing. Satisfied → mark off. Not →
+fix test-first, commit, re-verify; a gap needing a plan change is noted in
+the PR description. Lightweight, inline — *"did we build what the plan
+said?"*, not *"did the build pass?"*.
+
+## Phase 8 — Write the retrospective (pre-PR)
+
+Write the retro **now, before the PR opens, so it rides the PR itself** and
+the gate is never re-opened by a routine retro push. Mandatory. A dated entry
+in [`knowledge/delivery-retros.md`](../../../knowledge/delivery-retros.md),
+headed with the **branch name** (Phase 9 backfills the PR number): phases /
+skills telemetry, what worked, friction, deviations, one improvement; omit
+`watch:` (post-gate amendments only, Phase 11). **Commit it on the PR
+branch**, then run the **windowing step** (>~12 full entries → distil the
+oldest into the archive table). Format detail:
+[`references/wrap-up.md`](references/wrap-up.md).
+
+## Phase 9 — Create the PR
+
+**Gate check first (template→replicate only):** the `Phase 4a` ledger task
+must be **completed** — still open → back to Phase 4.
+
+Invoke **`/pr reviewed`** (Phase 4 already converged this code, so `/pr`
+skips its internal review). It formats, runs **`make ci`** — the mandatory
+gate; `/pr` scales it to a docs-only fast gate when nothing build-affecting
+changed — pushes, and opens the PR. **If `make ci` fails, triage** (§4): the
+failing test/file in `git diff --name-only origin/main...HEAD`? **In-diff** →
+fix test-first, commit, re-run; stop only if it can't converge (**Auto:**
+panel — open with the failure noted vs stop). **Pre-existing/unrelated** → a
+`main` problem: hand to `/fix-integration-failures`, update this branch,
+re-run — never patch an unrelated test here.
+
+Record the PR number/URL in the ledger. **Backfill the retro heading** with
+the PR number, commit, push immediately — pre-gate (the superseded CI run is
+cancelled by the concurrency group).
+
+## Phase 10 — Watch to ready → GATE: ready-to-merge
+
+Invoke **`/watch-pr`** in **watch-only** mode, **in the background** — it
+resolves threads, fixes failing checks (routing unrelated integration
+failures per §4), and loops until **ready** or **stuck**. Ready means
+**mergeable now** (branch brought up to date with `main`, re-run green).
+
+**THE GATE — hard stop.** Ready → stop; hand the merge to the user; report
+the PR URL and state; run Phase 11. The worktree **stays** (torn down only on
+merge, Phase 12). Stuck → stop, summarise what's blocking, **keep the
+worktree**. **Auto:** stuck → panel (retry via `ScheduleWakeup` vs stop); the
+gate itself is not a panel decision — in auto, ready behaves as the `merge`
+opt-in. **Opt-in auto-merge:** only if the user passed `merge`, forward it
+(`/watch-pr merge`) — the gate becomes "report the merge" → Phase 12.
+
+## Phase 11 — Wrap-up (wiki, pattern scan, exceptional retro amendment)
+
+The retro is already on the PR (Phase 8) — **the default path pushes nothing
+after the gate**. Guidance:
+[`references/wrap-up.md`](references/wrap-up.md).
+
+- **Amend the retro only for a noteworthy watch phase** (stuck check, new
+  Critical/High thread, routed flake, wrong readiness call): append a
+  one-line `watch:` bullet, commit, push — on the PR branch (watch-only), or
+  a fresh branch off `origin/main` as a small follow-up PR (`merge`/auto
+  mode, before teardown). Uneventful watch → don't touch it.
+- **Any post-gate push re-opens the gate** — after the last exceptional push
+  (amendment or approved skill edit), run the `/watch-pr` loop once more on
+  the new tip before merge.
+- **Update the personal wiki** — best-effort, `propose_entry` only (never
+  autonomous writes); degrade silently if absent.
+- **Recurring-pattern scan**: friction/deviations recurring across the last
+  ~12 retro entries → numbered proposals. **Consult
+  `skill-improvement-log.md` first** and skip anything already decided;
+  **wait for explicit approval on each proposal — never edit a skill file
+  unasked**; record **every** decision in the log (five-field format). No new
+  recurrence → say so and stop. **Auto:** the panel adjudicates instead.
+
+## Phase 12 — Teardown on merge (reclaim the worktree)
+
+**The trigger is the merge, and only the merge**: right after a `merge`-mode
+merge, or when a watch-only merge is confirmed *within this session*. Session
+ends with the PR open → **leave the worktree** (the next run's Phase 1 GC
+reclaims it once merged). Stuck/blocked/abandoned → **never** tear down.
+
+Two preconditions, both required, then
+`ExitWorktree(action: "remove", discard_changes: true)`:
+
+1. The PR is actually **merged** (`pull_request_read` → `merged: true`).
+2. **No unsaved work beyond what's merged**: `git status --porcelain` empty
+   **and** `git rev-parse HEAD` equals `git rev-parse @{u}`. Either fails →
+   land the work first; do **not** discard.
+
+`discard_changes` is safe *only because* precondition 2 proved nothing
+un-merged remains (a squash-merge means the branch commits aren't literally
+on `main`). Leave the main checkout as you found it. Detail:
+[`references/worktree-lifecycle.md`](references/worktree-lifecycle.md).
 
 ## When the pipeline stops
 
-Whether at the gate, a red gate it couldn't triage, or a stuck PR, always end with
-a concise status: the phase reached, the branch and PR (if any), what passed,
-what's blocking, and the single next action you need from the user. The destination
-is a green PR ready for their merge — say plainly whether you got there.
+Wherever it stops — the gate, an untriageable red gate, a stuck PR — end with
+a concise status: phase reached, branch and PR, what passed, what's blocking,
+and the single next action needed from the user. The destination is a green
+PR ready for their merge — say plainly whether you got there.

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -232,7 +232,9 @@ list as the skill argument (`$ARGUMENTS` — it travels with the call even
 after compaction). It curates: durable, non-obvious, reusable items only,
 deduped against `knowledge/`, written to the right file (gotchas / API notes
 / an ADR). Before `/pr`, so the notes ride the same PR. Capturing nothing is
-a valid outcome.
+a valid outcome. Exception: one or two small entries already authored during
+implementation may be committed inline instead — note the inline capture in
+the retro.
 
 ## Phase 7 — Rubric verification (exit gate)
 

--- a/.claude/skills/deliver/references/auto-and-async.md
+++ b/.claude/skills/deliver/references/auto-and-async.md
@@ -1,0 +1,81 @@
+# /deliver — auto mode & async invocation (reference)
+
+Read on demand when `/deliver auto` is invoked, or when queuing an unattended
+run. The one safety rule that lives in `SKILL.md` regardless: a **data-loss or
+breaking-change plan blocker is always a hard stop, even in auto** — it is
+never delegated to the panel. (Note: as of 2026-07, auto mode has not yet been
+exercised by a real delivery — validate against this spec on first use.)
+
+## Auto mode (unattended)
+
+`/deliver auto` runs the **entire** pipeline with **no human interaction** —
+every mid-run decision that would normally stop and ask the user is instead
+resolved by an **adversarial panel** of three Opus subagents, and the
+conductor acts on the majority verdict and keeps going through wrap-up.
+
+**The panel.** At each decision point, convene three subagents in parallel,
+each given the same context (the decision, the evidence, the options):
+
+- **Proceed** — argues the case for continuing the pipeline.
+- **Stop** — argues the case for halting and handing back to the user.
+- **Devil's advocate** — attacks whichever way looks easiest, so the other two
+  can't converge on a comfortable answer unchallenged.
+
+Each returns a one-line verdict (`proceed` / `stop`) and its reasoning.
+**Majority wins.** `proceed` resumes the pipeline; `stop` ends the run with
+the usual status summary.
+
+**Audit trail.** For **every** panel convened, write a ledger entry recording:
+the **decision point**, the **three subagent verdicts**, the **majority
+outcome**, and a **one-line rationale**. Autonomy *with* a full record — an
+unattended run must still be reviewable.
+
+**Panel decision points** (marked **Auto:** in `SKILL.md`):
+
+- Phase 0 — missing acceptance criteria: proceed without a rubric (Phase 7
+  becomes a no-op) vs stop.
+- Phase 2 — a plan-review blocker that is *not* data-loss/breaking: proceed
+  vs stop. (Data-loss/breaking = hard stop, never delegated.)
+- Phases 4/5 — Critical/High (or High security) findings persisting after the
+  3-iteration cap: note in the PR description and proceed, vs stop. A finding
+  that **leaks credentials or opens a clear exploit** is the security analogue
+  of the data-loss blocker — hard stop even in auto.
+- Phase 9 — an in-diff `make ci` failure that can't converge: open the PR
+  with the known-failing check noted, vs stop.
+- Phase 10 — a stuck PR: schedule a later re-check (`ScheduleWakeup`) and
+  resume watching, vs stop and report. The ready-to-merge gate itself is
+  **not** a panel decision: in auto it behaves as the `merge` opt-in — once
+  ready, proceed to wrap-up (and merge if `merge` was passed).
+- Phase 11 — recurring-pattern-scan proposals: the panel reviews **each**
+  proposal and applies approved ones directly (edit the skill, commit — an
+  exceptional post-gate push, so the re-watch rule applies); rejected
+  proposals are still recorded in `skill-improvement-log.md` with the panel's
+  rationale.
+
+## Async / queued invocation
+
+`/deliver` can be queued to run unattended — the worktree isolation, the
+ledger, the Phase 1 GC sweep, and auto mode are exactly what an unattended run
+needs. Two entry points already do this: a **CCR trigger** (`create_trigger`
+with `create_new_session_on_fire`, or the `/schedule` skill) fires a fresh
+session whose prompt is `/deliver auto …`, and `integration-failure.yml` runs
+a skill **headless** on a runner.
+
+If you queue a `/deliver`, mind two things:
+
+- **Inline the whole plan + acceptance criteria in the trigger prompt.** A
+  fresh session has no conversation history, and Phase 0's entry gate
+  **requires ACs** — so the plan text and its ACs must travel *in* the prompt,
+  or the run stops at the gate immediately.
+- **User-scoped MCP may be absent** (`mcp__github__*`, `wiki`). The `gh`
+  fallbacks in `/pr` and `/watch-pr` cover GitHub; the wiki step degrades
+  silently. A headless GitHub-Actions run has no user MCP at all (it uses
+  `git`/`gh`); a CCR-spawned session in your own environment usually keeps
+  them.
+
+**Recommendation — don't routinise async *feature* delivery here.** This is a
+single-maintainer package with public API surface, where the ready-to-merge
+human gate is deliberate — every change is a compatibility call worth a
+human's eyes. Async earns its place for the *occasional* away-from-keyboard
+run and for the self-healing integration cron (which already opens a PR for
+review, never merges) — not as the default path.

--- a/.claude/skills/deliver/references/auto-and-async.md
+++ b/.claude/skills/deliver/references/auto-and-async.md
@@ -48,7 +48,9 @@ unattended run must still be reviewable.
   ready, proceed to wrap-up (and merge if `merge` was passed).
 - Phase 11 — recurring-pattern-scan proposals: the panel reviews **each**
   proposal and applies approved ones directly (edit the skill, commit — an
-  exceptional post-gate push, so the re-watch rule applies); rejected
+  exceptional post-gate push, so the re-watch rule applies; if the PR branch
+  is already merged and deleted, commit on a fresh branch off `origin/main`
+  as a small follow-up PR, before teardown); rejected
   proposals are still recorded in `skill-improvement-log.md` with the panel's
   rationale.
 

--- a/.claude/skills/deliver/references/review-loops.md
+++ b/.claude/skills/deliver/references/review-loops.md
@@ -1,0 +1,80 @@
+# /deliver — review loops (reference)
+
+Read on demand from `/deliver` **Phase 4** (code review) and **Phase 5**
+(security review). The rules and caps live in `SKILL.md`; this file holds the
+procedure detail and the incidents behind the rules.
+
+## Why review once, after implementation settles (Phase 4)
+
+Code review is an independent, adversarial lens — apply it once the design has
+settled, not after every Canon TDD item. The test list is deliberately
+emergent; early items are reshaped by later ones, so per-item review just
+flags churn. The per-item quality gate already lives in the implement phase —
+the passing test, the inline docs, the lint hook, and refactor-on-green.
+
+## The 4a reference-unit gate (template→replicate deliveries)
+
+For one pattern applied across **N≥3 cohesive units** (e.g. 25 sibling mocks,
+"validate every public String input", one method mirrored across services):
+
+1. Add a `Phase 4a — reference-unit review @ <sha>` task to the ledger.
+2. Have the implement phase commit the **first unit on its own**.
+3. Run `/review-changes` scoped to that commit
+   (`git diff origin/main...<sha>`) and converge its Critical/High findings
+   per the standard loop.
+4. Only then replicate the pattern across the remaining units. **Phase 9 must
+   not start while the 4a task is open.**
+
+A wrong foundational pattern caught here is one *not* baked into all N units —
+the #359 "reference-first" win: a cross-module DocC break caught in
+`MockGenreService` before it replicated into 25 mocks. For **full-otherwise**
+deliveries (multi-unit but not template-replicate), do **not** interleave
+per-unit review — the units don't build on each other, so per-unit review only
+adds churn; the single end-diff fan-out's per-dimension adversarial pass
+already covers the whole diff.
+
+## Why review fixes must be committed
+
+`/review-changes` diffs **committed** history (`git diff origin/main...HEAD`),
+so an uncommitted fix re-reviews as still-broken and the loop never converges.
+Commit each fix before re-invoking.
+
+## Enumerate-all-sites: the incident behind the rule
+
+PR #364 ("encode every path interpolation, validate every public String
+input"): the plan grep and `/security-review` each missed a *different* subset
+of sites; Phase 4 review found a 4th encode site (`ReviewRequest`); the
+`claude-review` bot then flagged three more unvalidated `String`-ID service
+methods. Each pass found a subset; none enumerated the class. Sweep by
+**type**, not by eyeballing — e.g. `grep 'path = "/.*\('` for String-into-path
+interpolations *and* scan public service signatures for `String`/`*.ID`
+params (`Int` IDs are injection-safe and need nothing) — confirm the full
+list, then implement against it.
+
+## Specialist skills: the incident behind the checkpoint
+
+Delivery #359 hand-rolled an `NSLock`/`@unchecked Sendable` mock design and
+only consulted `swift-concurrency` when the user prompted — at which point the
+skill both validated the choice *and* caught a missing `@unchecked Sendable`
+removal plan the ADR had omitted. The checkpoint is topic-triggered (the
+moment the domain appears), not stuck-triggered, and applies to fanned-out
+subagents/Workflows too — give them the same instruction.
+
+## Security review (Phase 5) — what actually bites in this library
+
+- The `HTTPClient` / networking layer.
+- `api_key` and session / credential handling.
+- URL and query construction.
+- `Decodable` paths over untrusted API data.
+- Anything that logs.
+- Dependency / permission changes (`Package.swift` / `Package.resolved`,
+  `.github/workflows/`, `.claude/settings*`).
+
+`/security-review` grades **High / Medium / Low** (no "Critical" tier),
+filters out findings below confidence 8, and excludes documentation files —
+a docs-only diff returns nothing. It produces findings; it does **not** fix.
+Fix test-first via `canon-tdd` where the defect is reproducible (input
+validation at a public boundary, a decoding guard), or by the minimal direct
+change where it is not (removing a secret-leaking log line, tightening a
+permission). Phase 9's `make ci` is a **correctness** gate with no SAST step,
+so Phase 5 is the pipeline's **only** security gate.

--- a/.claude/skills/deliver/references/worktree-lifecycle.md
+++ b/.claude/skills/deliver/references/worktree-lifecycle.md
@@ -1,0 +1,113 @@
+# /deliver — worktree lifecycle (reference)
+
+Read on demand from `/deliver` **Phase 1** (enter) and **Phase 12** (teardown).
+The rules live in `SKILL.md`; this file holds the procedures and the traps.
+
+## GC sweep procedure (Phase 1, before entering)
+
+This run is the garbage collector for the *previous* delivery's deferred merge —
+Phase 12 only fires on an in-session merge, and the common path is "merged
+later, elsewhere". Reclaim any worktree whose PR has since merged:
+
+1. Get every PR's state in **one** call — `mcp__github__list_pull_requests`
+   (owner/repo from the `origin` remote, `state: all`, `perPage: 100`) — and
+   build a `head.ref → merged?` map (a merged PR reports `state: closed` +
+   `merged: true`).
+2. For each worktree under `.claude/worktrees/` whose branch the map marks
+   **merged** (get branches with `git -C "$wt" rev-parse --abbrev-ref HEAD`):
+
+   ```bash
+   git worktree remove --force "$wt" && git branch -D "$br" 2>/dev/null
+   ```
+
+   The map comes from the MCP call; the shell step only does the removal —
+   tool calls can't run inside a bash loop.
+
+This keeps `.claude/worktrees/` (each carrying a multi-GB `.build`) from
+accumulating across deliveries merged in the GitHub UI or a later session.
+Empty leftover directory husks can be cleared with
+`find .claude/worktrees -type d -empty -delete`.
+
+## Entering
+
+- `EnterWorktree(name: "feature/<slug>")` creates the worktree under
+  `.claude/worktrees/` and switches the session into it. This is the
+  sanctioned auto-use for `/deliver` — do it without asking.
+- **Verify the branch name after entering** — the tool has been seen to name
+  the branch `worktree-<slug>` (with `/` → `+`) instead of the requested name
+  (`knowledge/gotchas.md`). Rename before any push:
+  `git branch -m feature/<slug>` (safe — nothing is pushed yet), and confirm
+  with `git branch --show-current`.
+- **Base ref:** by default (`worktree.baseRef: fresh`) the branch is cut from
+  **`origin/main`**; with `worktree.baseRef: head` it's cut from local HEAD —
+  don't assume `origin/main` unconditionally. The `fresh` consequence: any
+  **uncommitted or local-only** state (including an uncommitted on-disk plan
+  file) is **absent** from the worktree — which is why Phase 0 reads the
+  plan's content into the conversation first.
+- **Already in a worktree?** Don't nest — use the current worktree and just
+  create the branch in it (`git checkout -b feature/<slug>`). `EnterWorktree`
+  refuses to nest anyway.
+
+## Restore the permission allowlist
+
+Credentials are **not** the concern — `TMDB_API_KEY` / `USERNAME` / `PASSWORD`
+are injected into the session's **process environment** at startup
+(CWD-independent), and `make ci` / `make integration-test` read them straight
+from the environment. What a fresh worktree lacks is the **gitignored
+`.claude/settings.local.json`**, which holds the **permission allowlist** —
+without it an autonomous run could stall on permission prompts. Copy it in as
+cheap insurance:
+
+```bash
+# CWD is the worktree; the main checkout is the first entry of `git worktree list`.
+main_root=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
+mkdir -p .claude
+cp "$main_root/.claude/settings.local.json" .claude/settings.local.json 2>/dev/null || true
+```
+
+It stays gitignored in the worktree, so it won't be committed. If `make ci`'s
+integration leg fails on **credentials**, the cause is the *env* not being
+inherited by whatever spawned the subshell — **not** this file; check the
+environment first.
+
+## The main-checkout path trap
+
+A file `Read` *before* `EnterWorktree` yields a **main-checkout** absolute
+path; continuing to `Edit` that exact path after entering writes to **`main`**,
+not the worktree (they share `.git` but have **separate working dirs**). The
+trap is self-concealing: the build/test then runs against the still-pristine
+worktree and returns **baseline** counts, so a green run "confirms" work that
+never landed (bit #359 via fanned-out subagents and #361 via the conductor —
+see `knowledge/gotchas.md` → *Edits can land in the main checkout*).
+
+Hence the Phase 1 checkpoint: after entering, **re-`Read` source files before
+editing them**, and **verify `git status` shows your diff in the worktree
+before trusting the first green build** (an empty diff + baseline test counts
+= edits went to `main`). Rescue stranded edits with a shared stash:
+`git -C <main-checkout> stash` then `git stash pop` in the worktree. When
+fanning work out to subagents, give them worktree-absolute paths explicitly.
+
+## Teardown procedure (Phase 12)
+
+Both preconditions from `SKILL.md` verified (PR `merged: true`; tree clean
+**and** `HEAD == @{u}`), then:
+
+```text
+ExitWorktree(action: "remove", discard_changes: true)
+```
+
+- `remove` deletes the worktree directory (which **is** its `.build` — the
+  multi-GB reclaim) and the local branch, then returns the session to the
+  main checkout.
+- `discard_changes: true` is needed only because a **squash**-merge lands the
+  work as a *new* commit on `main`, so the branch's pushed-and-merged commits
+  aren't *literally* on `main` and `ExitWorktree` would otherwise refuse. It
+  is safe **only because** the preconditions proved there's nothing un-merged
+  left to lose. Never pass it on an unverified tree.
+
+**Leave the main checkout as you found it.** Do *not* auto-`merge --ff-only`
+it: the user may be actively working there with uncommitted or diverged state.
+Only if it is **clean and on `main`** (`git status --porcelain` empty) may you
+fast-forward it (`git fetch origin && git merge --ff-only origin/main`);
+otherwise just note "main checkout left as-is (N commits behind)". Report the
+reclaimed worktree in the final summary.

--- a/.claude/skills/deliver/references/wrap-up.md
+++ b/.claude/skills/deliver/references/wrap-up.md
@@ -1,0 +1,101 @@
+# /deliver — retrospective & wrap-up (reference)
+
+Read on demand from `/deliver` **Phase 8** (retro, pre-PR) and **Phase 11**
+(wrap-up). The sequencing rules live in `SKILL.md`; this file holds the entry
+format, the wiki guidance, and the recurring-pattern-scan procedure.
+
+## Retro entry format (Phase 8)
+
+A dated entry in `knowledge/delivery-retros.md`, newest at the top — a log,
+not a ceremony (a handful of bullets):
+
+- **Feature / branch**, date, and delivery weight (lite/full). The PR number
+  doesn't exist yet — head the entry with the branch name; Phase 9 backfills
+  the number right after the PR is created.
+- **Phases completed / Skills invoked** — a compact one-liner each (e.g.
+  phases `0–9`; skills `review-plan, implement-plan, review-changes,
+  security-review, capture-knowledge`). Telemetry for the recurring-pattern
+  scan: which skills fire, which phases get skipped, where deliveries stop.
+- **What worked** — one or two things the pipeline did well.
+- **Friction** — where it was rough, slow, or stopped unnecessarily.
+- **Deviations** — anywhere you had to depart from the skill to do the right
+  thing (a strong signal the skill has a gap).
+- **One improvement** — the single highest-value change to `/deliver` (or a
+  sub-skill) suggested by this run.
+- **`watch:`** — omit at write time. Added only as a post-gate amendment for
+  a noteworthy Phase 10 event; an uneventful watch adds nothing.
+
+**Windowing.** After adding the entry, if `delivery-retros.md` holds more than
+**~12 full entries**, distil the oldest into the one-line archive table
+(`date · PR · weight · one-line outcome`) and drop the prose — per
+`knowledge/README.md` → *Maintenance & retention*. An old retro's lesson
+already lives in the skills and `skill-improvement-log.md`; the table
+preserves the telemetry without the bulk.
+
+## Why the retro is pre-PR
+
+Every push to the PR branch re-triggers `claude-review` and the CI matrix.
+When the retro was a routine post-gate push, every delivery paid a re-review +
+re-run + re-watch for a markdown file — and on #361 the post-gate push raised
+a High thread that blocked the merge. Writing the retro pre-PR (decision
+recorded 2026-07-05 in `skill-improvement-log.md`) makes the default post-gate
+push count **zero**; the re-watch rule survives only for the exceptions (a
+`watch:` amendment, an approved skill edit from the scan).
+
+## Update the personal wiki (Phase 11)
+
+The retro distils this delivery's durable learnings, so wrap-up is the moment
+to feed the **personal `wiki`** (Adam's cross-project engineering knowledge,
+via the `wiki` MCP). The `knowledge/` base is *project-specific*; the wiki is
+for **generalizable** opinions, heuristics, and patterns that would apply on
+the next project too.
+
+- **Degrade silently if the `wiki` MCP is absent** (a contributor's machine,
+  a headless/cron run) — never block on it.
+- **Search first** (`search_entries`) and prefer **updating** a near-match
+  over creating a duplicate.
+- **Propose, don't autonomously save.** Use **`propose_entry`** to render
+  each candidate for review; `add_entry`/`update_entry` only on Adam's
+  explicit approval. Cite the wiki when an answer later draws on it.
+- **Be selective** — one or two high-signal entries beat a dump; skip
+  anything project-specific (that lives in `knowledge/`) or already present.
+  Capturing nothing is a valid outcome.
+
+## Recurring-pattern scan (Phase 11)
+
+The loop that turns one-off retros into reviewed skill improvements:
+
+1. **Read the recent window + the log.** The **~last 12** entries of
+   `knowledge/delivery-retros.md` (older ones are archived one-liners, so
+   this is the whole live history), **all** of
+   `knowledge/skill-improvement-log.md`, and **every** `SKILL.md` under
+   `.claude/skills/`. The bounded retro read keeps the scan's cost flat as
+   history grows.
+2. **Find what recurs.** For any friction, deviation, or improvement
+   suggestion appearing in **more than one** retro entry, write a numbered
+   proposal in this exact format:
+
+   ```text
+   Pattern: [what keeps happening]
+   Seen in: [retro dates / feature names]
+   Skill: [relative path to SKILL.md]
+   Current text: [exact existing wording, or "missing"]
+   Proposed change: [exact new wording and location]
+   Rationale: [one sentence on why this eliminates the pattern]
+   ```
+
+   **Skip any pattern already decided in `skill-improvement-log.md`** — one
+   already **applied**, or **deferred/rejected** (don't re-propose a settled
+   *no*; only resurface it if its recorded "reconsider when…" condition now
+   holds).
+3. **Stop and ask.** **Do not edit any skill files.** Present the proposals
+   and wait for **explicit approval on each one**. If no *new* pattern recurs
+   across multiple entries, say so and stop — emit no proposals.
+   (**Auto:** the panel reviews each proposal instead — see
+   `references/auto-and-async.md`.)
+4. **Record every decision in the log**, in the five-field format documented
+   at the top of `skill-improvement-log.md` (date · title · status; Pattern /
+   Decision / Rationale / Reconsider when) — **applied** (with the skill +
+   commit), **deferred**, or **rejected**. The **Decision** and **Reconsider
+   when** fields are what step 2's dedup keys on; keeping them on every entry
+   is what stops the scan re-proposing a settled call.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -423,7 +423,8 @@ Use a descriptive branch name with a conventional prefix
 > worktree** (under `.claude/worktrees/`, branched off `origin/main`) so the main
 > checkout stays free for concurrent work, and tears the worktree down on merge.
 > The branch-off-`main` rule above is the floor; the worktree is how `/deliver`
-> meets it. See `.claude/skills/deliver/SKILL.md` (Phases 0.5 + 7).
+> meets it. See `.claude/skills/deliver/SKILL.md` (its worktree-entry and
+> teardown phases).
 
 ## Creating Pull Requests
 

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -13,8 +13,8 @@ this directory; the detail lives here and is read on demand.
 | [`decisions/`](decisions/) | **ADRs** — Architecture Decision Records, one per decision, numbered + dated. Use for any non-obvious design choice and its rationale. |
 | [`gotchas.md`](gotchas.md) | Implementation quirks, things that bit us, tooling traps, and anything that needed a web search / lookup to resolve. |
 | [`tmdb-api-notes.md`](tmdb-api-notes.md) | Behaviours of the **live TMDb API** discovered while implementing (nullable/absent fields, undocumented quirks, response-shape surprises). |
-| [`delivery-retros.md`](delivery-retros.md) | A short retrospective per feature delivered via `/deliver` (its Phase 3.7, written pre-PR so it rides the delivery's own PR) — what worked, friction, deviations, one improvement. |
-| [`skill-improvement-log.md`](skill-improvement-log.md) | Decisions on every skill-improvement proposal from `/deliver`'s Phase 6 recurring-pattern scan (applied / deferred / rejected), so the scan doesn't re-propose settled calls. |
+| [`delivery-retros.md`](delivery-retros.md) | A short retrospective per feature delivered via `/deliver` (written pre-PR so it rides the delivery's own PR) — what worked, friction, deviations, one improvement. |
+| [`skill-improvement-log.md`](skill-improvement-log.md) | Decisions on every skill-improvement proposal from `/deliver`'s wrap-up recurring-pattern scan (applied / deferred / rejected), so the scan doesn't re-propose settled calls. |
 
 ## How to use it
 
@@ -37,7 +37,7 @@ age differently:
     **last ~12 entries** in full prose, and distil older ones into a compact
     one-line archive table (`date · PR · weight · one-line outcome`), dropping the
     prose. The telemetry (which skills fired, where deliveries stopped) survives;
-    the bulk doesn't. A retro's job is to feed the Phase 6 recurring-pattern scan;
+    the bulk doesn't. A retro's job is to feed the wrap-up recurring-pattern scan;
     once its lesson is folded into a skill and recorded `applied` in
     `skill-improvement-log.md`, the prose is spent — the scan reads only the recent
     window plus the log, never the full history.

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,6 +14,31 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-07-05 — ♻️ Restructure /deliver for progressive disclosure (chore/deliver-skill-restructure) · lite
+
+- **Phases / skills:** phases 0–9 (new numbering); markdown-only so the Swift
+  review gates self-skipped — but the plan's **rule-inventory mapping check**
+  ran as a dedicated adversarial `code-reviewer` pass instead (the diff's real
+  risk was rule loss, not code). Stacked dependent PR: branched off
+  `chore/deliver-retro-before-pr` (#382), base retargets on its merge.
+- **Worked:** the **inventory-first** method — extract every load-bearing rule
+  with a destination *before* rewriting, then have an independent reviewer
+  diff old-vs-new against it. The reviewer confirmed all ten known
+  load-bearing rules survived in the core and caught **8 real text drops**
+  (1 Medium, 7 Low — e.g. the merge/auto-mode routing for scan-applied skill
+  edits), all restored. 915 → 343 core lines + four on-demand reference
+  files.
+- **Friction:** the ≤~350-line AC needed a second compression pass (first
+  rewrite landed at 401) — line budgets are easy to overshoot while
+  preserving every rule.
+- **Deviations:** `/pr`'s rebase-onto-`origin/main` step doesn't apply to a
+  stacked PR (it would fold the dependency's diff into this one) — based on
+  the dependency branch instead, per `/watch-pr`'s stacking guidance.
+- **One improvement:** the mapping-check-in-lieu-of-code-review worked well
+  for a docs-structure diff; if meta-changes to `.claude/skills/**` recur,
+  consider making "no-Swift but skill-structure diff → run a rule-loss
+  review" an explicit branch in the review phase.
+
 ## 2026-07-05 — 🔧 Write the /deliver retro pre-PR (#382) · lite
 
 - **Phases / skills:** phases 0–4; no sub-skills fired (markdown-only: code +

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,7 +14,7 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
-## 2026-07-05 — ♻️ Restructure /deliver for progressive disclosure (chore/deliver-skill-restructure) · lite
+## 2026-07-05 — ♻️ Restructure /deliver for progressive disclosure (#383) · lite
 
 - **Phases / skills:** phases 0–9 (new numbering); markdown-only so the Swift
   review gates self-skipped — but the plan's **rule-inventory mapping check**

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -1,7 +1,7 @@
 # Delivery Retrospectives
 
-A short, honest entry per feature delivered via `/deliver` (its Phase 3.7 —
-written **pre-PR** so the entry rides the delivery's own PR; the PR number is
+A short, honest entry per feature delivered via `/deliver` — written
+**pre-PR** so the entry rides the delivery's own PR (the PR number is
 backfilled once the PR opens), newest at the top. A noteworthy watch-phase event
 is appended post-gate as an optional *watch:* line — an uneventful watch adds
 nothing. The point is **continuous improvement**: when the same friction or

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,24 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-07-05 — Legitimize inline knowledge capture for small in-flight entries · applied
+
+- **Pattern:** five consecutive deliveries (#366, #368, #374, #382, #383)
+  captured knowledge **inline** instead of invoking `/capture-knowledge`,
+  each time flagged as a benign deviation — small entries (a gotcha, a log
+  entry) authored *during* implementation gain nothing from the full skill
+  pass.
+- **Decision:** **applied** (user-approved at the #382/#383 gate). The
+  capture phase of `/deliver` now allows: one or two small entries already
+  authored during implementation may be committed inline, noted in the
+  retro. Landed in `.claude/skills/deliver/SKILL.md` (PR #383).
+- **Rationale:** the deviation was the de-facto convention and consistently
+  harmless; legitimizing it stops every retro re-flagging it, while the full
+  skill pass stays the default for real candidate lists.
+- **Reconsider when:** inline captures start skipping the dedup/curation the
+  skill provides (duplicate or low-signal `knowledge/` entries traced back to
+  inline capture).
+
 ### 2026-07-05 — Retro moved pre-PR: routine post-gate push loop eliminated · applied
 
 - **Pattern:** every delivery pushed the retro to the PR branch **after** the

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -1,9 +1,9 @@
 # Skill-Improvement Log
 
 A durable record of every skill-improvement proposal raised by `/deliver`'s
-**Phase 6 recurring-pattern scan**, and the decision on it. Newest at the top.
+**wrap-up recurring-pattern scan**, and the decision on it. Newest at the top.
 
-**Why this exists:** the Phase 6 scan surfaces proposals and waits for approval.
+**Why this exists:** the scan surfaces proposals and waits for approval.
 Without a memory of past decisions, it would re-propose ideas already **applied**
 or deliberately **deferred/rejected** — wasting attention and re-litigating
 settled calls. The scan **consults this log before proposing** and skips any
@@ -20,7 +20,7 @@ Format per entry:
 - **Decision:** what was agreed, and where it landed (skill + commit/PR) if applied.
 - **Rationale:** one or two sentences — why this call.
 - **Reconsider when:** (deferred/rejected only) the condition under which the scan
-  should resurface this — or `n/a` for applied entries. The Phase 6 scan reads this
+  should resurface this — or `n/a` for applied entries. The scan reads this
   field to decide whether a settled *no* may be re-proposed.
 ```
 


### PR DESCRIPTION
## Summary

`deliver/SKILL.md` had grown to 915 lines — every rule carrying its incident history inline, ~90 lines of never-exercised auto/async machinery, and accreted phase numbering (0.5, 3.4, 3.5, 3.6, 3.7, "3a"). Every invocation loaded all of it, and prose overload is exactly how rules get skipped under momentum. This PR restructures the skill for **progressive disclosure** with **no semantic change**: a 343-line orchestration contract plus four reference files read on demand when their phase arrives.

> **Stacked on #382** (the retro-pre-PR sequencing change) — base retargets to `main` when it merges; this branch will then be rebased.

## Changes

**Core (`.claude/skills/deliver/SKILL.md`, 915 → 343 lines):**

- ♻️ Phases renumbered to consecutive integers **0–12** (ledger gate task `Phase 3a` → `Phase 4a`); each phase reduced to its imperative core + gate condition + pointer to its reference file.
- ♻️ Deliberately-duplicated load-bearing rules **stay in the core** per applied `skill-improvement-log.md` decisions (specialist-skills checkpoint, 4a reference-unit gate, enumerate-all-sites sweep, worktree path-trap checkpoint, red-gate triage, retro-pre-PR rules).

**New reference files (`.claude/skills/deliver/references/`):**

- ✨ `worktree-lifecycle.md` — GC sweep, EnterWorktree mechanics (incl. the branch-name rename gotcha), settings copy, path-trap detail, teardown procedure.
- ✨ `review-loops.md` — 4a procedure, convergence rationale, security surfaces, incident record (#359/#364).
- ✨ `auto-and-async.md` — panel procedure + decision-point list, queuing caveats (relocation, not removal; noted as not yet exercised).
- ✨ `wrap-up.md` — retro format + windowing, wiki guidance, recurring-pattern-scan procedure.

**Cross-references (number-free so future renumbering can't strand them):**

- 📝 `CLAUDE.md`, `knowledge/README.md`, `knowledge/delivery-retros.md` header, `knowledge/skill-improvement-log.md` format header, `.claude/skills/capture-knowledge/SKILL.md`. Historical log/retro entries untouched.

## Verification

- ✅ **Rule inventory first**: every load-bearing rule extracted with a destination before rewriting (inventory: `scratchpad/deliver-rule-inventory.md`, summarised below).
- ✅ **Adversarial mapping review**: an independent `code-reviewer` agent diffed the old 915-line skill against the new set — verdict **no Critical loss** (all ten known load-bearing rules confirmed in the core with equivalent force); its 8 findings (1 Medium, 7 Low text drops) were all restored in a follow-up commit.
- ✅ `make lint && make lint-markdown` green; stale-phase-ref grep clean outside historical logs; all four reference files linked from the core.

## Benefits

- **Cheaper, sharper invocations**: the conductor loads a 343-line contract; procedures and war stories arrive only when their phase does.
- **Fewer skipped rules**: less prose per rule is the practical mitigation for "unenforceable exhortations get skipped under momentum".
- **Stable cross-references**: external docs no longer name phase numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5GRMKxWvFUx8m9o5SF21M