### PR TITLE
🔧 Harden delivery sub-skills: worktree-safe flake fixing, PR-pinned watch, severity filter

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -301,7 +301,10 @@ cancelled by the concurrency group).
 
 ## Phase 10 — Watch to ready → GATE: ready-to-merge
 
-Invoke **`/watch-pr`** in **watch-only** mode, **in the background** — it
+Invoke **`/watch-pr`** in **watch-only** mode, **in the background**,
+**passing the PR number from the ledger** (`/watch-pr <number>`) — a
+background watch must be pinned to its PR, not to "current branch", which
+changes when the conductor moves to the next deliverable's worktree. It
 resolves threads, fixes failing checks (routing unrelated integration
 failures per §4), and loops until **ready** or **stuck**. Ready means
 **mergeable now** (branch brought up to date with `main`, re-run green).
@@ -312,7 +315,7 @@ merge, Phase 12). Stuck → stop, summarise what's blocking, **keep the
 worktree**. **Auto:** stuck → panel (retry via `ScheduleWakeup` vs stop); the
 gate itself is not a panel decision — in auto, ready behaves as the `merge`
 opt-in. **Opt-in auto-merge:** only if the user passed `merge`, forward it
-(`/watch-pr merge`) — the gate becomes "report the merge" → Phase 12.
+(`/watch-pr merge <number>`) — the gate becomes "report the merge" → Phase 12.
 
 ## Phase 11 — Wrap-up (wiki, pattern scan, exceptional retro amendment)
 

--- a/.claude/skills/fix-integration-failures/SKILL.md
+++ b/.claude/skills/fix-integration-failures/SKILL.md
@@ -89,11 +89,25 @@ that survives a re-run is uncommon — a repeat failure is usually real drift.)
 
 ## 3. Fix the real cause on a branch off `main`
 
