### PR TITLE
✨ Add a client-level cached image URL resolver (client.images)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   client's lifetime, so callers no longer have to fetch `APIConfiguration` and
   manage that object themselves. The configuration is fetched at most once
   however many callers ask concurrently; `preload()` warms it at launch and
-  `refresh()` discards it. A `nil` image path returns `nil` without making a
-  request. `MockImageService` and `ImagesConfiguration.sample` ship in
-  `TMDbTesting`.
+  `refresh()` re-fetches it, replacing the cached value only once a fresh one
+  arrives (so a failed refresh keeps the previous one). A `nil` image path
+  returns `nil` without making a request. `MockImageService` and
+  `ImagesConfiguration.sample` ship in `TMDbTesting`.
 - `TMDbStatusCode`, an enum modelling TMDb's documented numeric `status_code`
   values (with an `.unknown(Int)` fallback for codes not yet modelled).
 - `TMDbErrorContext`, carrying the HTTP status code, TMDb `TMDbStatusCode`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `ImageService`, exposed as `TMDbClient.images`, resolving a model's image
+  path to a fully qualified URL in one call:
+  `try await client.images.posterURL(for: movie.posterPath, size: .width(500))`.
+  It fetches TMDb's image configuration on first use and caches it for the
+  client's lifetime, so callers no longer have to fetch `APIConfiguration` and
+  manage that object themselves. The configuration is fetched at most once
+  however many callers ask concurrently; `preload()` warms it at launch and
+  `refresh()` discards it. A `nil` image path returns `nil` without making a
+  request. `MockImageService` and `ImagesConfiguration.sample` ship in
+  `TMDbTesting`.
 - `TMDbStatusCode`, an enum modelling TMDb's documented numeric `status_code`
   values (with an `.unknown(Int)` fallback for codes not yet modelled).
 - `TMDbErrorContext`, carrying the HTTP status code, TMDb `TMDbStatusCode`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ ADR for any non-obvious design decision.
 ### Service-Based Design
 
 The library uses protocol-based services with dependency injection.
-`TMDbClient` is the main facade exposing 25 service properties:
+`TMDbClient` is the main facade exposing 26 service properties:
 
 ```text
 TMDbClient (main facade)
@@ -48,6 +48,7 @@ TMDbClient (main facade)
 ├── FindService
 ├── GenreService
 ├── GuestSessionService
+├── ImageService
 ├── KeywordService
 ├── ListService
 ├── MovieService

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
 ## Features
 
 * **Comprehensive API Coverage**: Full support for TMDb API v3 with 26
-  specialized services
+  specialized services, plus 2 on-device intelligence extensions
 * **Append to Response**: Fetch details with credits, images, videos,
   and more in a single request using `append_to_response`
 * **Movie & TV Data**: Details, credits, images, videos, reviews,
@@ -25,9 +25,9 @@ A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
   (requires authentication)
 * **Metadata**: Genres, certifications, companies, collections, watch
   providers
-* **Image Generation**: Built-in URL generation for all image types with
-  size optimization, typed `ImageSize` selection, and convenience accessors
-  on models
+* **Image Generation**: One-call image URLs via `client.images`, which caches
+  TMDb's image configuration for you, with size optimization, typed
+  `ImageSize` selection, and convenience accessors on models
 * **Display Formatting**: Foundation `FormatStyle` conformances for
   rendering runtimes (`"2h 15m"`, `"139 min"`, `"2 hours, 15 minutes"`)
   and vote averages as percentages (e.g. `"85%"` in English locales)
@@ -80,6 +80,7 @@ A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
 | **reviews** | Review details with author and media information |
 | **tvEpisodeGroups** | TV episode group details and episode organization |
 | **guestSessions** | Guest session rated movies, TV series, and episodes |
+| **images** | Fully qualified image URLs from model image paths, with the image configuration fetched once and cached |
 | **naturalLanguageSearch** | On-device natural-language search (all Apple platforms; enhanced by Foundation Models with Apple Intelligence) — requires `import TMDbIntelligence` |
 | **languageModelTools** | Foundation Models tools for a `LanguageModelSession` movie assistant (iOS/macOS/visionOS 26, watchOS 27) — requires `import TMDbIntelligence` |
 
@@ -230,14 +231,19 @@ if let usProvider = watchProviders.first(where: { $0.countryCode == "US" }) {
     print("Available on: \(usProvider.watchProviders.flatRate?.map(\.name) ?? [])")
 }
 
-// Generate poster image URL
-let config = try await tmdbClient.configurations.apiConfiguration()
-if let posterPath = fightClub.posterPath {
-    let posterURL = config.images.posterURL(for: posterPath, idealWidth: 500)
-}
+// Generate a poster image URL — the image configuration is fetched
+// once and cached for you
+let posterURL = try await tmdbClient.images.posterURL(
+    for: fightClub.posterPath,
+    size: .width(500)
+)
 
-// Or request a specific size, directly from the model
-let posterURL = fightClub.posterURL(using: config.images, size: .width(500))
+// Resolving many at once? Fetch the configuration once and use its
+// synchronous helpers
+let imagesConfiguration = try await tmdbClient.images.imagesConfiguration()
+let posterURLs = popularMovies.map {
+    $0.posterURL(using: imagesConfiguration, size: .width(500))
+}
 ```
 
 ### Configuration

