### PR TITLE
🔧 Give docs builds their own scratch path, and stop agents building in parallel

### DIFF
--- a/.claude/agents/tooling-runner.md
+++ b/.claude/agents/tooling-runner.md
@@ -56,6 +56,13 @@ fall back to `pwd`:
 - For a **scoped** re-run, keep the package explicit:
   `swift test --package-path "<dir>" --scratch-path "<dir>/.build" --filter "SuiteName/testName"`.
 - Run targets **sequentially** — never two builds at once in one worktree.
+  You are the *only* sanctioned builder: your caller must await you before
+  starting anything else, and reviewer/grader subagents are told not to build
+  at all. If you were asked to run more than one target, run them one after
+  another, never in parallel — every target shares one SwiftPM scratch
+  directory, and concurrent builds there don't just queue, they invalidate each
+  other's build plans (see `knowledge/gotchas.md` → *`make build-docs` shares
+  `.build`*).
 - Never read or touch `.swiftpm/` or `.build/` beyond the log file.
 
 ## Judging pass/fail — the xcsift `.docc` trap

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -108,9 +108,26 @@ implementation = separate `/deliver` sessions.)
   **not** convert it to a silent subagent.
 - **The gate stays in the main agent**; phases hand off via git / disk / the
   PR, not context.
-- Separate worktrees get separate `.build` dirs; run builds sequentially
-  *within* one worktree. No `SCRATCH_PATH` override is needed — that flag is
-  only for multiple agents sharing one working directory.
+- Separate worktrees get separate `.build` dirs. No `SCRATCH_PATH` override is
+  needed — that flag is only for multiple agents sharing one working directory.
+- **One Swift process per worktree — at any instant, across every agent.** Not
+  "each agent runs its builds sequentially": *one build in the whole worktree,
+  full stop. The conductor owns it.* Concretely:
+  - Only the conductor and the `tooling-runner` it spawns may build. **Reviewer,
+    security and grader subagents must be told not to build** — their prompts
+    say so, and `/review-changes` and Phase 7 above already carry that
+    instruction.
+  - **Never run two analysis phases concurrently.** Phase 4 and Phase 5 read the
+    same commits and feel independent, so "run the security review while the
+    fan-out finishes" is tempting — it parallelises tokens but serialises
+    nothing on disk. Finish one, then start the next.
+  - Never spawn a `tooling-runner` in the background, and never two at once.
+  Why it matters more than ordinary contention: every target shares one scratch
+  directory, and a `build-docs` run flips the `SWIFTCI_DOCC` manifest, which
+  *invalidates* any concurrent build's plan rather than merely queueing behind
+  it — so the processes redo each other's work in a cycle. This once put ~10
+  `zsh` pipelines at 100% until the user killed them
+  (`knowledge/gotchas.md` → *`make build-docs` shares `.build`*).
 
 ## Phase 0 — Preconditions
 
@@ -267,13 +284,17 @@ is graded depends on weight:
 - **Full** → **an independent grader, not the conductor** — the maker does
   not grade its own homework. Spawn ONE subagent (general-purpose; inherit
   the model) given ONLY the rubric verbatim and the instruction to judge the
-  committed work (`git diff origin/main...HEAD`, reading files and running
-  targeted `swift test --filter …` as needed) — no conversation context, no
-  implementation narrative. It returns per-AC `met`/`not met` + one-line
-  evidence (file:line or test name). Run it **synchronously** — it may
-  build/test, and builds are sequential within a worktree. Grader dies or
-  returns unusable output → fall back to the inline path and note it in the
-  ledger — **a dead grader is not a pass**.
+  committed work by **reading** `git diff origin/main...HEAD` and the files —
+  no conversation context, no implementation narrative. It returns per-AC
+  `met`/`not met` + one-line evidence (file:line or test name). Run it
+  **synchronously**. Grader dies or returns unusable output → fall back to the
+  inline path and note it in the ledger — **a dead grader is not a pass**.
+  - **Cap what it may execute, explicitly.** Phase 3 and Phase 9 already run
+    the full gates; a grader re-running them proves nothing new and costs
+    minutes. Tell it: *at most one targeted `swift test --filter …`, and never
+    `make ci` / `make test` / `make integration-test` / `make build-docs`.*
+    Left unsaid, a thorough grader will run the whole of `make ci` — one did,
+    for 72 minutes, including the 300-test live suite.
 
 Satisfied → mark off. Not → fix test-first, commit, re-verify (full weight:
 re-run the grader); a gap needing a plan change is noted in the PR

