### PR TITLE
🔧 Pin the tooling-runner to the caller's package directory

### DIFF
--- a/.claude/agents/tooling-runner.md
+++ b/.claude/agents/tooling-runner.md
@@ -12,17 +12,49 @@ report the result concisely. Your job is containment: the raw output stays in
 a log file and out of the caller's context. Run only the target you were
 asked for — nothing else.
 
+## Working directory — required, and never assumed
+
+**Your shell does not reliably inherit the caller's working directory.** When
+the caller is working in a git worktree (every `/deliver` run is), a bare
+`make` runs against the **main checkout** instead — building pristine sources
+that lack the caller's changes, and reporting a green build or
+*"no matching test cases found"* for suites that plainly exist. Silent, and
+wrong in the most convincing direction.
+
+So the package directory is **passed to you explicitly** and you must never
+fall back to `pwd`:
+
+1. The task names an absolute **package directory**. If it does **not**, stop
+   and report: *"No package directory supplied — cannot run safely."* Do not
+   guess, and do not run the target.
+2. Verify it before running: `test -f "<dir>/Package.swift"`. If that fails,
+   stop and report the path you were given. A wrong path must be an error, not
+   a misleading result.
+3. Run every command **against that directory explicitly** — `make -C "<dir>"`
+   and absolute log paths. Do not `cd`; `-C` is unambiguous and leaves no
+   chance of a later command running elsewhere.
+4. Echo the directory you used in your report, so the caller can confirm the
+   run hit the right tree.
+
 ## How to run (all targets)
 
 - **Inside Xcode** (the `mcp__xcode-tools__*` MCP is available): use the MCP
-  tool named in the target's recipe below. On a build failure, get per-file
+  tool named in the target's recipe below — it operates on the open project,
+  so the directory rule above does not apply. On a build failure, get per-file
   error detail with `mcp__xcode-tools__XcodeRefreshCodeIssuesInFile` on each
   flagged file.
-- **Otherwise** (terminal): run the target's `make` command with output
-  redirected to its log file —
-  `mkdir -p .build && make <target> > .build/last-<name>.log 2>&1` — then
-  judge pass/fail **from the exit status** (the Makefile sets `pipefail`, so
-  a failure propagates through the xcsift pipe) and summarise from the log.
+- **Otherwise** (terminal): run the target's `make` command against the
+  supplied directory, with output redirected to its log file inside it —
+
+  ```bash
+  mkdir -p "<dir>/.build" && make -C "<dir>" <target> > "<dir>/.build/last-<name>.log" 2>&1
+  ```
+
+  — then judge pass/fail **from the exit status** (the Makefile sets
+  `pipefail`, so a failure propagates through the xcsift pipe) and summarise
+  from the log.
+- For a **scoped** re-run, keep the package explicit:
+  `swift test --package-path "<dir>" --scratch-path "<dir>/.build" --filter "SuiteName/testName"`.
 - Run targets **sequentially** — never two builds at once in one worktree.
 - Never read or touch `.swiftpm/` or `.build/` beyond the log file.
 
@@ -72,6 +104,8 @@ failure: a genuine assertion failure vs a **transient live-API issue**
 
 ## Report back ONLY
 
+- **Directory** — the package directory you ran against (one line, so the
+  caller can spot a wrong-tree run immediately)
 - **Status** — succeeded/passed or failed
 - **Counts** — errors + warnings (builds) or total / passed / failed (tests)
 - Each failure on one line: build errors as `file:line — message`, test

--- a/.claude/skills/build-for-testing/SKILL.md
+++ b/.claude/skills/build-for-testing/SKILL.md
@@ -12,6 +12,12 @@ one-line task:
 
 > Run the `build-for-testing` target: compile the TMDb package and all test
 > targets.
+> Package directory: `<your current working directory, absolute>`
+
+**Always include that directory line.** The subagent does not reliably inherit
+your working directory, and without it a run inside a git worktree silently
+builds the main checkout instead (see `.claude/agents/tooling-runner.md`).
+Use your actual CWD — run `pwd` if you are not certain of it.
 
 Relay its report. Do **not** run the build yourself.
 

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -11,6 +11,12 @@ reporting contract live in `.claude/agents/tooling-runner.md`) with the
 one-line task:
 
 > Run the `build` target: compile the TMDb Swift package.
