### PR TITLE
🔧 Consult knowledge/ at /deliver entry; grade the rubric independently at exit

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -121,6 +121,13 @@ implementation = separate `/deliver` sessions.)
 - **State the goal** in a sentence; **judge the weight**; open the ledger.
 - **Pull wiki context** best-effort (`get_context` on the goal); degrade
   silently if the `wiki` MCP is absent.
+- **Consult the knowledge base** — skim the entry headings of
+  [`knowledge/gotchas.md`](../../../knowledge/gotchas.md) and
+  [`knowledge/tmdb-api-notes.md`](../../../knowledge/tmdb-api-notes.md), read
+  the entries (and any `knowledge/decisions/` ADR) relevant to the goal's
+  area, and record one `consulted: <entries | none relevant>` line in the
+  ledger. Captured knowledge only compounds if it is read at entry — the
+  ledger line is what makes this step checkable.
 - **Decompose a multi-deliverable plan** (rules above); single-deliverable
   plans skip this.
 - **Entry gate — acceptance criteria required.** Plans are expected as
@@ -238,14 +245,28 @@ the retro.
 
 ## Phase 7 — Rubric verification (exit gate)
 
-Take the rubric (Phase 0 ACs) from the ledger; none extracted → skip. Verify
-each AC against the committed diff — behaviour by diff-scan or a targeted
-test (`swift test --filter …`), coverage by the test + assertion existing,
-integration by the integration test existing (the live run already passed in
-Phase 3 — no re-run needed). Satisfied → mark off. Not →
-fix test-first, commit, re-verify; a gap needing a plan change is noted in
-the PR description. Lightweight, inline — *"did we build what the plan
-said?"*, not *"did the build pass?"*.
+Take the rubric (Phase 0 ACs) from the ledger; none extracted → skip. How it
+is graded depends on weight:
+
+- **Lite** → verify inline: each AC against the committed diff — behaviour
+  by diff-scan or a targeted test (`swift test --filter …`), coverage by the
+  test + assertion existing, integration by the integration test existing
+  (the live run already passed in Phase 3 — no re-run needed).
+- **Full** → **an independent grader, not the conductor** — the maker does
+  not grade its own homework. Spawn ONE subagent (general-purpose; inherit
+  the model) given ONLY the rubric verbatim and the instruction to judge the
+  committed work (`git diff origin/main...HEAD`, reading files and running
+  targeted `swift test --filter …` as needed) — no conversation context, no
+  implementation narrative. It returns per-AC `met`/`not met` + one-line
+  evidence (file:line or test name). Run it **synchronously** — it may
+  build/test, and builds are sequential within a worktree. Grader dies or
+  returns unusable output → fall back to the inline path and note it in the
+  ledger — **a dead grader is not a pass**.
+
+Satisfied → mark off. Not → fix test-first, commit, re-verify (full weight:
+re-run the grader); a gap needing a plan change is noted in the PR
+description. *"Did we build what the plan said?"*, not *"did the build
+pass?"*.
 
 ## Phase 8 — Write the retrospective (pre-PR)
 

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,6 +14,27 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-07-05 — 🔧 Knowledge consult at entry + independent rubric grader (chore/deliver-consult-and-independent-grader) · lite
+
+- **Phases / skills:** phases 0–10; markdown-only, so `review-plan` skipped
+  (lite + `ExitPlanMode` approval), `review-changes` and `security-review`
+  self-skipped; capture was inline (the `skill-improvement-log.md` entry *is*
+  part of the delivery, per the 2026-07-05 inline-capture decision).
+- **Worked:** the plan arrived with the user story + ACs already in
+  Given/When/Then form, so the Phase 0 entry gate extracted the rubric with
+  zero friction; the diff-by-eye rule-loss check was proportionate for a
+  two-section edit (the full inventory method stayed shelved, correctly).
+- **Friction:** none material — smallest delivery to date (2 files at
+  implement, +49/−8).
+- **Deviations:** the change originated from an external article review
+  rather than a repo-native trigger; the knowledge-consult it adds was done
+  implicitly this run (the design phase had already read the relevant
+  gotchas/wiki material) — the new `consulted:` ledger line is what makes it
+  explicit from the next run on.
+- **One improvement:** extend the consult step to `/implement-plan`
+  standalone invocations (deliberately out of scope this run; noted in the
+  plan).
+
 ## 2026-07-05 — ♻️ Restructure /deliver for progressive disclosure (#383) · lite
 
 - **Phases / skills:** phases 0–9 (new numbering); markdown-only so the Swift
