### PR TITLE
📝 Add ADR-0010 + plan for TMDbIntelligence product extraction

### DIFF
--- a/knowledge/decisions/0010-tmdb-intelligence-product.md
+++ b/knowledge/decisions/0010-tmdb-intelligence-product.md
@@ -1,0 +1,127 @@
+# ADR-0010: Extract on-device intelligence into a `TMDbIntelligence` product
+
+- **Status:** Proposed
+- **Date:** 2026-07-06
+- **Deciders:** Adam Young
+
+## Context
+
+The package ships one main library product, `TMDb`, supporting all Apple
+platforms plus Linux and Windows. Two Apple-only feature clusters live inside
+it:
+
+- **Natural-language search** — 26 files under
+  `Sources/TMDb/Domain/Services/NaturalLanguageSearch/`.
+- **Language-model tools** — 14 files under
+  `Sources/TMDb/Domain/LanguageModelTools/`.
+
+Their platform gating is deliberately minimal: only the framework adapters
+(`PersonNameExtracting.swift`, `PromptLanguageDetecting.swift`) and the
+`TMDbClient.naturalLanguageSearch` accessor are gated on
+`#if canImport(NaturalLanguage)`, and the Foundation Models files on
+`#if canImport(FoundationModels)`. The remaining ~23 files — including six
+files of **public** types (`NaturalLanguageSearchService`, `SearchPlan`,
+`NaturalLanguageSearchResult`, `NaturalLanguageSearchError`,
+`NaturalLanguageSearchAvailability`, `SearchDegradation`) — are pure Swift and
+compile everywhere.
+
+**The problem (finding F9 of the 2026-06 external review):** on Linux and
+Windows those public types compile and are constructible, but the only factory
+(`TMDbClient.naturalLanguageSearch`, `TMDbClient.swift:317`) is gated away.
+The cross-platform core carries an orphaned public surface — API that can
+never function on two of the supported platforms.
+
+The direct fix — gating the whole feature per-file behind
+`#if canImport(NaturalLanguage)` — was assessed and rejected: swiftformat's
+default `ifdef` indentation would reindent ~38 files (whole-file `#if` wraps),
+plus ~13 test files and 4 `TMDbTesting` helpers, a churn-heavy diff that
+leaves the monolith intact. The decision was deferred to this ADR.
+
+**The enabling fact (verified 2026-07-06):** both feature clusters are built
+entirely from **public** `TMDbClient` service accessors. The
+`naturalLanguageSearch` factory composes its planner, executor, and data
+source from `client.discover`, `client.search`, `client.genres`, etc.;
+`TMDbToolbox.init(client:)` does the same for its eight tools. None of the 40
+files references `APIClient`, `TMDbFactory`, or any other TMDb-internal
+symbol. Extraction into a downstream module therefore requires **no** new
+public surface on the core and no `@_spi`/`@testable` tricks.
+
+## Decision
+
+We will extract the two clusters into a new target and library product,
+**`TMDbIntelligence`**, in the same package, depending on `TMDb`:
+
+1. **Move all 40 source files** into `Sources/TMDbIntelligence/`, preserving
+   the `NaturalLanguageSearch/` and `LanguageModelTools/` grouping. Types that
+   are `internal` stay `internal` (module scope moves with them).
+2. **Client accessors become extensions in the new module.** The gated
+   `TMDbClient.naturalLanguageSearch` extension moves out of
+   `TMDbClient.swift` into the new target verbatim;
+   `TMDbClient+LanguageModelTools.swift` moves as-is. For consumers this is
+   source-compatible modulo adding the product dependency and
+   `import TMDbIntelligence`.
+3. **Existing `#if canImport` gates move unchanged — no new per-file gating.**
+   On Linux/Windows the module compiles but is inert (value types exist, no
+   factory). The F9 objection is resolved at the *product* level: the core
+   `TMDb` product no longer carries any Apple-only API, and importing
+   `TMDbIntelligence` is an explicit opt-in to a module documented as
+   Apple-platforms-only. The reindent problem disappears entirely.
+4. **Mirror the testing kit:** a new `TMDbIntelligenceTesting` target and
+   product takes the four NL helpers from `TMDbTesting`
+   (`MockNaturalLanguageSearchService` and the three `+Sample` factories), so
+   `TMDbTesting` keeps zero intelligence dependencies.
+5. **New test targets** `TMDbIntelligenceTests` and
+   `TMDbIntelligenceTestingTests` receive the moved unit tests;
+   `TMDbIntegrationTests` stays a single target and gains a dependency on
+   `TMDbIntelligence`.
+6. **Release as 19.0.0** (source-breaking for feature users only).
+
+## Consequences
+
+- **The core becomes exactly cross-platform.** Every public symbol in the
+  `TMDb` product now functions on every supported platform.
+- **The boundary is physical.** A future dependency from core onto
+  intelligence code will not compile — the compiler, not convention, enforces
+  the layering.
+- **Breaking change, narrow blast radius.** Only consumers of
+  `naturalLanguageSearch`, `languageModelTools`, or `TMDbToolbox` change
+  anything: add the `TMDbIntelligence` product (and, for its test doubles,
+  `TMDbIntelligenceTesting`) plus an import. All other consumers upgrade
+  cleanly.
+- **CI must be swept, not just the build.** `ci.yml` (macOS **and** Linux
+  jobs) and the `Makefile` hardcode the test filter
+  `TMDbTests|TMDbTestingTests`; the new test targets must be added there and
+  to `TMDb.xctestplan`, or their tests silently never run. `.codecov.yml`
+  ignore paths for the three NL exclusions (and `Sources/TMDbTesting`) must
+  track the moved paths. The hosted-docs workflow builds `--target TMDb` only
+  and needs the combined-documentation setup.
+- **Inert surface on Linux is accepted, relocated.** `TMDbIntelligence` on
+  non-Apple platforms still exposes constructible value types with no
+  factory. That is now a documented property of an explicitly platform-scoped
+  opt-in module, not a wart on the core. If it ever proves confusing,
+  alternative 4 below (empty module via a nested `.swiftformat`) remains
+  available without another restructure.
+- **More targets to maintain:** 4 library targets and 5 test targets, each
+  with a DocC catalog to keep in sync.
+
+## Alternatives considered
+
+1. **Status quo** — keeps orphaned public API in the cross-platform core;
+   the review finding stands unaddressed.
+2. **Gate the whole feature per-file in place** (F9's original suggested
+   fix) — ~55 files touched, swiftformat reindents every wrapped file, and
+   the Apple-only code remains tangled through the core target.
+3. **A separate package/repository** — real isolation, but couples releases
+   across repos, splits the fixture corpus and CI, and violates
+   promote-a-boundary-only-when-needed; a target boundary gives the same
+   compiler enforcement at a fraction of the cost.
+4. **Empty-module-on-Linux gating inside the new target** — wrap every file
+   in `#if canImport(NaturalLanguage)` with a nested
+   `Sources/TMDbIntelligence/.swiftformat` setting `--ifdef no-indent` to
+   avoid the reindent. Viable follow-up if the inert surface causes support
+   noise; not required to fix F9, and it would gate pure-Swift logic (and its
+   Linux-runnable tests) out of Linux CI for no functional gain.
+5. **Keep the NL testing helpers in `TMDbTesting`** (add a dependency on
+   `TMDbIntelligence`) — fewer targets, but the cross-platform test kit would
+   drag the intelligence module into every consumer's graph and muddy the
+   per-product kit pattern established by ADR-0006.