+> Package directory: `<your current working directory, absolute>`
+
+**Always include that directory line.** The subagent does not reliably inherit
+your working directory, and without it a run inside a git worktree silently
+builds the main checkout instead (see `.claude/agents/tooling-runner.md`).
+Use your actual CWD — run `pwd` if you are not certain of it.
 
 Relay its report. Do **not** run the build yourself.
 

--- a/.claude/skills/integration-test/SKILL.md
+++ b/.claude/skills/integration-test/SKILL.md
@@ -11,6 +11,12 @@ reporting contract live in `.claude/agents/tooling-runner.md`) with the
 one-line task:
 
 > Run the `integration-test` target: the TMDb live-API integration suite.
+> Package directory: `<your current working directory, absolute>`
+
+**Always include that directory line.** The subagent does not reliably inherit
+your working directory, and without it a run inside a git worktree silently
+tests the main checkout instead (see `.claude/agents/tooling-runner.md`).
+Use your actual CWD — run `pwd` if you are not certain of it.
 
 Relay its report — it distinguishes genuine assertion failures from
 transient live-API issues (429/timeout/network) and env/precondition

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -11,6 +11,14 @@ reporting contract live in `.claude/agents/tooling-runner.md`) with the
 one-line task:
 
 > Run the `test` target: the TMDb unit test suite.
+> Package directory: `<your current working directory, absolute>`
+
+**Always include that directory line.** The subagent does not reliably inherit
+your working directory, and without it a run inside a git worktree silently
+tests the main checkout instead — which reports *"no matching test cases
+found"* for suites that exist, or passes without ever seeing your changes (see
+`.claude/agents/tooling-runner.md`). Use your actual CWD — run `pwd` if you are
+not certain of it.
 
 Relay its report. Do **not** run the tests yourself.
 
@@ -20,3 +28,4 @@ re-invoke this skill to re-check. To re-check just the previously failing
 tests faster, ask the runner for a scoped run instead:
 
 > Run the `test` target scoped to `SuiteName/testName`.
+> Package directory: `<your current working directory, absolute>`

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -106,11 +106,18 @@ worktree the conductor switched into. So `make test` spawned that way builds
 run's `.build/last-*.log` lands under the **main checkout** and the worktree's
 `.build/` has none — or, when the worktree adds a *new* suite, the run reports
 **"no matching test cases found"** for a `--filter` naming suites that plainly