@@ -415,33 +436,6 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
   *an adversarial drop that rests on a factual claim about sibling code must check
   that claim against the tree.*
 
-## 2026-06-19 — ✨ Add `networks` property to TVSeason (#349) · full
-
-- **Phases / skills:** phases 0–6; `review-plan, implement-plan, build-for-testing,
-  test, integration-test, lint, review-changes, capture-knowledge, pr, watch-pr`.
-- **Worked:** the work originated from a schema-diff scan (8 models vs the live
-  OpenAPI spec) that found exactly one field-level gap — a precise, pre-verified
-  target. `/review-plan`'s critics caught a real test trap *before* any code (the
-  `Network`-Equatable / over-populated-mock pitfall) and surfaced a free extra
-  assertion (networks surfacing through the shared `TVSeasonDetailsResponse`
-  decoder); both folded into the plan, so implementation hit zero surprises and
-  `/review-changes` came back 0/0/0 + one advisory Low.
-- **Friction:** local `make ci` went red on `lint-markdown` over an **unrelated,
-  pre-existing** `.claude/skills/deliver/SKILL.md:347` MD028 — a file not in the
-  diff. Root cause: the **local** `make lint-markdown` lints `.claude/**`, but the
-  **CI** job (`ci.yml:120`) lints only `README.md` + `**/*.docc/**` — so the local
-  gate can fail on `.claude/` markdown that the authoritative gate never checks.
-  Cost a triage detour to prove it was non-blocking.
-- **Deviations:** user changed `merge` → watch-only mid-run (honoured: stopped at
-  the gate). Did **not** route the markdown red to `/fix-integration-failures`
-  (that's for integration flakes); triaged it as local-gate-only and proceeded,
-  verifying the real legs (build-docs, build-release, unit, TVSeason integration)
-  passed individually.
-- **Improvement:** reconcile the **local `make lint-markdown` scope with CI's** —
-  either narrow the Makefile target to match `ci.yml` (`README.md` + docc), or add
-  `.claude/**` to the CI job so the two gates agree. Today a green CI can sit behind
-  a red local `make ci`, which repeatedly mis-signals "your change broke the gate."
-
 ## Archive (distilled)
 
 Older entries condensed per the rolling window (`knowledge/README.md` →
@@ -449,6 +443,7 @@ Older entries condensed per the rolling window (`knowledge/README.md` →
 
 | Date | PR | Weight | Outcome |
 | --- | --- | --- | --- |
+| 2026-06-19 | #349 | full | `networks` on TVSeason from a schema-diff scan; critics pre-caught the Equatable/over-populated-mock trap → 0/0/0 review; exposed the local-vs-CI `lint-markdown` scope mismatch. |
 | 2026-06-18 | #346 | full | AuthenticatedSession wrapper; 3 critics unanimously reversed deprecate-and-add to additive; local-vs-CI lint cache gap → `/pr` `--no-cache` step. |
 | 2026-06-18 | #344 | lite | Error-handling How-To guide; `make build-docs` was the real gate; reinforced the docs-only fast-gate need. |
 | 2026-06-18 | #343 | lite | Explicit `Sendable` on `URLSessionHTTPClientAdapter`; premise re-framed from bug fix to clarity. |

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,7 +14,7 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
-## 2026-07-05 — 🔧 Knowledge consult at entry + independent rubric grader (chore/deliver-consult-and-independent-grader) · lite
+## 2026-07-05 — 🔧 Knowledge consult at entry + independent rubric grader (#384) · lite
 
 - **Phases / skills:** phases 0–10; markdown-only, so `review-plan` skipped
   (lite + `ExitPlanMode` approval), `review-changes` and `security-review`

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,26 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-07-05 — Knowledge consult at entry + independent rubric grader · applied
+
+- **Pattern:** an external article-driven review of the pipeline (not the
+  wrap-up scan) found two gaps: (a) a **consult gap** — `knowledge/` is
+  written every delivery (Phase 6) but never read at entry, leaving the
+  advisory CLAUDE.md "skim the relevant file" rule silently skipped; and
+  (b) the Phase 7 rubric was graded by the **conductor that implemented the
+  work** — the one gate without the independent-verifier discipline the rest
+  of the pipeline is built on.
+- **Decision:** **applied** (user-directed, 2026-07-05, PR #TBD). Phase 0
+  gains a ledger-checkable knowledge-consult step (`consulted:` line);
+  Phase 7 splits by weight — full-weight grading is delegated to one
+  independent subagent given only the rubric + committed work (lite stays
+  inline; grader failure falls back inline and is noted — a dead grader is
+  not a pass).
+- **Rationale:** memory that isn't read at entry doesn't compound; a maker
+  grading its own rubric is the self-critique failure mode the pipeline's
+  critics/skeptics already design against.
+- **Reconsider when:** n/a (applied).
+
 ### 2026-07-05 — Legitimize inline knowledge capture for small in-flight entries · applied
 
 - **Pattern:** five consecutive deliveries (#366, #368, #374, #382, #383)

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -39,7 +39,7 @@ two fields the dedup step keys on.
   (b) the Phase 7 rubric was graded by the **conductor that implemented the
   work** — the one gate without the independent-verifier discipline the rest
   of the pipeline is built on.
-- **Decision:** **applied** (user-directed, 2026-07-05, PR #TBD). Phase 0
+- **Decision:** **applied** (user-directed, 2026-07-05, PR #384). Phase 0
   gains a ledger-checkable knowledge-consult step (`consulted:` line);
   Phase 7 splits by weight — full-weight grading is delegated to one
   independent subagent given only the rubric + committed work (lite stays


### PR DESCRIPTION
## Summary

Closes two gaps in the `/deliver` pipeline surfaced by an external review of the skill system against self-improving-agent patterns:

1. **Consult gap** — `knowledge/` is written every delivery (Phase 6) but was never *read* at entry, leaving the advisory CLAUDE.md "skim the relevant file" rule silently skipped. Memory that isn't read at entry doesn't compound.
2. **Self-graded rubric** — Phase 7's "did we build what the ACs say?" check was performed inline by the conductor that implemented the work — the one gate in the pipeline without the independent-verifier discipline the rest of it is built on (`/review-plan` critics, `/review-changes` skeptics).

## Changes

**`.claude/skills/deliver/SKILL.md`:**

- 🔧 Phase 0 gains a **knowledge-consult step**: skim `knowledge/gotchas.md` / `tmdb-api-notes.md` headings, read goal-relevant entries (and matching ADRs), and record one `consulted: <entries | none relevant>` line in the ledger — the ledger line makes the step checkable rather than advisory.
- 🔧 Phase 7 now splits by delivery weight: **lite** keeps the existing inline verification; **full** delegates grading to **one independent subagent** given only the rubric verbatim and the committed work (`git diff origin/main...HEAD`, targeted `swift test --filter`) — no conversation context — returning per-AC `met`/`not met` with evidence. Runs synchronously (sequential builds per worktree). A grader that dies or returns unusable output falls back to the inline path and is noted in the ledger — a dead grader is not a pass.

**`knowledge/skill-improvement-log.md`:**

- 📝 New **applied** entry recording both decisions (five-field format), so the wrap-up recurring-pattern scan never re-proposes them.

**`knowledge/delivery-retros.md`:**

- 📝 Pre-PR retro for this delivery; windowing distilled the oldest entry (#349) into the archive table (back to ~12 full entries).

## Benefits

- **Compounding memory**: captured knowledge is now consumed at pipeline entry, not just produced at exit — with a ledger artifact proving the consult happened.
- **Independent verification at the exit gate**: the maker no longer grades its own homework on full-weight deliveries, closing the last self-critique gap in the pipeline; the explicit dead-grader fallback keeps a silent subagent failure from reading as a pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5GRMKxWvFUx8m9o5SF21M