### PR TITLE
♻️ Consolidate build/test runner skills into a tooling-runner agent; pin subagent model tiers

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Code reviewer subagent to be used to review code changes when asked, or at appropriate points when implementing new features
-model: inherit
+model: opus
 permissionMode: auto
 skills:
   - swift-concurrency

--- a/.claude/agents/documentation-writer.md
+++ b/.claude/agents/documentation-writer.md
@@ -1,7 +1,7 @@
 ---
 name: documentation-writer
 description: Swift DocC subagent for BULK documentation work — documenting many public declarations across multiple files (e.g. a whole new service, or every undocumented symbol in a diff) in an isolated context. For documenting a single symbol as you write it, apply the `document-swift` skill inline instead.
-model: inherit
+model: sonnet
 permissionMode: restricted
 skills:
   - swift-concurrency

--- a/.claude/agents/tooling-runner.md
+++ b/.claude/agents/tooling-runner.md
@@ -1,0 +1,85 @@
+---
+name: tooling-runner
+description: Haiku runner for TMDb build/test commands — executes exactly one make target (or its xcode-tools MCP equivalent), writes the full output to a .build/last-*.log file, and returns only a concise pass/fail + failures-as-file:line summary. Spawned by the /build, /build-for-testing, /test, and /integration-test skills; not for ad-hoc shell work.
+model: haiku
+permissionMode: auto
+---
+
+# Claude Subagent: Tooling Runner (build/test)
+
+You run **exactly one** build or test target for the TMDb Swift package and
+report the result concisely. Your job is containment: the raw output stays in
+a log file and out of the caller's context. Run only the target you were
+asked for — nothing else.
+
+## How to run (all targets)
+
+- **Inside Xcode** (the `mcp__xcode-tools__*` MCP is available): use the MCP
+  tool named in the target's recipe below. On a build failure, get per-file
+  error detail with `mcp__xcode-tools__XcodeRefreshCodeIssuesInFile` on each
+  flagged file.
+- **Otherwise** (terminal): run the target's `make` command with output
+  redirected to its log file —
+  `mkdir -p .build && make <target> > .build/last-<name>.log 2>&1` — then
+  judge pass/fail **from the exit status** (the Makefile sets `pipefail`, so
+  a failure propagates through the xcsift pipe) and summarise from the log.
+- Run targets **sequentially** — never two builds at once in one worktree.
+- Never read or touch `.swiftpm/` or `.build/` beyond the log file.
+
+## Judging pass/fail — the xcsift `.docc` trap
+
+**Trust the exit status (and, for tests, the `failed_tests` count) — not
+xcsift's `status:` field or toon summary.** Outside a docs build, SwiftPM
+emits a benign `found N file(s) which are unhandled … *.docc` warning (the
+DocC plugin loads only under `SWIFTCI_DOCC=1`); xcsift lists it under
+`errors[]` with `null,null` coordinates and may print `status: failed` even
+though the run **exits 0**. A 0 exit whose only errors are these `.docc`
+unhandled-file entries (and, for test runs, `failed_tests: 0`) is a
+**PASS** — report succeeded and exclude those entries from the error count.
+
+## Targets
+
+### build
+
+`make build` → `.build/last-build.log` — compiles the package for the
+current platform. Xcode: `mcp__xcode-tools__BuildProject`.
+
+### build-for-testing
+
+`make build-tests` → `.build/last-build-tests.log` — compiles the package
+**and** all test targets without running them. Xcode:
+`mcp__xcode-tools__BuildProject` (pass `buildForTesting: true` if the tool
+supports it).
+
+### test
+
+`make test` → `.build/last-test.log` — the unit suite (Swift Testing, the
+**TMDb** test plan). Xcode: `mcp__xcode-tools__RunAllTests` with the TMDb
+test plan. If the caller asks for a scoped re-run, use
+`swift test --filter "SuiteName/testName"` instead of the full suite.
+
+### integration-test
+
+`make integration-test` → `.build/last-integration-test.log` — the live-API
+suite (the **Integration** test plan). Xcode:
+`mcp__xcode-tools__RunAllTests` with the Integration test plan. Requires
+`TMDB_API_KEY`, `TMDB_USERNAME`, and `TMDB_PASSWORD`, injected via the env
+block in `.claude/settings.local.json` — no sourcing needed. `make
+integration-test` checks these first: a missing var is an
+**environment/precondition** failure, not a test failure. Classify each
+failure: a genuine assertion failure vs a **transient live-API issue**
+(HTTP 429 / timeout / network) — transients are not code bugs.
+
+## Report back ONLY
+
+- **Status** — succeeded/passed or failed
+- **Counts** — errors + warnings (builds) or total / passed / failed (tests)
+- Each failure on one line: build errors as `file:line — message`, test
+  failures as `SuiteName/testName` with `file:line` and the assertion
+  message (omit the list when there are none)
+- For integration tests: whether failures look genuine vs transient/env
+- On failure, the log path (or, inside Xcode, the flagged files so the
+  caller can refresh their diagnostics)
+
+Do **not** paste raw logs, passing-test output, or successful-compilation
+output.

--- a/.claude/skills/build-for-testing/SKILL.md
+++ b/.claude/skills/build-for-testing/SKILL.md
@@ -1,48 +1,21 @@
 ---
 name: build-for-testing