-Reproduce locally first to confirm and to get a fast edit loop:
+Reproduce locally first to confirm and to get a fast edit loop. Branch **off
+`origin/main` directly — never `git checkout main` first**. This is
+**worktree-safe**: when this skill is invoked from a `/deliver` worktree (via
+`/watch-pr` §1c), `main` is usually checked out in the main working copy, so
+`git checkout main` fails with `fatal: 'main' is already used by worktree …` —
+the same trap `/pr` documents for its rebase step:
 
 ```bash
-git checkout main && git pull --ff-only
-git checkout -b fix/<slug>          # e.g. fix/<service>-integration-drift
+git fetch origin
+git checkout -b fix/<slug> origin/main   # e.g. fix/<service>-integration-drift
+```
+
+**Invoked mid-`/deliver` (from `/watch-pr`)?** Don't create the fix branch in
+the deliverable's worktree — that switches its checkout away from the feature
+branch being watched. Give the fix its own worktree instead and work there,
+removing it once the fix PR merges:
+
+```bash
+git worktree add .claude/worktrees/fix-<slug> -b fix/<slug> origin/main
 ```
 
 Run the failing suite locally to reproduce — `/integration-test` (or

--- a/.claude/skills/review-changes/SKILL.md
+++ b/.claude/skills/review-changes/SKILL.md
@@ -175,7 +175,7 @@ const confirmed = verified.filter(Boolean)
 return {
   critical: confirmed.filter((f) => f.severity === 'critical'),
   high: confirmed.filter((f) => f.severity === 'high'),
-  medium: advisory,
+  medium: advisory.filter((f) => f.severity === 'medium'),
   low: advisory.filter((f) => f.severity === 'low'),
   droppedByVerification: blocking.length - confirmed.length,
   dimensionsCovered: DIMENSIONS.map((d) => d.key),

--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -24,7 +24,14 @@ wait loop.
 
 ## 0. Find the PR
 
-Find the open PR for the current branch with `mcp__github__list_pull_requests`
+**A PR number in the arguments wins.** If the arguments include a PR number
+(e.g. `/watch-pr 123` or `/watch-pr merge 123`), watch that PR and skip branch
+discovery entirely. A caller that launches this skill **in the background**
+(e.g. `/deliver` Phase 10, which may move the session to another deliverable's
+worktree while the watch runs) must pass the number — the watch must never
+depend on "current branch" staying stable for its lifetime.
+
+Otherwise, find the open PR for the current branch with `mcp__github__list_pull_requests`
 (owner/repo from the `origin` remote, `head: <owner>:<branch>`, `state: open`), then
 read its details with `mcp__github__pull_request_read` method `get` — `number`,
 `html_url`, `state`,

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,37 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-07-08 — External-review fixes: worktree-safe flake fixing, PR-pinned watch, severity filter · applied
+
+- **Pattern:** an external model review of the `/deliver` pipeline (not the
+  wrap-up scan) surfaced three verified gaps: (a)
+  `/fix-integration-failures` §3 said `git checkout main`, which fails from
+  a `/deliver` worktree (`fatal: 'main' is already used by worktree …`) —
+  the exact trap `/pr` already documents for its rebase, learned in one
+  skill but not its sibling; (b) `/watch-pr` discovered "the current
+  branch's PR", so a background watch could misresolve after the conductor
+  moved to another deliverable's worktree; (c) `/review-changes`' fan-out
+  script returned `medium: advisory` where `advisory` held medium **and**
+  low findings, double-counting every low.
+- **Decision:** **applied** (user-approved, 2026-07-08, this branch).
+  `/fix-integration-failures` §3 branches off `origin/main` without
+  checking out `main`, and mid-`/deliver` gives the fix its own worktree;
+  `/watch-pr` §0 accepts a PR number argument that beats branch discovery,
+  and `/deliver` Phase 10 passes it from the ledger; the `/review-changes`
+  script filters `medium` by severity.
+- **Rationale:** the orchestrator must not be more rigorous than the paths
+  it calls — a routed flake fix that dies on `git checkout main`, or a
+  watch bound to a branch the session has left, stalls an unattended run.
+  Three other findings from the same review were assessed and not applied:
+  a "missing `/security-review`" claim (false positive — it is a built-in
+  Claude Code skill, and log entry 2026-06-24 shows it running), `/pr`'s
+  post-review `/format` mutating Swift (defused by the PostToolUse
+  format-on-edit hooks + `make ci`), and Phase 11 "undermining the one hard
+  stop" (post-gate proposals don't block the deliverable).
+- **Reconsider when:** n/a (applied); for the two rejected code-path
+  findings — if a `reviewed`-mode `/pr` ever produces a non-formatting
+  Swift diff, or a run genuinely blocks on a Phase 11 approval, revisit.
+
 ### 2026-07-05 — Knowledge consult at entry + independent rubric grader · applied
 
 - **Pattern:** an external article-driven review of the pipeline (not the


### PR DESCRIPTION
## Summary

Applies the three verified findings from an external model review of the `/deliver` pipeline. The theme: the orchestrator was more rigorous than some of the paths it calls — a routed integration-flake fix could die on `git checkout main` from inside a worktree, and a background PR watch was bound to "current branch" rather than its PR.

## Changes

**Existing Files:**

- 🔧 `/fix-integration-failures` §3 — branch off `origin/main` directly (`git checkout -b fix/<slug> origin/main`) instead of `git checkout main && git pull`, which fails from a `/deliver` worktree (`fatal: 'main' is already used by worktree …` — the same trap `/pr` already documents for its rebase). When invoked mid-`/deliver`, the fix gets its **own worktree** so the watched feature branch's checkout is never switched away.
- 🔧 `/watch-pr` §0 — an explicit PR number argument (`/watch-pr 123`, `/watch-pr merge 123`) now beats current-branch discovery; background watches must be pinned to their PR, not to a branch the session may leave.
- 🔧 `/deliver` Phase 10 — passes the PR number from the ledger when launching the background watch (both watch-only and `merge` forms).
- 🐛 `/review-changes` fan-out script — `medium:` now filters `advisory` by severity; it previously returned medium **and** low findings under `medium`, double-counting every low.

**Documentation:**

- 📚 `knowledge/skill-improvement-log.md` — 2026-07-08 entry recording the decision, rationale, and the three findings from the same review that were assessed and **not** applied (the "missing `/security-review`" false positive — it's a built-in Claude Code skill; `/pr`'s post-review `/format`, defused by the format-on-edit hooks; the Phase 11 "one hard stop" wording).

## Benefits

- **Unattended reliability**: a `/deliver` run that routes a pre-existing integration flake to `/fix-integration-failures`, or watches a PR across a worktree switch, no longer stalls on a failed checkout or misresolved branch.
- **Accurate review reports**: Medium findings no longer inflated by double-counted Lows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJkJsLEFpGM2oq16HWNgo4