-exist (observed 2026-07-24, #392). **Work around it for the duration of a worktree delivery:**
-run builds/tests **directly via `Bash`** (which does run in the worktree CWD) —
-`swift build --build-tests` then `swift test --skip-build --scratch-path .build
---filter "TMDbTests|TMDbTestingTests"` (see the `Makefile` `test` target for the
-exact incantation) — instead of delegating to the tooling-runner.
+exist (observed 2026-07-24, #392).
+
+**Fixed 2026-07-24** — the four skills now pass `Package directory: <absolute
+CWD>` in the task, and `tooling-runner` refuses to run without it, verifies
+`Package.swift` is there, uses `make -C "<dir>"` with absolute log paths, and
+echoes the directory it used. So the failure mode is now an explicit error
+rather than a plausible-looking wrong answer. **If you see a runner report
+without a `Directory:` line, it predates the fix — treat its result as
+untrusted** and re-run. The manual fallback (`swift build --build-tests`, then
+`swift test --skip-build --scratch-path .build --filter
+"TMDbTests|TMDbTestingTests"` directly via `Bash`, which does run in the
+worktree CWD) still works if you need it.
 
 ### swiftlint `file_length` / `type_body_length` — split into a `+Feature` extension file
 

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,35 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-07-24 — tooling-runner ran in the main checkout, not the worktree (#390, #397) · applied
+
+- **Pattern:** the `tooling-runner` (Haiku) subagent behind `/build`,
+  `/build-for-testing`, `/test` and `/integration-test` does not reliably
+  inherit the conductor's CWD, so during a `/deliver` — which always runs in a
+  worktree — a bare `make` executed against the **main checkout**. In #390 it
+  built `main`'s pristine sources and misreported the first build; in #397 a
+  delegated `swift test` returned *"no matching test cases found"* for suites
+  that plainly existed in the worktree. Both times the workaround was to
+  abandon the four skills and shell out via `Bash`, which makes them unusable
+  in the situation they exist for. Raised as #390's "one improvement" and
+  recurred verbatim one delivery later.
+- **Decision:** **applied** — the four skills now pass
+  `Package directory: <absolute CWD>` in the task, and `.claude/agents/tooling-runner.md`
+  gains a *Working directory — required, and never assumed* section: refuse to
+  run when no directory is supplied, verify `Package.swift` exists there, run
+  everything via `make -C "<dir>"` (and `swift test --package-path` for scoped
+  runs) with absolute log paths, and echo the directory used in the report. The
+  stale "work around it by bypassing the runner" advice in
+  `knowledge/gotchas.md` was replaced with the fix plus a way to spot a
+  pre-fix report.
+- **Rationale:** pinning the directory fixes the root cause; refusing to guess
+  converts the remaining failure mode from a *convincing wrong answer* (green
+  build, or zero tests found) into an explicit error. `make -C` was chosen over
+  `cd` so no later command in the same shell can drift back to the wrong tree.
+  Echoing the directory makes a wrong-tree run visible in the caller's context
+  rather than only in a log path.
+- **Reconsider when:** n/a (applied).
+
 ### 2026-07-08 — External-review fixes: worktree-safe flake fixing, PR-pinned watch, severity filter · applied
 
 - **Pattern:** an external model review of the `/deliver` pipeline (not the


### PR DESCRIPTION
## Summary

The `tooling-runner` subagent behind `/build`, `/build-for-testing`, `/test` and `/integration-test` does **not** reliably inherit the conductor's working directory. Since `/deliver` always runs in a git worktree, a bare `make` executed against the **main checkout** instead:

- **#390** — it built `main`'s pristine sources and misreported the first build.
- **#397** — a delegated `swift test` returned *"no matching test cases found"* for suites that plainly existed in the worktree.

Both times the workaround was to abandon the four skills and shell out via `Bash` — which makes them unusable in exactly the situation they exist for. Raised as #390's retro "one improvement" and recurred verbatim one delivery later, so it's a settled recurring pattern rather than a one-off.

The failure mode is the dangerous kind: **silent, and wrong in the convincing direction** — a green build, or zero tests found, against the wrong tree.

## Changes

**`.claude/agents/tooling-runner.md`** — new *Working directory — required, and never assumed* section:

1. Refuse to run when the task supplies no package directory (no falling back to `pwd`, no guessing).
2. Verify `Package.swift` exists at the given path; a wrong path is an **error**, not a misleading result.
3. Run everything explicitly against it — `make -C "<dir>"` with absolute log paths, and `swift test --package-path "<dir>" --scratch-path "<dir>/.build"` for scoped re-runs.
4. Echo the directory used, as a `Directory:` line in the report.

**The four skills** (`/build`, `/build-for-testing`, `/test`, `/integration-test`) now pass `Package directory: <your current working directory, absolute>` in the task, with a note on why omitting it is unsafe.

**`knowledge/gotchas.md`** — the entry told readers to bypass the runner; that advice is now wrong, so it's replaced with the fix, plus how to spot a pre-fix report (no `Directory:` line ⇒ untrusted, re-run). The manual fallback is kept for when it's genuinely needed.

**`knowledge/skill-improvement-log.md`** — decision recorded as **applied**, so the wrap-up scan doesn't re-propose it.

## Design notes

- **`make -C` rather than `cd`** — a `cd` fixes only the command it's chained to; `-C` leaves no chance of a later command in the same shell drifting back to the wrong tree. It also avoids the permission-prompt friction `cd` carries in this harness.
- **Refusing to guess is the point.** Pinning the directory fixes the root cause, but the guard is what converts any *remaining* variant of this bug from a plausible wrong answer into an obvious error — which is what would have saved the diagnostic cycles in #390 and #397.
- **Xcode path unaffected** — the `mcp__xcode-tools__*` tools operate on the open project, so the directory rule explicitly does not apply there.

## Testing

Docs/config only — no Swift changes, so the Swift CI jobs self-skip and `/review-changes` would too. `make lint-markdown` passes (`.claude/**` is in its scope). Verified all four skills carry the directory line, the agent contains the guard and no stale bare-`make` recipe remains.

The real test is the next `/deliver`: its `/test` run should report a `Directory:` line pointing at the worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)