### PR TITLE
🔧 Require a release build before /deliver declares implementation done

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -181,7 +181,19 @@ Invoke **`/implement-plan`** (Canon TDD: list shown first, one failing test
 at a time, done only when the list is empty and both suites green). It
 commits at logical checkpoints — required: Phase 4 reviews **committed**
 history. Don't advance until `/test` **and** `/integration-test` pass and the
-work is committed; re-confirm the weight from the diff. Two hard checkpoints:
+work is committed; re-confirm the weight from the diff. Three hard checkpoints:
+
+- **Run `swift build -c release` before declaring implementation done** —
+  debug-green is not evidence the release gate passes. `swift build`,
+  `--build-tests` and both suites all compile the package with
+  `-enable-testing`; the release build does not, so **access-level and
+  `@testable` mistakes fail there and nowhere else** — precisely what target
+  extractions, new non-test targets, and visibility changes are made of. It is
+  a ~30s check that guards `make build-release`, `make ci`, and both CI *Build
+  for Release* jobs. (Incident: PR #398 shipped a `@testable import` inside a
+  new non-test fixtures target; debug, `--build-tests`, 2869 unit and 291
+  integration tests all passed while release was red — caught only in code
+  review. See `knowledge/gotchas.md`.)
 
 - **"Fix every instance of pattern X" → enumerate ALL sites up front** with a
   single **type-driven sweep**, listed in the test list before implementing —

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,30 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-07-25 — `/deliver` Phase 3 must run a release build before declaring done (#398) · applied
+
+- **Pattern:** a **single** occurrence, not a recurrence — logged deliberately.
+  In #398 (the `TMDbIntelligence` extraction) implementation was declared
+  complete on debug-green evidence: `swift build`, `swift build --build-tests`,
+  2869 unit tests and 291 integration tests all passed. `swift build -c release`
+  was never run, and it was **broken** — a `@testable import` inside the new
+  non-test `TMDbTestFixtures` target, which only fails without
+  `-enable-testing`. That is `make build-release`, `make ci`, and both CI
+  *Build for Release* jobs. The code reviewer caught it; the pipeline did not.
+- **Decision:** add a third hard checkpoint to `/deliver` Phase 3 — run
+  `swift build -c release` before advancing. Applied in
+  `.claude/skills/deliver/SKILL.md` (this PR), cross-referencing the
+  `knowledge/gotchas.md` entry.
+- **Rationale:** normally the scan waits for a pattern to recur, and the user
+  was told this is single-occurrence before approving. It was accepted anyway
+  because the cost is ~30 seconds, the failure class is **systematically
+  invisible** to every other Phase 3 gate (all of which build with
+  `-enable-testing`), and it is most likely exactly when `/deliver` is doing
+  target extractions or visibility changes — the work where it matters most.
+  Waiting for a second incident would mean shipping another red release gate to
+  earn evidence we already have.
+- **Reconsider when:** n/a (applied).
+
 ### 2026-07-24 — tooling-runner ran in the main checkout, not the worktree (#390, #397) · applied
 
 - **Pattern:** the `tooling-runner` (Haiku) subagent behind `/build`,


### PR DESCRIPTION
## Summary

Adds a third hard checkpoint to `/deliver` Phase 3: run `swift build -c release` before advancing past implementation.

Every other Phase 3 gate compiles the package **with `-enable-testing`** — `swift build`, `swift build --build-tests`, and both test suites. The release build does not. So access-level and `@testable` mistakes fail *there and nowhere else*, which is precisely the shape of the work `/deliver` is most often pointed at: target extractions, new non-test targets, and visibility changes.

**The incident (#398).** Implementation was declared complete on debug-green evidence — 2869 unit tests and 291 integration tests passing — while `swift build -c release` was broken by a `@testable import` inside a new non-test fixtures target. That red-lined `make build-release`, `make ci`, and both CI *Build for Release* jobs. The code reviewer caught it; the pipeline had no gate that could.

## Changes

**Skill:**
- 🔧 `/deliver` Phase 3 gains the release-build checkpoint, with a pointer to the `knowledge/gotchas.md` entry explaining why debug-green is not evidence.

**Knowledge:**
- 📝 `knowledge/skill-improvement-log.md` records the decision in the log's five-field format.

## Note on the decision

This was applied off a **single occurrence**, not a recurrence — the wrap-up scan's usual bar. That deviation is deliberate and recorded in the log: the check costs ~30 seconds, the failure class is systematically invisible to every existing Phase 3 gate, and waiting for a second incident would mean shipping another red release gate to earn evidence we already have.

## Benefits

- **Closes a real gap** — the only Critical in #398 was invisible to every Phase 3 gate.
- **Cheap** — ~30 seconds against a multi-minute pipeline.
- **Targeted** — catches the failure mode that target extractions and access-level changes actually produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)