-description: Compile the TMDb package AND all test targets (without running the tests) to catch test-code compile errors. Use after changing tests or shared code to check everything still builds — delegates to a Haiku subagent and returns a concise pass/fail + errors-as-file:line summary. Differs from /build, which compiles only the library; to run the tests, use /test.
+description: Compile the TMDb package AND all test targets (without running the tests) to catch test-code compile errors. Use after changing tests or shared code to check everything still builds — delegates to the tooling-runner agent (Haiku) and returns a concise pass/fail + errors-as-file:line summary. Differs from /build, which compiles only the library; to run the tests, use /test.
 ---
 
 # Build for testing
 
-Delegate this to a **Haiku subagent** so the build output stays out of your
-context. Use the Agent tool with `subagent_type: general-purpose` and
-`model: haiku`, give it the prompt below, then relay its report. Do **not** run
-the build yourself.
+Spawn the **`tooling-runner`** agent (Agent tool,
+`subagent_type: tooling-runner` — its Haiku pin, command recipes, and
+reporting contract live in `.claude/agents/tooling-runner.md`) with the
+one-line task:
 
-Subagent prompt:
+> Run the `build-for-testing` target: compile the TMDb package and all test
+> targets.
 
-```text
-Build the TMDb Swift package and all test targets, then report concisely.
+Relay its report. Do **not** run the build yourself.
 
-- If the xcode-tools MCP is available (inside Xcode), run
-  `mcp__xcode-tools__BuildProject` so it builds the test targets (pass
-  `buildForTesting: true` if the tool supports it). On failure, get per-file
-  error detail with `mcp__xcode-tools__XcodeRefreshCodeIssuesInFile` on each
-  flagged file.
-- Otherwise run
-  `mkdir -p .build && make build-tests > .build/last-build-tests.log 2>&1`,
-  check the exit status for pass/fail (the Makefile sets `pipefail`), and
-  summarise from that log file.
-  **Trust the exit status, not xcsift's toon summary.** Outside a docs build,
-  SwiftPM emits a benign `found N file(s) which are unhandled … *.docc` warning
-  (the DocC plugin loads only under `SWIFTCI_DOCC=1`); xcsift lists it under
-  `errors[]` with `null,null` coordinates and may print `status: failed`, yet the
-  build still **exits 0**. A 0 exit whose only errors are these `.docc`
-  unhandled-file entries is a **PASS** — report succeeded and exclude them from
-  the error count.
-
-Report back ONLY:
-- Status: succeeded or failed
-- Error and warning counts
-- Each error/warning as `file:line — message` (omit this list if there are none)
-- On failure, the full log path `.build/last-build-tests.log` (or, inside Xcode,
-  the flagged files so the caller can refresh their diagnostics)
-
-Do not paste raw build logs or successful-compilation output.
-```
-
-If the report is unclear on a failure, read the log path it provides (or, inside
-Xcode, refresh diagnostics on the flagged files) rather than re-running. After
-fixing the issues, re-invoke this skill to re-check (a fresh subagent will
-rebuild).
+If the report is unclear on a failure, read the log path it reports
+(`.build/last-build-tests.log`) — or, inside Xcode, refresh diagnostics on
+the flagged files — rather than re-running. After fixing the issues,
+re-invoke this skill to re-check (a fresh subagent will rebuild).

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -1,45 +1,20 @@
 ---
 name: build
-description: Compile the TMDb Swift package for the current platform to check it builds. Use to verify code compiles after changes — delegates the build to a Haiku subagent and returns a concise pass/fail + errors-as-file:line summary, keeping logs out of context. To also compile the test targets, use /build-for-testing.
+description: Compile the TMDb Swift package for the current platform to check it builds. Use to verify code compiles after changes — delegates the build to the tooling-runner agent (Haiku) and returns a concise pass/fail + errors-as-file:line summary, keeping logs out of context. To also compile the test targets, use /build-for-testing.
 ---
 
 # Build project
 
-Delegate the build to a **Haiku subagent** so the (potentially verbose) build
-output stays out of your context. Use the Agent tool with
-`subagent_type: general-purpose` and `model: haiku`, give it the prompt below,
-then relay its report. Do **not** run the build yourself.
+Spawn the **`tooling-runner`** agent (Agent tool,
+`subagent_type: tooling-runner` — its Haiku pin, command recipes, and
+reporting contract live in `.claude/agents/tooling-runner.md`) with the
+one-line task:
 
-Subagent prompt:
+> Run the `build` target: compile the TMDb Swift package.
 