--- a/.claude/skills/review-changes/SKILL.md
+++ b/.claude/skills/review-changes/SKILL.md
@@ -58,9 +58,27 @@ genuinely broad.
 
 ## 2a. Small change → single agent
 
-Spawn the **`code-reviewer`** agent on `git diff origin/main...HEAD`. It follows
+Spawn the **`code-reviewer`** agent on `git diff origin/main...HEAD`, telling it
+**not to build or run tests** (see *Reviewers don't build* below). It follows
 `.github/CODE_REVIEW.md` including its own adversarial self-pass, and returns the
 full severity-graded report. Pass that report back to the caller. Done.
+
+### Reviewers don't build
+
+**No reviewer — single or fanned-out — may run `make`, `swift build` or
+`swift test`.** Reviewing is a reading task: the reviewer has the diff and the
+source, and the caller has already run every gate before invoking this skill.
+
+This is not a style preference. Every target shares one SwiftPM scratch
+directory per worktree, so N parallel reviewers each starting a build is N
+processes contending on one `.build/.lock` — and if any of them builds docs, the
+`SWIFTCI_DOCC` manifest flip *invalidates* the others' build plans, so they redo
+each other's work in a cycle rather than merely queueing. Observed once as ~10
+`zsh` pipelines pinned at 100% long enough that the user killed them (see
+`knowledge/gotchas.md` → *`make build-docs` shares `.build`*).
+
+If a finding genuinely cannot be settled without executing something, say so in
+the finding and let the caller run it — serially, once.
 
 ## 2b. Large change → fan-out + verify Workflow
 
@@ -130,6 +148,7 @@ const VERDICT_SCHEMA = {
 const reviewPrompt = (d) =>
   `Review the changes on this branch through ONE lens only: ${d.focus}.\n\n` +
   `Get the diff yourself with \`git diff ${BASE}...HEAD\`, and read the surrounding source as needed. ` +
+  `DO NOT BUILD OR RUN TESTS — no \`make\`, no \`swift build\`, no \`swift test\`. You are one of several reviewers running in parallel against one shared .build directory; a build here collides with theirs and with the caller's. The caller has already run every gate. Review by reading the diff and the source. ` +
   `Follow the project review guidelines in ${SPEC} — the severity rubric, in/out scope, and the MANDATORY adversarial re-evaluation (drop any finding that doesn't survive). ` +
   `Stay strictly within your lens; other reviewers cover the rest, so don't duplicate them. ` +
   `Report only findings that survive your adversarial pass, each with file, line, what's wrong, why it matters, and a concrete fix. If your lens is clean, return an empty findings array.`

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,22 @@ SWIFT_CONTAINER_IMAGE = swift:6.1-jammy
 # `make test SCRATCH_PATH=.build/agent-a` (stays under the gitignored .build).
 SCRATCH_PATH ?= .build
 
+# Documentation builds get their OWN scratch directory, and must keep it.
+#
+# Package.swift branches on SWIFTCI_DOCC: the =1 path adds the swift-docc-plugin
+# dependency, the else path sets `exclude` on the four .docc-bearing targets.
+# Those are two different dependency graphs *and* two different per-target source
+# lists. Pointing both at one scratch directory makes every switch between a docs
+# build and any other target re-resolve and rebuild — and under concurrency it is
+# worse than slow: a docs build re-resolves the manifest out from under an
+# in-flight build, so the two then contend on .build/.lock repeatedly redoing
+# work the other invalidated.
+DOCS_SCRATCH_PATH ?= $(SCRATCH_PATH)/docs
+
 .PHONY: clean
 clean:
 	swift package --scratch-path $(SCRATCH_PATH) clean
+	rm -rf $(DOCS_SCRATCH_PATH)
 	rm -rf docs
 
 .PHONY: format
@@ -57,16 +70,15 @@ build-linux-release:
 
 .PHONY: build-docs
 build-docs:
-	SWIFTCI_DOCC=1 swift package --scratch-path $(SCRATCH_PATH) generate-documentation --warnings-as-errors
-	swift package --scratch-path $(SCRATCH_PATH) resolve
+	SWIFTCI_DOCC=1 swift package --scratch-path $(DOCS_SCRATCH_PATH) generate-documentation --warnings-as-errors
 
 .PHONY: preview-docs
 preview-docs:
-	SWIFTCI_DOCC=1 swift package --scratch-path $(SCRATCH_PATH) --disable-sandbox preview-documentation --target $(TARGET)
+	SWIFTCI_DOCC=1 swift package --scratch-path $(DOCS_SCRATCH_PATH) --disable-sandbox preview-documentation --target $(TARGET)
 
 .PHONY: generate-docs
 generate-docs:
-	SWIFTCI_DOCC=1 swift package --scratch-path $(SCRATCH_PATH) --allow-writing-to-directory docs \
+	SWIFTCI_DOCC=1 swift package --scratch-path $(DOCS_SCRATCH_PATH) --allow-writing-to-directory docs \
 		generate-documentation \
 		--target TMDb \
 		--target TMDbIntelligence \

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -6,20 +6,20 @@ out of it.
 
 ## Tooling
 
-### `make build-docs` shares `.build` with every other target and invalidates it
+### Docs builds need their own scratch path — sharing one invalidates the other
 
-*2026-07-27 (#401).* `Package.swift` branches on `SWIFTCI_DOCC`: the `=1` path
-**adds** the swift-docc-plugin dependency, the `else` path **sets `exclude`** on
-the four `.docc`-bearing targets. Those are two different dependency graphs *and*
-two different per-target source lists — and every `make` target shares one
-`SCRATCH_PATH`, which defaults to `.build`.
+*2026-07-27 (#401, fixed in #402).* `Package.swift` branches on `SWIFTCI_DOCC`:
+the `=1` path **adds** the swift-docc-plugin dependency, the `else` path **sets
+`exclude`** on the four `.docc`-bearing targets. Those are two different
+dependency graphs *and* two different per-target source lists. Every `make`
+target used to share one `SCRATCH_PATH`.
 
-`Makefile:61` concedes the point: `build-docs` runs a bare
-`swift package resolve` **after** the docs build purely to undo the resolution
-the first line performed. Confirmable at a glance: `Package.resolved` is
-gitignored (the package has **no** dependencies in normal mode) yet exists once
-docs have been built, and `.build/checkouts/` then holds `swift-docc-plugin` and
-`swift-docc-symbolkit`.
+Verify the divergence in seconds — no build needed:
+
+```bash
+swift package resolve                 # no Package.resolved at all: zero dependencies
+SWIFTCI_DOCC=1 swift package resolve  # two pins: swift-docc-plugin, swift-docc-symbolkit
+```
 
 Consequences:
 
@@ -33,9 +33,15 @@ Consequences:
   symptom is many `zsh` pipelines (each target is `swift … | xcsift`) pinned at
   100% for far longer than the work justifies. Observed: a 5-step gate reporting
   **69 minutes** against a true cost of a few.
-- **Mitigation:** run docs with a separate scratch path —
-  `make build-docs SCRATCH_PATH=.build/docs` — so it never touches the directory
-  the other targets use. Any path under `.build` is already gitignored.
+- **Fixed in #402:** the three `SWIFTCI_DOCC` targets now use their own
+  `DOCS_SCRATCH_PATH` (`.build/docs`), so a docs build never touches the
+  directory the other targets use — after `make build-docs`, `.build/` contains
+  only `docs`. **Keep it that way**: pointing docs back at `SCRATCH_PATH`, or
+  adding a fourth docs target that forgets the variable, reintroduces all of the
+  above.
+- The same reasoning applies to any future manifest-conditional build mode: a
+  build whose *manifest* differs needs its own scratch directory, not just its
+  own flags.
 
 Related and often mistaken for this: the live integration suite is *deliberately*
 serialised (40 suites carry `.integrationGate`, a global semaphore), so 300 live


### PR DESCRIPTION
## The problem

`Package.swift` branches on `SWIFTCI_DOCC`: the `=1` path **adds** the
swift-docc-plugin dependency, the `else` path **sets `exclude`** on the four
`.docc`-bearing targets. Those are two different dependency graphs *and* two
different per-target source lists — and every `make` target pointed at one
`SCRATCH_PATH`.

Measured on this branch:

```console
$ swift package resolve                    # no Package.resolved created — zero dependencies
$ SWIFTCI_DOCC=1 swift package resolve     # Package.resolved appears: swift-docc-plugin, swift-docc-symbolkit
```

So switching between a docs build and any other target re-resolves and rebuilds.
Under concurrency it is **destructive rather than merely slow**: a docs build
re-resolves the manifest out from under an in-flight build, so the two then
contend on `.build/.lock` repeatedly redoing work the other invalidated — a
cycle, not a queue.

That is not hypothetical. Interleaving `build-docs` with test and release runs
while several review subagents were independently building put **~10 `zsh`
pipelines at 100%** for long enough that they had to be killed by hand. A 5-step
gate reported **69 minutes**; a cold docs build is **29 seconds**.

## The fix

The three `SWIFTCI_DOCC` targets (`build-docs`, `preview-docs`, `generate-docs`)
now use `DOCS_SCRATCH_PATH` — `.build/docs` by default, still gitignored, still
overridable. Verified: after `make build-docs`, `.build/` contains **only**
`docs`. It no longer touches the directory the other targets build into.

The `swift package resolve` that followed `build-docs` is dropped. It was
resetting the *shared* scratch directory's workspace state, which the split makes
unnecessary. It never reset `Package.resolved` — verified, the pin count is
unchanged across it — so removing it changes nothing there. (I added that line
back mid-review on a wrong assumption, then measured and removed it again.)

## Prevention, so it can't recur through agents

The Makefile change removes the *destructive* half. These stop the *concurrent*
half:

- **`/review-changes`** — reviewers must not build or run tests, single or
  fanned-out. They have the diff, and the caller has already run every gate. N
  parallel reviewers sharing one scratch directory was the original trigger.
- **`/deliver`** — states the rule as **"one Swift process per worktree at any
  instant, across every agent"**, not "each agent builds sequentially", and
  forbids running two analysis phases concurrently (which is how a security
  review ended up alongside a five-agent fan-out).
- **`/deliver` Phase 7** — the rubric grader is capped to one targeted
  `swift test --filter`. Left unsaid, a thorough grader runs the whole of
  `make ci`; one did, for 72 minutes, including the 300-test live suite.
- **`tooling-runner`** — spelled out that it is the only sanctioned builder, and
  that concurrent builds invalidate rather than queue.

## Testing

- `make -n` on every affected target: docs on `.build/docs`; `test`,
  `build-release` and `build-tests` unchanged on `.build`; `DOCS_SCRATCH_PATH`
  override works; `clean` removes both.
- `make build-docs` run for real: exit 0, 0 errors, 29s, and `.build/` left
  containing only `docs`.
- `make lint-markdown` clean (the `.claude/**` skills are in its scope).
- `.build/docs` confirmed gitignored by the existing `/.build` rule.

Not run here: the full `make ci` — this changes only the docs scratch directory
and prose, and CI exercises `build-docs` itself.

Follow-up: the gotcha entry arriving with #401 documents the old manual
mitigation (`SCRATCH_PATH=.build/docs`); once both land it should say the
Makefile now does this for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01138xB9HCp2cnYGkjd6mFBz