--- a/Sources/TMDb/Domain/Models/ImagesConfiguration+URLs.swift
+++ b/Sources/TMDb/Domain/Models/ImagesConfiguration+URLs.swift
@@ -14,10 +14,10 @@ public extension ImagesConfiguration {
     ///
     /// - Parameters:
     ///   - path: Path to the backdrop image.
-    ///   - width: The ideal width of the image. The actual image maybe be larger. When no width is given, the original
+    ///   - width: The ideal width of the image. The actual image may be larger. When no width is given, the original
     ///            image URL is returned.
     ///
-    /// - Returns: A fully qualified URL to a backdrop image.
+    /// - Returns: A fully qualified URL to a backdrop image, or `nil` if `path` is `nil`.
     ///
     func backdropURL(for path: URL?, idealWidth width: Int = Int.max) -> URL? {
         imageURL(for: path, idealWidth: width, sizes: backdropSizes)
@@ -28,10 +28,10 @@ public extension ImagesConfiguration {
     ///
     /// - Parameters:
     ///   - path: Path to the logo image.
-    ///   - width: The ideal width of the image. The actual image maybe be larger. When no width is given, the original
+    ///   - width: The ideal width of the image. The actual image may be larger. When no width is given, the original
     ///            image URL is returned.
     ///
-    /// - Returns: A fully qualified URL to a logo image.
+    /// - Returns: A fully qualified URL to a logo image, or `nil` if `path` is `nil`.
     ///
     func logoURL(for path: URL?, idealWidth width: Int = Int.max) -> URL? {
         imageURL(for: path, idealWidth: width, sizes: logoSizes)
@@ -42,10 +42,10 @@ public extension ImagesConfiguration {
     ///
     /// - Parameters:
     ///   - path: Path to the poster image.
-    ///   - width: The ideal width of the image. The actual image maybe be larger. When no width is given, the original
+    ///   - width: The ideal width of the image. The actual image may be larger. When no width is given, the original
     ///            image URL is returned.
     ///
-    /// - Returns: A fully qualified URL to a poster image.
+    /// - Returns: A fully qualified URL to a poster image, or `nil` if `path` is `nil`.
     ///
     func posterURL(for path: URL?, idealWidth width: Int = Int.max) -> URL? {
         imageURL(for: path, idealWidth: width, sizes: posterSizes)
@@ -56,10 +56,10 @@ public extension ImagesConfiguration {
     ///
     /// - Parameters:
     ///   - path: Path to the profile image.
-    ///   - width: The ideal width of the image. The actual image maybe be larger. When no width is given, the original
+    ///   - width: The ideal width of the image. The actual image may be larger. When no width is given, the original
     ///            image URL is returned.
     ///
-    /// - Returns: A fully qualified URL to a profile image.
+    /// - Returns: A fully qualified URL to a profile image, or `nil` if `path` is `nil`.
     ///
     func profileURL(for path: URL?, idealWidth width: Int = Int.max) -> URL? {
         imageURL(for: path, idealWidth: width, sizes: profileSizes)
@@ -70,10 +70,10 @@ public extension ImagesConfiguration {
     ///
     /// - Parameters:
     ///   - path: Path to the still image.
-    ///   - width: The ideal width of the image. The actual image maybe be larger. When no width is given, the original
+    ///   - width: The ideal width of the image. The actual image may be larger. When no width is given, the original
     ///            image URL is returned.
     ///
-    /// - Returns: A fully qualified URL to a still image.
+    /// - Returns: A fully qualified URL to a still image, or `nil` if `path` is `nil`.
     ///
     func stillURL(for path: URL?, idealWidth width: Int = Int.max) -> URL? {
         imageURL(for: path, idealWidth: width, sizes: stillSizes)

--- a/Sources/TMDb/Domain/Services/Images/APIConfigurationStore.swift
+++ b/Sources/TMDb/Domain/Services/Images/APIConfigurationStore.swift
@@ -18,11 +18,23 @@ actor APIConfigurationStore {
     private var generation: UInt64 = 0
     private var refreshGeneration: UInt64?
 
+    /// The number of calls that have entered ``apiConfiguration()`` or ``refresh()``.
+    ///
+    /// Incremented on the actor before the first suspension point, so a test can
+    /// wait until callers have provably joined an in-flight fetch rather than
+    /// assuming task-start ordering. It has no effect on behaviour.
+    private(set) var entryCount = 0
+
     init(configurationService: some ConfigurationService) {
         self.configurationService = configurationService
     }
 
     func apiConfiguration() async throws(TMDbError) -> APIConfiguration {
+        entryCount += 1
+
+        // Checked before joining any in-flight fetch, so a refresh in progress
+        // does not make readers wait: they keep getting the cached value until
+        // the replacement lands.
         if let cachedConfiguration {
             return cachedConfiguration
         }
@@ -31,11 +43,18 @@ actor APIConfigurationStore {
     }
 
     func refresh() async throws(TMDbError) -> APIConfiguration {
+        entryCount += 1
+
         // Coalesce concurrent refreshes. A refresh arriving while an earlier
-        // refresh's fetch is still running joins it: that fetch started after this
-        // caller's own refresh boundary, so it is genuinely fresh for them too.
-        // Superseding it instead would waste its round trip against a rate-limited
-        // API and discard its result without ever caching it.
+        // refresh's fetch is still running joins it rather than superseding it,
+        // which would waste that round trip against a rate-limited API and
+        // discard its result without ever caching it.
+        //
+        // Joining is sound because the in-flight fetch was issued after the
+        // cached value it will replace, so it is strictly fresher than anything
+        // this caller could already have observed. Note it may have been issued
+        // slightly *before* this call, so a change made in that window is not
+        // guaranteed to be reflected.
         if let inFlightFetch, refreshGeneration == generation {
             return try await result(of: inFlightFetch)
         }

--- a/Sources/TMDb/Domain/Services/Images/APIConfigurationStore.swift
+++ b/Sources/TMDb/Domain/Services/Images/APIConfigurationStore.swift
@@ -16,6 +16,7 @@ actor APIConfigurationStore {
     private var cachedConfiguration: APIConfiguration?
     private var inFlightFetch: Fetch?
     private var generation: UInt64 = 0
+    private var refreshGeneration: UInt64?
 
     init(configurationService: some ConfigurationService) {
         self.configurationService = configurationService
@@ -30,7 +31,17 @@ actor APIConfigurationStore {
     }
 
     func refresh() async throws(TMDbError) -> APIConfiguration {
+        // Coalesce concurrent refreshes. A refresh arriving while an earlier
+        // refresh's fetch is still running joins it: that fetch started after this
+        // caller's own refresh boundary, so it is genuinely fresh for them too.
+        // Superseding it instead would waste its round trip against a rate-limited
+        // API and discard its result without ever caching it.
+        if let inFlightFetch, refreshGeneration == generation {
+            return try await result(of: inFlightFetch)
+        }
+
         invalidate()
+        refreshGeneration = generation
 
         return try await result(of: currentFetch())
     }
@@ -41,9 +52,14 @@ actor APIConfigurationStore {
     /// awaiters, and cancelling it would fail all of them because someone else
     /// refreshed. It is left to run and deliver its value to the callers that
     /// asked before the refresh; the generation bump stops it committing.
+    ///
+    /// The cached value is deliberately **kept**. Clearing it here would mean a
+    /// refresh that then fails leaves the store with no configuration at all, so
+    /// a transient network loss during a refresh would degrade every later image
+    /// URL until connectivity returned. ``complete(_:generation:)`` swaps the
+    /// cached value only once a replacement has actually arrived.
     private func invalidate() {
         generation &+= 1
-        cachedConfiguration = nil
         inFlightFetch = nil
     }
 
@@ -103,6 +119,7 @@ actor APIConfigurationStore {
         }
 
         inFlightFetch = nil
+        refreshGeneration = nil
 
         // Only successes are memoised, so a failure retries on the next call.
         if case .success(let configuration) = result {

--- a/Sources/TMDb/Domain/Services/Images/APIConfigurationStore.swift
+++ b/Sources/TMDb/Domain/Services/Images/APIConfigurationStore.swift
@@ -1,0 +1,113 @@
+//
+//  APIConfigurationStore.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+actor APIConfigurationStore {
+
+    private typealias Fetch = Task<Result<APIConfiguration, TMDbError>, Never>
+
+    private let configurationService: any ConfigurationService
+    private var cachedConfiguration: APIConfiguration?
+    private var inFlightFetch: Fetch?
+    private var generation: UInt64 = 0
+
+    init(configurationService: some ConfigurationService) {
+        self.configurationService = configurationService
+    }
+
+    func apiConfiguration() async throws(TMDbError) -> APIConfiguration {
+        if let cachedConfiguration {
+            return cachedConfiguration
+        }
+
+        return try await result(of: currentFetch())
+    }
+
+    func refresh() async throws(TMDbError) -> APIConfiguration {
+        invalidate()
+
+        return try await result(of: currentFetch())
+    }
+
+    /// Starts a new generation, detaching any in-flight fetch.
+    ///
+    /// The in-flight fetch is deliberately **not** cancelled: it may have many
+    /// awaiters, and cancelling it would fail all of them because someone else
+    /// refreshed. It is left to run and deliver its value to the callers that
+    /// asked before the refresh; the generation bump stops it committing.
+    private func invalidate() {
+        generation &+= 1
+        cachedConfiguration = nil
+        inFlightFetch = nil
+    }
+
+    private func result(of fetch: Fetch) async throws(TMDbError) -> APIConfiguration {
+        try await fetch.value.get()
+    }
+
+    private func currentFetch() -> Fetch {
+        if let inFlightFetch {
+            return inFlightFetch
+        }
+
+        let configurationService = configurationService
+        let generation = generation
+
+        // `do throws(TMDbError)` is mandatory: typed-throws inference does not
+        // apply inside a closure, so a bare `catch` would bind `any Error`.
+        // `complete` is called WITHOUT `await` — this Task inherits the actor's
+        // isolation, and a redundant `await` is fatal under -warnings-as-errors.
+        let fetch = Fetch {
+            let result: Result<APIConfiguration, TMDbError>
+            do throws(TMDbError) {
+                result = try await .success(configurationService.apiConfiguration())
+            } catch {
+                result = .failure(error)
+            }
+
+            self.complete(result, generation: generation)
+
+            return result
+        }
+
+        // Published before the first suspension point, so a concurrent caller can
+        // never observe "no cache and no fetch" while this fetch is running.
+        inFlightFetch = fetch
+
+        return fetch
+    }
+
+    /// Commits a completed fetch, unless it has been superseded by a ``refresh()``.
+    ///
+    /// Called from inside the fetch task itself rather than from an awaiter's
+    /// continuation. Once the task resumes it is back on the actor, and runs this
+    /// commit and its return with no suspension in between — so nothing can
+    /// interleave between the commit and the task completing. That yields the
+    /// invariant `inFlightFetch != nil` **iff** its task has not yet committed,
+    /// which is what stops a late caller joining an already-finished fetch.
+    private func complete(
+        _ result: Result<APIConfiguration, TMDbError>,
+        generation: UInt64
+    ) {
+        // Superseded by a refresh: touch nothing. Clearing `inFlightFetch` here
+        // would detach the refresh's live fetch (causing a redundant third fetch),
+        // and caching this value would clobber the newer one.
+        guard generation == self.generation else {
+            return
+        }
+
+        inFlightFetch = nil
+
+        // Only successes are memoised, so a failure retries on the next call.
+        if case .success(let configuration) = result {
+            cachedConfiguration = configuration
+        }
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/Images/ImageService+URLs.swift
+++ b/Sources/TMDb/Domain/Services/Images/ImageService+URLs.swift
@@ -1,0 +1,240 @@
+//
+//  ImageService+URLs.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+public extension ImageService {
+
+    ///
+    /// Fetches and caches the images configuration ahead of its first use.
+    ///
+    /// Resolving an image URL fetches the configuration if it is not already
+    /// cached. Call this at launch to pay that cost up front, so the first image
+    /// URL resolves without a network round trip.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    func preload() async throws(TMDbError) {
+        _ = try await imagesConfiguration()
+    }
+
+    ///
+    /// Generates the fully qualified URL for a backdrop image.
+    ///
+    /// - Parameters:
+    ///   - path: Path to the backdrop image.
+    ///   - width: The ideal width of the image. The actual image may be larger. When no width is
+    ///            given, the original image URL is returned.
+    ///
+    /// - Throws: TMDb error ``TMDbError``. Not thrown when `path` is `nil`.
+    ///
+    /// - Returns: A fully qualified URL to a backdrop image, or `nil` if `path` is `nil`.
+    ///
+    func backdropURL(
+        for path: URL?,
+        idealWidth width: Int = Int.max
+    ) async throws(TMDbError) -> URL? {
+        guard let path else {
+            return nil
+        }
+
+        return try await imagesConfiguration().backdropURL(for: path, idealWidth: width)
+    }
+
+    ///
+    /// Generates the fully qualified URL for a logo image.
+    ///
+    /// - Parameters:
+    ///   - path: Path to the logo image.
+    ///   - width: The ideal width of the image. The actual image may be larger. When no width is
+    ///            given, the original image URL is returned.
+    ///
+    /// - Throws: TMDb error ``TMDbError``. Not thrown when `path` is `nil`.
+    ///
+    /// - Returns: A fully qualified URL to a logo image, or `nil` if `path` is `nil`.
+    ///
+    func logoURL(for path: URL?, idealWidth width: Int = Int.max) async throws(TMDbError) -> URL? {
+        guard let path else {
+            return nil
+        }
+
+        return try await imagesConfiguration().logoURL(for: path, idealWidth: width)
+    }
+
+    ///
+    /// Generates the fully qualified URL for a poster image.
+    ///
+    /// - Parameters:
+    ///   - path: Path to the poster image.
+    ///   - width: The ideal width of the image. The actual image may be larger. When no width is
+    ///            given, the original image URL is returned.
+    ///
+    /// - Throws: TMDb error ``TMDbError``. Not thrown when `path` is `nil`.
+    ///
+    /// - Returns: A fully qualified URL to a poster image, or `nil` if `path` is `nil`.
+    ///
+    func posterURL(
+        for path: URL?,
+        idealWidth width: Int = Int.max
+    ) async throws(TMDbError) -> URL? {
+        guard let path else {
+            return nil
+        }
+
+        return try await imagesConfiguration().posterURL(for: path, idealWidth: width)
+    }
+
+    ///
+    /// Generates the fully qualified URL for a profile image.
+    ///
+    /// - Parameters:
+    ///   - path: Path to the profile image.
+    ///   - width: The ideal width of the image. The actual image may be larger. When no width is
+    ///            given, the original image URL is returned.
+    ///
+    /// - Throws: TMDb error ``TMDbError``. Not thrown when `path` is `nil`.
+    ///
+    /// - Returns: A fully qualified URL to a profile image, or `nil` if `path` is `nil`.
+    ///
+    func profileURL(
+        for path: URL?,
+        idealWidth width: Int = Int.max
+    ) async throws(TMDbError) -> URL? {
+        guard let path else {
+            return nil
+        }
+
+        return try await imagesConfiguration().profileURL(for: path, idealWidth: width)
+    }
+
+    ///
+    /// Generates the fully qualified URL for a still image.
+    ///
+    /// - Parameters:
+    ///   - path: Path to the still image.
+    ///   - width: The ideal width of the image. The actual image may be larger. When no width is
+    ///            given, the original image URL is returned.
+    ///
+    /// - Throws: TMDb error ``TMDbError``. Not thrown when `path` is `nil`.
+    ///
+    /// - Returns: A fully qualified URL to a still image, or `nil` if `path` is `nil`.
+    ///
+    func stillURL(for path: URL?, idealWidth width: Int = Int.max) async throws(TMDbError) -> URL? {
+        guard let path else {
+            return nil
+        }
+
+        return try await imagesConfiguration().stillURL(for: path, idealWidth: width)
+    }
+
+    ///
+    /// Generates the fully qualified URL for a backdrop image at a specific size.
+    ///
+    /// - Parameters:
+    ///   - path: Path to the backdrop image.
+    ///   - size: The desired image size. ``ImageSize/original`` is always supported; any other
+    ///           size must be present in ``ImagesConfiguration/backdropSizes``.
+    ///
+    /// - Throws: TMDb error ``TMDbError``. Not thrown when `path` is `nil`.
+    ///
+    /// - Returns: A fully qualified URL to a backdrop image, or `nil` if `path` is `nil` or the
+    ///            size is not supported.
+    ///
+    func backdropURL(for path: URL?, size: ImageSize) async throws(TMDbError) -> URL? {
+        guard let path else {
+            return nil
+        }
+
+        return try await imagesConfiguration().backdropURL(for: path, size: size)
+    }
+
+    ///
+    /// Generates the fully qualified URL for a logo image at a specific size.
+    ///
+    /// - Parameters:
+    ///   - path: Path to the logo image.
+    ///   - size: The desired image size. ``ImageSize/original`` is always supported; any other
+    ///           size must be present in ``ImagesConfiguration/logoSizes``.
+    ///
+    /// - Throws: TMDb error ``TMDbError``. Not thrown when `path` is `nil`.
+    ///
+    /// - Returns: A fully qualified URL to a logo image, or `nil` if `path` is `nil` or the size
+    ///            is not supported.
+    ///
+    func logoURL(for path: URL?, size: ImageSize) async throws(TMDbError) -> URL? {
+        guard let path else {
+            return nil
+        }
+
+        return try await imagesConfiguration().logoURL(for: path, size: size)
+    }
+
+    ///
+    /// Generates the fully qualified URL for a poster image at a specific size.
+    ///
+    /// - Parameters:
+    ///   - path: Path to the poster image.
+    ///   - size: The desired image size. ``ImageSize/original`` is always supported; any other
+    ///           size must be present in ``ImagesConfiguration/posterSizes``.
+    ///
+    /// - Throws: TMDb error ``TMDbError``. Not thrown when `path` is `nil`.
+    ///
+    /// - Returns: A fully qualified URL to a poster image, or `nil` if `path` is `nil` or the
+    ///            size is not supported.
+    ///
+    func posterURL(for path: URL?, size: ImageSize) async throws(TMDbError) -> URL? {
+        guard let path else {
+            return nil
+        }
+
+        return try await imagesConfiguration().posterURL(for: path, size: size)
+    }
+
+    ///
+    /// Generates the fully qualified URL for a profile image at a specific size.
+    ///
+    /// - Parameters:
+    ///   - path: Path to the profile image.
+    ///   - size: The desired image size. ``ImageSize/original`` is always supported; any other
+    ///           size must be present in ``ImagesConfiguration/profileSizes``.
+    ///
+    /// - Throws: TMDb error ``TMDbError``. Not thrown when `path` is `nil`.
+    ///
+    /// - Returns: A fully qualified URL to a profile image, or `nil` if `path` is `nil` or the
+    ///            size is not supported.
+    ///
+    func profileURL(for path: URL?, size: ImageSize) async throws(TMDbError) -> URL? {
+        guard let path else {
+            return nil
+        }
+
+        return try await imagesConfiguration().profileURL(for: path, size: size)
+    }
+
+    ///
+    /// Generates the fully qualified URL for a still image at a specific size.
+    ///
+    /// - Parameters:
+    ///   - path: Path to the still image.
+    ///   - size: The desired image size. ``ImageSize/original`` is always supported; any other
+    ///           size must be present in ``ImagesConfiguration/stillSizes``.
+    ///
+    /// - Throws: TMDb error ``TMDbError``. Not thrown when `path` is `nil`.
+    ///
+    /// - Returns: A fully qualified URL to a still image, or `nil` if `path` is `nil` or the size
+    ///            is not supported.
+    ///
+    func stillURL(for path: URL?, size: ImageSize) async throws(TMDbError) -> URL? {
+        guard let path else {
+            return nil
+        }
+
+        return try await imagesConfiguration().stillURL(for: path, size: size)
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/Images/ImageService.swift
+++ b/Sources/TMDb/Domain/Services/Images/ImageService.swift
@@ -1,0 +1,65 @@
+//
+//  ImageService.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// Provides an interface for generating fully qualified image URLs from the image
+/// paths returned by TMDb.
+///
+/// Models such as ``Movie``, ``TVSeries`` and ``Person`` carry image *paths*, not
+/// URLs. Building a URL from a path needs TMDb's images configuration, which this
+/// service fetches on first use and caches for the lifetime of the client — so
+/// resolving an image URL is a single call:
+///
+/// ```swift
+/// let url = try await client.images.posterURL(for: movie.posterPath, size: .width(500))
+/// ```
+///
+/// The configuration is fetched **at most once**, no matter how many callers ask
+/// concurrently. Call ``preload()`` at launch to pay that cost up front rather
+/// than on the first image.
+///
+/// - Note: For resolving many URLs at once, prefer fetching
+///   ``imagesConfiguration()`` once and calling the synchronous helpers on
+///   ``ImagesConfiguration`` directly — that avoids an `await` per image.
+///
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+public protocol ImageService: Sendable {
+
+    ///
+    /// Returns TMDb's images configuration, fetching it on first use and caching
+    /// it for the lifetime of the client.
+    ///
+    /// Concurrent callers share a single fetch. A failed fetch is not cached, so a
+    /// later call retries.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The images configuration.
+    ///
+    func imagesConfiguration() async throws(TMDbError) -> ImagesConfiguration
+
+    ///
+    /// Discards the cached images configuration and fetches it again.
+    ///
+    /// TMDb's images configuration changes rarely, so this is seldom needed — it
+    /// exists for long-lived processes that would otherwise hold one value
+    /// indefinitely.
+    ///
+    /// A fetch already in progress when this is called is left to run: callers
+    /// that asked before the refresh receive that earlier value, and callers
+    /// arriving afterwards join the new fetch.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The freshly fetched images configuration.
+    ///
+    @discardableResult
+    func refresh() async throws(TMDbError) -> ImagesConfiguration
+
+}

--- a/Sources/TMDb/Domain/Services/Images/ImageService.swift
+++ b/Sources/TMDb/Domain/Services/Images/ImageService.swift
@@ -67,7 +67,10 @@ public protocol ImageService: Sendable {
     ///
     /// A fetch already in progress when this is called is left running rather
     /// than cancelled, so callers waiting on it still receive its value.
-    /// Concurrent calls to this method share a single fetch.
+    ///
+    /// Concurrent calls to this method share a single fetch. That fetch may have
+    /// been issued fractionally before a given call, so a change made in that
+    /// window is not guaranteed to be reflected in the value it returns.
     ///
     /// - Throws: TMDb error ``TMDbError``.
     ///

--- a/Sources/TMDb/Domain/Services/Images/ImageService.swift
+++ b/Sources/TMDb/Domain/Services/Images/ImageService.swift
@@ -28,6 +28,13 @@ import Foundation
 ///   ``imagesConfiguration()`` once and calling the synchronous helpers on
 ///   ``ImagesConfiguration`` directly — that avoids an `await` per image.
 ///
+/// - Important: Because concurrent callers share a single fetch, these methods
+///   are deliberately not cancellable by any one caller. Cancelling a task that
+///   is waiting on the shared fetch neither interrupts it nor makes it throw
+///   `CancellationError`: it waits for the fetch to finish and receives its
+///   value. Cancelling on behalf of one caller would otherwise fail every other
+///   caller waiting on the same fetch.
+///
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public protocol ImageService: Sendable {
 
@@ -45,15 +52,22 @@ public protocol ImageService: Sendable {
     func imagesConfiguration() async throws(TMDbError) -> ImagesConfiguration
 
     ///
-    /// Discards the cached images configuration and fetches it again.
+    /// Fetches the images configuration again, replacing the cached value once a
+    /// fresh one arrives.
     ///
     /// TMDb's images configuration changes rarely, so this is seldom needed — it
     /// exists for long-lived processes that would otherwise hold one value
     /// indefinitely.
     ///
-    /// A fetch already in progress when this is called is left to run: callers
-    /// that asked before the refresh receive that earlier value, and callers
-    /// arriving afterwards join the new fetch.
+    /// The cached value is replaced only on success: if the refresh fails, the
+    /// previously cached configuration is kept, so a transient network failure
+    /// during a refresh does not degrade later image URLs. Callers using
+    /// ``imagesConfiguration()`` meanwhile continue to receive the cached value
+    /// rather than waiting for the refresh.
+    ///
+    /// A fetch already in progress when this is called is left running rather
+    /// than cancelled, so callers waiting on it still receive its value.
+    /// Concurrent calls to this method share a single fetch.
     ///
     /// - Throws: TMDb error ``TMDbError``.
     ///

--- a/Sources/TMDb/Domain/Services/Images/TMDbImageService.swift
+++ b/Sources/TMDb/Domain/Services/Images/TMDbImageService.swift
@@ -1,0 +1,28 @@
+//
+//  TMDbImageService.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+final class TMDbImageService: ImageService, Sendable {
+
+    private let store: APIConfigurationStore
+
+    init(configurationService: some ConfigurationService) {
+        self.store = APIConfigurationStore(configurationService: configurationService)
+    }
+
+    func imagesConfiguration() async throws(TMDbError) -> ImagesConfiguration {
+        try await store.apiConfiguration().images
+    }
+
+    @discardableResult
+    func refresh() async throws(TMDbError) -> ImagesConfiguration {
+        try await store.refresh().images
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/Images/TMDbImageService.swift
+++ b/Sources/TMDb/Domain/Services/Images/TMDbImageService.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-final class TMDbImageService: ImageService, Sendable {
+final class TMDbImageService: ImageService {
 
     private let store: APIConfigurationStore
 

--- a/Sources/TMDb/TMDb.docc/Extensions/ImageService.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/ImageService.md
@@ -1,0 +1,34 @@
+# ``ImageService``
+
+## Topics
+
+### Poster Images
+
+- ``posterURL(for:idealWidth:)``
+- ``posterURL(for:size:)``
+
+### Backdrop Images
+
+- ``backdropURL(for:idealWidth:)``
+- ``backdropURL(for:size:)``
+
+### Profile Images
+
+- ``profileURL(for:idealWidth:)``
+- ``profileURL(for:size:)``
+
+### Logo Images
+
+- ``logoURL(for:idealWidth:)``
+- ``logoURL(for:size:)``
+
+### Still Images
+
+- ``stillURL(for:idealWidth:)``
+- ``stillURL(for:size:)``
+
+### Managing the Cached Configuration
+
+- ``preload()``
+- ``imagesConfiguration()``
+- ``refresh()``

--- a/Sources/TMDb/TMDb.docc/Extensions/TMDbClient.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/TMDbClient.md
@@ -36,6 +36,7 @@
 - ``lists``
 - ``watchProviders``
 - ``configurations``
+- ``images``
 - ``account``
 - ``authentication``
 - ``changes``

--- a/Sources/TMDb/TMDb.docc/HowTos/GeneratingImageURLs.md
+++ b/Sources/TMDb/TMDb.docc/HowTos/GeneratingImageURLs.md
@@ -8,46 +8,72 @@ TMDb returns paths to images in objects such as ``Movie``, ``TVSeries`` and
 ``Person``. In order to get the actual image the full URL needs to be
 generated.
 
-## Fetching Images Configuration
+There are two ways to do this. Reach for ``TMDbClient/images`` for everyday
+use; drop down to ``ImagesConfiguration`` when you are resolving many URLs at
+once.
 
-Before an image's full URL can be generated from its path, the
-``ImagesConfiguration`` needs to be fetched from TMDb using your
-``TMDbClient`` instance.
+## Resolving a Single Image URL
+
+``TMDbClient/images`` resolves an image path in one call. It fetches TMDb's
+images configuration the first time it needs it and caches it for the lifetime
+of the client, so you do not have to hold that object yourself.
 
 ```swift
 let tmdbClient = TMDbClient(apiKey: "<your-tmdb-api-key>")
 
-let apiConfiguration = try await tmdbClient.configurations.apiConfiguration()
-let imagesConfiguration = apiConfiguration.images
-```
-
-## Generate the Image URL
-
-Once you have the ``ImagesConfiguration`` it can be used to generate the full
-URL to an image.
-
-```swift
 let barbieMovie = try await tmdbClient.movies.details(forMovie: 346698)
 
-let barbiePosterURL = imagesConfiguration.posterURL(
-    for: barbieMovie.posterPath
+let barbiePosterURL = try await tmdbClient.images.posterURL(
+    for: barbieMovie.posterPath,
+    size: .width(500)
 )
 ```
 
-> Tip: You can add the `idealWidth` parameter to generate the URL for the image
-best suited to a width. If `idealWidth` is not given, the URL to the original
-image will be generated.
+> Tip: Use `idealWidth` instead of `size` to ask for the best available image
+for a width, rather than an exact size. Without either, you get the original
+image.
+
+A `nil` path returns `nil` without making a request, so a model with no image
+costs nothing and never surfaces a network error.
+
+### Warming the Cache
+
+The first URL you resolve pays for fetching the configuration. Call
+``ImageService/preload()`` at launch to pay that cost up front instead:
+
+```swift
+try await tmdbClient.images.preload()
+```
+
+The configuration is fetched **at most once**, however many callers ask for it
+concurrently.
+
+## Resolving Many Image URLs
+
+Every resolver method is `async`, so resolving a screenful of images means an
+`await` apiece. When you have a batch, fetch the ``ImagesConfiguration`` once
+and use its synchronous helpers directly:
+
+```swift
+let imagesConfiguration = try await tmdbClient.images.imagesConfiguration()
+
+let posterURLs = movies.map { movie in
+    imagesConfiguration.posterURL(for: movie.posterPath, size: .width(500))
+}
+```
+
+This is the same cached configuration ``TMDbClient/images`` uses, so it costs
+no extra request.
 
 ## Requesting a Specific Size
 
-Instead of an ideal width, you can request a specific ``ImageSize`` such as a
-fixed width, a fixed height, or the original image. The size must be one of the
-sizes available in the ``ImagesConfiguration`` for that image type (for example
-``ImagesConfiguration/posterSizes``); ``ImageSize/original`` is always
-supported. If an unsupported size is requested, `nil` is returned.
+The size must be one of the sizes available in the ``ImagesConfiguration`` for
+that image type (for example ``ImagesConfiguration/posterSizes``);
+``ImageSize/original`` is always supported. If an unsupported size is
+requested, `nil` is returned.
 
 ```swift
-let barbiePosterURL = imagesConfiguration.posterURL(
+let barbiePosterURL = try await tmdbClient.images.posterURL(
     for: barbieMovie.posterPath,
     size: .width(500)
 )
@@ -70,19 +96,32 @@ let posterURL = barbieMovie.posterURL(
 
 ## Image types
 
-Use the following methods on ``ImagesConfiguration`` to generate image URLs
+Use the following methods on ``TMDbClient/images`` to generate image URLs
 depending on the type of image needed:
 
-* ``ImagesConfiguration/backdropURL(for:idealWidth:)``
-* ``ImagesConfiguration/logoURL(for:idealWidth:)``
-* ``ImagesConfiguration/posterURL(for:idealWidth:)``
-* ``ImagesConfiguration/profileURL(for:idealWidth:)``
-* ``ImagesConfiguration/stillURL(for:idealWidth:)``
+* ``ImageService/backdropURL(for:idealWidth:)``
+* ``ImageService/logoURL(for:idealWidth:)``
+* ``ImageService/posterURL(for:idealWidth:)``
+* ``ImageService/profileURL(for:idealWidth:)``
+* ``ImageService/stillURL(for:idealWidth:)``
 
 Or, to request a specific ``ImageSize``:
 
-* ``ImagesConfiguration/backdropURL(for:size:)``
-* ``ImagesConfiguration/logoURL(for:size:)``
-* ``ImagesConfiguration/posterURL(for:size:)``
-* ``ImagesConfiguration/profileURL(for:size:)``
-* ``ImagesConfiguration/stillURL(for:size:)``
+* ``ImageService/backdropURL(for:size:)``
+* ``ImageService/logoURL(for:size:)``
+* ``ImageService/posterURL(for:size:)``
+* ``ImageService/profileURL(for:size:)``
+* ``ImageService/stillURL(for:size:)``
+
+The same ten methods exist on ``ImagesConfiguration`` in synchronous form, for
+the batch case above.
+
+## Keeping the Configuration Fresh
+
+TMDb's images configuration changes rarely, so caching it for the lifetime of
+the client is normally the right thing. A long-lived process that wants to pick
+up a change can call ``ImageService/refresh()``:
+
+```swift
+try await tmdbClient.images.refresh()
+```

--- a/Sources/TMDb/TMDb.docc/HowTos/GeneratingImageURLs.md
+++ b/Sources/TMDb/TMDb.docc/HowTos/GeneratingImageURLs.md
@@ -48,6 +48,12 @@ try await tmdbClient.images.preload()
 The configuration is fetched **at most once**, however many callers ask for it
 concurrently.
 
+> Important: Because concurrent callers share one fetch, these methods are
+deliberately not cancellable by any single caller. A cancelled task waiting on
+the shared fetch is not interrupted and does not throw `CancellationError` — it
+waits for the fetch to finish and receives its value. Cancelling for one caller
+would otherwise fail every other caller waiting on the same fetch.
+
 ## Resolving Many Image URLs
 
 Every resolver method is `async`, so resolving a screenful of images means an
@@ -125,3 +131,8 @@ up a change can call ``ImageService/refresh()``:
 ```swift
 try await tmdbClient.images.refresh()
 ```
+
+The cached value is replaced only once a fresh one arrives, so a refresh that
+fails leaves the previous configuration in place rather than leaving you with
+none. Callers resolving image URLs during the refresh continue to use the
+cached value instead of waiting.

--- a/Sources/TMDb/TMDb.docc/TMDb.md
+++ b/Sources/TMDb/TMDb.docc/TMDb.md
@@ -369,6 +369,7 @@ Watch providers provided by [JustWatch](https://www.justwatch.com).
 
 ### Image URLs
 
+- ``ImageService``
 - ``ImageSize``
 - ``PosterImageProviding``
 - ``BackdropImageProviding``

--- a/Sources/TMDb/TMDbClient.swift
+++ b/Sources/TMDb/TMDbClient.swift
@@ -96,6 +96,15 @@ public final class TMDbClient: Sendable {
     public let guestSessions: any GuestSessionService
 
     ///
+    /// Provides access to fully qualified image URLs, resolved from the image
+    /// paths carried by models such as ``Movie``, ``TVSeries`` and ``Person``.
+    ///
+    /// The images configuration this needs is fetched on first use and cached
+    /// for the lifetime of this client.
+    ///
+    public let images: any ImageService
+
+    ///
     /// Provides access to keyword details and discovering movies by
     /// keyword.
     ///
@@ -278,6 +287,12 @@ public final class TMDbClient: Sendable {
         let authAPIClient = dependencies.authAPIClient
         let authenticateURLBuilder = dependencies.authenticateURLBuilder
 
+        // Hoisted into a local so the image service can share this exact instance:
+        // `self.configurations` cannot be read until every stored property is
+        // initialised. Sharing it means the memo sits above the same service the
+        // `configurations` property exposes.
+        let configurationService = TMDbConfigurationService(apiClient: apiClient)
+
         self.configuration = configuration
         self.account = TMDbAccountService(apiClient: apiClient)
         self.authentication = TMDbAuthenticationService(
@@ -287,12 +302,13 @@ public final class TMDbClient: Sendable {
         self.certifications = TMDbCertificationService(apiClient: apiClient)
         self.collections = TMDbCollectionService(apiClient: apiClient, configuration: configuration)
         self.companies = TMDbCompanyService(apiClient: apiClient)
-        self.configurations = TMDbConfigurationService(apiClient: apiClient)
+        self.configurations = configurationService
         self.credits = TMDbCreditService(apiClient: apiClient)
         self.discover = TMDbDiscoverService(apiClient: apiClient, configuration: configuration)
         self.find = TMDbFindService(apiClient: apiClient, configuration: configuration)
         self.genres = TMDbGenreService(apiClient: apiClient, configuration: configuration)
         self.guestSessions = TMDbGuestSessionService(apiClient: apiClient)
+        self.images = TMDbImageService(configurationService: configurationService)
         self.keywords = TMDbKeywordService(apiClient: apiClient)
         self.lists = TMDbListService(apiClient: apiClient)
         self.movies = TMDbMovieService(apiClient: apiClient, configuration: configuration)

--- a/Sources/TMDbTesting/Samples/APIConfiguration+Sample.swift
+++ b/Sources/TMDbTesting/Samples/APIConfiguration+Sample.swift
@@ -12,20 +12,8 @@ public extension APIConfiguration {
 
     /// A sample `APIConfiguration` for use in previews and tests.
     static var sample: APIConfiguration {
-        let baseURL = URL(string: "http://image.tmdb.org/t/p/") ?? URL(fileURLWithPath: "/")
-        let secureBaseURL = URL(string: "https://image.tmdb.org/t/p/")
-            ?? URL(fileURLWithPath: "/")
-
-        return APIConfiguration(
-            images: ImagesConfiguration(
-                baseURL: baseURL,
-                secureBaseURL: secureBaseURL,
-                backdropSizes: ["w300", "w780", "w1280", "original"],
-                logoSizes: ["w45", "w92", "w154", "w185", "w300", "w500", "original"],
-                posterSizes: ["w92", "w154", "w185", "w342", "w500", "w780", "original"],
-                profileSizes: ["w45", "w185", "h632", "original"],
-                stillSizes: ["w92", "w185", "w300", "original"]
-            ),
+        APIConfiguration(
+            images: .sample,
             changeKeys: ["adult", "air_date", "also_known_as"]
         )
     }

--- a/Sources/TMDbTesting/Samples/ImagesConfiguration+Sample.swift
+++ b/Sources/TMDbTesting/Samples/ImagesConfiguration+Sample.swift
@@ -1,0 +1,30 @@
+//
+//  ImagesConfiguration+Sample.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import TMDb
+
+public extension ImagesConfiguration {
+
+    /// A sample `ImagesConfiguration` for use in previews and tests.
+    static var sample: ImagesConfiguration {
+        let baseURL = URL(string: "http://image.tmdb.org/t/p/") ?? URL(fileURLWithPath: "/")
+        let secureBaseURL = URL(string: "https://image.tmdb.org/t/p/")
+            ?? URL(fileURLWithPath: "/")
+
+        return ImagesConfiguration(
+            baseURL: baseURL,
+            secureBaseURL: secureBaseURL,
+            backdropSizes: ["w300", "w780", "w1280", "original"],
+            logoSizes: ["w45", "w92", "w154", "w185", "w300", "w500", "original"],
+            posterSizes: ["w92", "w154", "w185", "w342", "w500", "w780", "original"],
+            profileSizes: ["w45", "w185", "h632", "original"],
+            stillSizes: ["w92", "w185", "w300", "original"]
+        )
+    }
+
+}

--- a/Sources/TMDbTesting/Services/MockImageService.swift
+++ b/Sources/TMDbTesting/Services/MockImageService.swift
@@ -60,7 +60,7 @@ public final class MockImageService: ImageService, @unchecked Sendable {
     ///
     /// Returns the stubbed images configuration.
     ///
-    /// - Throws: TMDb error ``TMDbError``.
+    /// - Throws: TMDb error `TMDbError`.
     ///
     /// - Returns: The images configuration.
     ///
@@ -93,7 +93,7 @@ public final class MockImageService: ImageService, @unchecked Sendable {
     ///
     /// Returns the stubbed refreshed images configuration.
     ///
-    /// - Throws: TMDb error ``TMDbError``.
+    /// - Throws: TMDb error `TMDbError`.
     ///
     /// - Returns: The images configuration.
     ///

--- a/Sources/TMDbTesting/Services/MockImageService.swift
+++ b/Sources/TMDbTesting/Services/MockImageService.swift
@@ -18,6 +18,9 @@ import TMDb
 /// - Note: Unstubbed methods return sample data, so assert on values you have
 ///   stubbed rather than on the defaults.
 ///
+/// The mock is safe to share across concurrent calls: its recorded state is
+/// guarded by a lock.
+///
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public final class MockImageService: ImageService, @unchecked Sendable {
 
@@ -31,7 +34,9 @@ public final class MockImageService: ImageService, @unchecked Sendable {
         var refreshResult: Result<ImagesConfiguration, TMDbError> = .success(.sample)
     }
 
+    ///
     /// Creates a mock image service.
+    ///
     public init() {}
 
     private func withLock<R>(_ body: () -> R) -> R {
@@ -43,26 +48,32 @@ public final class MockImageService: ImageService, @unchecked Sendable {
 
     // MARK: - imagesConfiguration
 
+    ///
     /// The arguments of a single call to ``imagesConfiguration()``.
+    ///
     public struct ImagesConfigurationCall: Sendable {}
 
-    /// The calls made to ``imagesConfiguration()``.
+    ///
+    /// The recorded calls to ``imagesConfiguration()``, in the order they were made.
+    ///
     public var imagesConfigurationCalls: [ImagesConfigurationCall] {
         withLock { storage.imagesConfigurationCalls }
     }
 
-    /// The result returned by ``imagesConfiguration()``.
+    ///
+    /// The stubbed result returned by ``imagesConfiguration()``.
+    ///
     public var imagesConfigurationResult: Result<ImagesConfiguration, TMDbError> {
         get { withLock { storage.imagesConfigurationResult } }
         set { withLock { storage.imagesConfigurationResult = newValue } }
     }
 
     ///
-    /// Returns the stubbed images configuration.
+    /// Records the call and returns ``imagesConfigurationResult``.
     ///
     /// - Throws: TMDb error `TMDbError`.
     ///
-    /// - Returns: The images configuration.
+    /// - Returns: The stubbed images configuration.
     ///
     public func imagesConfiguration() async throws(TMDbError) -> ImagesConfiguration {
         let result = withLock {
@@ -76,26 +87,32 @@ public final class MockImageService: ImageService, @unchecked Sendable {
 
     // MARK: - refresh
 
+    ///
     /// The arguments of a single call to ``refresh()``.
+    ///
     public struct RefreshCall: Sendable {}
 
-    /// The calls made to ``refresh()``.
+    ///
+    /// The recorded calls to ``refresh()``, in the order they were made.
+    ///
     public var refreshCalls: [RefreshCall] {
         withLock { storage.refreshCalls }
     }
 
-    /// The result returned by ``refresh()``.
+    ///
+    /// The stubbed result returned by ``refresh()``.
+    ///
     public var refreshResult: Result<ImagesConfiguration, TMDbError> {
         get { withLock { storage.refreshResult } }
         set { withLock { storage.refreshResult = newValue } }
     }
 
     ///
-    /// Returns the stubbed refreshed images configuration.
+    /// Records the call and returns ``refreshResult``.
     ///
     /// - Throws: TMDb error `TMDbError`.
     ///
-    /// - Returns: The images configuration.
+    /// - Returns: The stubbed images configuration.
     ///
     @discardableResult
     public func refresh() async throws(TMDbError) -> ImagesConfiguration {

--- a/Sources/TMDbTesting/Services/MockImageService.swift
+++ b/Sources/TMDbTesting/Services/MockImageService.swift
@@ -1,0 +1,111 @@
+//
+//  MockImageService.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import TMDb
+
+///
+/// A mock `ImageService` that records calls and returns injected results.
+///
+/// The URL-generating methods are protocol-extension methods over
+/// `imagesConfiguration()`, so stubbing `imagesConfigurationResult` transitively
+/// controls every URL this service produces.
+///
+/// - Note: Unstubbed methods return sample data, so assert on values you have
+///   stubbed rather than on the defaults.
+///
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+public final class MockImageService: ImageService, @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var storage = Storage()
+
+    private struct Storage {
+        var imagesConfigurationCalls: [ImagesConfigurationCall] = []
+        var imagesConfigurationResult: Result<ImagesConfiguration, TMDbError> = .success(.sample)
+        var refreshCalls: [RefreshCall] = []
+        var refreshResult: Result<ImagesConfiguration, TMDbError> = .success(.sample)
+    }
+
+    /// Creates a mock image service.
+    public init() {}
+
+    private func withLock<R>(_ body: () -> R) -> R {
+        lock.lock()
+        defer { lock.unlock() }
+
+        return body()
+    }
+
+    // MARK: - imagesConfiguration
+
+    /// The arguments of a single call to ``imagesConfiguration()``.
+    public struct ImagesConfigurationCall: Sendable {}
+
+    /// The calls made to ``imagesConfiguration()``.
+    public var imagesConfigurationCalls: [ImagesConfigurationCall] {
+        withLock { storage.imagesConfigurationCalls }
+    }
+
+    /// The result returned by ``imagesConfiguration()``.
+    public var imagesConfigurationResult: Result<ImagesConfiguration, TMDbError> {
+        get { withLock { storage.imagesConfigurationResult } }
+        set { withLock { storage.imagesConfigurationResult = newValue } }
+    }
+
+    ///
+    /// Returns the stubbed images configuration.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The images configuration.
+    ///
+    public func imagesConfiguration() async throws(TMDbError) -> ImagesConfiguration {
+        let result = withLock {
+            storage.imagesConfigurationCalls.append(ImagesConfigurationCall())
+
+            return storage.imagesConfigurationResult
+        }
+
+        return try result.get()
+    }
+
+    // MARK: - refresh
+
+    /// The arguments of a single call to ``refresh()``.
+    public struct RefreshCall: Sendable {}
+
+    /// The calls made to ``refresh()``.
+    public var refreshCalls: [RefreshCall] {
+        withLock { storage.refreshCalls }
+    }
+
+    /// The result returned by ``refresh()``.
+    public var refreshResult: Result<ImagesConfiguration, TMDbError> {
+        get { withLock { storage.refreshResult } }
+        set { withLock { storage.refreshResult = newValue } }
+    }
+
+    ///
+    /// Returns the stubbed refreshed images configuration.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The images configuration.
+    ///
+    @discardableResult
+    public func refresh() async throws(TMDbError) -> ImagesConfiguration {
+        let result = withLock {
+            storage.refreshCalls.append(RefreshCall())
+
+            return storage.refreshResult
+        }
+
+        return try result.get()
+    }
+
+}

--- a/Sources/TMDbTesting/TMDbTesting.docc/TMDbTesting.md
+++ b/Sources/TMDbTesting/TMDbTesting.docc/TMDbTesting.md
@@ -72,6 +72,7 @@ let genres = [Genre].samples
 - ``MockFindService``
 - ``MockGenreService``
 - ``MockGuestSessionService``
+- ``MockImageService``
 - ``MockKeywordService``
 - ``MockListService``
 - ``MockMovieService``

--- a/Tests/TMDbIntegrationTests/ImageIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/ImageIntegrationTests.swift
@@ -55,6 +55,31 @@ struct ImageIntegrationTests {
         #expect(posterURL.absoluteString.contains("/w500/"))
     }
 
+    @Test("posterURL for an ideal width selects a sized variant from the live configuration")
+    func posterURLForIdealWidthSelectsSizedVariant() async throws {
+        let movie = try await client.movies.details(forMovie: 346_698)
+
+        let url = try await client.images.posterURL(for: movie.posterPath, idealWidth: 300)
+
+        // Exercises a different path from the `size:` family: this one parses the
+        // live size strings ("w500", "h632", "original") to pick the smallest
+        // that is at least this wide. A TMDb-side format change would break it
+        // silently, which is what this suite exists to catch.
+        let posterURL = try #require(url)
+        #expect(posterURL.scheme == "https")
+        #expect(!posterURL.absoluteString.contains("/original/"))
+    }
+
+    @Test("profileURL for an ideal width resolves against the live configuration")
+    func profileURLForIdealWidthResolvesAgainstLiveConfiguration() async throws {
+        let person = try await client.people.details(forPerson: 287)
+
+        let url = try await client.images.profileURL(for: person.profilePath, idealWidth: 200)
+
+        let profileURL = try #require(url)
+        #expect(profileURL.scheme == "https")
+    }
+
     @Test("posterURL for a nil path returns nil")
     func posterURLForNilPathReturnsNil() async throws {
         let url = try await client.images.posterURL(for: nil, size: .width(500))

--- a/Tests/TMDbIntegrationTests/ImageIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/ImageIntegrationTests.swift
@@ -1,0 +1,75 @@
+//
+//  ImageIntegrationTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(
+    .integrationGate,
+    .serialized,
+    .tags(.images),
+    .enabled(if: CredentialHelper.shared.hasAPIKey)
+)
+struct ImageIntegrationTests {
+
+    var client: TMDbClient!
+
+    init() throws {
+        self.client = CredentialHelper.shared.makeClient()
+    }
+
+    @Test("preload")
+    func preload() async throws {
+        try await client.images.preload()
+
+        let configuration = try await client.images.imagesConfiguration()
+
+        #expect(!configuration.posterSizes.isEmpty)
+    }
+
+    @Test("imagesConfiguration")
+    func imagesConfiguration() async throws {
+        let configuration = try await client.images.imagesConfiguration()
+
+        #expect(!configuration.backdropSizes.isEmpty)
+        #expect(!configuration.logoSizes.isEmpty)
+        #expect(!configuration.posterSizes.isEmpty)
+        #expect(!configuration.profileSizes.isEmpty)
+        #expect(!configuration.stillSizes.isEmpty)
+        #expect(configuration.secureBaseURL.scheme == "https")
+    }
+
+    @Test("posterURL for a movie's poster path")
+    func posterURLForMoviePosterPath() async throws {
+        let movie = try await client.movies.details(forMovie: 346_698)
+
+        let url = try await client.images.posterURL(for: movie.posterPath, size: .width(500))
+
+        let posterURL = try #require(url)
+        #expect(posterURL.scheme == "https")
+        #expect(posterURL.absoluteString.contains("/w500/"))
+    }
+
+    @Test("posterURL for a nil path returns nil")
+    func posterURLForNilPathReturnsNil() async throws {
+        let url = try await client.images.posterURL(for: nil, size: .width(500))
+
+        #expect(url == nil)
+    }
+
+    @Test("refresh")
+    func refresh() async throws {
+        let before = try await client.images.imagesConfiguration()
+
+        let refreshed = try await client.images.refresh()
+
+        #expect(!refreshed.posterSizes.isEmpty)
+        #expect(refreshed == before)
+    }
+
+}

--- a/Tests/TMDbIntegrationTests/ImageIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/ImageIntegrationTests.swift
@@ -89,12 +89,21 @@ struct ImageIntegrationTests {
 
     @Test("refresh")
     func refresh() async throws {
-        let before = try await client.images.imagesConfiguration()
+        _ = try await client.images.imagesConfiguration()
 
         let refreshed = try await client.images.refresh()
 
+        // Assert the refresh returned a usable configuration, not that it equals
+        // the previous one: that would be a weak assertion (it holds trivially
+        // for a static endpoint) and would break if TMDb ever changed the
+        // configuration between the two calls.
         #expect(!refreshed.posterSizes.isEmpty)
-        #expect(refreshed == before)
+        #expect(!refreshed.profileSizes.isEmpty)
+        #expect(refreshed.secureBaseURL.scheme == "https")
+
+        // The refreshed value must be what later resolutions use.
+        let after = try await client.images.imagesConfiguration()
+        #expect(after == refreshed)
     }
 
 }

--- a/Tests/TMDbIntegrationTests/TestUtils/Tags.swift
+++ b/Tests/TMDbIntegrationTests/TestUtils/Tags.swift
@@ -15,12 +15,12 @@ extension Tag {
     @Tag static var collection: Self
     @Tag static var company: Self
     @Tag static var configuration: Self
-    @Tag static var images: Self
     @Tag static var credit: Self
     @Tag static var discover: Self
     @Tag static var find: Self
     @Tag static var genre: Self
     @Tag static var guestSession: Self
+    @Tag static var images: Self
     @Tag static var keyword: Self
     @Tag static var list: Self
     @Tag static var movie: Self

--- a/Tests/TMDbIntegrationTests/TestUtils/Tags.swift
+++ b/Tests/TMDbIntegrationTests/TestUtils/Tags.swift
@@ -15,6 +15,7 @@ extension Tag {
     @Tag static var collection: Self
     @Tag static var company: Self
     @Tag static var configuration: Self
+    @Tag static var images: Self
     @Tag static var credit: Self
     @Tag static var discover: Self
     @Tag static var find: Self

--- a/Tests/TMDbTestFixtures/Mocks/CountingConfigurationService.swift
+++ b/Tests/TMDbTestFixtures/Mocks/CountingConfigurationService.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Testing
 import TMDb
 
 ///
@@ -50,9 +51,36 @@ package actor FetchGate {
         }
     }
 
-    /// Suspends until at least `count` fetches have reached the gate.
-    package func waitUntilEntered(atLeast count: Int) async {
+    ///
+    /// Suspends until at least `count` fetches have reached the gate, or the
+    /// deadline passes.
+    ///
+    /// The deadline matters: the regressions these tests exist to catch are ones
+    /// where an expected fetch never starts. An unbounded wait would turn such a
+    /// regression into a CI job timeout with no diagnostic, which is far worse
+    /// than a failed assertion. On expiry this records an issue and returns, so
+    /// the caller's own expectations fail with a real message.
+    ///
+    package func waitUntilEntered(
+        atLeast count: Int,
+        within timeout: Duration = .seconds(10),
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) async {
+        let deadline = ContinuousClock.now + timeout
+
         while entered < count {
+            guard ContinuousClock.now < deadline else {
+                Issue.record(
+                    """
+                    Only \(entered) of \(count) fetches reached the gate within \
+                    \(timeout). The fetch that was expected to start never did.
+                    """,
+                    sourceLocation: sourceLocation
+                )
+
+                return
+            }
+
             await Task.yield()
         }
     }

--- a/Tests/TMDbTestFixtures/Mocks/CountingConfigurationService.swift
+++ b/Tests/TMDbTestFixtures/Mocks/CountingConfigurationService.swift
@@ -1,0 +1,148 @@
+//
+//  CountingConfigurationService.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import TMDb
+
+///
+/// Holds a fetch open until the test explicitly releases it.
+///
+/// Interleaving tests must not depend on a `Task.sleep` being "long enough" —
+/// that is flaky on loaded CI. A gate holds the race window open until `open()`
+/// is called, making the interleaving deterministic.
+///
+package actor FetchGate {
+
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var entered = 0
+
+    package init() {}
+
+    /// The number of fetches that have reached the gate.
+    package var enteredCount: Int {
+        entered
+    }
+
+    /// Suspends the caller until ``open()`` is called. Returns immediately once open.
+    package func wait() async {
+        entered += 1
+        if isOpen {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    /// Releases every parked caller, and lets subsequent callers straight through.
+    package func open() {
+        isOpen = true
+        let pending = waiters
+        waiters.removeAll()
+        for continuation in pending {
+            continuation.resume()
+        }
+    }
+
+    /// Suspends until at least `count` fetches have reached the gate.
+    package func waitUntilEntered(atLeast count: Int) async {
+        while entered < count {
+            await Task.yield()
+        }
+    }
+
+}
+
+///
+/// A `ConfigurationService` double that counts `apiConfiguration()` calls and
+/// records how many were ever in flight at once.
+///
+/// State is `NSLock`-guarded so this is safe to drive from many concurrent
+/// callers — unlike `MockAPIClient`, whose mutable state is unsynchronised.
+///
+/// - Note: Only `apiConfiguration()` is implemented; the remaining requirements
+///   trap, so an unexpected call is loud rather than silent.
+///
+package final class CountingConfigurationService: ConfigurationService, @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var results: [Result<APIConfiguration, TMDbError>] = []
+    private var count = 0
+    private var activeFetches = 0
+    private var peak = 0
+    private let gate: FetchGate?
+
+    /// Creates a counting double, optionally parked behind `gate`.
+    package init(gate: FetchGate? = nil) {
+        self.gate = gate
+    }
+
+    /// The number of times `apiConfiguration()` has been called.
+    package var apiConfigurationCallCount: Int {
+        lock.withLock { count }
+    }
+
+    /// The greatest number of fetches ever in flight at once. Greater than 1 proves
+    /// de-duplication failed.
+    package var peakConcurrency: Int {
+        lock.withLock { peak }
+    }
+
+    /// Appends a result to the queue. The last enqueued result serves any further calls.
+    package func enqueue(_ result: Result<APIConfiguration, TMDbError>) {
+        lock.withLock { results.append(result) }
+    }
+
+    package func apiConfiguration() async throws(TMDbError) -> APIConfiguration {
+        let index: Int = lock.withLock {
+            let index = count
+            count += 1
+            activeFetches += 1
+            peak = max(peak, activeFetches)
+            return index
+        }
+
+        // Decremented only after the gate releases, so `peak` counts fetches that
+        // are concurrently suspended — which is the whole point of the measurement.
+        defer { lock.withLock { activeFetches -= 1 } }
+
+        await gate?.wait()
+
+        let result: Result<APIConfiguration, TMDbError> = lock.withLock {
+            guard results.indices.contains(index) else {
+                return results.last ?? .failure(.unknown)
+            }
+
+            return results[index]
+        }
+
+        return try result.get()
+    }
+
+    package func countries(language _: String?) async throws(TMDbError) -> [Country] {
+        preconditionFailure("Unused by CountingConfigurationService")
+    }
+
+    package func jobsByDepartment() async throws(TMDbError) -> [Department] {
+        preconditionFailure("Unused by CountingConfigurationService")
+    }
+
+    package func languages() async throws(TMDbError) -> [Language] {
+        preconditionFailure("Unused by CountingConfigurationService")
+    }
+
+    package func primaryTranslations() async throws(TMDbError) -> [String] {
+        preconditionFailure("Unused by CountingConfigurationService")
+    }
+
+    package func timezones() async throws(TMDbError) -> [Timezone] {
+        preconditionFailure("Unused by CountingConfigurationService")
+    }
+
+}

--- a/Tests/TMDbTestFixtures/Mocks/CountingConfigurationService.swift
+++ b/Tests/TMDbTestFixtures/Mocks/CountingConfigurationService.swift
@@ -51,6 +51,14 @@ package actor FetchGate {
         }
     }
 
+    /// Parks callers arriving from now on. Already-released callers are unaffected.
+    ///
+    /// Lets a test prime a cache through an open gate and then hold a later fetch
+    /// open, without needing a second store.
+    package func close() {
+        isOpen = false
+    }
+
     ///
     /// Suspends until at least `count` fetches have reached the gate, or the
     /// deadline passes.

--- a/Tests/TMDbTestFixtures/TestUtils/Tags.swift
+++ b/Tests/TMDbTestFixtures/TestUtils/Tags.swift
@@ -34,6 +34,7 @@ package extension Tag {
     @Tag static var find: Self
     @Tag static var genre: Self
     @Tag static var guestSession: Self
+    @Tag static var images: Self
     @Tag static var keyword: Self
     @Tag static var list: Self
     @Tag static var movie: Self

--- a/Tests/TMDbTestingTests/Services/AllMocksSmokeTests.swift
+++ b/Tests/TMDbTestingTests/Services/AllMocksSmokeTests.swift
@@ -55,6 +55,13 @@ struct AllMocksSmokeTests {
         #expect(service.apiConfigurationCalls.count == 1)
     }
 
+    @Test("MockImageService is usable with zero setup")
+    func imageServiceSmoke() async throws {
+        let service = MockImageService()
+        _ = try await service.imagesConfiguration()
+        #expect(service.imagesConfigurationCalls.count == 1)
+    }
+
     @Test("MockCreditService is usable with zero setup")
     func creditServiceSmoke() async throws {
         let service = MockCreditService()

--- a/Tests/TMDbTestingTests/Services/MockImageServiceTests.swift
+++ b/Tests/TMDbTestingTests/Services/MockImageServiceTests.swift
@@ -1,0 +1,110 @@
+//
+//  MockImageServiceTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+import TMDb
+import TMDbTesting
+
+@Suite(.tags(.testingSupport, .mocks, .images))
+struct MockImageServiceTests {
+
+    var service: MockImageService
+
+    init() {
+        self.service = MockImageService()
+    }
+
+    @Test("imagesConfiguration by default returns the sample configuration")
+    func imagesConfigurationByDefaultReturnsSample() async throws {
+        let result = try await service.imagesConfiguration()
+
+        #expect(result == ImagesConfiguration.sample)
+    }
+
+    @Test("imagesConfiguration records the call")
+    func imagesConfigurationRecordsCall() async throws {
+        _ = try await service.imagesConfiguration()
+
+        #expect(service.imagesConfigurationCalls.count == 1)
+    }
+
+    @Test("imagesConfiguration throws the injected failure")
+    func imagesConfigurationThrowsInjectedFailure() async {
+        service.imagesConfigurationResult = .failure(.unknown)
+
+        await #expect(throws: TMDbError.unknown) {
+            try await service.imagesConfiguration()
+        }
+    }
+
+    @Test("imagesConfiguration returns the injected success value")
+    func imagesConfigurationReturnsInjectedSuccess() async throws {
+        let injected = try ImagesConfiguration(
+            baseURL: #require(URL(string: "http://example.com/")),
+            secureBaseURL: #require(URL(string: "https://example.com/")),
+            backdropSizes: ["original"],
+            logoSizes: ["original"],
+            posterSizes: ["original"],
+            profileSizes: ["original"],
+            stillSizes: ["original"]
+        )
+        service.imagesConfigurationResult = .success(injected)
+
+        let result = try await service.imagesConfiguration()
+
+        #expect(result == injected)
+    }
+
+    @Test("refresh by default returns the sample configuration")
+    func refreshByDefaultReturnsSample() async throws {
+        let result = try await service.refresh()
+
+        #expect(result == ImagesConfiguration.sample)
+    }
+
+    @Test("refresh records the call")
+    func refreshRecordsCall() async throws {
+        _ = try await service.refresh()
+
+        #expect(service.refreshCalls.count == 1)
+    }
+
+    @Test("refresh throws the injected failure")
+    func refreshThrowsInjectedFailure() async {
+        service.refreshResult = .failure(.unknown)
+
+        await #expect(throws: TMDbError.unknown) {
+            try await service.refresh()
+        }
+    }
+
+    @Test("URL methods resolve against the stubbed configuration")
+    func urlMethodsResolveAgainstStubbedConfiguration() async throws {
+        let path = try #require(URL(string: "/image.jpg"))
+
+        let poster = try await service.posterURL(for: path, size: .width(500))
+
+        #expect(poster == URL(string: "https://image.tmdb.org/t/p/w500/image.jpg"))
+    }
+
+    @Test("concurrent calls over one instance record every call without racing")
+    func concurrentCallsAreThreadSafe() async {
+        let iterations = 100
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0 ..< iterations {
+                group.addTask {
+                    _ = try? await service.imagesConfiguration()
+                }
+            }
+        }
+
+        #expect(service.imagesConfigurationCalls.count == iterations)
+    }
+
+}

--- a/Tests/TMDbTestingTests/TestUtils/Tags.swift
+++ b/Tests/TMDbTestingTests/TestUtils/Tags.swift
@@ -15,6 +15,7 @@ extension Tag {
 
     @Tag static var authentication: Self
     @Tag static var genre: Self
+    @Tag static var images: Self
     @Tag static var movie: Self
 
 }

--- a/Tests/TMDbTests/Domain/Services/Images/APIConfigurationStore+TestBarrier.swift
+++ b/Tests/TMDbTests/Domain/Services/Images/APIConfigurationStore+TestBarrier.swift
@@ -1,0 +1,47 @@
+//
+//  APIConfigurationStore+TestBarrier.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+extension APIConfigurationStore {
+
+    ///
+    /// Suspends until at least `count` callers have entered the store, or the
+    /// deadline passes.
+    ///
+    /// A caller that *joins* an in-flight fetch never reaches `FetchGate`, so the
+    /// gate cannot observe it. This barrier can, which is what keeps the
+    /// coalescing, shared-failure and cancellation tests from depending on
+    /// task-start ordering.
+    ///
+    /// On expiry it records an issue and returns rather than spinning forever, so
+    /// a regression fails loudly instead of hanging CI with no diagnostic.
+    ///
+    func waitUntilCallersEntered(
+        atLeast count: Int,
+        within timeout: Duration = .seconds(10),
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) async {
+        let deadline = ContinuousClock.now + timeout
+
+        while entryCount < count {
+            guard ContinuousClock.now < deadline else {
+                Issue.record(
+                    "Only \(entryCount) of \(count) callers entered the store within \(timeout).",
+                    sourceLocation: sourceLocation
+                )
+
+                return
+            }
+
+            await Task.yield()
+        }
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Images/APIConfigurationStoreRefreshTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Images/APIConfigurationStoreRefreshTests.swift
@@ -1,0 +1,204 @@
+//
+//  APIConfigurationStoreRefreshTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.services, .images))
+struct APIConfigurationStoreRefreshTests {
+
+    @Test("refresh re-fetches and re-memoises the new value")
+    func refreshReFetchesAndReMemoisesNewValue() async throws {
+        let configurationService = CountingConfigurationService()
+        let firstResult = APIConfiguration.mock(changeKeys: ["first"])
+        let secondResult = APIConfiguration.mock(changeKeys: ["second"])
+        configurationService.enqueue(.success(firstResult))
+        configurationService.enqueue(.success(secondResult))
+        let store = APIConfigurationStore(configurationService: configurationService)
+
+        let first = try await store.apiConfiguration()
+        let cached = try await store.apiConfiguration()
+        #expect(configurationService.apiConfigurationCallCount == 1)
+
+        let refreshed = try await store.refresh()
+        let afterRefresh = try await store.apiConfiguration()
+
+        #expect(first == firstResult)
+        #expect(cached == firstResult)
+        #expect(refreshed == secondResult)
+        #expect(afterRefresh == secondResult)
+        #expect(configurationService.apiConfigurationCallCount == 2)
+    }
+
+    @Test("refresh while a first fetch is in flight does not let the superseded fetch win")
+    func refreshWhileFirstFetchInFlightDoesNotLetSupersededFetchWin() async throws {
+        let gate = FetchGate()
+        let configurationService = CountingConfigurationService(gate: gate)
+        let firstResult = APIConfiguration.mock(changeKeys: ["first"])
+        let secondResult = APIConfiguration.mock(changeKeys: ["second"])
+        configurationService.enqueue(.success(firstResult))
+        configurationService.enqueue(.success(secondResult))
+        let store = APIConfigurationStore(configurationService: configurationService)
+
+        // Park a first fetch at the gate.
+        async let parked = store.apiConfiguration()
+        await gate.waitUntilEntered(atLeast: 1)
+
+        // Supersede it. Its own fetch also parks at the gate.
+        async let refreshed = store.refresh()
+        await gate.waitUntilEntered(atLeast: 2)
+
+        await gate.open()
+
+        let parkedResult = try await parked
+        let refreshedResult = try await refreshed
+
+        // The parked caller asked before the refresh, so it correctly receives the
+        // pre-refresh value; the refresh caller receives the fresh one.
+        #expect(parkedResult == firstResult)
+        #expect(refreshedResult == secondResult)
+        #expect(configurationService.apiConfigurationCallCount == 2)
+
+        // The superseded fetch must not have clobbered the cache, nor detached the
+        // refresh's fetch (which would cause a third fetch here).
+        let afterRefresh = try await store.apiConfiguration()
+
+        #expect(afterRefresh == secondResult)
+        #expect(configurationService.apiConfigurationCallCount == 2)
+    }
+
+    @Test("concurrent refresh calls share a single fetch")
+    func concurrentRefreshCallsShareSingleFetch() async throws {
+        let gate = FetchGate()
+        let configurationService = CountingConfigurationService(gate: gate)
+        let expectedResult = APIConfiguration.mock(changeKeys: ["first"])
+        configurationService.enqueue(.success(expectedResult))
+        configurationService.enqueue(.success(.mock(changeKeys: ["second"])))
+        let store = APIConfigurationStore(configurationService: configurationService)
+
+        let firstRefresh = Task { try await store.refresh() }
+        await gate.waitUntilEntered(atLeast: 1)
+
+        // Arrives while the first refresh is still fetching: it should join that
+        // fetch rather than supersede it, which would waste the first's round trip
+        // and discard its result.
+        //
+        // A joining refresh never reaches the gate, so wait on the store's own
+        // entry count instead. Without this barrier the fetch could commit first,
+        // leaving the second refresh to start its own — an intermittent red on
+        // exactly the guarantee this test exists to protect.
+        let secondRefresh = Task { try await store.refresh() }
+        await store.waitUntilCallersEntered(atLeast: 2)
+
+        await gate.open()
+
+        let firstResult = try await firstRefresh.value
+        let secondResult = try await secondRefresh.value
+
+        #expect(firstResult == expectedResult)
+        #expect(secondResult == expectedResult)
+        #expect(configurationService.apiConfigurationCallCount == 1)
+
+        // …and that shared fetch must still have been memoised.
+        let cached = try await store.apiConfiguration()
+
+        #expect(cached == expectedResult)
+        #expect(configurationService.apiConfigurationCallCount == 1)
+    }
+
+    @Test("apiConfiguration during an in-flight refresh serves the cached value")
+    func apiConfigurationDuringInFlightRefreshServesCachedValue() async throws {
+        let gate = FetchGate()
+        let configurationService = CountingConfigurationService(gate: gate)
+        let firstResult = APIConfiguration.mock(changeKeys: ["first"])
+        configurationService.enqueue(.success(firstResult))
+        configurationService.enqueue(.success(.mock(changeKeys: ["second"])))
+        let store = APIConfigurationStore(configurationService: configurationService)
+
+        // Prime the cache through an open gate, then close it so the refresh parks.
+        await gate.open()
+        let cached = try await store.apiConfiguration()
+        #expect(cached == firstResult)
+        #expect(configurationService.apiConfigurationCallCount == 1)
+        await gate.close()
+
+        let refreshing = Task { try await store.refresh() }
+        await store.waitUntilCallersEntered(atLeast: 2)
+
+        // Readers must not block on the in-flight refresh — they keep the cached
+        // value until a replacement actually lands. Moving apiConfiguration()'s
+        // cache check after the fetch join would make every reader wait here.
+        let during = try await store.apiConfiguration()
+
+        #expect(during == firstResult)
+        #expect(configurationService.apiConfigurationCallCount == 2)
+
+        await gate.open()
+        _ = try await refreshing.value
+    }
+
+    @Test("a failed refresh keeps the previously cached configuration")
+    func failedRefreshKeepsPreviouslyCachedConfiguration() async throws {
+        let configurationService = CountingConfigurationService()
+        let expectedResult = APIConfiguration.mock(changeKeys: ["first"])
+        configurationService.enqueue(.success(expectedResult))
+        configurationService.enqueue(.failure(.unknown))
+        let store = APIConfigurationStore(configurationService: configurationService)
+
+        let before = try await store.apiConfiguration()
+        #expect(configurationService.apiConfigurationCallCount == 1)
+
+        await #expect(throws: TMDbError.unknown) {
+            _ = try await store.refresh()
+        }
+
+        // A refresh that fails must not destroy a known-good configuration: losing
+        // it would make every later image URL re-fetch until the network recovers.
+        let after = try await store.apiConfiguration()
+
+        #expect(before == expectedResult)
+        #expect(after == expectedResult)
+        #expect(configurationService.apiConfigurationCallCount == 2)
+    }
+
+    @Test("a superseded fetch that fails does not detach the refresh's fetch")
+    func supersededFetchThatFailsDoesNotDetachRefreshFetch() async throws {
+        let gate = FetchGate()
+        let configurationService = CountingConfigurationService(gate: gate)
+        let expectedResult = APIConfiguration.mock(changeKeys: ["second"])
+        configurationService.enqueue(.failure(.unknown))
+        configurationService.enqueue(.success(expectedResult))
+        let store = APIConfigurationStore(configurationService: configurationService)
+
+        // Explicit `Task` handles rather than `async let`: an `async let` binding
+        // cannot be captured by the `#expect(throws:)` closure.
+        let parkedCaller = Task { try await store.apiConfiguration() }
+        await gate.waitUntilEntered(atLeast: 1)
+
+        let refreshCaller = Task { try await store.refresh() }
+        await gate.waitUntilEntered(atLeast: 2)
+
+        await gate.open()
+
+        await #expect(throws: TMDbError.unknown) {
+            _ = try await parkedCaller.value
+        }
+        let refreshedResult = try await refreshCaller.value
+
+        #expect(refreshedResult == expectedResult)
+        #expect(configurationService.apiConfigurationCallCount == 2)
+
+        // The superseded failure must not have cleared the refresh's committed
+        // cache entry — a third fetch here would mean it did.
+        let afterRefresh = try await store.apiConfiguration()
+
+        #expect(afterRefresh == expectedResult)
+        #expect(configurationService.apiConfigurationCallCount == 2)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Images/APIConfigurationStoreTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Images/APIConfigurationStoreTests.swift
@@ -63,9 +63,10 @@ struct APIConfigurationStoreTests {
                 }
             }
 
-            // Hold the window open until a fetch has provably reached the gate,
-            // then release. Without this the test could pass by scheduling luck.
-            await gate.waitUntilEntered(atLeast: 1)
+            // Hold the window open until every caller has provably joined the
+            // in-flight fetch, then release. Without this the test could pass by
+            // scheduling luck.
+            await store.waitUntilCallersEntered(atLeast: 100)
             await gate.open()
 
             var results: [Result<APIConfiguration, TMDbError>] = []
@@ -134,7 +135,11 @@ struct APIConfigurationStoreTests {
                 }
             }
 
-            await gate.waitUntilEntered(atLeast: 1)
+            // All ten must have joined the in-flight fetch before it is released.
+            // A failure is deliberately not memoised, so a straggler arriving
+            // after it completes would find no cache and no in-flight fetch and
+            // start a second one.
+            await store.waitUntilCallersEntered(atLeast: 10)
             await gate.open()
 
             return await group.reduce(into: 0) { count, didFail in
@@ -155,158 +160,6 @@ struct APIConfigurationStoreTests {
         #expect(configurationService.apiConfigurationCallCount == 2)
     }
 
-    @Test("refresh discards the memo, re-fetches, and re-memoises the new value")
-    func refreshDiscardsMemoAndReMemoisesNewValue() async throws {
-        let configurationService = CountingConfigurationService()
-        let firstResult = APIConfiguration.mock(changeKeys: ["first"])
-        let secondResult = APIConfiguration.mock(changeKeys: ["second"])
-        configurationService.enqueue(.success(firstResult))
-        configurationService.enqueue(.success(secondResult))
-        let store = APIConfigurationStore(configurationService: configurationService)
-
-        let first = try await store.apiConfiguration()
-        let cached = try await store.apiConfiguration()
-        #expect(configurationService.apiConfigurationCallCount == 1)
-
-        let refreshed = try await store.refresh()
-        let afterRefresh = try await store.apiConfiguration()
-
-        #expect(first == firstResult)
-        #expect(cached == firstResult)
-        #expect(refreshed == secondResult)
-        #expect(afterRefresh == secondResult)
-        #expect(configurationService.apiConfigurationCallCount == 2)
-    }
-
-    @Test("refresh while a first fetch is in flight does not let the superseded fetch win")
-    func refreshWhileFirstFetchInFlightDoesNotLetSupersededFetchWin() async throws {
-        let gate = FetchGate()
-        let configurationService = CountingConfigurationService(gate: gate)
-        let firstResult = APIConfiguration.mock(changeKeys: ["first"])
-        let secondResult = APIConfiguration.mock(changeKeys: ["second"])
-        configurationService.enqueue(.success(firstResult))
-        configurationService.enqueue(.success(secondResult))
-        let store = APIConfigurationStore(configurationService: configurationService)
-
-        // Park a first fetch at the gate.
-        async let parked = store.apiConfiguration()
-        await gate.waitUntilEntered(atLeast: 1)
-
-        // Supersede it. Its own fetch also parks at the gate.
-        async let refreshed = store.refresh()
-        await gate.waitUntilEntered(atLeast: 2)
-
-        await gate.open()
-
-        let parkedResult = try await parked
-        let refreshedResult = try await refreshed
-
-        // The parked caller asked before the refresh, so it correctly receives the
-        // pre-refresh value; the refresh caller receives the fresh one.
-        #expect(parkedResult == firstResult)
-        #expect(refreshedResult == secondResult)
-        #expect(configurationService.apiConfigurationCallCount == 2)
-
-        // The superseded fetch must not have clobbered the cache, nor detached the
-        // refresh's fetch (which would cause a third fetch here).
-        let afterRefresh = try await store.apiConfiguration()
-
-        #expect(afterRefresh == secondResult)
-        #expect(configurationService.apiConfigurationCallCount == 2)
-    }
-
-    @Test("concurrent refresh calls share a single fetch")
-    func concurrentRefreshCallsShareSingleFetch() async throws {
-        let gate = FetchGate()
-        let configurationService = CountingConfigurationService(gate: gate)
-        let expectedResult = APIConfiguration.mock(changeKeys: ["first"])
-        configurationService.enqueue(.success(expectedResult))
-        configurationService.enqueue(.success(.mock(changeKeys: ["second"])))
-        let store = APIConfigurationStore(configurationService: configurationService)
-
-        let firstRefresh = Task { try await store.refresh() }
-        await gate.waitUntilEntered(atLeast: 1)
-
-        // Arrives while the first refresh is still fetching: it should join that
-        // fetch rather than supersede it, which would waste the first's round trip
-        // and discard its result.
-        let secondRefresh = Task { try await store.refresh() }
-
-        await gate.open()
-
-        let firstResult = try await firstRefresh.value
-        let secondResult = try await secondRefresh.value
-
-        #expect(firstResult == expectedResult)
-        #expect(secondResult == expectedResult)
-        #expect(configurationService.apiConfigurationCallCount == 1)
-
-        // …and that shared fetch must still have been memoised.
-        let cached = try await store.apiConfiguration()
-
-        #expect(cached == expectedResult)
-        #expect(configurationService.apiConfigurationCallCount == 1)
-    }
-
-    @Test("a failed refresh keeps the previously cached configuration")
-    func failedRefreshKeepsPreviouslyCachedConfiguration() async throws {
-        let configurationService = CountingConfigurationService()
-        let expectedResult = APIConfiguration.mock(changeKeys: ["first"])
-        configurationService.enqueue(.success(expectedResult))
-        configurationService.enqueue(.failure(.unknown))
-        let store = APIConfigurationStore(configurationService: configurationService)
-
-        let before = try await store.apiConfiguration()
-        #expect(configurationService.apiConfigurationCallCount == 1)
-
-        await #expect(throws: TMDbError.unknown) {
-            _ = try await store.refresh()
-        }
-
-        // A refresh that fails must not destroy a known-good configuration: losing
-        // it would make every later image URL re-fetch until the network recovers.
-        let after = try await store.apiConfiguration()
-
-        #expect(before == expectedResult)
-        #expect(after == expectedResult)
-        #expect(configurationService.apiConfigurationCallCount == 2)
-    }
-
-    @Test("a superseded fetch that fails does not detach the refresh's fetch")
-    func supersededFetchThatFailsDoesNotDetachRefreshFetch() async throws {
-        let gate = FetchGate()
-        let configurationService = CountingConfigurationService(gate: gate)
-        let expectedResult = APIConfiguration.mock(changeKeys: ["second"])
-        configurationService.enqueue(.failure(.unknown))
-        configurationService.enqueue(.success(expectedResult))
-        let store = APIConfigurationStore(configurationService: configurationService)
-
-        // Explicit `Task` handles rather than `async let`: an `async let` binding
-        // cannot be captured by the `#expect(throws:)` closure.
-        let parkedCaller = Task { try await store.apiConfiguration() }
-        await gate.waitUntilEntered(atLeast: 1)
-
-        let refreshCaller = Task { try await store.refresh() }
-        await gate.waitUntilEntered(atLeast: 2)
-
-        await gate.open()
-
-        await #expect(throws: TMDbError.unknown) {
-            _ = try await parkedCaller.value
-        }
-        let refreshedResult = try await refreshCaller.value
-
-        #expect(refreshedResult == expectedResult)
-        #expect(configurationService.apiConfigurationCallCount == 2)
-
-        // The superseded failure must not have cleared the refresh's committed
-        // cache entry — a third fetch here would mean it did.
-        let afterRefresh = try await store.apiConfiguration()
-
-        #expect(afterRefresh == expectedResult)
-        #expect(configurationService.apiConfigurationCallCount == 2)
-    }
-
     @Test("cancelling one caller does not starve the others sharing the fetch")
     func cancellingOneCallerDoesNotStarveTheOthers() async throws {
         let gate = FetchGate()
@@ -318,17 +171,12 @@ struct APIConfigurationStoreTests {
         let cancelledCaller = Task { try await store.apiConfiguration() }
         await gate.waitUntilEntered(atLeast: 1)
 
-        // These two are given a chance to join the in-flight fetch before the gate
-        // opens. Their ordering is not guaranteed — if they arrive late they read
-        // the committed cache instead — so they are corroborating, not
-        // load-bearing. The guarantee this test actually rests on is the cancelled
-        // caller below, which `waitUntilEntered` proves was parked inside the
-        // shared fetch at the moment it was cancelled.
+        // Both must have joined the same in-flight fetch before the gate opens,
+        // otherwise they would read the committed cache instead and the test
+        // would not exercise sharing at all.
         let second = Task { try await store.apiConfiguration() }
         let third = Task { try await store.apiConfiguration() }
-        for _ in 0 ..< 10 {
-            await Task.yield()
-        }
+        await store.waitUntilCallersEntered(atLeast: 3)
 
         cancelledCaller.cancel()
         await gate.open()

--- a/Tests/TMDbTests/Domain/Services/Images/APIConfigurationStoreTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Images/APIConfigurationStoreTests.swift
@@ -1,0 +1,287 @@
+//
+//  APIConfigurationStoreTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.services, .images))
+struct APIConfigurationStoreTests {
+
+    @Test("apiConfiguration fetches and returns the configuration")
+    func apiConfigurationFetchesAndReturnsConfiguration() async throws {
+        let configurationService = CountingConfigurationService()
+        let expectedResult = APIConfiguration.mock()
+        configurationService.enqueue(.success(expectedResult))
+        let store = APIConfigurationStore(configurationService: configurationService)
+
+        let result = try await store.apiConfiguration()
+
+        #expect(result == expectedResult)
+        #expect(configurationService.apiConfigurationCallCount == 1)
+    }
+
+    @Test("apiConfiguration when called twice fetches only once")
+    func apiConfigurationWhenCalledTwiceFetchesOnlyOnce() async throws {
+        let configurationService = CountingConfigurationService()
+        let expectedResult = APIConfiguration.mock()
+        configurationService.enqueue(.success(expectedResult))
+        let store = APIConfigurationStore(configurationService: configurationService)
+
+        let first = try await store.apiConfiguration()
+        let second = try await store.apiConfiguration()
+
+        #expect(first == expectedResult)
+        #expect(second == expectedResult)
+        #expect(configurationService.apiConfigurationCallCount == 1)
+    }
+
+    @Test("apiConfiguration under 100 concurrent callers fetches exactly once")
+    func apiConfigurationUnderConcurrentCallersFetchesExactlyOnce() async throws {
+        let gate = FetchGate()
+        let configurationService = CountingConfigurationService(gate: gate)
+        let expectedResult = APIConfiguration.mock()
+        configurationService.enqueue(.success(expectedResult))
+        let store = APIConfigurationStore(configurationService: configurationService)
+
+        let results = await withTaskGroup(
+            of: Result<APIConfiguration, TMDbError>.self
+        ) { group in
+            for _ in 0 ..< 100 {
+                group.addTask {
+                    // Typed-throws inference does not apply inside a closure, so a
+                    // bare `catch` would bind `any Error`.
+                    do throws(TMDbError) {
+                        return try await .success(store.apiConfiguration())
+                    } catch {
+                        return .failure(error)
+                    }
+                }
+            }
+
+            // Hold the window open until a fetch has provably reached the gate,
+            // then release. Without this the test could pass by scheduling luck.
+            await gate.waitUntilEntered(atLeast: 1)
+            await gate.open()
+
+            var results: [Result<APIConfiguration, TMDbError>] = []
+            for await result in group {
+                results.append(result)
+            }
+
+            return results
+        }
+
+        #expect(configurationService.apiConfigurationCallCount == 1)
+        #expect(configurationService.peakConcurrency == 1)
+        #expect(results.count == 100)
+        for result in results {
+            #expect(try result.get() == expectedResult)
+        }
+    }
+
+    @Test("apiConfiguration when the fetch fails throws the error")
+    func apiConfigurationWhenFetchFailsThrowsError() async throws {
+        let configurationService = CountingConfigurationService()
+        configurationService.enqueue(.failure(.unknown))
+        let store = APIConfigurationStore(configurationService: configurationService)
+
+        await #expect(throws: TMDbError.unknown) {
+            _ = try await store.apiConfiguration()
+        }
+
+        #expect(configurationService.apiConfigurationCallCount == 1)
+    }
+
+    @Test("apiConfiguration when the first fetch fails retries on the next call")
+    func apiConfigurationWhenFirstFetchFailsRetriesOnNextCall() async throws {
+        let configurationService = CountingConfigurationService()
+        let expectedResult = APIConfiguration.mock()
+        configurationService.enqueue(.failure(.unknown))
+        configurationService.enqueue(.success(expectedResult))
+        let store = APIConfigurationStore(configurationService: configurationService)
+
+        await #expect(throws: TMDbError.unknown) {
+            _ = try await store.apiConfiguration()
+        }
+
+        let result = try await store.apiConfiguration()
+
+        #expect(result == expectedResult)
+        #expect(configurationService.apiConfigurationCallCount == 2)
+    }
+
+    @Test("apiConfiguration when a concurrent fetch fails shares the failure, then retries")
+    func apiConfigurationWhenConcurrentFetchFailsSharesFailureThenRetries() async throws {
+        let gate = FetchGate()
+        let configurationService = CountingConfigurationService(gate: gate)
+        configurationService.enqueue(.failure(.unknown))
+        let store = APIConfigurationStore(configurationService: configurationService)
+
+        let failureCount = await withTaskGroup(of: Bool.self) { group in
+            for _ in 0 ..< 10 {
+                group.addTask {
+                    do {
+                        _ = try await store.apiConfiguration()
+                        return false
+                    } catch {
+                        return true
+                    }
+                }
+            }
+
+            await gate.waitUntilEntered(atLeast: 1)
+            await gate.open()
+
+            return await group.reduce(into: 0) { count, didFail in
+                count += didFail ? 1 : 0
+            }
+        }
+
+        // One fetch, ten shared failures — and nothing memoised.
+        #expect(failureCount == 10)
+        #expect(configurationService.apiConfigurationCallCount == 1)
+
+        let expectedResult = APIConfiguration.mock()
+        configurationService.enqueue(.success(expectedResult))
+
+        let result = try await store.apiConfiguration()
+
+        #expect(result == expectedResult)
+        #expect(configurationService.apiConfigurationCallCount == 2)
+    }
+
+    @Test("refresh discards the memo, re-fetches, and re-memoises the new value")
+    func refreshDiscardsMemoAndReMemoisesNewValue() async throws {
+        let configurationService = CountingConfigurationService()
+        let firstResult = APIConfiguration.mock(changeKeys: ["first"])
+        let secondResult = APIConfiguration.mock(changeKeys: ["second"])
+        configurationService.enqueue(.success(firstResult))
+        configurationService.enqueue(.success(secondResult))
+        let store = APIConfigurationStore(configurationService: configurationService)
+
+        let first = try await store.apiConfiguration()
+        let cached = try await store.apiConfiguration()
+        #expect(configurationService.apiConfigurationCallCount == 1)
+
+        let refreshed = try await store.refresh()
+        let afterRefresh = try await store.apiConfiguration()
+
+        #expect(first == firstResult)
+        #expect(cached == firstResult)
+        #expect(refreshed == secondResult)
+        #expect(afterRefresh == secondResult)
+        #expect(configurationService.apiConfigurationCallCount == 2)
+    }
+
+    @Test("refresh while a first fetch is in flight does not let the superseded fetch win")
+    func refreshWhileFirstFetchInFlightDoesNotLetSupersededFetchWin() async throws {
+        let gate = FetchGate()
+        let configurationService = CountingConfigurationService(gate: gate)
+        let firstResult = APIConfiguration.mock(changeKeys: ["first"])
+        let secondResult = APIConfiguration.mock(changeKeys: ["second"])
+        configurationService.enqueue(.success(firstResult))
+        configurationService.enqueue(.success(secondResult))
+        let store = APIConfigurationStore(configurationService: configurationService)
+
+        // Park a first fetch at the gate.
+        async let parked = store.apiConfiguration()
+        await gate.waitUntilEntered(atLeast: 1)
+
+        // Supersede it. Its own fetch also parks at the gate.
+        async let refreshed = store.refresh()
+        await gate.waitUntilEntered(atLeast: 2)
+
+        await gate.open()
+
+        let parkedResult = try await parked
+        let refreshedResult = try await refreshed
+
+        // The parked caller asked before the refresh, so it correctly receives the
+        // pre-refresh value; the refresh caller receives the fresh one.
+        #expect(parkedResult == firstResult)
+        #expect(refreshedResult == secondResult)
+        #expect(configurationService.apiConfigurationCallCount == 2)
+
+        // The superseded fetch must not have clobbered the cache, nor detached the
+        // refresh's fetch (which would cause a third fetch here).
+        let afterRefresh = try await store.apiConfiguration()
+
+        #expect(afterRefresh == secondResult)
+        #expect(configurationService.apiConfigurationCallCount == 2)
+    }
+
+    @Test("a superseded fetch that fails does not detach the refresh's fetch")
+    func supersededFetchThatFailsDoesNotDetachRefreshFetch() async throws {
+        let gate = FetchGate()
+        let configurationService = CountingConfigurationService(gate: gate)
+        let expectedResult = APIConfiguration.mock(changeKeys: ["second"])
+        configurationService.enqueue(.failure(.unknown))
+        configurationService.enqueue(.success(expectedResult))
+        let store = APIConfigurationStore(configurationService: configurationService)
+
+        // Explicit `Task` handles rather than `async let`: an `async let` binding
+        // cannot be captured by the `#expect(throws:)` closure.
+        let parkedCaller = Task { try await store.apiConfiguration() }
+        await gate.waitUntilEntered(atLeast: 1)
+
+        let refreshCaller = Task { try await store.refresh() }
+        await gate.waitUntilEntered(atLeast: 2)
+
+        await gate.open()
+
+        await #expect(throws: TMDbError.unknown) {
+            _ = try await parkedCaller.value
+        }
+        let refreshedResult = try await refreshCaller.value
+
+        #expect(refreshedResult == expectedResult)
+        #expect(configurationService.apiConfigurationCallCount == 2)
+
+        // The superseded failure must not have cleared the refresh's committed
+        // cache entry — a third fetch here would mean it did.
+        let afterRefresh = try await store.apiConfiguration()
+
+        #expect(afterRefresh == expectedResult)
+        #expect(configurationService.apiConfigurationCallCount == 2)
+    }
+
+    @Test("cancelling one caller does not starve the others sharing the fetch")
+    func cancellingOneCallerDoesNotStarveTheOthers() async throws {
+        let gate = FetchGate()
+        let configurationService = CountingConfigurationService(gate: gate)
+        let expectedResult = APIConfiguration.mock()
+        configurationService.enqueue(.success(expectedResult))
+        let store = APIConfigurationStore(configurationService: configurationService)
+
+        let cancelledCaller = Task { try await store.apiConfiguration() }
+        await gate.waitUntilEntered(atLeast: 1)
+
+        async let second: APIConfiguration = store.apiConfiguration()
+        async let third: APIConfiguration = store.apiConfiguration()
+
+        cancelledCaller.cancel()
+        await gate.open()
+
+        let secondResult = try await second
+        let thirdResult = try await third
+
+        // The shared fetch is deliberately not cancellable by any one awaiter:
+        // forwarding cancellation into it (as PagedAsyncSequence does, correctly,
+        // for its single owner) would fail every other caller here.
+        #expect(secondResult == expectedResult)
+        #expect(thirdResult == expectedResult)
+        #expect(configurationService.apiConfigurationCallCount == 1)
+
+        // Documented consequence: the cancelled caller is unresponsive to
+        // cancellation — it completes with the value rather than throwing.
+        let cancelledResult = try await cancelledCaller.value
+
+        #expect(cancelledResult == expectedResult)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Images/APIConfigurationStoreTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Images/APIConfigurationStoreTests.swift
@@ -215,6 +215,63 @@ struct APIConfigurationStoreTests {
         #expect(configurationService.apiConfigurationCallCount == 2)
     }
 
+    @Test("concurrent refresh calls share a single fetch")
+    func concurrentRefreshCallsShareSingleFetch() async throws {
+        let gate = FetchGate()
+        let configurationService = CountingConfigurationService(gate: gate)
+        let expectedResult = APIConfiguration.mock(changeKeys: ["first"])
+        configurationService.enqueue(.success(expectedResult))
+        configurationService.enqueue(.success(.mock(changeKeys: ["second"])))
+        let store = APIConfigurationStore(configurationService: configurationService)
+
+        let firstRefresh = Task { try await store.refresh() }
+        await gate.waitUntilEntered(atLeast: 1)
+
+        // Arrives while the first refresh is still fetching: it should join that
+        // fetch rather than supersede it, which would waste the first's round trip
+        // and discard its result.
+        let secondRefresh = Task { try await store.refresh() }
+
+        await gate.open()
+
+        let firstResult = try await firstRefresh.value
+        let secondResult = try await secondRefresh.value
+
+        #expect(firstResult == expectedResult)
+        #expect(secondResult == expectedResult)
+        #expect(configurationService.apiConfigurationCallCount == 1)
+
+        // …and that shared fetch must still have been memoised.
+        let cached = try await store.apiConfiguration()
+
+        #expect(cached == expectedResult)
+        #expect(configurationService.apiConfigurationCallCount == 1)
+    }
+
+    @Test("a failed refresh keeps the previously cached configuration")
+    func failedRefreshKeepsPreviouslyCachedConfiguration() async throws {
+        let configurationService = CountingConfigurationService()
+        let expectedResult = APIConfiguration.mock(changeKeys: ["first"])
+        configurationService.enqueue(.success(expectedResult))
+        configurationService.enqueue(.failure(.unknown))
+        let store = APIConfigurationStore(configurationService: configurationService)
+
+        let before = try await store.apiConfiguration()
+        #expect(configurationService.apiConfigurationCallCount == 1)
+
+        await #expect(throws: TMDbError.unknown) {
+            _ = try await store.refresh()
+        }
+
+        // A refresh that fails must not destroy a known-good configuration: losing
+        // it would make every later image URL re-fetch until the network recovers.
+        let after = try await store.apiConfiguration()
+
+        #expect(before == expectedResult)
+        #expect(after == expectedResult)
+        #expect(configurationService.apiConfigurationCallCount == 2)
+    }
+
     @Test("a superseded fetch that fails does not detach the refresh's fetch")
     func supersededFetchThatFailsDoesNotDetachRefreshFetch() async throws {
         let gate = FetchGate()
@@ -261,14 +318,23 @@ struct APIConfigurationStoreTests {
         let cancelledCaller = Task { try await store.apiConfiguration() }
         await gate.waitUntilEntered(atLeast: 1)
 
-        async let second: APIConfiguration = store.apiConfiguration()
-        async let third: APIConfiguration = store.apiConfiguration()
+        // These two are given a chance to join the in-flight fetch before the gate
+        // opens. Their ordering is not guaranteed — if they arrive late they read
+        // the committed cache instead — so they are corroborating, not
+        // load-bearing. The guarantee this test actually rests on is the cancelled
+        // caller below, which `waitUntilEntered` proves was parked inside the
+        // shared fetch at the moment it was cancelled.
+        let second = Task { try await store.apiConfiguration() }
+        let third = Task { try await store.apiConfiguration() }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
 
         cancelledCaller.cancel()
         await gate.open()
 
-        let secondResult = try await second
-        let thirdResult = try await third
+        let secondResult = try await second.value
+        let thirdResult = try await third.value
 
         // The shared fetch is deliberately not cancellable by any one awaiter:
         // forwarding cancellation into it (as PagedAsyncSequence does, correctly,

--- a/Tests/TMDbTests/Domain/Services/Images/TMDbImageServiceTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Images/TMDbImageServiceTests.swift
@@ -1,0 +1,182 @@
+//
+//  TMDbImageServiceTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.services, .images))
+struct TMDbImageServiceTests {
+
+    private static func makeConfiguration() throws -> ImagesConfiguration {
+        try ImagesConfiguration(
+            baseURL: #require(URL(string: "http://image.tmdb.org/t/p/")),
+            secureBaseURL: #require(URL(string: "https://image.tmdb.org/t/p/")),
+            backdropSizes: ["w300", "w780", "w1280", "original"],
+            logoSizes: ["w45", "w92", "w154", "w185", "w300", "w500", "original"],
+            posterSizes: ["w92", "w154", "w185", "w342", "w500", "w780", "original"],
+            profileSizes: ["w45", "w185", "h632", "original"],
+            stillSizes: ["w92", "w185", "w300", "original"]
+        )
+    }
+
+    private static func makeService(
+        configuration: ImagesConfiguration
+    ) -> (TMDbImageService, CountingConfigurationService) {
+        let configurationService = CountingConfigurationService()
+        configurationService.enqueue(.success(.mock(images: configuration)))
+
+        return (TMDbImageService(configurationService: configurationService), configurationService)
+    }
+
+    @Test("imagesConfiguration returns the images configuration, fetching once")
+    func imagesConfigurationReturnsImagesConfigurationFetchingOnce() async throws {
+        let expectedResult = ImagesConfiguration.mock()
+        let configurationService = CountingConfigurationService()
+        configurationService.enqueue(.success(.mock(images: expectedResult)))
+        let service = TMDbImageService(configurationService: configurationService)
+
+        let first = try await service.imagesConfiguration()
+        let second = try await service.imagesConfiguration()
+
+        #expect(first == expectedResult)
+        #expect(second == expectedResult)
+        #expect(configurationService.apiConfigurationCallCount == 1)
+    }
+
+    @Test("URL for a specific size resolves against the fetched configuration")
+    func urlForSpecificSizeResolvesAgainstFetchedConfiguration() async throws {
+        let configuration = try Self.makeConfiguration()
+        let (service, configurationService) = Self.makeService(configuration: configuration)
+        let path = try #require(URL(string: "/image.jpg"))
+
+        let poster = try await service.posterURL(for: path, size: .width(500))
+        let backdrop = try await service.backdropURL(for: path, size: .width(780))
+        let logo = try await service.logoURL(for: path, size: .width(154))
+        let profile = try await service.profileURL(for: path, size: .height(632))
+        let still = try await service.stillURL(for: path, size: .width(185))
+
+        #expect(poster == URL(string: "https://image.tmdb.org/t/p/w500/image.jpg"))
+        #expect(backdrop == URL(string: "https://image.tmdb.org/t/p/w780/image.jpg"))
+        #expect(logo == URL(string: "https://image.tmdb.org/t/p/w154/image.jpg"))
+        #expect(profile == URL(string: "https://image.tmdb.org/t/p/h632/image.jpg"))
+        #expect(still == URL(string: "https://image.tmdb.org/t/p/w185/image.jpg"))
+        #expect(configurationService.apiConfigurationCallCount == 1)
+    }
+
+    @Test("URL for an ideal width picks the smallest size at least that wide")
+    func urlForIdealWidthPicksSmallestSizeAtLeastThatWide() async throws {
+        let configuration = try Self.makeConfiguration()
+        let (service, configurationService) = Self.makeService(configuration: configuration)
+        let path = try #require(URL(string: "/image.jpg"))
+
+        let poster = try await service.posterURL(for: path, idealWidth: 300)
+        let backdrop = try await service.backdropURL(for: path, idealWidth: 500)
+        let logo = try await service.logoURL(for: path, idealWidth: 100)
+        let profile = try await service.profileURL(for: path, idealWidth: 50)
+        let still = try await service.stillURL(for: path, idealWidth: 200)
+
+        #expect(poster == URL(string: "https://image.tmdb.org/t/p/w342/image.jpg"))
+        #expect(backdrop == URL(string: "https://image.tmdb.org/t/p/w780/image.jpg"))
+        #expect(logo == URL(string: "https://image.tmdb.org/t/p/w154/image.jpg"))
+        #expect(profile == URL(string: "https://image.tmdb.org/t/p/w185/image.jpg"))
+        #expect(still == URL(string: "https://image.tmdb.org/t/p/w300/image.jpg"))
+        #expect(configurationService.apiConfigurationCallCount == 1)
+    }
+
+    @Test("URL with no ideal width defaults to the original image")
+    func urlWithNoIdealWidthDefaultsToOriginal() async throws {
+        let configuration = try Self.makeConfiguration()
+        let (service, _) = Self.makeService(configuration: configuration)
+        let path = try #require(URL(string: "/image.jpg"))
+
+        let poster = try await service.posterURL(for: path)
+
+        #expect(poster == URL(string: "https://image.tmdb.org/t/p/original/image.jpg"))
+    }
+
+    @Test("URL for a nil path returns nil without fetching the configuration")
+    func urlForNilPathReturnsNilWithoutFetching() async throws {
+        let configuration = try Self.makeConfiguration()
+        let (service, configurationService) = Self.makeService(configuration: configuration)
+
+        let poster = try await service.posterURL(for: nil, size: .width(500))
+        let backdrop = try await service.backdropURL(for: nil)
+        let logo = try await service.logoURL(for: nil, size: .width(154))
+        let profile = try await service.profileURL(for: nil)
+        let still = try await service.stillURL(for: nil, size: .width(185))
+
+        #expect(poster == nil)
+        #expect(backdrop == nil)
+        #expect(logo == nil)
+        #expect(profile == nil)
+        #expect(still == nil)
+
+        // A model with no image must never cost a network request, and must never
+        // surface a network error — rendering a list of placeholders offline would
+        // otherwise produce one error per missing image.
+        #expect(configurationService.apiConfigurationCallCount == 0)
+    }
+
+    @Test("URL for an unsupported size returns nil")
+    func urlForUnsupportedSizeReturnsNil() async throws {
+        let configuration = try Self.makeConfiguration()
+        let (service, configurationService) = Self.makeService(configuration: configuration)
+        let path = try #require(URL(string: "/image.jpg"))
+
+        let poster = try await service.posterURL(for: path, size: .width(999))
+
+        #expect(poster == nil)
+
+        // Unlike the nil-path case, this one must consult the configuration to
+        // know the size is unsupported.
+        #expect(configurationService.apiConfigurationCallCount == 1)
+    }
+
+    @Test("preload fetches the configuration once, and later URLs reuse it")
+    func preloadFetchesOnceAndLaterURLsReuseIt() async throws {
+        let configuration = try Self.makeConfiguration()
+        let (service, configurationService) = Self.makeService(configuration: configuration)
+        let path = try #require(URL(string: "/image.jpg"))
+
+        try await service.preload()
+        #expect(configurationService.apiConfigurationCallCount == 1)
+
+        let poster = try await service.posterURL(for: path, size: .width(500))
+
+        #expect(poster == URL(string: "https://image.tmdb.org/t/p/w500/image.jpg"))
+        #expect(configurationService.apiConfigurationCallCount == 1)
+    }
+
+    @Test("refresh fetches the configuration again")
+    func refreshFetchesConfigurationAgain() async throws {
+        let first = try Self.makeConfiguration()
+        let second = try ImagesConfiguration(
+            baseURL: #require(URL(string: "http://image.tmdb.org/t/p/")),
+            secureBaseURL: #require(URL(string: "https://cdn.tmdb.org/t/p/")),
+            backdropSizes: ["original"],
+            logoSizes: ["original"],
+            posterSizes: ["original"],
+            profileSizes: ["original"],
+            stillSizes: ["original"]
+        )
+        let configurationService = CountingConfigurationService()
+        configurationService.enqueue(.success(.mock(images: first)))
+        configurationService.enqueue(.success(.mock(images: second)))
+        let service = TMDbImageService(configurationService: configurationService)
+
+        let before = try await service.imagesConfiguration()
+        let refreshed = try await service.refresh()
+        let after = try await service.imagesConfiguration()
+
+        #expect(before == first)
+        #expect(refreshed == second)
+        #expect(after == second)
+        #expect(configurationService.apiConfigurationCallCount == 2)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/Images/TMDbImageServiceTests.swift
+++ b/Tests/TMDbTests/Domain/Services/Images/TMDbImageServiceTests.swift
@@ -104,17 +104,27 @@ struct TMDbImageServiceTests {
         let configuration = try Self.makeConfiguration()
         let (service, configurationService) = Self.makeService(configuration: configuration)
 
-        let poster = try await service.posterURL(for: nil, size: .width(500))
-        let backdrop = try await service.backdropURL(for: nil)
-        let logo = try await service.logoURL(for: nil, size: .width(154))
-        let profile = try await service.profileURL(for: nil)
-        let still = try await service.stillURL(for: nil, size: .width(185))
+        // All ten methods, not a representative five: the `guard let path` is
+        // copy-pasted per method, and dropping one still compiles and still
+        // returns nil — it just silently fetches, breaking the guarantee below.
+        let sizedURLs = try await [
+            service.posterURL(for: nil, size: .width(500)),
+            service.backdropURL(for: nil, size: .width(780)),
+            service.logoURL(for: nil, size: .width(154)),
+            service.profileURL(for: nil, size: .height(632)),
+            service.stillURL(for: nil, size: .width(185))
+        ]
 
-        #expect(poster == nil)
-        #expect(backdrop == nil)
-        #expect(logo == nil)
-        #expect(profile == nil)
-        #expect(still == nil)
+        let idealWidthURLs = try await [
+            service.posterURL(for: nil, idealWidth: 500),
+            service.backdropURL(for: nil, idealWidth: 780),
+            service.logoURL(for: nil, idealWidth: 154),
+            service.profileURL(for: nil, idealWidth: 185),
+            service.stillURL(for: nil, idealWidth: 185)
+        ]
+
+        #expect(sizedURLs.allSatisfy { $0 == nil })
+        #expect(idealWidthURLs.allSatisfy { $0 == nil })
 
         // A model with no image must never cost a network request, and must never
         // surface a network error — rendering a list of placeholders offline would

--- a/Tests/TMDbTests/TMDbClientTests.swift
+++ b/Tests/TMDbTests/TMDbClientTests.swift
@@ -66,6 +66,13 @@ struct TMDbClientTests {
         #expect(client.discover is TMDbDiscoverService)
     }
 
+    @Test("init with API key creates image service")
+    func initWithAPIKeyCreatesImageService() {
+        let client = TMDbClient(apiKey: apiKey)
+
+        #expect(client.images is TMDbImageService)
+    }
+
     @Test("init with API key creates genre service")
     func initWithAPIKeyCreatesGenreService() {
         let client = TMDbClient(apiKey: apiKey)

--- a/knowledge/decisions/0013-cached-image-url-resolver.md
+++ b/knowledge/decisions/0013-cached-image-url-resolver.md
@@ -1,0 +1,125 @@
+# ADR-0013: Cache the image configuration in an actor behind `client.images`
+
+- **Status:** Accepted (targets 19.x)
+- **Date:** 2026-07-27
+- **Deciders:** Adam Young
+
+## Context
+
+Turning `movie.posterPath` into a `URL` is the single most common thing consumers
+of this package do, and it was a manual two-step: fetch `APIConfiguration` via
+`client.configurations.apiConfiguration()`, hold on to its `ImagesConfiguration`,
+then call the synchronous helpers in `ImagesConfiguration+URLs`. Nothing cached
+that object at the client level, so every consumer invented its own lifecycle for
+it. Competing clients (TMDbLib, tmdb-kotlin, brettohland/swift-tmdb) all resolve
+an image URL in one call. Issue #391.
+
+Constraints: Swift 6 strict concurrency; typed throws (`throws(TMDbError)`)
+throughout; a macOS 13 / iOS 16 deployment floor, so `Synchronization.Mutex` is
+unavailable and an `actor` is the only primitive that can hold state across an
+`await`.
+
+## Decision
+
+We will add an `ImageService` protocol exposed as `TMDbClient.images`, backed by
+an internal `APIConfigurationStore` actor that fetches `APIConfiguration` **at
+most once per client** and shares that fetch with every concurrent caller.
+
+**Why memoise at all.** Not primarily as a network win — that would be a weak
+argument, since `/configuration` returns `Cache-Control: public, max-age` +
+`ETag` and the default `URLCache` already caches the HTTP response on Apple
+platforms (see *HTTP caching* in `tmdb-api-notes.md`, and
+[ADR-0007](0007-document-existing-response-caching.md)). It earns its place
+because it removes the config-lifecycle burden from the caller (the actual point
+of #391), skips re-decoding `APIConfiguration` per image, does real caching work
+on **Linux and Windows** where corelibs-foundation ships no `URLCache`, and is
+**always on**, whereas `CacheHTTPClient` is opt-in and so cannot be relied on for
+de-duplication.
+
+**Publish the in-flight handle before the first suspension point.** A plain
+`if let cached { … }; cached = try await fetch()` memo suspends *before* writing
+anything, so N concurrent first-callers all miss and all fetch. Measured against
+the naive version: **100 callers produced 100 fetches at peak concurrency 76.**
+The store now stores the in-flight `Task` and publishes it synchronously on the
+actor, so a later caller joins it.
+
+**Carry the error as a value.** Typed throws cannot cross a `Task` — the stdlib
+only vends initialisers constrained to `Failure == Never` and
+`Failure == any Error`. We store `Task<Result<APIConfiguration, TMDbError>, Never>`
+and unwrap with `Result.get()`, which is itself `throws(Failure)` in the Swift 6
+stdlib, so `throws(TMDbError)` is preserved at the public boundary with no
+untyped rethrow shim.
+
+**Guard commits with a generation counter, and commit inside the task.** Without
+this, a fetch superseded by `refresh()` would commit its stale value over the
+newer one (leaving the cache **permanently stale**) and null out the live
+in-flight handle (causing a redundant third fetch). The commit happens inside the
+fetch task rather than in an awaiter's continuation: once the task resumes it is
+back on the actor and runs the commit and its return with no suspension between,
+giving the invariant *`inFlightFetch` is non-nil iff its task has not yet
+committed* — which is what stops a late caller joining an already-finished fetch.
+
+**`refresh()` detaches rather than cancels, keeps the cache until a replacement
+lands, and coalesces.** Cancelling a superseded fetch would fail its other
+awaiters because someone else refreshed. Clearing the cached value eagerly would
+mean a refresh that then fails leaves the store cold, so a connectivity blip
+during a pull-to-refresh would degrade every later image URL. And concurrent
+refreshes join one fetch rather than each starting their own against a
+rate-limited API.
+
+**Cancellation is deliberately not forwarded.** This is the opposite call from
+[ADR-0003](0003-opt-in-pagination-prefetch.md), and the difference is the awaiter
+count: the prefetch iterator has exactly **one** owner-awaiter, so forwarding via
+`withTaskCancellationHandler` is correct there. This fetch has **N** awaiters, so
+forwarding would let any single cancelled caller fail all the others.
+
+**Ten URL methods as protocol-extension methods over two requirements.** The
+protocol requires only `imagesConfiguration()` and `refresh()`; `preload()` and
+the ten `*URL(for:idealWidth:)` / `*URL(for:size:)` methods are extension methods
+over them.
+
+## Consequences
+
+- The public API is **cancellation-unresponsive**: a cancelled caller waiting on
+  the shared fetch is not interrupted and does not throw `CancellationError` — it
+  waits for the fetch and receives its value. Bounded (one small request), and
+  typed `throws(TMDbError)` could not honestly surface a `CancellationError`
+  anyway. Documented on the protocol and in the How-To.
+- `refresh()` may return a configuration fetched fractionally *before* the call,
+  when it coalesces onto an in-flight refresh. Documented.
+- Two ways now exist to build an image URL. The How-To leads with `client.images`
+  and keeps the synchronous `ImagesConfiguration` helpers as the documented
+  **batch** path, where an `await` per image would be wasteful.
+- The extension-method shape avoids a real hazard: declaring the ten methods as
+  requirements would need the same-signature default-witness idiom used by
+  `AccountService+Defaults`, where a third-party conformer that skips a
+  requirement compiles cleanly and then **infinitely recurses at runtime**. As
+  extension methods that cannot arise. The cost is that they are statically
+  dispatched and not individually stubbable — `MockImageService` stubs the two
+  requirements, which transitively control every URL.
+- **Watch:** the two families are unambiguous at the call site *only* because the
+  `size:` family has no default argument. Adding `size: ImageSize = .original`
+  would make `posterURL(for: x)` ambiguous at every call site.
+- The store carries an internal `entryCount` used only by tests, because a caller
+  that joins the shared fetch never reaches the mock and so cannot otherwise be
+  observed (see *Testing a memoising actor* in `gotchas.md`).
+
+## Alternatives considered
+
+- **A nil-returning convenience** instead of `async throws(TMDbError)` — more
+  convenient, but it hides a network fetch and an error surface behind something
+  that looks total, and diverges from every other service. Rejected.
+- **`actor TMDbImageService`** rather than a `final class` wrapping the actor.
+  Compiles, but makes each of the ten synchronous `ImagesConfiguration` helpers a
+  cross-actor hop, serialising pure string formatting even when the config is
+  cached. Rejected.
+- **A TTL on the cached value.** TMDb's image configuration changes roughly
+  never; a TTL adds a clock, a config knob, and time-dependent tests for no real
+  benefit. `refresh()` is the escape hatch instead.
+- **Task identity instead of a generation counter** for the commit guard. `Task`
+  is `Equatable`, but a task cannot reference itself from inside its own closure
+  without a two-phase dance, and the commit lives inside the task. The counter is
+  simpler and allocation-free.
+- **Model-level async accessors** (`movie.posterURL(using: client.images, …)`)
+  and a video-URL builder — both deferred to follow-ups to keep this change one
+  coherent unit.

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,7 +14,7 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
-## 2026-07-27 — ✨ Cached image URL resolver, `client.images` (feature/cached-image-url-resolver) · full
+## 2026-07-27 — ✨ Cached image URL resolver, `client.images` (#401) · full
 
 - **Phases / skills:** 0–8 pre-PR; full weight (new public service + actor,
   8 commits). `/plan` → adversarial review by a Fable reviewer **plus** an

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -44,14 +44,32 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
   wrong by construction, not by observation. Fixed with an on-actor entry
   counter. **Lesson: after a concurrency fix, re-review the tests, not just the
   code.**
-- **Friction — the one that actually cost the user.** I ran the security review
-  *concurrently with* code-review round 2, reasoning it "parallelises cleanly".
-  It does for tokens; it does not for CPU. Combined with two 5-agent fan-outs and
-  a grader that ran all of `make ci` unbidden, ~10 concurrent build pipelines
-  collided on one `.build`: a 5-step gate reported **69 minutes** and a
-  `make test` **36 minutes** against a true cost of ~2 each. The user force-quit
-  them. `CLAUDE.md` mandates sequential builds within a worktree, but **subagents
-  cannot see each other**, so nothing enforced it across parallel agents.
+- **Friction — the one that actually cost the user: ~10 zsh pipelines pinned at
+  100% until they force-quit them.** My first explanation ("parallel agents,
+  build contention") was only half of it, and the smaller half. The real
+  amplifier is **`make build-docs` mutually invalidating every other build**:
+  `Package.swift` branches on `SWIFTCI_DOCC`, and the `=1` path *adds* the
+  swift-docc-plugin dependency while the else path *sets `exclude`* on four
+  targets — two different dependency graphs and two different per-target source
+  lists, sharing **one** `SCRATCH_PATH` (default `.build`). `Makefile:61` even
+  runs a bare `swift package resolve` after the docs build purely to undo the
+  first line's resolution, which is the Makefile conceding the point. Evidence:
+  `Package.resolved` is gitignored (the package normally has *no* dependencies)
+  yet exists, and `.build/checkouts/` holds `swift-docc-plugin` +
+  `swift-docc-symbolkit`.
+  So when I interleaved `build-docs` (×5) with `make test` / `build-release`
+  **while 5–7 review agents were independently building into the same
+  `.build`**, each docs run re-resolved the manifest out from under an in-flight
+  build; they then fought over `.build/.lock` and repeatedly redid work the other
+  had invalidated. Not slow work — *cyclical* work.
+  Two things I had wrongly folded into "CPU": the live integration suite is
+  **deliberately serialised** (40 suites carry `.integrationGate`, a global
+  semaphore), so 300 live tests run one at a time — that is most of the 69- and
+  72-minute wall-clock, and it is by design; and sheer redundancy (full unit
+  suite ×7, `build-docs` ×5, release ×3, a 12× filtered loop, plus a grader that
+  re-ran all of `make ci` unbidden, plus the real `make ci`).
+  `CLAUDE.md` mandates sequential builds within a worktree, but **subagents
+  cannot see each other**, so nothing could enforce it.
 - **Deviations:** (a) `TMDbFactory` was not touched — the issue's AC says
   "registered in `TMDbFactory.swift`", but the factory vends only plumbing and
   every service is built in `TMDbClient`'s private init; the grader independently
@@ -60,10 +78,15 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
   production state for the test suite, accepted deliberately and flagged by the
   grader. (c) The ten URL methods are protocol-*extension* members, not
   requirements, to kill the same-signature default-witness recursion hazard.
-- **Improvement:** `/deliver` should forbid builds in reviewer/grader subagent
-  prompts and serialise its review phases. Reviewers have the diff and the
-  conductor has already run every gate, so a reviewer running `make ci` is pure
-  duplicate CPU — and with N parallel agents it is superlinear.
+- **Improvement (two, in priority order):** (1) **Give `build-docs` its own
+  scratch path** — `SCRATCH_PATH ?= .build/docs` for that target alone — so the
+  docc manifest never touches the directory every other target builds into. One
+  line, and it removes the invalidation cycle at the source rather than relying
+  on nobody ever running two things at once. (2) `/deliver` should forbid builds
+  in reviewer/grader subagent prompts and serialise its review phases: reviewers
+  have the diff and the conductor has already run every gate, so a reviewer
+  running `make ci` is duplicate CPU — and with N parallel agents on a shared
+  scratch path it is not merely N×, it is cyclical.
 
 ## 2026-07-24 — 📦 Extract the `TMDbIntelligence` product (#398) · full
 

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,6 +14,57 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-07-27 — ✨ Cached image URL resolver, `client.images` (feature/cached-image-url-resolver) · full
+
+- **Phases / skills:** 0–8 pre-PR; full weight (new public service + actor,
+  8 commits). `/plan` → adversarial review by a Fable reviewer **plus** an
+  independent Swift-6 design pass, which converged on the same critical flaw, so
+  `/review-plan` was skipped as already-reviewed. `implement-plan` in 4
+  checkpoints. `review-changes` ×2 (5-dimension fan-out) → **0 Critical, 0 High
+  both rounds**, 15 then 7 advisory, all applied. `security-review` → 0 findings.
+  `capture-knowledge` → ADR-0013 + 3 gotchas + 1 correction to an existing entry.
+  Rubric: **6/6 ACs met**, independently graded.
+- **Worked — driving each mechanism out of a genuine red.** Rather than writing
+  the final actor from the plan, each hazard got its own failing test first: the
+  naive memo measured **100 fetches at peak concurrency 76** under 100 concurrent
+  callers, and the refresh ABA returned `["first"]` where `["second"]` was
+  expected. That produced *evidence* those are real regression tests, for free —
+  the plan had asked for a deliberate "revert and watch it fail" step, and this
+  made it unnecessary.
+- **Worked — plan review caught a bug the plan could not have shipped without.**
+  Both plan reviewers independently found that the cache rules said *what* to
+  memoise but never *who writes state*, so a superseded fetch would clobber a
+  newer `refresh()` — a permanently stale cache that **none of the 13 planned
+  tests would have caught**. The generation counter came from that, pre-code.
+- **Friction — I introduced two flaky tests while fixing review round 1, and only
+  round 2 caught them.** A caller that *joins* a shared in-flight fetch never
+  reaches the mock or gate, so a gate-based barrier cannot observe it; both new
+  tests opened the gate and then asserted on coalescing. Neither ever failed
+  locally (one reviewer measured 0/65 reproductions, 25 under load) — they were
+  wrong by construction, not by observation. Fixed with an on-actor entry
+  counter. **Lesson: after a concurrency fix, re-review the tests, not just the
+  code.**
+- **Friction — the one that actually cost the user.** I ran the security review
+  *concurrently with* code-review round 2, reasoning it "parallelises cleanly".
+  It does for tokens; it does not for CPU. Combined with two 5-agent fan-outs and
+  a grader that ran all of `make ci` unbidden, ~10 concurrent build pipelines
+  collided on one `.build`: a 5-step gate reported **69 minutes** and a
+  `make test` **36 minutes** against a true cost of ~2 each. The user force-quit
+  them. `CLAUDE.md` mandates sequential builds within a worktree, but **subagents
+  cannot see each other**, so nothing enforced it across parallel agents.
+- **Deviations:** (a) `TMDbFactory` was not touched — the issue's AC says
+  "registered in `TMDbFactory.swift`", but the factory vends only plumbing and
+  every service is built in `TMDbClient`'s private init; the grader independently
+  confirmed the criterion is stale. (b) `APIConfigurationStore` carries an
+  internal `entryCount` that exists only so tests can observe joining callers —
+  production state for the test suite, accepted deliberately and flagged by the
+  grader. (c) The ten URL methods are protocol-*extension* members, not
+  requirements, to kill the same-signature default-witness recursion hazard.
+- **Improvement:** `/deliver` should forbid builds in reviewer/grader subagent
+  prompts and serialise its review phases. Reviewers have the diff and the
+  conductor has already run every gate, so a reviewer running `make ci` is pure
+  duplicate CPU — and with N parallel agents it is superlinear.
+
 ## 2026-07-24 — 📦 Extract the `TMDbIntelligence` product (#398) · full
 
 - **Phases / skills:** phases 0–8 pre-PR; full weight (~40 sources + ~110

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -6,6 +6,42 @@ out of it.
 
 ## Tooling
 
+### `make build-docs` shares `.build` with every other target and invalidates it
+
+*2026-07-27 (#401).* `Package.swift` branches on `SWIFTCI_DOCC`: the `=1` path
+**adds** the swift-docc-plugin dependency, the `else` path **sets `exclude`** on
+the four `.docc`-bearing targets. Those are two different dependency graphs *and*
+two different per-target source lists — and every `make` target shares one
+`SCRATCH_PATH`, which defaults to `.build`.
+
+`Makefile:61` concedes the point: `build-docs` runs a bare
+`swift package resolve` **after** the docs build purely to undo the resolution
+the first line performed. Confirmable at a glance: `Package.resolved` is
+gitignored (the package has **no** dependencies in normal mode) yet exists once
+docs have been built, and `.build/checkouts/` then holds `swift-docc-plugin` and
+`swift-docc-symbolkit`.
+
+Consequences:
+
+- **Interleaving `make build-docs` with `make test` / `build-release` rebuilds
+  far more than you expect**, because each flip changes the manifest under the
+  shared build plan. `make ci` does this flip once by design.
+- **It is actively destructive under concurrency.** If anything else is building
+  into `.build` — notably fanned-out review subagents, which cannot see each
+  other — a docs run re-resolves the manifest out from under an in-flight build.
+  They then contend on `.build/.lock` and repeatedly redo invalidated work. The
+  symptom is many `zsh` pipelines (each target is `swift … | xcsift`) pinned at
+  100% for far longer than the work justifies. Observed: a 5-step gate reporting
+  **69 minutes** against a true cost of a few.
+- **Mitigation:** run docs with a separate scratch path —
+  `make build-docs SCRATCH_PATH=.build/docs` — so it never touches the directory
+  the other targets use. Any path under `.build` is already gitignored.
+
+Related and often mistaken for this: the live integration suite is *deliberately*
+serialised (40 suites carry `.integrationGate`, a global semaphore), so 300 live
+tests run one at a time. That is long wall-clock by design, not contention —
+don't "fix" it.
+
 ### A non-test target can never `@testable import` — it breaks `swift build -c release` only
 
 *2026-07-24 (#395).* Sharing test fixtures between two test targets needs a

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -481,6 +481,56 @@ separator. That residual is path-only — `urlFromPath` force-overrides
 
 ## Swift concurrency
 
+### Writing a `Task {}` body inside an actor: typed throws and the missing `await`
+
+*2026-07-27 (#391).* Two compiler rules bite together when an actor stores an
+unstructured `Task` and commits its result back to the actor (the memo in
+`APIConfigurationStore`).
+
+**Typed-throws `do`/`catch` inference does not apply inside a closure.** It works
+in a function body, but in a `Task { }` or `group.addTask { }` body a bare
+`catch` binds `any Error`:
+
+```text
+error: cannot convert value of type 'any Error' to expected argument type 'TMDbError'
+```
+
+Write the effect explicitly — `do throws(TMDbError) { … } catch { … }`. An
+explicit closure signature (`Task { () async -> Result<…> in … }`) does **not**
+fix it. And `catch let error as TMDbError` compiles but emits *"'as' test is
+always true"*, which is fatal under `--Werror`. The alternative that also works
+is extracting the `do`/`catch` into a plain `private func … async -> Result<…>`
+and calling that from the `Task`.
+
+**A `Task {}` capturing `self` inside an actor inherits that actor's isolation.**
+So calling back into the actor from the task body must **omit** `await` — a
+redundant one is `#UnnecessaryEffectMarker`, also fatal under `--Werror`. With
+`[weak self]` the isolation is *not* inherited and `await self?.foo()` **is**
+required. Strong `self` is usually what you want: the commit then happens in the
+same actor-isolated, suspension-free region as the task's completion.
+
+### Testing a memoising actor: a caller that *joins* is invisible to the mock
+
+*2026-07-27 (#391).* When an actor de-duplicates concurrent work by sharing one
+in-flight `Task`, only the **first** caller reaches the underlying mock or gate.
+Every later caller awaits the existing handle and never touches the double — so
+a `FetchGate`-style barrier cannot observe it, and a test that opens the gate and
+then asserts on de-duplication is **flaky by construction**: if the shared fetch
+commits first, the "joiner" starts its own fetch and the assertion fails.
+
+- **Fix:** count arrivals on the actor itself — an internal counter incremented
+  **before the first suspension point**, which is a true "has joined" signal —
+  and poll it. Production cost is one `private(set) var` and one increment per
+  entry point; the alternative is a test that asserts a guarantee it cannot
+  actually observe.
+- **Always bound such a barrier.** An unbounded `while x < n { await Task.yield() }`
+  turns the very regression it guards into a **CI hang with no diagnostic**,
+  which is strictly worse than a failed assertion. Give it a deadline and
+  `Issue.record` on expiry.
+- Both traps were found by code review *after* the tests were green, not by
+  running them — they are ordering assumptions, not reproducible failures. One
+  reviewer measured 0/65 reproductions including 25 under 12-way CPU load.
+
 ### Deterministically testing that cancellation is *forwarded* into an unstructured `Task`
 
 *2026-06-18.* An unstructured `Task {}` does **not** inherit its parent's
@@ -508,6 +558,12 @@ Drive such sequences directly via their `init(pageFetcher:)` with the `actor`
 recorder — **never** `MockAPIClient` (it is `@unchecked Sendable` with
 unsynchronised state and would data-race under concurrent fetches).
 
+**Forwarding is not always right.** It is correct here because the prefetch task
+has exactly **one** owner-awaiter. A task shared by **N** awaiters — such as the
+configuration memo in [ADR-0013](decisions/0013-cached-image-url-resolver.md) —
+must *not* forward, or one cancelled caller fails all the others. Check the
+awaiter count before copying this pattern.
+
 ### Public enums are not implicitly `Sendable` — explicit conformance needed for `@Sendable` capture
 
 *2026-06-18.* Adding auto-pagination over a service method captures that method's
@@ -525,6 +581,20 @@ in a '@Sendable' closure"*.
   `Sendable`; don't assume a simple value enum already is.
 
 ## Testing
+
+### An `async let` binding cannot be captured by `#expect(throws:)`
+
+*2026-07-27 (#391).* Awaiting an `async let` inside the `#expect(throws:)`
+closure fails to compile:
+
+```text
+error: capturing 'async let' variables is not supported
+```
+
+Use an explicit `Task {}` handle instead and await its `.value` inside the macro
+— `let caller = Task { try await store.foo() }`, then
+`await #expect(throws: TMDbError.unknown) { _ = try await caller.value }`. A
+plain `let` task handle is capturable; the `async let` binding is not.
 
 ### Integration tests need live-API env vars, and can fail transiently
 


### PR DESCRIPTION
Closes #391.

## Summary

Turning `movie.posterPath` into a `URL` was a manual two-step: fetch
`APIConfiguration`, hold on to its `ImagesConfiguration`, then resolve through the
synchronous helpers. Nothing cached that object at the client level, so every
consumer invented its own lifecycle for it.

```swift
let url = try await client.images.posterURL(for: movie.posterPath, size: .width(500))
```

`client.images` fetches TMDb's image configuration on first use and caches it for
the client's lifetime — **at most once, however many callers ask concurrently**.
`preload()` warms it at launch; `refresh()` re-fetches it.

`ImagesConfiguration+URLs` is untouched and remains the documented path for batch
use, where an `await` per image would be wasteful. All URL construction delegates
to it — no logic is duplicated.

## Design notes

**Why memoise at all**, given `URLCache` already caches `/configuration` on Apple
platforms: the memo is not primarily a network win. It removes the config
lifecycle from the caller (the point of the issue), skips re-decoding per image,
does real work on Linux/Windows where no `URLCache` exists, and is always on where
`CacheHTTPClient` is opt-in. [ADR-0013](knowledge/decisions/0013-cached-image-url-resolver.md)
says so plainly rather than claiming a benefit it doesn't have.

Two concurrency hazards, each fixed and pinned by a test **shown to fail first**:

| Hazard | Measured against the simpler version |
| --- | --- |
| Actor reentrancy — a plain `if let cached` memo suspends before writing anything | 100 concurrent callers → **100 fetches, peak concurrency 76** |
| ABA on `refresh()` — a superseded fetch commits over a newer value | cache left **permanently stale**, plus a redundant third fetch |

**Cancellation is deliberately not forwarded** into the shared fetch. This is the
opposite call from [ADR-0003](knowledge/decisions/0003-opt-in-pagination-prefetch.md),
and the difference is the awaiter count: the prefetch iterator has one
owner-awaiter so forwarding is correct there; this fetch has N, so forwarding
would let one cancelled caller fail all the others. The consequence — these
methods are cancellation-unresponsive — is documented publicly, not just in a test
comment.

The ten URL methods are protocol-**extension** members over two requirements,
rather than requirements with the same-signature default-witness idiom used by
`AccountService+Defaults`, where a third-party conformer that skips a requirement
compiles cleanly and then infinitely recurses at runtime.

## Two things a reviewer may want to push back on

- `APIConfigurationStore` carries an internal `entryCount` that exists **only so
  tests can observe callers that join a shared fetch** — such callers never reach
  the mock, so a gate-based barrier cannot see them. It's internal and
  behaviourally inert, but it is production state serving the test suite.
- `client.configurations.apiConfiguration()` remains **uncached**. Two doors to the
  same endpoint with different caching semantics; deliberate, and recorded in the
  ADR.

The issue's acceptance criterion *"registered in `TMDbFactory.swift`"* is stale
against the current architecture — the factory vends only plumbing, and all 26
services are constructed in `TMDbClient`'s private init. No factory change was
needed.

## Testing

- **Unit:** 2,901 passing. 13 store tests covering de-duplication, failure
  sharing, refresh/ABA, coalescing and cancellation; 8 service tests; the ADR-0006
  mock suite.
- **Integration:** 300 passing against the live API, including the `idealWidth`
  family, which parses the live size strings and so exercises a different path
  from the `size:` family.
- The concurrency suite was run 12 consecutive times to verify determinism rather
  than trusting a single green.
- `make ci` green: lint, lint-markdown, test, integration-test, build-release,
  build-docs.

## Review

Two full 5-dimension review rounds (correctness, concurrency, architecture,
testing, api-docs) with adversarial verification: **0 Critical and 0 High in
both**; all 14 distinct advisory findings applied, none deferred. Security review:
0 findings. Acceptance criteria independently graded **6/6 met**.

Round 2 caught that my round-1 fix had introduced two tests that were flaky *by
construction* — they asserted on coalescing while waiting on a barrier that cannot
observe a joining caller. Neither ever failed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01138xB9HCp2cnYGkjd6mFBz