-```text
-Build the TMDb Swift package and report the result concisely.
+Relay its report. Do **not** run the build yourself.
 
-- If the xcode-tools MCP is available (running inside Xcode), run
-  `mcp__xcode-tools__BuildProject`. On failure, get per-file error detail with
-  `mcp__xcode-tools__XcodeRefreshCodeIssuesInFile` on each flagged file.
-- Otherwise run `mkdir -p .build && make build > .build/last-build.log 2>&1`,
-  check the exit status for pass/fail (the Makefile sets `pipefail`, so a compile
-  failure propagates through the xcsift pipe), and summarise from that log file.
-  **Trust the exit status, not xcsift's toon summary.** Outside a docs build,
-  SwiftPM emits a benign `found N file(s) which are unhandled … *.docc` warning
-  (the DocC plugin loads only under `SWIFTCI_DOCC=1`); xcsift lists it under
-  `errors[]` with `null,null` coordinates and may print `status: failed`, yet the
-  build still **exits 0**. A 0 exit whose only errors are these `.docc`
-  unhandled-file entries is a **PASS** — report succeeded and exclude them from
-  the error count.
-
-Report back ONLY:
-- Status: succeeded or failed
-- Error and warning counts
-- Each error/warning as `file:line — message` (omit this list if there are none)
-- On failure, the full log path `.build/last-build.log` (or, inside Xcode, the
-  flagged files so the caller can refresh their diagnostics)
-
-Do not paste raw build logs or successful-compilation output.
-```
-
-If the report is unclear on a failure, read the log path it provides (or, inside
-Xcode, refresh diagnostics on the flagged files) rather than re-running. After
-fixing the issues, re-invoke this skill to re-check (a fresh subagent will
-rebuild).
+If the report is unclear on a failure, read the log path it reports
+(`.build/last-build.log`) — or, inside Xcode, refresh diagnostics on the
+flagged files — rather than re-running. After fixing the issues, re-invoke
+this skill to re-check (a fresh subagent will rebuild).

--- a/.claude/skills/fix-pr-checks/SKILL.md
+++ b/.claude/skills/fix-pr-checks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fix-pr-checks
-description: Fix the currently-failing status checks on the current branch's PR in one sweep — route each failing check to the right diagnosis skill (via a Haiku subagent), apply and verify the fix, commit, and push once — then return a summary. Use standalone when CI is red, or as the check-fixing step invoked by /watch-pr. Repo is adamayoung/TMDb.
+description: Fix the currently-failing status checks on the current branch's PR in one sweep — route each failing check to the right diagnosis skill (via a Haiku subagent, escalating to Opus on a repeat failure), apply and verify the fix, commit, and push once — then return a summary. Use standalone when CI is red, or as the check-fixing step invoked by /watch-pr. Repo is adamayoung/TMDb.
 ---
 
 # Fix PR Checks
