### PR TITLE
♻️ Represent model runtimes as `Duration` instead of `Int`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [19.0.0] - 2026-07-24
+
+### Changed
+
+- **Breaking:** Model runtimes are now Swift `Duration` values instead of
+  `Int` minutes — `Movie.runtime`, `TVEpisode.runtime`,
+  `TVEpisodeAirDate.runtime` (`Duration?`) and `TVSeries.episodeRunTime`
+  (`[Duration]?`). The JSON wire format is unchanged (integer minutes).
+- **Breaking:** `DiscoverMovieFilter` and `DiscoverTVSeriesFilter`
+  `runtimeMin` / `runtimeMax`, and the fluent `runtime(in:)`, now take
+  `Duration` (a `ClosedRange<Duration>`) rather than `Int` minutes.
+- **Breaking:** `RuntimeFormatStyle` now formats a `Duration` rather than an
+  `Int`; `.runtimeStyle(...)` composes on `Duration.formatted(_:)`.
+
 ## [18.1.0] - 2026-06-18
 
 ### Added

--- a/Sources/TMDb/Domain/Formatting/RuntimeFormatStyle.swift
+++ b/Sources/TMDb/Domain/Formatting/RuntimeFormatStyle.swift
@@ -8,27 +8,27 @@
 import Foundation
 
 ///
-/// A format style that renders a runtime, given in whole minutes, as a
-/// human-readable string.
+/// A format style that renders a runtime `Duration` as a human-readable string.
 ///
-/// TMDb exposes movie and television episode runtimes as an integer number of
-/// minutes (for example ``Movie/runtime`` and ``TVEpisode/runtime``). This
-/// format style turns that integer into a display-ready string. Numeric
-/// components are formatted using the provided `locale`, while the unit labels
-/// (such as `"h"`, `"m"`, `"min"`, `"hour"`, and `"minute"`) are in English.
+/// TMDb exposes movie and television episode runtimes as durations (for example
+/// ``Movie/runtime`` and ``TVEpisode/runtime``). This format style turns a
+/// `Duration` into a display-ready string, rounded down to whole minutes.
+/// Numeric components are formatted using the provided `locale`, while the unit
+/// labels (such as `"h"`, `"m"`, `"min"`, `"hour"`, and `"minute"`) are in
+/// English.
 ///
 /// Use it directly:
 ///
 /// ```swift
 /// let style = RuntimeFormatStyle(style: .abbreviated, displayUnit: .hourMinute)
-/// style.format(135)
+/// style.format(.seconds(135 * 60))
 /// // "2h 15m"
 /// ```
 ///
-/// Or via the `FormatStyle` convenience on `Int`:
+/// Or via the `FormatStyle` convenience on `Duration`:
 ///
 /// ```swift
-/// let runtime = 135
+/// let runtime = Duration.seconds(135 * 60)
 ///
 /// runtime.formatted(.runtimeStyle(.full, displayUnit: .hourMinute))
 /// // "2 hours, 15 minutes"
@@ -40,9 +40,9 @@ import Foundation
 public struct RuntimeFormatStyle: FormatStyle, Codable, Equatable, Hashable, Sendable {
 
     ///
-    /// The runtime, in minutes, to be formatted.
+    /// The runtime to be formatted.
     ///
-    public typealias FormatInput = Int
+    public typealias FormatInput = Duration
 
     ///
     /// The formatted, human-readable runtime string.
@@ -123,17 +123,18 @@ public struct RuntimeFormatStyle: FormatStyle, Codable, Equatable, Hashable, Sen
     }
 
     ///
-    /// Formats a runtime, given in minutes, into a human-readable string.
+    /// Formats a runtime into a human-readable string.
     ///
-    /// Negative values are treated as zero.
+    /// The duration is rounded down to whole minutes; negative values are
+    /// treated as zero.
     ///
-    /// - Parameter value: The runtime, in minutes.
+    /// - Parameter value: The runtime to format.
     ///
     /// - Returns: A human-readable runtime string. Numeric components use the
     ///   format style's `locale`; unit labels are in English.
     ///