--- a/plans/tmdb-intelligence-product-extraction.md
+++ b/plans/tmdb-intelligence-product-extraction.md
@@ -1,0 +1,231 @@
+# Plan: Extract `TMDbIntelligence` target + product
+
+Implements [ADR-0010](../knowledge/decisions/0010-tmdb-intelligence-product.md).
+Read the ADR first — it holds the rationale and the alternatives already
+rejected; this plan is the mechanics. Drafted 2026-07-06 against `main` at
+`07439fe` (post-18.2.0).
+
+## Goal
+
+Move the two Apple-only feature clusters — natural-language search and the
+FoundationModels language-model tools — out of the `TMDb` target into a new
+`TMDbIntelligence` target/product (and their test doubles into
+`TMDbIntelligenceTesting`), so the core `TMDb` product carries no public API
+that cannot function on Linux/Windows (review finding F9). Behaviour-preserving
+throughout: **no logic changes, no renames, no new features** — files move,
+imports and wiring follow.
+
+## Verified grounding (do not re-derive)
+
+- Both `TMDbClient.naturalLanguageSearch` (`TMDbClient.swift:317–373`) and
+  `TMDbToolbox.init(client:)` build everything from **public** `TMDbClient`
+  service accessors. No file in either cluster references `APIClient`,
+  `TMDbFactory`, or `APIRequest`. Extraction needs no core changes beyond
+  deleting the moved extension from `TMDbClient.swift`.
+- The only reference to any moved type outside the two directories is
+  `TMDbClient.swift` itself.
+- `#if canImport(NaturalLanguage)` appears in exactly 3 source files
+  (`PersonNameExtracting.swift`, `PromptLanguageDetecting.swift`,
+  `TMDbClient.swift`); `#if canImport(FoundationModels)` in 14. Everything
+  else in the clusters is pure Swift and compiles on Linux. **Keep all gates
+  exactly as they are** — per ADR-0010 no new gating is added.
+- CI test filters are **hardcoded strings in three places** (step 6) — the
+  classic failure mode of this change is tests that silently stop running.
+
+## Non-goals
+
+- No `TMDbIntelligence`-internal API redesign (e.g. making the planner
+  protocol public) — move, don't improve.
+- No empty-module-on-Linux gating (ADR-0010 alternative 4).
+- No repo split, no new external dependencies.
+
+## Steps
+
+### 1. Package manifest
+
+In `Package.swift`:
+
+- Add target `TMDbIntelligence` (depends on `TMDb`) and target
+  `TMDbIntelligenceTesting` (depends on `TMDbIntelligence`; add `TMDbTesting`
+  only if the moved samples actually use its helpers — check imports when
+  moving).
+- Add products `.library(name: "TMDbIntelligence", …)` and
+  `.library(name: "TMDbIntelligenceTesting", …)`.
+- Add test targets `TMDbIntelligenceTests` (depends on `TMDbIntelligence`,
+  `TMDb`) and `TMDbIntelligenceTestingTests` (depends on
+  `TMDbIntelligenceTesting`, `TMDbIntelligence`, `TMDb` — **no `@testable`**,
+  see step 5).
+- Add `TMDbIntelligence` to `TMDbIntegrationTests`' dependencies.
+
+### 2. Move library sources
+
+`git mv` (preserves history through the rename detection):
+
+- `Sources/TMDb/Domain/Services/NaturalLanguageSearch/` (26 files)
+  → `Sources/TMDbIntelligence/NaturalLanguageSearch/`
+- `Sources/TMDb/Domain/LanguageModelTools/` (14 files)
+  → `Sources/TMDbIntelligence/LanguageModelTools/`
+
+Then:
+
+- Every moved file gains `import TMDb` (alongside its existing imports).
+  Public models/services it references (`Genre`, `MovieListItem`,
+  `DiscoverMovieFilter`, service protocols, …) come from there.
+- Cut the `#if canImport(NaturalLanguage)` extension block from
+  `TMDbClient.swift:317–373` **verbatim** into a new file
+  `Sources/TMDbIntelligence/NaturalLanguageSearch/TMDbClient+NaturalLanguageSearch.swift`
+  (with `import TMDb`, keeping the gate, the `@available` line, and the DocC
+  comment). `TMDbClient+LanguageModelTools.swift` already moved with its
+  directory — it needs only the added import.
+- File header comments say `TMDb` (the project, not the target) — the
+  swiftformat `--header` rule is target-agnostic, so expect **no** header
+  churn. If the post-edit hooks reformat anything else, re-`Read` before
+  dependent edits.
+
+### 3. Move the testing kit
+
+`git mv` from `Sources/TMDbTesting/` to `Sources/TMDbIntelligenceTesting/`:
+
+- `Services/MockNaturalLanguageSearchService.swift`
+- `Samples/NaturalLanguageSearchResult+Sample.swift`
+- `Samples/NaturalLanguageSearchAvailability+Sample.swift`
+- `Samples/SearchPlan+Sample.swift`
+
+Each gains `import TMDbIntelligence` (they already `import TMDb`, non-
+`@testable` — keep it that way). Prune the NL mentions from
+`Sources/TMDbTesting/TMDbTesting.docc/TMDbTesting.md` and create a minimal
+`Sources/TMDbIntelligenceTesting/TMDbIntelligenceTesting.docc/TMDbIntelligenceTesting.md`
+modelled on it.
+
+### 4. Move unit tests
+
+`git mv` the whole directories into `Tests/TMDbIntelligenceTests/`:
+
+- `Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/` (~15 files incl.
+  `Mocks/` and `Helpers/`)
+- `Tests/TMDbTests/Domain/LanguageModelTools/` (~5 files)
+
+In each moved file change `@testable import TMDb` to
+`@testable import TMDbIntelligence`, and add a plain `import TMDb` where core
+public types are used (most files — fixtures build `MovieListItem` etc.).
+Files testing gated code keep their existing `#if canImport` gates unchanged.
+
+### 5. Move the testing-kit tests
+
+`git mv Tests/TMDbTestingTests/Services/MockNaturalLanguageSearchServiceTests.swift`
+→ `Tests/TMDbIntelligenceTestingTests/Services/`. Imports become
+`import TMDbIntelligenceTesting` + `import TMDbIntelligence` + `import TMDb` —
+**public imports only, no `@testable`**: this target exists to prove the kit
+works through the public API a real consumer sees (the ADR-0006 pattern).
+
+Integration tests (`Tests/TMDbIntegrationTests/NaturalLanguageSearch*.swift`,
+3 files) stay put; each adds `import TMDbIntelligence`.
+
+### 6. The CI/tooling sweep — the silent-failure step, do not skim
+
+The filter string `TMDbTests|TMDbTestingTests` becomes
+`TMDbTests|TMDbTestingTests|TMDbIntelligenceTests|TMDbIntelligenceTestingTests`
+in **all three** places:
+
+1. `Makefile` — `TEST_TARGET` variable.
+2. `.github/workflows/ci.yml` — the macOS `Test` step (`swift test --filter …`).
+3. `.github/workflows/ci.yml` — the Linux `Test` step (same flag, second job).
+
+After the PR's CI runs, **verify from the run logs that the new targets'
+suites actually executed** — a green run proves nothing if the filter missed
+them. Then:
+
+- `TMDb.xctestplan` — add the two new unit-test targets (mirror the existing
+  entries). `Integration.xctestplan` is unchanged.
+- `.codecov.yml` — update the three moved ignore paths to
+  `Sources/TMDbIntelligence/NaturalLanguageSearch/FoundationModelsSearchPlanGenerator.swift`,
+  `…/GeneratedSearchPlan.swift`, `…/LiveNaturalLanguageSearchDataSource.swift`,
+  and add `Sources/TMDbIntelligenceTesting` beside the existing
+  `Sources/TMDbTesting` ignore (same rationale comment). Do this **in the
+  same commit as the move** or codecov/patch will grade the uncovered moved
+  lines against the 80% target.
+- Coverage export in `ci.yml` reads the single `TMDbPackageTests.xctest`
+  binary — all test targets land in it, so no change needed there.
+
+### 7. Documentation
+
+- New `Sources/TMDbIntelligence/TMDbIntelligence.docc/` catalog with a
+  landing page (overview: what the product is, Apple-platforms-only, the
+  opt-in import) and Topics sections for the NL search types and
+  `TMDbToolbox`. Move into it from `Sources/TMDb/TMDb.docc/`:
+  `Extensions/NaturalLanguageSearchService.md`, `Extensions/TMDbToolbox.md`,
+  `HowTos/UsingLanguageModelTools.md`.
+- Prune `TMDb.docc/TMDb.md`: the `<doc:/UsingLanguageModelTools>` line (61)
+  and the NL/toolbox topic entries (lines 242–251).
+- **Cross-module DocC links do not resolve** (known gotcha from the
+  `TMDbTesting` build): inside `TMDbIntelligence.docc`, reference `TMDb`
+  types (`TMDbClient`, `MovieListItem`, …) with inline code spans, never
+  ` ``symbol`` ` links; reserve ` ``links`` ` for same-module symbols.
+  `make build-docs` runs warnings-as-errors and will catch violations.
+- `.github/workflows/documentation.yml` builds `--target TMDb` only. Switch
+  the hosted build to combined documentation
+  (`--enable-experimental-combined-documentation`, listing the doc-bearing
+  targets; swift-docc-plugin ≥ 1.4 supports it — already pinned 1.4.6).
+  **Fallback if that fights back:** keep hosting `--target TMDb` and note in
+  its landing page that `TMDbIntelligence` docs build locally/in Xcode —
+  don't let docs hosting block the extraction PR; file a follow-up instead.
+- `README.md`: the features list (lines ~45–47), the services table
+  (`naturalLanguageSearch`, `languageModelTools` rows — note the required
+  import), and the installation section (show adding the `TMDbIntelligence`
+  product). Add a short "Migrating to 19.0" note: add the product dependency
+  - `import TMDbIntelligence` (and `TMDbIntelligenceTesting` for the mocks);
+  no code changes otherwise.
+- `CLAUDE.md`: Architecture section — the facade list and the
+  `naturalLanguageSearch` paragraph move under a new `TMDbIntelligence`
+  bullet; update the Language Model Tools section's path.
+- Flip ADR-0010's status to **Accepted** in the delivery PR.
+
+### 8. Verification gates (in order, after the moves compile)
+
+1. `/build` then `/build-for-testing` — expect SourceKit "cannot find X"
+   false positives on freshly-moved files; trust the build, not the editor.
+2. `/test` — all suites green, **confirm the run's suite list includes
+   `TMDbIntelligenceTests` and `TMDbIntelligenceTestingTests`**.
+3. `make test-linux` — proves the inert-module story: everything still
+   compiles on Linux and the pure-Swift NL tests still run there.
+4. `make build-docs` — catches missing `///` on anything whose access level
+   shifted, and any cross-module DocC link.
+5. `/integration-test` — the three NL integration suites still pass.
+6. `make ci` — mandatory pre-PR gate.
+
+## Test-first framing (for `/implement-plan`)
+
+This is a behaviour-preserving refactor, so the canon-tdd test list is
+mostly *inherited*: the moved suites are the reproduction tests and must pass
+unmodified (imports aside). Genuinely new items:
+
+1. A `TMDbIntelligenceTestingTests` suite compiles with **public imports
+   only** (compiler-enforced; the moved mock tests provide it).
+2. `swift build` succeeds on Linux (`make test-linux`) with the new targets —
+   the Linux-inertness claim, exercised.
+3. A consumer-shaped smoke assertion that `TMDbClient().naturalLanguageSearch`
+   and `TMDbToolbox(client:)` resolve via `import TMDbIntelligence` (the
+   moved `TMDbClientNaturalLanguageSearchTests` /
+   `TMDbClientLanguageModelToolsTests` already cover this once their imports
+   are updated — verify, don't duplicate).
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| New test targets never run in CI (hardcoded filters) | Step 6; eyeball the CI logs for the new suite names on the PR |
+| codecov/patch fails on moved lines | Ignore-path updates land in the same commit as the move; moved tests keep the lines covered |
+| DocC cross-module links break `build-docs` | Code spans for `TMDb` types in the new catalog; gate 4 catches stragglers |
+| Combined-docs flag misbehaves on CI | Explicit fallback in step 7 — hosting stays `--target TMDb`, follow-up issue |
+| SourceKit false positives after mass `git mv` | Known gotcha; trust `make build` / `make build-tests` |
+| Hidden internal dependency the greps missed | First `swift build` after step 2 surfaces it as a missing-symbol error; resolve by moving the symbol with the cluster, never by widening core API without discussion |
+
+## Delivery notes
+
+- Run as a full (not lite) `/deliver`: ~50 files move, ~15 edit, CI and docs
+  infra change — worktree off `origin/main`, `/review-plan` first.
+- Suggested checkpoints: (1) manifest + source moves building;
+  (2) testing kit + tests moved, unit tests green; (3) CI/tooling sweep;
+  (4) docs + README + CLAUDE.md.
+- Release: tag **19.0.0** after merge (breaking for feature users only).
+  Release notes: the migration note from step 7.


### PR DESCRIPTION
## Summary

Drafts the design decision (ADR-0010) and a self-contained implementation plan to extract the two Apple-only feature clusters — the **NaturalLanguage search planner** (26 files) and the **FoundationModels language-model tools** (14 files) — out of the cross-platform `TMDb` target into a new **`TMDbIntelligence`** target/product depending on `TMDb`.

**Docs-only** — no Swift, no build/CI-tracked files. Adds:

- `knowledge/decisions/0010-tmdb-intelligence-product.md` — the ADR (status: **Proposed**).
- `plans/tmdb-intelligence-product-extraction.md` — the implementation plan, in a new `plans/` directory.

## Why

Resolves review finding **F9**: the public `NaturalLanguageSearch*` types compile and are constructible on Linux/Windows, but the only factory (`TMDbClient.naturalLanguageSearch`) is `#if canImport(NaturalLanguage)`-gated — leaving orphaned public API in the flagship cross-platform module. F9 was deferred (2026-07-03) precisely to this ADR because the direct fix — per-file `#if` gating — would reindent ~38 files via swiftformat and leave the monolith intact.

## The decision

Solve it at the **product** level instead: move the clusters into `TMDbIntelligence` (+ a mirrored `TMDbIntelligenceTesting` kit), keeping every existing `#if canImport` gate **unchanged**. The core `TMDb` product becomes exactly cross-platform; importing `TMDbIntelligence` is an explicit opt-in to the platform-scoped feature.

**Verified enabling fact:** both clusters compose entirely from *public* `TMDbClient` service accessors — none of the 40 files touches `APIClient`/`TMDbFactory`/`APIRequest` — so extraction is a pure relocation with zero new core API. Release as **19.0.0** (breaking only for consumers of `naturalLanguageSearch`/`languageModelTools`; migration is one product dependency + one import).

## Not in this PR

The extraction itself. This PR lands the ADR + plan so the work can be run through `/review-plan` → `/deliver`. The delivery PR flips ADR-0010 to **Accepted**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)