@@ -18,8 +18,9 @@ Repo is `adamayoung/TMDb`. GitHub reads use the **GitHub MCP** (`mcp__github__*`
 ## It stands on the diagnosis skills
 
 Don't read CI logs yourself. The analysis is already a capability — delegate it to
-a **Haiku subagent** running the matching diagnosis skill, so raw logs never enter
-your context and you get back a `file:line` cause and a concrete fix:
+a **Haiku subagent** running the matching diagnosis skill (a repeat failure
+re-diagnoses on **Opus** — see §2), so raw logs never enter your context and you
+get back a `file:line` cause and a concrete fix:
 
 - The **Integration** check (live-API suite from `integration.yml`) →
   `/diagnose-integration-failure`
@@ -33,9 +34,10 @@ This skill is the **act-on-it** layer: route → fix → verify → commit → p
 1. **One sweep, then return.** Handle every check failing at invocation, push
    once, report. Don't loop waiting for the re-run — that convergence is the
    caller's job.
-2. **Diagnose via Haiku, fix locally.** Get Cause/Fix from the diagnosis skill,
-   then apply it and **verify before claiming it fixed** with the delegated build/
-   test skills.
+2. **Diagnose via Haiku, escalate a repeat to Opus, fix locally.** Get Cause/Fix
+   from the diagnosis skill, then apply it and **verify before claiming it
+   fixed** with the delegated build/test skills. First diagnosis of a check runs
+   on Haiku; a check that comes back after a fix re-diagnoses on Opus (§2).
 3. **Respect the attempt cap.** A check gets at most **3** fix→push attempts
    (tracked in the run ledger). If it still fails on the same root cause, stop
    touching it and report it exhausted — never loop forever.
@@ -71,11 +73,18 @@ commit. Classify each by `status` + `conclusion`:
 
 If nothing is failing, return immediately (note any pending checks).
 
-## 2. Diagnose each failing check (Haiku)
+## 2. Diagnose each failing check (Haiku first, Opus on a repeat)
 
 For each `fail` check under its attempt cap, spawn a diagnosis subagent — Agent
-tool, `subagent_type: general-purpose`, `model: haiku` — substituting the check
-name and the routed skill:
+tool, `subagent_type: general-purpose` — substituting the check name and the
+routed skill. Pick the model from the check's ledger history:
+
+- **First attempt** → `model: haiku`.
+- **Repeat** (the ledger shows a prior attempt for this check — a fix that
+  didn't verify, or the check failed again after the push) → `model: opus`,
+  prepending one line of prior-attempt context to the prompt: the previous
+  Cause/Fix and why it didn't stick. A misdiagnosis costs a full
+  fix→push→CI round trip; don't pay it twice on the same model tier.
 
 ```text
 The `<CHECK NAME>` check failed on the TMDb PR for branch `<branch>`.

--- a/.claude/skills/integration-test/SKILL.md
+++ b/.claude/skills/integration-test/SKILL.md
@@ -1,51 +1,23 @@
 ---
 name: integration-test
-description: Run the TMDb integration tests against the live TMDb API (the Integration test plan; requires TMDB_API_KEY/USERNAME/PASSWORD). Use before a PR, or after model/fixture changes, to validate against real API responses — delegates to a Haiku subagent and returns counts + failures, distinguishing genuine failures from transient live-API/env issues. For mocked unit tests, use /test.
+description: Run the TMDb integration tests against the live TMDb API (the Integration test plan; requires TMDB_API_KEY/USERNAME/PASSWORD). Use before a PR, or after model/fixture changes, to validate against real API responses — delegates to the tooling-runner agent (Haiku) and returns counts + failures, distinguishing genuine failures from transient live-API/env issues. For mocked unit tests, use /test.
 ---
 
 # Run integration tests
 
-Delegate the test run to a **Haiku subagent** so the output stays out of your
-context. Use the Agent tool with `subagent_type: general-purpose` and
-`model: haiku`, give it the prompt below, then relay its report. Do **not** run
-the tests yourself.
+Spawn the **`tooling-runner`** agent (Agent tool,
+`subagent_type: tooling-runner` — its Haiku pin, command recipes, and
+reporting contract live in `.claude/agents/tooling-runner.md`) with the
+one-line task:
 
-Subagent prompt:
+> Run the `integration-test` target: the TMDb live-API integration suite.
 
-```text
-Run the TMDb integration tests against the live API and report concisely.
+Relay its report — it distinguishes genuine assertion failures from
+transient live-API issues (429/timeout/network) and env/precondition
+failures. Do **not** run the tests yourself.
 
-- If the xcode-tools MCP is available (inside Xcode), run
-  `mcp__xcode-tools__RunAllTests` with the Integration test plan.
-- Otherwise run
-  `mkdir -p .build && make integration-test > .build/last-integration-test.log 2>&1`,
-  check the exit status for pass/fail, and summarise from that log file.
-  **Trust the exit status and `failed_tests` count, not xcsift's `status:`
-  field.** Outside a docs build, SwiftPM emits a benign `found N file(s) which
-  are unhandled … *.docc` warning that xcsift lists under `errors[]` (with
-  `null,null` coordinates) and that can make it print `status: failed` even when
-  the run succeeded and `failed_tests: 0`. Treat a 0 exit with `failed_tests: 0`
-  as **passed** regardless of that `.docc` entry.
-
-These require TMDB_API_KEY, TMDB_USERNAME, and TMDB_PASSWORD, which are injected
-via the env block in .claude/settings.local.json — no sourcing is needed. `make
-integration-test` checks these first: if a var is missing, report that as an
-**environment/precondition** failure, not a test failure.
-
-Report back ONLY:
-- Status: passed or failed
-- Counts: total / passed / failed
-- Each failing test as `SuiteName/testName` with its `file:line` and the
-  failure message (omit this list if there are none)
-- Whether the failures look like genuine assertion failures vs a **transient
-  live-API issue** (HTTP 429 / timeout / network) or the env/precondition failure
-  above — these are not code bugs
-- On failure, the full log path `.build/last-integration-test.log`
-
-Do not paste passing-test output or raw logs.
-```
-
-If the report is unclear on a failure, read the log path it provides rather than
-re-running. After fixing the issues, re-invoke this skill to re-check. To
-attribute a failure (live-API/backend drift vs a regression in your change), use
+If the report is unclear on a failure, read the log path it reports
+(`.build/last-integration-test.log`) rather than re-running. After fixing
+the issues, re-invoke this skill to re-check. To attribute a failure
+(live-API/backend drift vs a regression in your change), use
 `/diagnose-integration-failure`.

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,46 +1,22 @@
 ---
 name: test
-description: Run all TMDb unit tests (Swift Testing, the TMDb test plan). Use after code changes and before a PR to verify unit tests pass — delegates the run to a Haiku subagent and returns total/passed/failed counts plus each failure as Suite/test with file:line. For the live-API suite, use /integration-test.
+description: Run all TMDb unit tests (Swift Testing, the TMDb test plan). Use after code changes and before a PR to verify unit tests pass — delegates the run to the tooling-runner agent (Haiku) and returns total/passed/failed counts plus each failure as Suite/test with file:line. For the live-API suite, use /integration-test.
 ---
 
 # Run tests
 
-Delegate the test run to a **Haiku subagent** so the test output stays out of
-your context. Use the Agent tool with `subagent_type: general-purpose` and
-`model: haiku`, give it the prompt below, then relay its report. Do **not** run
-the tests yourself.
+Spawn the **`tooling-runner`** agent (Agent tool,
+`subagent_type: tooling-runner` — its Haiku pin, command recipes, and
+reporting contract live in `.claude/agents/tooling-runner.md`) with the
+one-line task:
 
-Subagent prompt:
+> Run the `test` target: the TMDb unit test suite.
 
-```text
-Run the TMDb unit tests and report concisely.
+Relay its report. Do **not** run the tests yourself.
 
-- If the xcode-tools MCP is available (inside Xcode), run
-  `mcp__xcode-tools__RunAllTests` with the TMDb test plan. If a build error
-  caused the failure, get per-file detail with
-  `mcp__xcode-tools__XcodeRefreshCodeIssuesInFile` on the flagged files.
-- Otherwise run `mkdir -p .build && make test > .build/last-test.log 2>&1`,
-  check the exit status for pass/fail (the Makefile sets `pipefail`), and
-  summarise from that log file.
-  **Trust the exit status and `failed_tests` count, not xcsift's `status:`
-  field.** Outside a docs build, SwiftPM emits a benign `found N file(s) which
-  are unhandled … *.docc` warning that xcsift lists under `errors[]` (with
-  `null,null` coordinates) and that can make it print `status: failed` even when
-  the run succeeded and `failed_tests: 0`. Treat a 0 exit with `failed_tests: 0`
-  as **passed** regardless of that `.docc` entry.
+If the report is unclear on a failure, read the log path it reports
+(`.build/last-test.log`) rather than re-running. After fixing the issues,
+re-invoke this skill to re-check. To re-check just the previously failing
+tests faster, ask the runner for a scoped run instead:
 
-Report back ONLY:
-- Status: passed or failed
-- Counts: total / passed / failed
-- Each failing test as `SuiteName/testName` with its `file:line` and the
-  assertion message (omit this list if there are none)
-- On failure, the full log path `.build/last-test.log` (or, inside Xcode, the
-  flagged files so the caller can refresh their diagnostics)
-
-Do not paste passing-test output or raw logs.
-```
-
-If the report is unclear on a failure, read the log path it provides rather than
-re-running. After fixing the issues, re-invoke this skill to re-check. To re-check
-just the previously failing tests faster, the subagent can scope the run with
-`swift test --filter "SuiteName/testName"` instead of the full suite.
+> Run the `test` target scoped to `SuiteName/testName`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,8 +201,9 @@ verifies with the targeted suite (not full `make ci`) and opens the PR via
 **Code review** — both the local `/review-changes` and the GitHub Actions reviewer
 follow one shared spec, [`.github/CODE_REVIEW.md`](.github/CODE_REVIEW.md), and
 **run only when the change touches Swift** (docs/config-only changes are not
-reviewed). Two subagents back the pipeline: `code-reviewer` (deep Swift/TMDb
-review) and `documentation-writer` (bulk DocC generation).
+reviewed). Three subagents back the pipeline: `code-reviewer` (deep Swift/TMDb
+review, pinned to Opus), `documentation-writer` (bulk DocC generation, pinned
+to Sonnet), and `tooling-runner` (build/test execution, pinned to Haiku).
 
 ## Build and Test Tooling
 
@@ -210,7 +211,8 @@ review) and `documentation-writer` (bulk DocC generation).
 
 For builds and test runs, invoke the project skills rather than calling `make`
 or the Xcode MCP directly: `/build`, `/build-for-testing`, `/test`, and
-`/integration-test`. Each delegates to a Haiku subagent that runs the command,
+`/integration-test`. Each spawns the shared `tooling-runner` agent
+(`.claude/agents/tooling-runner.md`, pinned to Haiku), which runs the command,
 writes the full output to a `.build/last-*.log` file, and returns only a
 concise summary (status, counts, failures as `file:line`) — keeping this
 context lean. `/lint` and `/format` run `make` directly (they are fast and

--- a/README.md
+++ b/README.md
@@ -507,7 +507,9 @@ that automate the development workflow. Invoke any of them with `/<name>`.
 
 #### Build, test & quality
 
-These delegate to a Haiku subagent to keep the main context lean.
+The build/test rows delegate to the shared `tooling-runner` agent (pinned to
+Haiku) to keep the main context lean; `/lint` and `/format` run `make`
+directly.
 
 | Skill | Purpose |
 | --- | --- |
@@ -528,9 +530,10 @@ These delegate to a Haiku subagent to keep the main context lean.
 | `/canon-tdd` | Drive test-first development (test list → failing test → pass → refactor) |
 | `/document-swift` | Write DocC documentation for public API per project conventions |
 
-Two subagents back the review and documentation steps: `code-reviewer`
-(deep Swift/TMDb review) and `documentation-writer` (bulk DocC generation).
-The reviewer follows the shared spec in
+Three subagents back the pipeline: `code-reviewer` (deep Swift/TMDb review,
+pinned to Opus), `documentation-writer` (bulk DocC generation, pinned to
+Sonnet), and `tooling-runner` (build/test execution, pinned to Haiku). The
+reviewer follows the shared spec in
 [`.github/CODE_REVIEW.md`](.github/CODE_REVIEW.md).
 
 #### Self-healing weekly integration run

--- a/knowledge/decisions/0010-subagent-model-tiers.md
+++ b/knowledge/decisions/0010-subagent-model-tiers.md
@@ -1,0 +1,76 @@
+# ADR-0010: Model-tier policy for skills and subagents
+
+- **Status:** Accepted
+- **Date:** 2026-07-06
+- **Deciders:** Adam Young, Claude
+
+## Context
+
+The project's Claude Code pipeline fans work out to subagents in three very
+different shapes: mechanical run-and-summarise jobs (builds, test runs,
+first-pass CI-log diagnosis), bulk-but-style-sensitive generation (DocC
+sweeps), and high-judgment review (code review, plan critics, the `/deliver`
+auto-panel). Before this ADR the model choice was scattered: the four
+build/test skills each embedded a `model: haiku` instruction the caller had
+to remember, both agent definitions used `model: inherit` (so bulk DocC
+billed at the session model's rate, and review quality silently followed
+whatever session spawned it), and a wrong Haiku CI diagnosis had no
+escalation path — it would be retried on the same tier after costing a full
+fix→push→CI round trip.
+
+A relevant mechanic: an Agent-tool call-site `model:` override **beats** the
+agent definition's frontmatter pin, so a frontmatter pin acts as a *floor*,
+not a ceiling.
+
+## Decision
+
+Assign model tiers by the shape of the work, and pin them where the work is
+defined (agent frontmatter or the skill's call-site instruction):
+
+- **Haiku — mechanical runners and first-pass diagnosis.** The
+  `tooling-runner` agent (`/build`, `/build-for-testing`, `/test`,
+  `/integration-test`) and the first diagnosis attempt in `/fix-pr-checks`.
+  The playbook (skill/agent prompt) carries the judgment — known gotchas,
+  failure taxonomies, report contracts — so the executor can be cheap and
+  fast.
+- **Sonnet — bulk, style-sensitive generation.** The `documentation-writer`
+  agent: DocC sweeps follow a fixed convention (`document-swift`) and don't
+  reward top-tier reasoning.
+- **Opus — judgment floors and escalation.** The `code-reviewer` agent's
+  frontmatter (a floor for spawns without a call-site pin), the
+  `/review-changes` find/verify stages, the `/review-plan` critics, the
+  `/deliver` auto-panel, and the `/fix-pr-checks` **re-diagnosis** of a check
+  that failed again after a fix (the repeat proves the cheap tier missed;
+  prior-attempt context travels with the escalation).
+
+The smart model always sits **downstream** of the cheap one: Haiku reports,
+the conductor (session model) applies and verifies fixes, and Opus grades or
+re-diagnoses only where judgment demonstrably matters.
+
+## Consequences
+
+- Model choice is no longer a caller responsibility for the runners — the
+  pin lives in `tooling-runner.md` and can't be forgotten.
+- Review quality has a floor: `code-reviewer` never silently degrades below
+  Opus in a cheaper session, while call sites may still override upward.
+- Bulk documentation gets cheaper without a quality change worth caring
+  about; if DocC quality ever regresses, the Sonnet pin is the first suspect.
+- A repeated CI failure now costs one Opus diagnosis instead of a second
+  wasted CI round trip.
+- The tiers name the current line-up (Haiku 4.5, Sonnet, Opus). A future
+  model family shift (e.g. pinning the top judgment calls to a Fable-class
+  model) revisits this ADR — the *shape → tier* mapping is the durable part,
+  not the model names.
+
+## Alternatives considered
+
+- **`inherit` everywhere** — follows the session model, but makes review
+  quality and doc cost accidents of which session spawned the agent.
+- **Opus for CI diagnosis from the first attempt** — most CI failures are
+  mundane (the error line is in the log); paying top-tier rates to read
+  2,000 lines of compiler output is the most expensive possible use of it.
+  Escalation-on-repeat captures the benefit at a fraction of the cost.
+- **Pinning the `/review-plan` critics and `/deliver` panel to a
+  Fable-class model** — capability ceiling is higher, but the price on
+  every plan review isn't justified while Opus-tier critics are converging
+  fine; revisit if they start missing blockers.

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,6 +14,31 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-07-06 — ♻️ Consolidate build/test runners into a tooling-runner agent (chore/tooling-runner-agent) · lite
+
+- **Phases / skills:** phases 0–10; markdown/config-only, so `review-plan`
+  skipped (lite + `ExitPlanMode` approval — the two open design choices were
+  settled pre-plan via `AskUserQuestion`), `review-changes` and
+  `security-review` self-skipped, `/capture-knowledge` returned nothing (the
+  sole candidate was already documented inside the `capture-knowledge` skill
+  itself); ADR-0010 (model tiers) authored inline in Phase 3.
+- **Worked:** the plan-time Explore cross-reference sweep pre-scoped the prose
+  blast radius — spotting that "delegates to a Haiku subagent" prose stays
+  *true* after the refactor (the runner agent **is** Haiku) cut the edit list
+  to 11 files, only 4 of them prose spots. Phase 0's gotcha consult paid off
+  twice within minutes (branch rename after `EnterWorktree`; `.md` tail check
+  after every `Write`).
+- **Friction:** none material.
+- **Deviations:** `canon-tdd` not applicable — no test surface on a pure
+  skills/agents/docs change; the plan's Changes list served as the checklist,
+  and the rubric came from its Changes + Verification sections rather than
+  Given/When/Then ACs (chore plan, no user story).
+- **One improvement:** a freshly added `.claude/agents/*.md` may not register
+  as a spawnable `subagent_type` until a new session, so the consolidation
+  can't be smoke-tested end-to-end inside the delivering session — the first
+  post-merge `/build` is the real verification; if it surprises, that's a
+  `gotchas.md` entry.
+
 ## 2026-07-05 — 🔧 Knowledge consult at entry + independent rubric grader (#384) · lite
 
 - **Phases / skills:** phases 0–10; markdown-only, so `review-plan` skipped
@@ -346,96 +371,6 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
   the first green build**. (This is the **second** delivery to hit main-vs-worktree
   path confusion — see #359 — so it's now a recurring pattern worth a skill edit.)
 
-## 2026-06-23 — ✨ Add `TMDbTesting` public mocks & sample-data library (#359) · full
-
-- **Phases / skills:** phases 0–6; `review-plan, implement-plan, build-for-testing,
-  test, integration-test, lint, review-changes, capture-knowledge, pr, watch-pr`,
-  plus three bespoke Workflows (mock/sample generation, test generation, the
-  review fan-out).
-- **Worked:** the **reference-first** discipline paid off massively — building and
-  *reviewing* `MockGenreService` before replicating caught a cross-module DocC
-  break that would otherwise have been baked into all 26 mocks. Fanning the bulk
-  generation out to 14 sonnet agents over a precise pre-computed spec (signatures,
-  return-type ownership, batch partitions) turned a ~16k-line mechanical job into
-  a handful of build-and-fix passes; the final 5-dimension review found **0
-  critical / 0 high** across it. `/review-plan`'s three critics were genuinely
-  load-bearing (they killed the plan's false "gate the NL mock" premise up front).
-- **Friction:** (1) some generation subagents wrote files to the **main checkout**
-  path instead of the worktree — had to detect and consolidate (now a captured
-  gotcha). (2) The generation Workflow failed on the **args-stringification**
-  gotcha despite it being in memory — I forgot the `JSON.parse` guard and lost one
-  run. (3) `codecov/patch`/`project` go red on a 15k-line mock library (inherently
-  low line-coverage of trivial record-return boilerplate) — non-blocking here, but
-  noise. (4) couldn't run `make build-linux` locally (Docker down) — leaned on CI's
-  `build-test-linux` job.
-- **Deviations:** for the bulk (25 mocks + 87 samples) I inverted strict
-  test-first — generated production from the reviewed template, then added
-  representative + smoke tests — rather than red-green per method. Defensible for
-  mechanical replication of an already-test-driven reference, but a deviation from
-  `/implement-plan`'s one-test-at-a-time contract. Also expanded the main-target
-  change beyond the planned `GuestSession` init (9 filter types → `Sendable`).
-- **Improvement:** the Workflow tool's own description warns about
-  args-stringification, yet it bit again — worth a **standard `args` parse-guard
-  preamble** baked into any `/deliver` generation-Workflow snippet (or a lint of
-  the script before launch), so the guard isn't re-derived from memory each time.
-- **Specialist skills under-used (`swift-concurrency`, `swift-testing-expert`):**
-  `/implement-plan`'s contract says to route anything touching actors/`Sendable`/
-  data races through `swift-concurrency`, and test structuring through
-  `swift-testing-expert`. I did neither — the `NSLock`/`@unchecked Sendable` mock
-  design and the 9-filter-types `Sendable` change were hand-rolled, and tests
-  followed the reference pattern via general-purpose agents. It compiled and
-  passed, but the user had to prompt me to consult `swift-concurrency` on the
-  actor-vs-lock question. When finally invoked, the skill *validated* the lock
-  choice **and** surfaced a real gap: `@unchecked Sendable` needs a documented
-  safety invariant **and a removal plan** (migrate to `Mutex` once the floor
-  reaches iOS 18/macOS 15) — which I'd omitted from the ADR. **Lesson:** invoke
-  the specialist skill *at the moment its domain appears* (lock/`Sendable`/actor
-  design, test structure), not only when asked — that's the difference between
-  "it passed" and "it's right, and the rationale is recorded."
-- **Gate-driven refinements (post-PR, pre-merge):** the human gate caught two
-  things the autonomous run had shipped sub-optimally, both fixed before merge:
-  (a) **sample data wasn't from the live MCP** — I'd relaxed the locked "real MCP
-  data" decision in Phase 1 to "reuse existing fixtures", and agents fabricated
-  placeholders (`"Cast Member"`, `"Movie Overview"`) for the ~12 fixture-less
-  types; re-sourced all 67 API-backed samples from real `mcp__tmdb__*` responses.
-  (b) **`TMDbTesting` tests lived inside `TMDbTests`** (per the plan) rather than a
-  dedicated target; split them into `TMDbTestingTests` with public-only imports so
-  the consumer story is compiler-enforced. **Lesson:** when I relax a *locked*
-  user decision during plan-hardening (here "samples from real MCP"), that's a
-  choice to flag back to the user at the gate, not absorb silently — both fixes
-  were cheap pre-merge but would have been debt post-merge.
-
-## 2026-06-23 — ✨ Add `movieCredits` language-model tool to TMDbToolbox (#357) · lite
-
-- **Phases / skills:** phases 0–6; `implement-plan, build-for-testing, test,
-  integration-test, lint, review-changes, capture-knowledge, pr, watch-pr`
-  (skipped `review-plan` — lite).
-- **Worked:** lite path fit a mechanical mirror of `MovieDetailsTool`; reading the
-  sibling source first meant a faithful copy with zero implementation surprises
-  (2714 unit tests green first try). The **`swiftlint --no-cache` step in `/pr`
-  step 4** (the #346 improvement) earned its keep: adding the credits block tipped
-  the formatter file/test over `file_length`/`type_body_length`, caught **locally**
-  and fixed by splitting into a `+Credits` extension file + separate `@Suite`
-  before any CI round-trip.
-- **Friction — the standout:** the local `code-reviewer`'s adversarial pass
-  **dropped a real High** — "missing integration test for `movieCredits`" — with
-  the false reasoning *"no sibling toolbox tool has a per-tool integration test."*
-  In fact `Tests/TMDbIntegrationTests/LanguageModelToolsIntegrationTests.swift` has
-  one per tool; the reviewer only inspected the per-tool **unit** tests and never
-  listed the integration dir. The `claude-review` bot on the PR caught it
-  correctly, costing a post-PR fix + a second full CI run. Phase 3 is supposed to
-  converge Critical/High *before* the PR; a fabricated "siblings don't either"
-  dismissal defeated that.
-- **Deviations:** the integration-test gap was fixed in **Phase 5 (watch-pr)**, not
-  Phase 3, because the local review wrongly cleared it.
-- **Improvement:** when a reviewer is about to drop a "missing integration test"
-  (or any "siblings don't do this either") finding, it must **verify the
-  sibling-convention claim by listing the actual directory** (here
-  `Tests/TMDbIntegrationTests/`) — not assume from the unit-test dir. Worth a line
-  in `.github/CODE_REVIEW.md` / the `code-reviewer` adversarial-pass guidance:
-  *an adversarial drop that rests on a factual claim about sibling code must check
-  that claim against the tree.*
-
 ## Archive (distilled)
 
 Older entries condensed per the rolling window (`knowledge/README.md` →
@@ -443,6 +378,8 @@ Older entries condensed per the rolling window (`knowledge/README.md` →
 
 | Date | PR | Weight | Outcome |
 | --- | --- | --- | --- |
+| 2026-06-23 | #359 | full | `TMDbTesting` mocks + samples (~16k lines, 14-agent fan-out); reference-first review caught a cross-module DocC break pre-replication; gate re-sourced samples from live MCP + split `TMDbTestingTests`; lessons: invoke specialist skills when their domain appears, never silently relax a locked user decision. |
+| 2026-06-23 | #357 | lite | `movieCredits` toolbox tool; local reviewer's adversarial pass dropped a real High on a fabricated "no sibling has one" claim → adversarial drops must verify sibling-convention claims against the tree. |
 | 2026-06-19 | #349 | full | `networks` on TVSeason from a schema-diff scan; critics pre-caught the Equatable/over-populated-mock trap → 0/0/0 review; exposed the local-vs-CI `lint-markdown` scope mismatch. |
 | 2026-06-18 | #346 | full | AuthenticatedSession wrapper; 3 critics unanimously reversed deprecate-and-add to additive; local-vs-CI lint cache gap → `/pr` `--no-cache` step. |
 | 2026-06-18 | #344 | lite | Error-handling How-To guide; `make build-docs` was the real gate; reinforced the docs-only fast-gate need. |

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,7 +14,7 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
-## 2026-07-06 — ♻️ Consolidate build/test runners into a tooling-runner agent (chore/tooling-runner-agent) · lite
+## 2026-07-06 — ♻️ Consolidate build/test runners into a tooling-runner agent (#385) · lite
 
 - **Phases / skills:** phases 0–10; markdown/config-only, so `review-plan`
   skipped (lite + `ExitPlanMode` approval — the two open design choices were


### PR DESCRIPTION
## Summary

The `/build`, `/build-for-testing`, `/test`, and `/integration-test` skills were agents in disguise: each embedded a ~30-line subagent prompt (duplicating the xcsift `.docc` false-failure gotcha four times) and relied on the caller remembering to pass `model: haiku`. This PR moves that prompt into a single shared agent definition and, alongside it, makes the pipeline's model tiers deliberate: pins in agent frontmatter where the work is defined, and an Opus escalation path for repeat CI diagnosis. Rationale is recorded as ADR-0010.

## Changes

**New agent:**

- ✨ `.claude/agents/tooling-runner.md` — Haiku-pinned runner holding the shared report contract, the xcsift `.docc` pass/fail trap (stated once), the inside-Xcode branch, and the four per-target recipes (`build`, `build-tests`, `test`, `integration-test` → their `.build/last-*.log` files)

**Existing files:**

- ♻️ The four runner `SKILL.md`s slim to thin entry points that spawn `subagent_type: tooling-runner` and keep only the caller-side tips (log-path-on-unclear-failure, re-invoke to re-check, scoped `--filter` re-runs, `/diagnose-integration-failure` routing)
- 🔧 `code-reviewer` pins `model: opus` — a quality floor for spawns without a call-site override (call-site pins still win)
- 🔧 `documentation-writer` pins `model: sonnet` — bulk DocC sweeps stop billing at the session model's rate
- 🔧 `/fix-pr-checks` diagnoses a failing check on Haiku first and re-diagnoses on **Opus** when a fix didn't stick, carrying prior-attempt context
- 📝 `CLAUDE.md` + `README.md` mechanics prose updated (three pipeline subagents; runners spawn `tooling-runner`)

**Documentation:**

- 📚 ADR-0010 (`knowledge/decisions/0010-subagent-model-tiers.md`) — the shape→tier policy: Haiku for mechanical runners/first-pass diagnosis, Sonnet for bulk style-bound generation, Opus for judgment floors and escalation
- 📚 Delivery retro added to `knowledge/delivery-retros.md`; two oldest entries distilled into the archive table per the rolling window

## Benefits

- **Single source of truth**: the runner prompt and the xcsift gotcha live in one file instead of four; skills stay as thin routing entry points
- **Leaner main context**: the subagent prompt no longer loads into the conductor's context on every `/build`/`/test` invocation
- **Deliberate spend**: cheap tiers for mechanical work, top tier only where judgment pays — with a floor so review quality can't silently degrade
- **Fewer wasted CI round trips**: a repeated check failure earns one Opus diagnosis instead of a second identical Haiku attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8LNF8yVWsnqjHV4rnQceP