-    public func format(_ value: Int) -> String {
-        let totalMinutes = max(0, value)
+    public func format(_ value: Duration) -> String {
+        let totalMinutes = max(0, RuntimeMinutes.minutes(from: value))
 
         switch displayUnit {
         case .minutesOnly:
@@ -210,7 +211,7 @@ extension RuntimeFormatStyle {
 public extension FormatStyle where Self == RuntimeFormatStyle {
 
     ///
-    /// A runtime format style for use with `Int.formatted(_:)`.
+    /// A runtime format style for use with `Duration.formatted(_:)`.
     ///
     /// ```swift
     /// movie.runtime?.formatted(.runtimeStyle(.full, displayUnit: .hourMinute))

--- a/Sources/TMDb/Domain/Formatting/RuntimeMinutes.swift
+++ b/Sources/TMDb/Domain/Formatting/RuntimeMinutes.swift
@@ -1,0 +1,43 @@
+//
+//  RuntimeMinutes.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// Bridges TMDb's integer-minute runtimes to and from `Duration`.
+///
+/// TMDb represents runtimes as a whole number of minutes on the wire, while the
+/// package exposes them as `Duration`. These helpers convert between the two
+/// representations at that boundary.
+///
+enum RuntimeMinutes {
+
+    ///
+    /// Converts a whole number of minutes into a `Duration`.
+    ///
+    /// - Parameter minutes: A number of whole minutes.
+    ///
+    /// - Returns: The equivalent `Duration`.
+    ///
+    static func duration(fromMinutes minutes: Int) -> Duration {
+        .seconds(minutes * 60)
+    }
+
+    ///
+    /// Converts a `Duration` into a whole number of minutes.
+    ///
+    /// Any sub-minute remainder is truncated towards zero.
+    ///
+    /// - Parameter duration: A duration.
+    ///
+    /// - Returns: The number of whole minutes in `duration`.
+    ///
+    static func minutes(from duration: Duration) -> Int {
+        Int(duration.components.seconds / 60)
+    }
+
+}

--- a/Sources/TMDb/Domain/LanguageModelTools/ToolOutputFormatter.swift
+++ b/Sources/TMDb/Domain/LanguageModelTools/ToolOutputFormatter.swift
@@ -169,8 +169,8 @@ extension ToolOutputFormatter {
         var lines = ["movie | \(movie.id) | \(titleWithYear(movie.title, movie.releaseDate))"]
 
         var facts: [String] = []
-        if let runtime = movie.runtime, runtime > 0 {
-            facts.append("\(runtime) min")
+        if let runtime = movie.runtime, runtime > .zero {
+            facts.append("\(RuntimeMinutes.minutes(from: runtime)) min")
         }
         if let genres = genreNames(movie.genres) {
             facts.append("genres: \(genres)")

--- a/Sources/TMDb/Domain/Models/Movie.swift
+++ b/Sources/TMDb/Domain/Models/Movie.swift
@@ -50,6 +50,9 @@ public struct Movie: Identifiable, Codable, Equatable, Hashable, Sendable {
     ///
     /// Movie runtime.
     ///
+    /// Runtimes have whole-minute granularity; any sub-minute component is
+    /// truncated to match TMDb's wire format.
+    ///
     public var runtime: Duration? {
         runtimeInMinutes.map { RuntimeMinutes.duration(fromMinutes: $0) }
     }

--- a/Sources/TMDb/Domain/Models/Movie.swift
+++ b/Sources/TMDb/Domain/Models/Movie.swift
@@ -48,9 +48,13 @@ public struct Movie: Identifiable, Codable, Equatable, Hashable, Sendable {
     public let overview: String?
 
     ///
-    /// Movie runtime, in minutes.
+    /// Movie runtime.
     ///
-    public let runtime: Int?
+    public var runtime: Duration? {
+        runtimeInMinutes.map { RuntimeMinutes.duration(fromMinutes: $0) }
+    }
+
+    private let runtimeInMinutes: Int?
 
     ///
     /// Movie genres.
@@ -157,7 +161,7 @@ public struct Movie: Identifiable, Codable, Equatable, Hashable, Sendable {
     ///    - originalLanguage: Original language of the movie.
     ///    - originCountry: Origin countries of the movie.
     ///    - overview: Movie overview.
-    ///    - runtime: Movie runtime, in minutes.
+    ///    - runtime: Movie runtime.
     ///    - genres: Movie genres.
     ///    - releaseDate: Movie release date.
     ///    - posterPath: Movie poster path.
@@ -185,7 +189,7 @@ public struct Movie: Identifiable, Codable, Equatable, Hashable, Sendable {
         originalLanguage: String? = nil,
         originCountry: [String]? = nil,
         overview: String? = nil,
-        runtime: Int? = nil,
+        runtime: Duration? = nil,
         genres: [Genre]? = nil,
         releaseDate: Date? = nil,
         posterPath: URL? = nil,
@@ -212,7 +216,7 @@ public struct Movie: Identifiable, Codable, Equatable, Hashable, Sendable {
         self.originalLanguage = originalLanguage
         self.originCountry = originCountry
         self.overview = overview
-        self.runtime = runtime
+        self.runtimeInMinutes = runtime.map { RuntimeMinutes.minutes(from: $0) }
         self.genres = genres
         self.releaseDate = releaseDate
         self.posterPath = posterPath
@@ -245,7 +249,7 @@ extension Movie {
         case originalLanguage
         case originCountry
         case overview
-        case runtime
+        case runtimeInMinutes = "runtime"
         case genres
         case releaseDate
         case posterPath
@@ -293,7 +297,7 @@ extension Movie {
             [String].self, forKey: .originCountry
         )
         self.overview = try container.decodeIfPresent(String.self, forKey: .overview)
-        self.runtime = try container.decodeIfPresent(Int.self, forKey: .runtime)
+        self.runtimeInMinutes = try container.decodeIfPresent(Int.self, forKey: .runtimeInMinutes)
         self.genres = try container.decodeIfPresent([Genre].self, forKey: .genres)
         self.releaseDate = try container.decodeNonEmptyDateIfPresent(forKey: .releaseDate)
         self.posterPath = try container.decodeIfPresent(URL.self, forKey: .posterPath)

--- a/Sources/TMDb/Domain/Models/TVEpisode.swift
+++ b/Sources/TMDb/Domain/Models/TVEpisode.swift
@@ -48,9 +48,13 @@ public struct TVEpisode: Identifiable, Codable, Equatable, Hashable, Sendable {
     public let episodeType: String?
 
     ///
-    /// Episode runtime in minutes.
+    /// Episode runtime.
     ///
-    public let runtime: Int?
+    public var runtime: Duration? {
+        runtimeInMinutes.map { RuntimeMinutes.duration(fromMinutes: $0) }
+    }
+
+    private let runtimeInMinutes: Int?
 
     ///
     /// Identifier of the parent TV series.
@@ -100,7 +104,7 @@ public struct TVEpisode: Identifiable, Codable, Equatable, Hashable, Sendable {
     ///    - overview: TV episode overview.
     ///    - airDate: TV episode air date.
     ///    - episodeType: Type of episode.
-    ///    - runtime: Episode runtime in minutes.
+    ///    - runtime: Episode runtime.
     ///    - showID: Identifier of the parent TV series.
     ///    - productionCode: TV episode production code.
     ///    - stillPath: TV episode still image path.
@@ -117,7 +121,7 @@ public struct TVEpisode: Identifiable, Codable, Equatable, Hashable, Sendable {
         overview: String? = nil,
         airDate: Date? = nil,
         episodeType: String? = nil,
-        runtime: Int? = nil,
+        runtime: Duration? = nil,
         showID: Int? = nil,
         productionCode: String? = nil,
         stillPath: URL? = nil,
@@ -133,7 +137,7 @@ public struct TVEpisode: Identifiable, Codable, Equatable, Hashable, Sendable {
         self.overview = overview
         self.airDate = airDate
         self.episodeType = episodeType
-        self.runtime = runtime
+        self.runtimeInMinutes = runtime.map { RuntimeMinutes.minutes(from: $0) }
         self.showID = showID
         self.productionCode = productionCode
         self.stillPath = stillPath
@@ -155,7 +159,7 @@ extension TVEpisode {
         case overview
         case airDate
         case episodeType
-        case runtime
+        case runtimeInMinutes = "runtime"
         case showID = "showId"
         case productionCode
         case stillPath
@@ -186,7 +190,7 @@ extension TVEpisode {
         self.overview = try container.decodeIfPresent(String.self, forKey: .overview)
         self.airDate = try container.decodeNonEmptyDateIfPresent(forKey: .airDate)
         self.episodeType = try container.decodeIfPresent(String.self, forKey: .episodeType)
-        self.runtime = try container.decodeIfPresent(Int.self, forKey: .runtime)
+        self.runtimeInMinutes = try container.decodeIfPresent(Int.self, forKey: .runtimeInMinutes)
         self.showID = try container.decodeIfPresent(Int.self, forKey: .showID)
         self.productionCode = try container.decodeIfPresent(String.self, forKey: .productionCode)
         self.stillPath = try container.decodeIfPresent(URL.self, forKey: .stillPath)

--- a/Sources/TMDb/Domain/Models/TVEpisode.swift
+++ b/Sources/TMDb/Domain/Models/TVEpisode.swift
@@ -50,6 +50,9 @@ public struct TVEpisode: Identifiable, Codable, Equatable, Hashable, Sendable {
     ///
     /// Episode runtime.
     ///
+    /// Runtimes have whole-minute granularity; any sub-minute component is
+    /// truncated to match TMDb's wire format.
+    ///
     public var runtime: Duration? {
         runtimeInMinutes.map { RuntimeMinutes.duration(fromMinutes: $0) }
     }

--- a/Sources/TMDb/Domain/Models/TVEpisodeAirDate.swift
+++ b/Sources/TMDb/Domain/Models/TVEpisodeAirDate.swift
@@ -51,9 +51,13 @@ public struct TVEpisodeAirDate: Identifiable, Codable, Equatable, Hashable, Send
     public let episodeType: String?
 
     ///
-    /// Episode runtime in minutes.
+    /// Episode runtime.
     ///
-    public let runtime: Int?
+    public var runtime: Duration? {
+        runtimeInMinutes.map { RuntimeMinutes.duration(fromMinutes: $0) }
+    }
+
+    private let runtimeInMinutes: Int?
 
     ///
     /// Identifier of the parent TV series.
@@ -93,7 +97,7 @@ public struct TVEpisodeAirDate: Identifiable, Codable, Equatable, Hashable, Send
     ///    - overview: TV episode overview.
     ///    - airDate: TV episode air date.
     ///    - episodeType: Type of episode.
-    ///    - runtime: Episode runtime in minutes.
+    ///    - runtime: Episode runtime.
     ///    - showID: Identifier of the parent TV series.
     ///    - productionCode: TV episode production code.
     ///    - stillPath: TV episode still image path.
@@ -108,7 +112,7 @@ public struct TVEpisodeAirDate: Identifiable, Codable, Equatable, Hashable, Send
         overview: String? = nil,
         airDate: Date? = nil,
         episodeType: String? = nil,
-        runtime: Int? = nil,
+        runtime: Duration? = nil,
         showID: Int? = nil,
         productionCode: String? = nil,
         stillPath: URL? = nil,
@@ -122,7 +126,7 @@ public struct TVEpisodeAirDate: Identifiable, Codable, Equatable, Hashable, Send
         self.overview = overview
         self.airDate = airDate
         self.episodeType = episodeType
-        self.runtime = runtime
+        self.runtimeInMinutes = runtime.map { RuntimeMinutes.minutes(from: $0) }
         self.showID = showID
         self.productionCode = productionCode
         self.stillPath = stillPath
@@ -142,7 +146,7 @@ extension TVEpisodeAirDate {
         case overview
         case airDate
         case episodeType
-        case runtime
+        case runtimeInMinutes = "runtime"
         case showID = "showId"
         case productionCode
         case stillPath
@@ -173,7 +177,7 @@ extension TVEpisodeAirDate {
         self.overview = try container.decodeIfPresent(String.self, forKey: .overview)
         self.airDate = try container.decodeNonEmptyDateIfPresent(forKey: .airDate)
         self.episodeType = try container.decodeIfPresent(String.self, forKey: .episodeType)
-        self.runtime = try container.decodeIfPresent(Int.self, forKey: .runtime)
+        self.runtimeInMinutes = try container.decodeIfPresent(Int.self, forKey: .runtimeInMinutes)
         self.showID = try container.decodeIfPresent(Int.self, forKey: .showID)
         self.productionCode = try container.decodeIfPresent(String.self, forKey: .productionCode)
         self.stillPath = try container.decodeIfPresent(URL.self, forKey: .stillPath)

--- a/Sources/TMDb/Domain/Models/TVEpisodeAirDate.swift
+++ b/Sources/TMDb/Domain/Models/TVEpisodeAirDate.swift
@@ -53,6 +53,9 @@ public struct TVEpisodeAirDate: Identifiable, Codable, Equatable, Hashable, Send
     ///
     /// Episode runtime.
     ///
+    /// Runtimes have whole-minute granularity; any sub-minute component is
+    /// truncated to match TMDb's wire format.
+    ///
     public var runtime: Duration? {
         runtimeInMinutes.map { RuntimeMinutes.duration(fromMinutes: $0) }
     }

--- a/Sources/TMDb/Domain/Models/TVSeries.swift
+++ b/Sources/TMDb/Domain/Models/TVSeries.swift
@@ -45,6 +45,9 @@ public struct TVSeries: Identifiable, Codable, Equatable, Hashable, Sendable {
     ///
     /// TV series episode run times.
     ///
+    /// Each run time has whole-minute granularity; any sub-minute component is
+    /// truncated to match TMDb's wire format.
+    ///
     public var episodeRunTime: [Duration]? {
         episodeRunTimeInMinutes?.map { RuntimeMinutes.duration(fromMinutes: $0) }
     }

--- a/Sources/TMDb/Domain/Models/TVSeries.swift
+++ b/Sources/TMDb/Domain/Models/TVSeries.swift
@@ -43,9 +43,13 @@ public struct TVSeries: Identifiable, Codable, Equatable, Hashable, Sendable {
     public let overview: String?
 
     ///
-    /// TV series episode run times, in minutes.
+    /// TV series episode run times.
     ///
-    public let episodeRunTime: [Int]?
+    public var episodeRunTime: [Duration]? {
+        episodeRunTimeInMinutes?.map { RuntimeMinutes.duration(fromMinutes: $0) }
+    }
+
+    private let episodeRunTimeInMinutes: [Int]?
 
     ///
     /// Number of seasons in the TV series.
@@ -190,7 +194,7 @@ public struct TVSeries: Identifiable, Codable, Equatable, Hashable, Sendable {
     ///    - originalName: Original TV series name.
     ///    - originalLanguage: Original language of the TV series.
     ///    - overview: TV series overview.
-    ///    - episodeRunTime: TV series episode run times, in minutes.
+    ///    - episodeRunTime: TV series episode run times.
     ///    - numberOfSeasons: Number of seasons in the TV series.
     ///    - numberOfEpisodes: Total number of episodes in the TV series.
     ///    - seasons: Seasons in the TV series.
@@ -224,7 +228,7 @@ public struct TVSeries: Identifiable, Codable, Equatable, Hashable, Sendable {
         originalName: String? = nil,
         originalLanguage: String? = nil,
         overview: String? = nil,
-        episodeRunTime: [Int]? = nil,
+        episodeRunTime: [Duration]? = nil,
         numberOfSeasons: Int? = nil,
         numberOfEpisodes: Int? = nil,
         seasons: [TVSeason]? = nil,
@@ -257,7 +261,7 @@ public struct TVSeries: Identifiable, Codable, Equatable, Hashable, Sendable {
         self.originalName = originalName
         self.originalLanguage = originalLanguage
         self.overview = overview
-        self.episodeRunTime = episodeRunTime
+        self.episodeRunTimeInMinutes = episodeRunTime?.map { RuntimeMinutes.minutes(from: $0) }
         self.numberOfSeasons = numberOfSeasons
         self.numberOfEpisodes = numberOfEpisodes
         self.seasons = seasons
@@ -296,7 +300,7 @@ extension TVSeries {
         case originalName
         case originalLanguage
         case overview
-        case episodeRunTime
+        case episodeRunTimeInMinutes = "episodeRunTime"
         case numberOfSeasons
         case numberOfEpisodes
         case seasons
@@ -346,7 +350,9 @@ extension TVSeries {
             String.self, forKey: .originalLanguage
         )
         self.overview = try container.decodeIfPresent(String.self, forKey: .overview)
-        self.episodeRunTime = try container.decodeIfPresent([Int].self, forKey: .episodeRunTime)
+        self.episodeRunTimeInMinutes = try container.decodeIfPresent(
+            [Int].self, forKey: .episodeRunTimeInMinutes
+        )
         self.numberOfSeasons = try container.decodeIfPresent(Int.self, forKey: .numberOfSeasons)
         self.numberOfEpisodes = try container.decodeIfPresent(Int.self, forKey: .numberOfEpisodes)
         self.seasons = try container.decodeIfPresent([TVSeason].self, forKey: .seasons)

--- a/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverMovieFilter+Fluent.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverMovieFilter+Fluent.swift
@@ -160,11 +160,11 @@ public extension DiscoverMovieFilter {
     ///
     /// Returns a copy of the filter restricted to the given runtime range.
     ///
-    /// - Parameter range: The inclusive runtime range, in minutes.
+    /// - Parameter range: The inclusive runtime range.
     ///
     /// - Returns: A new filter with the runtime range applied.
     ///
-    func runtime(in range: ClosedRange<Int>) -> Self {
+    func runtime(in range: ClosedRange<Duration>) -> Self {
         copy(runtimeMin: range.lowerBound, runtimeMax: range.upperBound)
     }
 
@@ -227,8 +227,8 @@ extension DiscoverMovieFilter {
         companies: [Company.ID]? = nil,
         keywords: [Keyword.ID]? = nil,
         withoutKeywords: [Keyword.ID]? = nil,
-        runtimeMin: Int? = nil,
-        runtimeMax: Int? = nil,
+        runtimeMin: Duration? = nil,
+        runtimeMax: Duration? = nil,
         includeAdult: Bool? = nil,
         includeVideo: Bool? = nil,
         watchProviders: [WatchProvider.ID]? = nil,

--- a/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverMovieFilter.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverMovieFilter.swift
@@ -73,14 +73,14 @@ public struct DiscoverMovieFilter: Equatable, Hashable, Sendable {
     public let withoutKeywords: [Keyword.ID]?
 
     ///
-    /// Minimum runtime in minutes.
+    /// Minimum runtime.
     ///
-    public let runtimeMin: Int?
+    public let runtimeMin: Duration?
 
     ///
-    /// Maximum runtime in minutes.
+    /// Maximum runtime.
     ///
-    public let runtimeMax: Int?
+    public let runtimeMax: Duration?
 
     ///
     /// Include adult content.
@@ -201,8 +201,8 @@ public struct DiscoverMovieFilter: Equatable, Hashable, Sendable {
     ///   - companies: A list of production company identifiers.
     ///   - keywords: A list of keyword identifiers to include.
     ///   - withoutKeywords: A list of keyword identifiers to exclude.
-    ///   - runtimeMin: Minimum runtime in minutes.
-    ///   - runtimeMax: Maximum runtime in minutes.
+    ///   - runtimeMin: Minimum runtime.
+    ///   - runtimeMax: Maximum runtime.
     ///   - includeAdult: Include adult content.
     ///   - includeVideo: Include video content.
     ///   - watchProviders: A list of watch provider identifiers.
@@ -236,8 +236,8 @@ public struct DiscoverMovieFilter: Equatable, Hashable, Sendable {
         companies: [Company.ID]? = nil,
         keywords: [Keyword.ID]? = nil,
         withoutKeywords: [Keyword.ID]? = nil,
-        runtimeMin: Int? = nil,
-        runtimeMax: Int? = nil,
+        runtimeMin: Duration? = nil,
+        runtimeMax: Duration? = nil,
         includeAdult: Bool? = nil,
         includeVideo: Bool? = nil,
         watchProviders: [WatchProvider.ID]? = nil,

--- a/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverTVSeriesFilter+Fluent.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverTVSeriesFilter+Fluent.swift
@@ -163,11 +163,11 @@ public extension DiscoverTVSeriesFilter {
     ///
     /// Returns a copy of the filter restricted to the given runtime range.
     ///
-    /// - Parameter range: The inclusive runtime range, in minutes.
+    /// - Parameter range: The inclusive runtime range.
     ///
     /// - Returns: A new filter with the runtime range applied.
     ///
-    func runtime(in range: ClosedRange<Int>) -> Self {
+    func runtime(in range: ClosedRange<Duration>) -> Self {
         copy(runtimeMin: range.lowerBound, runtimeMax: range.upperBound)
     }
 
@@ -219,8 +219,8 @@ extension DiscoverTVSeriesFilter {
         companies: [Company.ID]? = nil,
         keywords: [Keyword.ID]? = nil,
         withoutKeywords: [Keyword.ID]? = nil,
-        runtimeMin: Int? = nil,
-        runtimeMax: Int? = nil,
+        runtimeMin: Duration? = nil,
+        runtimeMax: Duration? = nil,
         includeAdult: Bool? = nil,
         watchProviders: [WatchProvider.ID]? = nil,
         watchRegion: String? = nil,

--- a/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverTVSeriesFilter.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Filters/DiscoverTVSeriesFilter.swift
@@ -93,14 +93,14 @@ public struct DiscoverTVSeriesFilter: Equatable, Hashable, Sendable {
     public let withoutKeywords: [Keyword.ID]?
 
     ///
-    /// Minimum runtime in minutes.
+    /// Minimum runtime.
     ///
-    public let runtimeMin: Int?
+    public let runtimeMin: Duration?
 
     ///
-    /// Maximum runtime in minutes.
+    /// Maximum runtime.
     ///
-    public let runtimeMax: Int?
+    public let runtimeMax: Duration?
 
     ///
     /// Include adult content.
@@ -199,8 +199,8 @@ public struct DiscoverTVSeriesFilter: Equatable, Hashable, Sendable {
     ///   - companies: A list of production company identifiers.
     ///   - keywords: A list of keyword identifiers to include.
     ///   - withoutKeywords: A list of keyword identifiers to exclude.
-    ///   - runtimeMin: Minimum runtime in minutes.
-    ///   - runtimeMax: Maximum runtime in minutes.
+    ///   - runtimeMin: Minimum runtime.
+    ///   - runtimeMax: Maximum runtime.
     ///   - includeAdult: Include adult content.
     ///   - watchProviders: A list of watch provider identifiers.
     ///   - watchRegion: ISO-3166-1 watch region code.
@@ -235,8 +235,8 @@ public struct DiscoverTVSeriesFilter: Equatable, Hashable, Sendable {
         companies: [Company.ID]? = nil,
         keywords: [Keyword.ID]? = nil,
         withoutKeywords: [Keyword.ID]? = nil,
-        runtimeMin: Int? = nil,
-        runtimeMax: Int? = nil,
+        runtimeMin: Duration? = nil,
+        runtimeMax: Duration? = nil,
         includeAdult: Bool? = nil,
         watchProviders: [WatchProvider.ID]? = nil,
         watchRegion: String? = nil,

--- a/Sources/TMDb/Domain/Services/Discover/Requests/DiscoverMoviesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Requests/DiscoverMoviesRequest.swift
@@ -93,7 +93,9 @@ private extension APIRequestQueryItems {
         }
 
         self[ifPresent: .withRuntimeGreaterThan] = filter.runtimeMin
+            .map { RuntimeMinutes.minutes(from: $0) }
         self[ifPresent: .withRuntimeLessThan] = filter.runtimeMax
+            .map { RuntimeMinutes.minutes(from: $0) }
     }
 
     mutating func applyContentAndProviderFilters(

--- a/Sources/TMDb/Domain/Services/Discover/Requests/DiscoverTVSeriesRequest.swift
+++ b/Sources/TMDb/Domain/Services/Discover/Requests/DiscoverTVSeriesRequest.swift
@@ -106,7 +106,9 @@ private extension APIRequestQueryItems {
         from filter: DiscoverTVSeriesFilter
     ) {
         self[ifPresent: .withRuntimeGreaterThan] = filter.runtimeMin
+            .map { RuntimeMinutes.minutes(from: $0) }
         self[ifPresent: .withRuntimeLessThan] = filter.runtimeMax
+            .map { RuntimeMinutes.minutes(from: $0) }
         self[ifPresent: .includeAdult] = filter.includeAdult
 
         if let watchProviders = filter.watchProviders {

--- a/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanExecutor+Helpers.swift
+++ b/Sources/TMDb/Domain/Services/NaturalLanguageSearch/SearchPlanExecutor+Helpers.swift
@@ -145,7 +145,7 @@ extension SearchPlanExecutor {
             primaryReleaseYear: inputs.bounds.map(primaryReleaseYear(for:)),
             voteAverageMin: Self.sanitizedRating(inputs.minRating),
             companies: inputs.companyIDs.isEmpty ? nil : inputs.companyIDs,
-            runtimeMax: inputs.runtimeMax,
+            runtimeMax: inputs.runtimeMax.map { RuntimeMinutes.duration(fromMinutes: $0) },
             includeAdult: false,
             withCast: (!usesCrew && !inputs.personIDs.isEmpty) ? inputs.personIDs : nil,
             withCrew: (usesCrew && !inputs.personIDs.isEmpty) ? inputs.personIDs : nil
@@ -172,7 +172,7 @@ extension SearchPlanExecutor {
             firstAirDateMax: firstAirDateMax,
             voteAverageMin: Self.sanitizedRating(inputs.minRating),
             companies: inputs.companyIDs.isEmpty ? nil : inputs.companyIDs,
-            runtimeMax: inputs.runtimeMax,
+            runtimeMax: inputs.runtimeMax.map { RuntimeMinutes.duration(fromMinutes: $0) },
             includeAdult: false,
             withPeople: inputs.personIDs.isEmpty ? nil : inputs.personIDs
         )

--- a/Sources/TMDbTesting/Samples/Movie+Sample.swift
+++ b/Sources/TMDbTesting/Samples/Movie+Sample.swift
@@ -23,7 +23,7 @@ public extension Movie {
                 + "primal male aggression into a shocking new form of therapy. Their concept "
                 + "catches on, with underground \"fight clubs\" forming in every town, until an "
                 + "eccentric gets in the way and ignites an out-of-control spiral toward oblivion.",
-            runtime: 139,
+            runtime: .seconds(139 * 60),
             genres: [
                 Genre(id: 18, name: "Drama"),
                 Genre(id: 53, name: "Thriller")

--- a/Sources/TMDbTesting/Samples/MovieDetailsResponse+Sample.swift
+++ b/Sources/TMDbTesting/Samples/MovieDetailsResponse+Sample.swift
@@ -29,7 +29,7 @@ public extension MovieDetailsResponse {
             underground "fight clubs" forming in every town, until an eccentric gets in the \
             way and ignites an out-of-control spiral toward oblivion.
             """,
-            runtime: 139,
+            runtime: .seconds(139 * 60),
             genres: [Genre(id: 18, name: "Drama")],
             releaseDate: Date(timeIntervalSince1970: 939_945_600),
             posterPath: posterPath,

--- a/Tests/TMDbIntegrationTests/TVEpisodeServiceTests.swift
+++ b/Tests/TMDbIntegrationTests/TVEpisodeServiceTests.swift
@@ -54,7 +54,7 @@ struct TVEpisodeServiceTests {
         )
 
         let runtime = try #require(episode.runtime)
-        #expect(runtime > 0)
+        #expect(runtime > .zero)
         let episodeType = try #require(episode.episodeType)
         #expect(!episodeType.isEmpty)
     }

--- a/Tests/TMDbTests/Domain/Formatting/RuntimeFormatStyleTests.swift
+++ b/Tests/TMDbTests/Domain/Formatting/RuntimeFormatStyleTests.swift
@@ -9,6 +9,11 @@ import Foundation
 import Testing
 @testable import TMDb
 
+/// A whole number of minutes expressed as a `Duration`, for readable test inputs.
+private func minutes(_ value: Int) -> Duration {
+    .seconds(value * 60)
+}
+
 @Suite("RuntimeFormatStyle", .tags(.formatting))
 struct RuntimeFormatStyleTests {
 
@@ -25,42 +30,42 @@ struct RuntimeFormatStyleTests {
 
         @Test("more than one hour")
         func formatsHoursAndMinutes() {
-            #expect(style.format(135) == "2h 15m")
+            #expect(style.format(minutes(135)) == "2h 15m")
         }
 
         @Test("exact hours omits minutes")
         func formatsExactHours() {
-            #expect(style.format(120) == "2h")
+            #expect(style.format(minutes(120)) == "2h")
         }
 
         @Test("less than one hour omits hours")
         func formatsMinutesOnly() {
-            #expect(style.format(45) == "45m")
+            #expect(style.format(minutes(45)) == "45m")
         }
 
         @Test("single hour and minute")
         func formatsSingleHourAndMinute() {
-            #expect(style.format(61) == "1h 1m")
+            #expect(style.format(minutes(61)) == "1h 1m")
         }
 
         @Test("zero minutes")
         func formatsZero() {
-            #expect(style.format(0) == "0m")
+            #expect(style.format(minutes(0)) == "0m")
         }
 
         @Test("exact single hour omits minutes")
         func formatsSingleHour() {
-            #expect(style.format(60) == "1h")
+            #expect(style.format(minutes(60)) == "1h")
         }
 
         @Test("large value")
         func formatsLargeValue() {
-            #expect(style.format(605) == "10h 5m")
+            #expect(style.format(minutes(605)) == "10h 5m")
         }
 
         @Test("negative input is treated as zero")
         func formatsNegativeAsZero() {
-            #expect(style.format(-10) == "0m")
+            #expect(style.format(minutes(-10)) == "0m")
         }
     }
 
@@ -75,17 +80,17 @@ struct RuntimeFormatStyleTests {
 
         @Test("renders total minutes")
         func formatsTotalMinutes() {
-            #expect(style.format(139) == "139 min")
+            #expect(style.format(minutes(139)) == "139 min")
         }
 
         @Test("under an hour")
         func formatsUnderAnHour() {
-            #expect(style.format(45) == "45 min")
+            #expect(style.format(minutes(45)) == "45 min")
         }
 
         @Test("zero minutes")
         func formatsZero() {
-            #expect(style.format(0) == "0 min")
+            #expect(style.format(minutes(0)) == "0 min")
         }
     }
 
@@ -100,32 +105,32 @@ struct RuntimeFormatStyleTests {
 
         @Test("more than one hour")
         func formatsHoursAndMinutes() {
-            #expect(style.format(135) == "2 hours, 15 minutes")
+            #expect(style.format(minutes(135)) == "2 hours, 15 minutes")
         }
 
         @Test("singular hour and minute")
         func formatsSingular() {
-            #expect(style.format(61) == "1 hour, 1 minute")
+            #expect(style.format(minutes(61)) == "1 hour, 1 minute")
         }
 
         @Test("exact single hour uses singular hour and omits minutes")
         func formatsSingleHour() {
-            #expect(style.format(60) == "1 hour")
+            #expect(style.format(minutes(60)) == "1 hour")
         }
 
         @Test("exact hours omits minutes")
         func formatsExactHours() {
-            #expect(style.format(120) == "2 hours")
+            #expect(style.format(minutes(120)) == "2 hours")
         }
 
         @Test("less than one hour omits hours")
         func formatsMinutesOnly() {
-            #expect(style.format(45) == "45 minutes")
+            #expect(style.format(minutes(45)) == "45 minutes")
         }
 
         @Test("zero minutes")
         func formatsZero() {
-            #expect(style.format(0) == "0 minutes")
+            #expect(style.format(minutes(0)) == "0 minutes")
         }
     }
 
@@ -140,35 +145,35 @@ struct RuntimeFormatStyleTests {
 
         @Test("renders total minutes")
         func formatsTotalMinutes() {
-            #expect(style.format(139) == "139 minutes")
+            #expect(style.format(minutes(139)) == "139 minutes")
         }
 
         @Test("singular minute")
         func formatsSingularMinute() {
-            #expect(style.format(1) == "1 minute")
+            #expect(style.format(minutes(1)) == "1 minute")
         }
 
         @Test("zero minutes")
         func formatsZero() {
-            #expect(style.format(0) == "0 minutes")
+            #expect(style.format(minutes(0)) == "0 minutes")
         }
     }
 
     @Test("default initialiser uses abbreviated hour-minute")
     func defaultInitialiser() {
         let style = RuntimeFormatStyle(locale: locale)
-        #expect(style.format(135) == "2h 15m")
+        #expect(style.format(minutes(135)) == "2h 15m")
     }
 
     @Test("defaulted runtimeStyle accessor uses abbreviated hour-minute")
     func defaultedRuntimeStyleAccessor() {
-        let result = 135.formatted(.runtimeStyle().locale(locale))
+        let result = minutes(135).formatted(.runtimeStyle().locale(locale))
         #expect(result == "2h 15m")
     }
 
-    @Test("Int convenience formatted accessor")
-    func intConvenience() {
-        let runtime = 139
+    @Test("Duration convenience formatted accessor")
+    func durationConvenience() {
+        let runtime = minutes(139)
         let result = runtime.formatted(.runtimeStyle(.abbreviated, displayUnit: .minutesOnly)
             .locale(locale))
         #expect(result == "139 min")
@@ -178,7 +183,7 @@ struct RuntimeFormatStyleTests {
     func localeModifier() {
         let style = RuntimeFormatStyle(style: .abbreviated, displayUnit: .hourMinute)
             .locale(locale)
-        #expect(style.format(135) == "2h 15m")
+        #expect(style.format(minutes(135)) == "2h 15m")
     }
 
     @Test("conforms to Codable")

--- a/Tests/TMDbTests/Domain/Formatting/RuntimeMinutesTests.swift
+++ b/Tests/TMDbTests/Domain/Formatting/RuntimeMinutesTests.swift
@@ -1,0 +1,40 @@
+//
+//  RuntimeMinutesTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite("RuntimeMinutes", .tags(.formatting))
+struct RuntimeMinutesTests {
+
+    @Test("duration(fromMinutes:) converts whole minutes to a Duration")
+    func durationFromMinutes() {
+        #expect(RuntimeMinutes.duration(fromMinutes: 139) == .seconds(139 * 60))
+        #expect(RuntimeMinutes.duration(fromMinutes: 0) == .zero)
+    }
+
+    @Test("minutes(from:) converts a Duration to whole minutes")
+    func minutesFromDuration() {
+        #expect(RuntimeMinutes.minutes(from: .seconds(139 * 60)) == 139)
+        #expect(RuntimeMinutes.minutes(from: .zero) == 0)
+    }
+
+    @Test("minutes(from:) truncates a sub-minute remainder")
+    func minutesTruncatesSubMinute() {
+        #expect(RuntimeMinutes.minutes(from: .seconds(90)) == 1)
+    }
+
+    @Test("round-trips whole minutes")
+    func roundTripsWholeMinutes() {
+        for minutes in [0, 1, 45, 60, 139, 600] {
+            let duration = RuntimeMinutes.duration(fromMinutes: minutes)
+            #expect(RuntimeMinutes.minutes(from: duration) == minutes)
+        }
+    }
+
+}

--- a/Tests/TMDbTests/Domain/LanguageModelTools/ToolOutputFormatterTests.swift
+++ b/Tests/TMDbTests/Domain/LanguageModelTools/ToolOutputFormatterTests.swift
@@ -192,7 +192,7 @@ struct ToolOutputFormatterTests {
             title: "Inception",
             tagline: "Your mind is the scene of the crime.",
             overview: "A thief enters dreams.",
-            runtime: 148,
+            runtime: .seconds(148 * 60),
             genres: [Genre(id: 28, name: "Action"), Genre(id: 878, name: "Science Fiction")],
             releaseDate: Date(iso8601: "2010-07-16T00:00:00Z"),
             status: .released,

--- a/Tests/TMDbTests/Domain/Models/FindResultsTests.swift
+++ b/Tests/TMDbTests/Domain/Models/FindResultsTests.swift
@@ -43,7 +43,7 @@ extension FindResultsTests {
                     overview:
                     // swiftlint:disable:next line_length
                     "A ticking-time-bomb insomniac and a slippery soap salesman channel primal male aggression into a shocking new form of therapy.",
-                    runtime: 139,
+                    runtime: .seconds(139 * 60),
                     genres: [
                         Genre(id: 18, name: "Drama")
                     ],

--- a/Tests/TMDbTests/Domain/Models/MovieTests.swift
+++ b/Tests/TMDbTests/Domain/Models/MovieTests.swift
@@ -52,6 +52,32 @@ struct MovieTests {
         #expect(result.releaseDate == nil)
     }
 
+    @Test("runtime decodes from integer minutes into a Duration", .tags(.decoding))
+    func decodeRepresentsRuntimeAsDuration() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(Movie.self, fromResource: "movie")
+
+        #expect(result.runtime == .seconds(139 * 60))
+    }
+
+    @Test("runtime is nil when absent from the response", .tags(.decoding))
+    func decodeWhenRuntimeAbsentReturnsNilRuntime() throws {
+        let json = Data(#"{"id": 550, "title": "Fight Club"}"#.utf8)
+
+        let result = try JSONDecoder.theMovieDatabase.decode(Movie.self, from: json)
+
+        #expect(result.runtime == nil)
+    }
+
+    @Test("encoding represents runtime as integer minutes")
+    func encodeRepresentsRuntimeAsIntegerMinutes() throws {
+        let movie = Movie(id: 550, title: "Fight Club", runtime: .seconds(139 * 60))
+
+        let data = try JSONEncoder().encode(movie)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(json["runtime"] as? Int == 139)
+    }
+
 }
 
 extension MovieTests {
@@ -67,7 +93,7 @@ extension MovieTests {
             overview:
             // swiftlint:disable:next line_length
             "A ticking-time-bomb insomniac and a slippery soap salesman channel primal male aggression into a shocking new form of therapy. Their concept catches on, with underground \"fight clubs\" forming in every town, until an eccentric gets in the way and ignites an out-of-control spiral toward oblivion.",
-            runtime: 139,
+            runtime: .seconds(139 * 60),
             genres: [
                 Genre(id: 18, name: "Drama")
             ],

--- a/Tests/TMDbTests/Domain/Models/TVEpisodeAirDateTests.swift
+++ b/Tests/TMDbTests/Domain/Models/TVEpisodeAirDateTests.swift
@@ -28,7 +28,7 @@ struct TVEpisodeAirDateTests {
         )
 
         #expect(result.episodeType == "finale")
-        #expect(result.runtime == 56)
+        #expect(result.runtime == .seconds(56 * 60))
         #expect(result.overview != nil)
     }
 
@@ -44,6 +44,18 @@ struct TVEpisodeAirDateTests {
         #expect(result.showID == nil)
     }
 
+    @Test("encoding represents runtime as integer minutes")
+    func encodeRepresentsRuntimeAsIntegerMinutes() throws {
+        let airDate = TVEpisodeAirDate(
+            id: 1, name: "Ep", episodeNumber: 1, seasonNumber: 1, runtime: .seconds(56 * 60)
+        )
+
+        let data = try JSONEncoder().encode(airDate)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(json["runtime"] as? Int == 56)
+    }
+
 }
 
 extension TVEpisodeAirDateTests {
@@ -57,7 +69,7 @@ extension TVEpisodeAirDateTests {
             overview: "All bad things must come to an end.",
             airDate: DateFormatter.theMovieDatabase.date(from: "2013-09-29"),
             episodeType: "finale",
-            runtime: 56,
+            runtime: .seconds(56 * 60),
             showID: 1396,
             productionCode: "",
             stillPath: URL(string: "/pA0YwyhvdDXP3BEGL2grrIhq8aM.jpg"),

--- a/Tests/TMDbTests/Domain/Models/TVEpisodeAirDateTests.swift
+++ b/Tests/TMDbTests/Domain/Models/TVEpisodeAirDateTests.swift
@@ -44,6 +44,15 @@ struct TVEpisodeAirDateTests {
         #expect(result.showID == nil)
     }
 
+    @Test("runtime is nil when absent from the response", .tags(.decoding))
+    func decodeWhenRuntimeAbsentReturnsNilRuntime() throws {
+        let json = Data(#"{"id": 1, "name": "Ep", "episode_number": 1, "season_number": 1}"#.utf8)
+
+        let result = try JSONDecoder.theMovieDatabase.decode(TVEpisodeAirDate.self, from: json)
+
+        #expect(result.runtime == nil)
+    }
+
     @Test("encoding represents runtime as integer minutes")
     func encodeRepresentsRuntimeAsIntegerMinutes() throws {
         let airDate = TVEpisodeAirDate(

--- a/Tests/TMDbTests/Domain/Models/TVEpisodeTests.swift
+++ b/Tests/TMDbTests/Domain/Models/TVEpisodeTests.swift
@@ -45,6 +45,27 @@ struct TVEpisodeTests {
         #expect(result.voteCount == tvEpisode.voteCount)
     }
 
+    @Test("runtime is nil when absent from the response", .tags(.decoding))
+    func decodeWhenRuntimeAbsentReturnsNilRuntime() throws {
+        let json = Data(#"{"id": 1, "name": "Ep", "episode_number": 1, "season_number": 1}"#.utf8)
+
+        let result = try JSONDecoder.theMovieDatabase.decode(TVEpisode.self, from: json)
+
+        #expect(result.runtime == nil)
+    }
+
+    @Test("encoding represents runtime as integer minutes")
+    func encodeRepresentsRuntimeAsIntegerMinutes() throws {
+        let episode = TVEpisode(
+            id: 1, name: "Ep", episodeNumber: 1, seasonNumber: 1, runtime: .seconds(62 * 60)
+        )
+
+        let data = try JSONEncoder().encode(episode)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(json["runtime"] as? Int == 62)
+    }
+
     private let tvEpisode = TVEpisode(
         id: 63056,
         name: "Winter Is Coming",
@@ -55,7 +76,7 @@ struct TVEpisodeTests {
         "Jon Arryn, the Hand of the King, is dead. King Robert Baratheon plans to ask his oldest friend, Eddard Stark, to take Jon's place. Across the sea, Viserys Targaryen plans to wed his sister to a nomadic warlord in exchange for an army.",
         airDate: DateFormatter.theMovieDatabase.date(from: "2011-04-17"),
         episodeType: "standard",
-        runtime: 62,
+        runtime: .seconds(62 * 60),
         showID: 1399,
         productionCode: "101",
         stillPath: URL(string: "/wrGWeW4WKxnaeA8sxJb2T9O6ryo.jpg"),

--- a/Tests/TMDbTests/Domain/Models/TVSeriesTests.swift
+++ b/Tests/TMDbTests/Domain/Models/TVSeriesTests.swift
@@ -21,6 +21,41 @@ struct TVSeriesTests {
         #expect(result == tvSeries)
     }
 
+    @Test("episodeRunTime decodes integer minutes into Durations", .tags(.decoding))
+    func decodeRepresentsEpisodeRunTimeAsDurations() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(TVSeries.self, fromResource: "tv-series")
+
+        #expect(result.episodeRunTime == [.seconds(60 * 60)])
+    }
+
+    @Test("episodeRunTime is empty when the response array is empty", .tags(.decoding))
+    func decodeWhenEpisodeRunTimeEmptyReturnsEmptyArray() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            TVSeries.self, fromResource: "tv-series-blank-homepage-first-air-date"
+        )
+
+        #expect(result.episodeRunTime?.isEmpty == true)
+    }
+
+    @Test("episodeRunTime is nil when absent from the response", .tags(.decoding))
+    func decodeWhenEpisodeRunTimeAbsentReturnsNil() throws {
+        let json = Data(#"{"id": 1, "name": "Show"}"#.utf8)
+
+        let result = try JSONDecoder.theMovieDatabase.decode(TVSeries.self, from: json)
+
+        #expect(result.episodeRunTime == nil)
+    }
+
+    @Test("encoding represents episodeRunTime as integer minutes")
+    func encodeRepresentsEpisodeRunTimeAsIntegerMinutes() throws {
+        let series = TVSeries(id: 1, name: "Show", episodeRunTime: [.seconds(60 * 60)])
+
+        let data = try JSONEncoder().encode(series)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(json["episodeRunTime"] as? [Int] == [60])
+    }
+
     @Test("JSON decoding of TVSeries with blank homepage and first air date")
     func decodeWhenHomepageIsEmptyStringReturnsTVSeries() throws {
         let result = try JSONDecoder.theMovieDatabase.decode(
@@ -122,7 +157,7 @@ extension TVSeriesTests {
             originalLanguage: "en",
             // swiftlint:disable:next line_length
             overview: "Seven noble families fight for control of the mythical land of Westeros. Friction between the houses leads to full-scale war. All while a very ancient evil awakens in the farthest north. Amidst the war, a neglected military order of misfits, the Night's Watch, is all that stands between the realms of men and icy horrors beyond.",
-            episodeRunTime: [60],
+            episodeRunTime: [.seconds(60 * 60)],
             numberOfSeasons: 7,
             numberOfEpisodes: 67,
             seasons: [

--- a/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverMovieFilterFluentTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverMovieFilterFluentTests.swift
@@ -120,10 +120,10 @@ struct DiscoverMovieFilterFluentTests {
 
     @Test("runtime with closed range maps to min and max")
     func runtimeWithClosedRangeMapsToMinAndMax() {
-        let filter = DiscoverMovieFilter().runtime(in: 90 ... 180)
+        let filter = DiscoverMovieFilter().runtime(in: .seconds(90 * 60) ... .seconds(180 * 60))
 
-        #expect(filter.runtimeMin == 90)
-        #expect(filter.runtimeMax == 180)
+        #expect(filter.runtimeMin == .seconds(90 * 60))
+        #expect(filter.runtimeMax == .seconds(180 * 60))
     }
 
     @Test("includeAdult sets include adult")
@@ -189,8 +189,8 @@ struct DiscoverMovieFilterFluentTests {
             companies: [5],
             keywords: [10],
             withoutKeywords: [11],
-            runtimeMin: 90,
-            runtimeMax: 180,
+            runtimeMin: .seconds(90 * 60),
+            runtimeMax: .seconds(180 * 60),
             includeAdult: includeAdult,
             includeVideo: true,
             watchProviders: [8],

--- a/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverMovieFilterTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverMovieFilterTests.swift
@@ -173,10 +173,10 @@ struct DiscoverMovieFilterTests { // swiftlint:disable:this type_body_length
 
     @Test("init with runtime range sets runtime properties")
     func initWithRuntimeRangeSetsRuntimeProperties() {
-        let filter = DiscoverMovieFilter(runtimeMin: 90, runtimeMax: 180)
+        let filter = DiscoverMovieFilter(runtimeMin: .seconds(90 * 60), runtimeMax: .seconds(180 * 60))
 
-        #expect(filter.runtimeMin == 90)
-        #expect(filter.runtimeMax == 180)
+        #expect(filter.runtimeMin == .seconds(90 * 60))
+        #expect(filter.runtimeMax == .seconds(180 * 60))
     }
 
     @Test("init with include adult sets include adult property")
@@ -323,8 +323,8 @@ struct DiscoverMovieFilterTests { // swiftlint:disable:this type_body_length
             companies: companies,
             keywords: keywords,
             withoutKeywords: withoutKeywords,
-            runtimeMin: 90,
-            runtimeMax: 180,
+            runtimeMin: .seconds(90 * 60),
+            runtimeMax: .seconds(180 * 60),
             includeAdult: false,
             includeVideo: true,
             watchProviders: watchProviders,
@@ -356,8 +356,8 @@ struct DiscoverMovieFilterTests { // swiftlint:disable:this type_body_length
         #expect(filter.companies == companies)
         #expect(filter.keywords == keywords)
         #expect(filter.withoutKeywords == withoutKeywords)
-        #expect(filter.runtimeMin == 90)
-        #expect(filter.runtimeMax == 180)
+        #expect(filter.runtimeMin == .seconds(90 * 60))
+        #expect(filter.runtimeMax == .seconds(180 * 60))
         #expect(filter.includeAdult == false)
         #expect(filter.includeVideo == true)
         #expect(filter.watchProviders == watchProviders)

--- a/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverTVSeriesFilterFluentTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverTVSeriesFilterFluentTests.swift
@@ -122,10 +122,10 @@ struct DiscoverTVSeriesFilterFluentTests {
 
     @Test("runtime with closed range maps to min and max")
     func runtimeWithClosedRangeMapsToMinAndMax() {
-        let filter = DiscoverTVSeriesFilter().runtime(in: 30 ... 60)
+        let filter = DiscoverTVSeriesFilter().runtime(in: .seconds(30 * 60) ... .seconds(60 * 60))
 
-        #expect(filter.runtimeMin == 30)
-        #expect(filter.runtimeMax == 60)
+        #expect(filter.runtimeMin == .seconds(30 * 60))
+        #expect(filter.runtimeMax == .seconds(60 * 60))
     }
 
     @Test("chaining composes multiple fields without mutating the base")
@@ -186,8 +186,8 @@ struct DiscoverTVSeriesFilterFluentTests {
             companies: [5],
             keywords: [10],
             withoutKeywords: [11],
-            runtimeMin: 30,
-            runtimeMax: 60,
+            runtimeMin: .seconds(30 * 60),
+            runtimeMax: .seconds(60 * 60),
             includeAdult: includeAdult,
             watchProviders: [8],
             watchRegion: "US",

--- a/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverTVSeriesFilterTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Filters/DiscoverTVSeriesFilterTests.swift
@@ -188,10 +188,10 @@ struct DiscoverTVSeriesFilterTests { // swiftlint:disable:this type_body_length
 
     @Test("init with runtime range sets runtime properties")
     func initWithRuntimeRangeSetsRuntimeProperties() {
-        let filter = DiscoverTVSeriesFilter(runtimeMin: 30, runtimeMax: 60)
+        let filter = DiscoverTVSeriesFilter(runtimeMin: .seconds(30 * 60), runtimeMax: .seconds(60 * 60))
 
-        #expect(filter.runtimeMin == 30)
-        #expect(filter.runtimeMax == 60)
+        #expect(filter.runtimeMin == .seconds(30 * 60))
+        #expect(filter.runtimeMax == .seconds(60 * 60))
     }
 
     @Test("init with include adult sets include adult property")
@@ -310,8 +310,8 @@ struct DiscoverTVSeriesFilterTests { // swiftlint:disable:this type_body_length
             companies: [100, 200],
             keywords: [10, 20],
             withoutKeywords: [30, 40],
-            runtimeMin: 30,
-            runtimeMax: 60,
+            runtimeMin: .seconds(30 * 60),
+            runtimeMax: .seconds(60 * 60),
             includeAdult: false,
             watchProviders: [8, 9],
             watchRegion: "US",
@@ -342,8 +342,8 @@ struct DiscoverTVSeriesFilterTests { // swiftlint:disable:this type_body_length
         #expect(filter.companies == [100, 200])
         #expect(filter.keywords == [10, 20])
         #expect(filter.withoutKeywords == [30, 40])
-        #expect(filter.runtimeMin == 30)
-        #expect(filter.runtimeMax == 60)
+        #expect(filter.runtimeMin == .seconds(30 * 60))
+        #expect(filter.runtimeMax == .seconds(60 * 60))
         #expect(filter.includeAdult == false)
         #expect(filter.watchProviders == [8, 9])
         #expect(filter.watchRegion == "US")

--- a/Tests/TMDbTests/Domain/Services/Discover/Requests/DiscoverMoviesRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Requests/DiscoverMoviesRequestTests.swift
@@ -200,7 +200,7 @@ struct DiscoverMoviesRequestTests { // swiftlint:disable:this type_body_length
 
     @Test("queryItems with runtime range")
     func queryItemsWithRuntimeRange() {
-        let filter = DiscoverMovieFilter(runtimeMin: 90, runtimeMax: 180)
+        let filter = DiscoverMovieFilter(runtimeMin: .seconds(90 * 60), runtimeMax: .seconds(180 * 60))
         let request = DiscoverMoviesRequest(filter: filter)
 
         #expect(
@@ -386,8 +386,8 @@ struct DiscoverMoviesRequestTests { // swiftlint:disable:this type_body_length
             voteAverageMax: 9.0,
             companies: [420, 7505],
             keywords: [9715, 180_547],
-            runtimeMin: 90,
-            runtimeMax: 180
+            runtimeMin: .seconds(90 * 60),
+            runtimeMax: .seconds(180 * 60)
         )
         let request = DiscoverMoviesRequest(filter: filter)
 

--- a/Tests/TMDbTests/Domain/Services/Discover/Requests/DiscoverTVSeriesRequestTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Discover/Requests/DiscoverTVSeriesRequestTests.swift
@@ -182,8 +182,8 @@ struct DiscoverTVSeriesRequestTests { // swiftlint:disable:this type_body_length
     @Test("queryItems with runtime range")
     func queryItemsWithRuntimeRange() {
         let filter = DiscoverTVSeriesFilter(
-            runtimeMin: 30,
-            runtimeMax: 60
+            runtimeMin: .seconds(30 * 60),
+            runtimeMax: .seconds(60 * 60)
         )
         let request = DiscoverTVSeriesRequest(filter: filter)
 

--- a/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/SearchPlanExecutorTests.swift
+++ b/Tests/TMDbTests/Domain/Services/NaturalLanguageSearch/SearchPlanExecutorTests.swift
@@ -80,7 +80,7 @@ struct SearchPlanExecutorTests {
 
         let filter = try #require(dataSource.lastMovieFilter)
         #expect(filter.primaryReleaseYear == .on(2019))
-        #expect(filter.runtimeMax == 120)
+        #expect(filter.runtimeMax == .seconds(120 * 60))
         #expect(filter.voteAverageMin == 7)
     }
 

--- a/Tests/TMDbTests/Mocks/Models/Movie+Mocks.swift
+++ b/Tests/TMDbTests/Mocks/Models/Movie+Mocks.swift
@@ -18,7 +18,7 @@ extension Movie {
         originalLanguage: String? = "en",
         originCountry: [String]? = ["US"],
         overview: String? = "Movie Overview",
-        runtime: Int? = 120,
+        runtime: Duration? = .seconds(120 * 60),
         genres: [Genre]? = [.action, .drama],
         releaseDate: Date? = Date(iso8601: "2013-11-15T10:20:00Z"),
         posterPath: URL? = URL(string: "/t2yyOv40HZeVlLjYsCsPHnWLk4W.jpg"),

--- a/Tests/TMDbTests/Mocks/Models/TVEpisode+Mocks.swift
+++ b/Tests/TMDbTests/Mocks/Models/TVEpisode+Mocks.swift
@@ -18,7 +18,7 @@ extension TVEpisode {
         overview: String? = "Overview for TV Episode",
         airDate: Date? = Date(iso8601: "2013-11-15T10:20:00Z"),
         episodeType: String? = nil,
-        runtime: Int? = nil,
+        runtime: Duration? = nil,
         showID: Int? = nil,
         productionCode: String? = nil,
         stillPath: URL? = nil,

--- a/Tests/TMDbTests/Mocks/Models/TVSeries+Mocks.swift
+++ b/Tests/TMDbTests/Mocks/Models/TVSeries+Mocks.swift
@@ -16,7 +16,7 @@ extension TVSeries {
         originalName: String? = nil,
         originalLanguage: String? = nil,
         overview: String? = "TV Series Overview",
-        episodeRunTime: [Int]? = nil,
+        episodeRunTime: [Duration]? = nil,
         numberOfSeasons: Int? = nil,
         numberOfEpisodes: Int? = nil,
         seasons: [TVSeason]? = nil,

--- a/knowledge/decisions/0011-duration-for-runtime.md
+++ b/knowledge/decisions/0011-duration-for-runtime.md
@@ -1,0 +1,79 @@
+# ADR-0011: Represent runtimes as `Duration`, bridging integer minutes at the wire boundary
+
+- **Status:** Accepted
+- **Date:** 2026-07-24
+- **Deciders:** Adam Young (with Claude Code)
+
+## Context
+
+TMDb model runtimes were exposed as bare `Int` values documented as "minutes"
+(`Movie.runtime`, `TVEpisode.runtime`, `TVEpisodeAirDate.runtime`,
+`TVSeries.episodeRunTime`), alongside the request-side runtime filters
+(`DiscoverMovieFilter` / `DiscoverTVSeriesFilter` `runtimeMin`/`runtimeMax`, the
+fluent `runtime(in:)`) and the `RuntimeFormatStyle` that rendered those minutes.
+A bare `Int` carries no unit in the type — a caller cannot tell minutes from
+seconds without reading the doc comment, and cannot use the value with
+duration-aware APIs.
+
+Constraints:
+
+- The TMDb API represents runtime as an **integer number of minutes** on both
+  response bodies and the `with_runtime.gte` / `with_runtime.lte` query
+  parameters. The wire format must not change.
+- `Duration` is available on every supported platform (iOS 16+, macOS 13+,
+  watchOS 9+, tvOS 16+, visionOS 1+, Linux, Windows) and conforms to `Codable`,
+  `Equatable`, `Hashable`, `Sendable`, and `Comparable`.
+- `Duration`'s own `Codable` representation is a `(seconds, attoseconds)` pair —
+  **not** an integer of minutes — so naively changing the property type would
+  silently break the wire format.
+
+## Decision
+
+Expose runtimes as `Duration` at the public surface while keeping integer minutes
+on the wire.
+
+- **Response models** store the raw minute count in a
+  `private let …InMinutes: Int?` and expose a computed `public var runtime:
+  Duration?` (`[Duration]?` for `TVSeries.episodeRunTime`). The existing custom
+  `init(from:)` decodes the `Int`; the **synthesized** `encode(to:)` re-emits the
+  `Int`. The Codable wire format therefore stays integer minutes on both decode
+  and encode, with no hand-written encode to keep in sync. `CodingKeys` keep the
+  camelCase rawValue that the `.convertFromSnakeCase` decoder expects (e.g.
+  `episodeRunTimeInMinutes = "episodeRunTime"`, not `"episode_run_time"`).
+- **Request filters** hold `Duration?` directly (they are never decoded from the
+  API); the request builders convert to integer minutes when setting the query
+  items.
+- A single internal `RuntimeMinutes` enum performs the minutes⇄`Duration`
+  conversion. It is deliberately **not** a public `Duration` extension (a future
+  stdlib `Duration.minutes` would collide) and **not** a
+  `KeyedDecodingContainer` extension (keep those generic; localise the domain
+  conversion).
+- `RuntimeFormatStyle.FormatInput` becomes `Duration`, so
+  `movie.runtime?.formatted(.runtimeStyle(…))` keeps working.
+
+## Consequences
+
+- **Breaking public-API change:** runtime property types, memberwise-initialiser
+  signatures, and `RuntimeFormatStyle`'s input all change from `Int` to
+  `Duration` — warranting a major version bump (19.0.0).
+- The type now carries its unit; runtimes compose with `Comparable`, arithmetic,
+  and Foundation's duration formatting.
+- Truncation to whole minutes happens at the wire boundary (a caller-supplied
+  `.seconds(90)` stores and encodes as 1 minute), matching the API's minute
+  granularity — documented on the models and the format style.
+- Guarded by per-model encode round-trip tests asserting the integer-minute wire
+  format.
+
+## Alternatives considered
+
+- **Store `Duration` directly and hand-write `encode(to:)` per model.** Rejected:
+  `Movie` alone has ~30 properties, and a forgotten field in a hand-written
+  encode is silent data loss. The stored-minutes / computed-`Duration` approach
+  keeps encode synthesized and correct for free.
+- **A public `Duration.minutes(_:)` convenience** for construction ergonomics.
+  Rejected: extending a stdlib type with API Apple may later add risks a
+  source-breaking collision. Callers use `.seconds(minutes * 60)`.
+- **Leave the request-side filters as `Int`.** Rejected: full type consistency
+  across the runtime surface was preferred; only the NaturalLanguageSearch
+  internal slot (`SearchPlan.runtimeMaxMinutes` and `ResolvedInputs`) stays
+  `Int`, converting to `Duration` at the filter-construction seam.

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,7 +14,7 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
-## 2026-07-24 — ♻️ Represent model runtimes as `Duration` instead of `Int` (branch refactor/runtime-as-duration) · full
+## 2026-07-24 — ♻️ Represent model runtimes as `Duration` instead of `Int` (#390) · full
 
 - **Phases / skills:** phases 0–8 pre-PR; full weight (breaking public API,
   `Codable`/`CodingKeys`). `review-plan` skipped (`ExitPlanMode` approval this

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,6 +14,40 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-07-24 — ♻️ Represent model runtimes as `Duration` instead of `Int` (branch refactor/runtime-as-duration) · full
+
+- **Phases / skills:** phases 0–8 pre-PR; full weight (breaking public API,
+  `Codable`/`CodingKeys`). `review-plan` skipped (`ExitPlanMode` approval this
+  session). `implement-plan`/`canon-tdd`: TDD'd the `RuntimeMinutes` converter,
+  then did the type migration as one **atomic** increment (a breaking type
+  change doesn't compile in partial states). `review-changes` fan-out (5 dims +
+  adversarial verify) → 0 Critical/High/Medium, 2 Low (both fixed).
+  `security-review` → 0 findings. `capture-knowledge` → 3 tooling gotchas +
+  ADR-0011 (inline). Independent grader: 6/6 ACs MET.
+- **Worked:** the stored-minutes / computed-`Duration` design keeps `encode`
+  synthesized, so the integer-minute wire format can't silently drift — no
+  hand-written 30-property encode to maintain — and per-model encode
+  round-trip tests lock it. Two plan-time Explore agents pre-mapped the whole
+  consume/format + test surface, making the migration mechanical. The
+  `.convertFromSnakeCase` → camelCase-`CodingKeys` check (wiki/gotcha) caught
+  the `episodeRunTime` rawValue trap before it silently broke decode.
+- **Friction (environmental, not the change):** the beta Swift 6.4 / macOS 27
+  toolchain makes `-Werror` promote the `.docc` "unhandled file" false alarm to
+  a **fatal** error, so `make test` / `make build-tests` / `make ci` fail
+  locally — and the tooling-runner (Haiku, running in the **main** checkout)
+  misreported the very first build as a failure. Homebrew had also drifted
+  swiftformat to 0.62.1 vs the 0.61.1 pin, flagging unchanged files and
+  reshaping edits. Both cost real diagnosis time.
+- **Deviations:** ran every build/test **directly via `Bash`** in the worktree
+  (the tooling-runner runs in `main` and never saw the worktree diff); built
+  tests without `-Werror` to run them, with `-Werror` + a grep-filter to catch
+  real warnings; reinstalled pinned swiftformat 0.61.1 to `~/.local/bin`.
+- **One improvement:** the tooling-runner / `/deliver` skills should run the
+  tooling-runner **in the active worktree** (or explicitly require builds to go
+  direct-via-`Bash` there) — the CWD mismatch silently builds/reviews the wrong
+  tree. Captured as a gotcha this delivery; a skill fix would stop the next
+  worktree run hitting it cold.
+
 ## 2026-07-08 — 👷 Bump CI workflows to Xcode 26.6 (#387) · lite
 
 - **Phases / skills:** phases 0–10; config-only (`.github/workflows/`), so

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -95,6 +95,21 @@ checkout stayed clean) before trusting a green run. To rescue edits already made
 `main`: `git -C <main> stash` then `git -C <worktree> stash pop` (stash is shared
 across worktrees).
 
+### The build/test tooling-runner runs in the main checkout, not the active worktree
+
+*2026-07-24.* During a `/deliver` in a worktree, the `tooling-runner` (Haiku)
+subagent behind `/build` / `/build-for-testing` / `/test` / `/integration-test` —
+and Agent-tool subagents generally — execute in the **main checkout**, not the
+worktree the conductor switched into. So `make test` spawned that way builds
+`main`'s pristine sources, **misses the worktree's committed changes**, and
+(compounded by the toon `errors[]` quirk below) misreports. **Detect it:** the
+run's `.build/last-*.log` lands under the **main checkout** and the worktree's
+`.build/` has none. **Work around it for the duration of a worktree delivery:**
+run builds/tests **directly via `Bash`** (which does run in the worktree CWD) —
+`swift build --build-tests` then `swift test --skip-build --scratch-path .build
+--filter "TMDbTests|TMDbTestingTests"` (see the `Makefile` `test` target for the
+exact incantation) — instead of delegating to the tooling-runner.
+
 ### swiftlint `file_length` / `type_body_length` — split into a `+Feature` extension file
 
 *2026-06-22.* Adding a new `block(for:)` formatter plus its helpers to
@@ -145,6 +160,13 @@ members). Every time, `swift build` / `make build-tests` reported **0 errors /
   a version-drift artifact (a rule's behaviour changed between versions), **not**
   a real violation. Check `swiftlint version` against the pin before editing
   code — don't "fix" a non-issue.
+- Homebrew silently drifts `swiftformat` (seen: 0.62.1 vs the 0.61.1 pin), which
+  then flags **`wrapIfStatementBodies`** on unchanged files *and*, worse, makes
+  the PostToolUse format hook reshape edited files away from CI's output.
+  Reinstall the pin to `~/.local/bin` (which precedes Homebrew on `PATH`, like
+  the swiftlint pin) from the same URL CI uses:
+  `curl -fsSL https://github.com/nicklockwood/SwiftFormat/releases/download/0.61.1/swiftformat.zip`,
+  unzip, and `install` the binary to `~/.local/bin/swiftformat`.
 
 ### `make` build/test targets pipe through xcsift with `pipefail`
 
@@ -166,6 +188,16 @@ members). Every time, `swift build` / `make build-tests` reported **0 errors /
   `null,null` coordinates, so a Haiku `/build-for-testing` subagent that keys off
   that array (instead of the exit status) will wrongly report the build as
   **failed**. Re-check the actual exit code before believing it.
+
+  **Beta-toolchain caveat (Swift 6.4 / macOS 27, Xcode 27):** on this toolchain
+  `swift build --build-tests -Xswiftc -warnings-as-errors` now **exits 1** on the
+  same `.docc` diagnostic, so `make build-tests` / `make test` / `make ci` fail
+  locally even though the code is clean (plain `swift build` — no `--build-tests`,
+  no `-Werror` — still exits 0). Workaround while on the beta: build tests
+  **without** `-Werror` (`swift build --build-tests`) and run them via `swift test
+  --skip-build`; to still catch real warnings, build with `-Werror` and require
+  `… 2>&1 | grep 'error:' | grep -v unhandled` to be empty. `make build-docs` is
+  unaffected — it sets `SWIFTCI_DOCC=1`, so the plugin handles the catalogs.
 
 ### The `xcode-tools` MCP only exists inside Xcode
 


### PR DESCRIPTION
## Summary

Migrates the public runtime surface from bare `Int` minutes to Swift's
`Duration`, so the type itself carries the unit. TMDb represents runtime as an
integer number of minutes on the wire (response bodies **and** the
`with_runtime.gte`/`.lte` query parameters); the wire format is **unchanged** —
`Duration` lives only at the Swift surface.

**Breaking change → 19.0.0.**

## Changes

**Runtime type migration:**

- ♻️ Response models expose `Duration`: `Movie.runtime`, `TVEpisode.runtime`,
  `TVEpisodeAirDate.runtime` (`Duration?`) and `TVSeries.episodeRunTime`
  (`[Duration]?`). Each stores the raw integer minutes privately and bridges at
  the public boundary, so the `Codable` wire format stays integer minutes on
  **both** decode and encode — encode remains synthesized, so it cannot silently
  drift.
- ♻️ Request filters take `Duration`: `DiscoverMovieFilter` /
  `DiscoverTVSeriesFilter` `runtimeMin`/`runtimeMax` and the fluent
  `runtime(in: ClosedRange<Duration>)`; the request builders convert back to
  integer-minute `with_runtime.gte`/`.lte`.
- ♻️ `RuntimeFormatStyle.FormatInput` is now `Duration`, so
  `movie.runtime?.formatted(.runtimeStyle(...))` keeps working.
- ✨ New internal `RuntimeMinutes` converter (minutes ⇄ `Duration`). The
  NaturalLanguageSearch internals stay integer-minute, converting only at the
  filter-construction seam.

**Tests:**

- ✅ Per-model encode round-trip guards asserting the integer-minute wire format;
  decode / absent-`nil` / empty-array branch coverage for every runtime model;
  Discover filter/request and format-style tests updated to `Duration`.

**Documentation:**

- 📚 ADR-0011 (Duration-at-surface / integer-minutes-on-wire), a CHANGELOG
  19.0.0 breaking-change entry, and whole-minute-granularity / truncation notes
  on each model.

## Benefits

- **Type safety**: the unit lives in the type — no guessing minutes vs seconds;
  runtimes compose with `Comparable`, arithmetic, and Foundation's duration
  formatting.
- **No wire-format change**: integer minutes are preserved on decode and encode,
  verified by per-model round-trip tests and the live integration suite (291
  tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZBYvKShZoDs9LHpXysGLq