### PR TITLE
🔧 Audit the knowledge base: retire stale entries and add a retirement trigger

### DIFF
--- a/.claude/agents/tooling-runner.md
+++ b/.claude/agents/tooling-runner.md
@@ -61,20 +61,27 @@ fall back to `pwd`:
   at all. If you were asked to run more than one target, run them one after
   another, never in parallel — every target shares one SwiftPM scratch
   directory, and concurrent builds there don't just queue, they invalidate each
-  other's build plans (see `knowledge/gotchas.md` → *`make build-docs` shares
-  `.build`*).
+  other's build plans (see `knowledge/gotchas.md` → *Docs builds need their own
+  scratch path*).
 - Never read or touch `.swiftpm/` or `.build/` beyond the log file.
 
-## Judging pass/fail — the xcsift `.docc` trap
+## Judging pass/fail — the exit status is the verdict
 
 **Trust the exit status (and, for tests, the `failed_tests` count) — not
-xcsift's `status:` field or toon summary.** Outside a docs build, SwiftPM
-emits a benign `found N file(s) which are unhandled … *.docc` warning (the
-DocC plugin loads only under `SWIFTCI_DOCC=1`); xcsift lists it under
-`errors[]` with `null,null` coordinates and may print `status: failed` even
-though the run **exits 0**. A 0 exit whose only errors are these `.docc`
-unhandled-file entries (and, for test runs, `failed_tests: 0`) is a
-**PASS** — report succeeded and exclude those entries from the error count.
+xcsift's `status:` field or toon summary.** xcsift can print `status: failed`
+while the run **exits 0**, because its toon `errors[]` array also collects
+package-load diagnostics (they appear with `null,null` coordinates). Judge on
+the exit code; use `errors[]` only to *describe* a failure the exit code
+already established.
+
+> **Do not special-case the `.docc` "unhandled files" diagnostic as benign.**
+> It used to be a harmless package-load warning, but `Package.swift` now
+> `exclude`s every `.docc` catalog outside a docs build, so it no longer
+> appears for existing targets — and when it *does* appear it means a new
+> target's catalog is missing from that `exclude` list, which is **fatal**
+> under `-warnings-as-errors` on Xcode 27 (both local and CI). Report it as
+> the failure it now is; see `knowledge/gotchas.md` → *A new target with a
+> `.docc` catalog must be added to `Package.swift`'s exclude list*.
 
 ## Targets
 

--- a/.claude/skills/capture-knowledge/SKILL.md
+++ b/.claude/skills/capture-knowledge/SKILL.md
@@ -19,9 +19,15 @@ a future me waste time without this?":
   surprise, anything that needed a **web search or doc lookup** to resolve.
 - **Live-API behaviours** → `knowledge/tmdb-api-notes.md` — a nullable/absent
   field, an undocumented response shape, an enum value the docs omit.
-- **Design decisions** → a new **ADR** in `knowledge/decisions/` (next number),
-  using `decisions/0000-template.md`. Any non-obvious choice and its rationale —
-  why this approach over the alternatives.
+- **Design decisions** → a new **ADR** in `knowledge/decisions/` (next number —
+  take it from [`decisions/README.md`](../../../knowledge/decisions/README.md)'s
+  index, not a directory listing), using `decisions/0000-template.md`. Any
+  non-obvious choice and its rationale — why this approach over the
+  alternatives. Add the new row to that index.
+- **Deferred breaking changes** → `knowledge/next-major.md` — any fix
+  rejected or deferred *because* it is breaking. The skill-improvement log
+  remembers the "no"; this file is what makes the deferred "yes" resurface
+  at the next major.
 
 ## What NOT to capture
 
@@ -52,13 +58,38 @@ Quality over volume: a few high-signal entries beat a long dump.
    - Decisions: copy `decisions/0000-template.md` to
      `decisions/NNNN-<kebab-title>.md` (next free number), fill in Status / Date /
      Context / Decision / Consequences / Alternatives. Cross-link related ADRs.
-5. **Retire what's no longer true.** The base is a **cache of current truths, not
-   an archive** (git history is the archive — see
+5. **Retire what the diff invalidates — sweep by citation, not by
+   neighbourhood.** The base is a **cache of current truths, not an archive**
+   (git history is the archive — see
    [`knowledge/README.md`](../../../knowledge/README.md) → *Maintenance &
-   retention*). While you're in `gotchas.md` / `tmdb-api-notes.md`, scan the
-   neighbouring entries and **delete** any now obsolete — an upstream bug fixed, a
-   pinned version lifted, the code removed, a quirk that no longer reproduces. The
-   file should describe the present, not narrate the past.
+   retention*). Staleness is usually caused by the very change you are
+   capturing for, so find it from the diff:
+
+   1. List the infrastructure files this change touched:
+
+      ```bash
+      git diff --name-only origin/main...HEAD | \
+        grep -E '^(Makefile|Package\.swift|Package\.resolved|\.github/workflows/|\.claude/)'
+      ```
+
+   2. For each hit, grep **all of `knowledge/`** (not just the file you are
+      writing to) for entries citing that file, its targets, or its pinned
+      values — e.g. `grep -n 'Makefile\|make ci\|TEST_TARGET' knowledge/*.md`,
+      `grep -n 'ci\.yml\|Xcode_[0-9]' knowledge/*.md`. Test-target lists,
+      pinned tool/Xcode versions, `SWIFTCI_DOCC`, scratch paths, and workflow
+      step names are the usual casualties. If the change renames or removes a
+      `knowledge/` entry heading, also grep `.claude/` and `CLAUDE.md` for
+      citations of the old title — skills cite gotchas by title.
+   3. **Read every citing entry and reconcile it**: still true → leave it;
+      partly true → rewrite it in the present tense; no longer true → delete
+      it. **Never append an "Update:" / "Resolved in #NNN" note to a stale
+      entry — rewrite or delete it.** An entry that narrates its own history
+      contradicts itself within weeks (this is exactly how the `.docc` gotcha
+      decayed across #396–#402).
+   4. Report the sweep as one line:
+      `swept: <infra files touched> → <entries rewritten/deleted | none cited>`.
+      No infra files in the diff → `swept: n/a`, and fall back to scanning
+      the neighbouring entries of any knowledge file you edited.
 6. **Keep it tidy by hand** — blank lines around headings/lists/code fences, a
    language on every fence, one `#` H1 per file. Note `knowledge/` is **not** in
    the `make lint-markdown` scope (which covers `README.md`, `CLAUDE.md`,

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -127,7 +127,7 @@ implementation = separate `/deliver` sessions.)
   *invalidates* any concurrent build's plan rather than merely queueing behind
   it — so the processes redo each other's work in a cycle. This once put ~10
   `zsh` pipelines at 100% until the user killed them
-  (`knowledge/gotchas.md` → *`make build-docs` shares `.build`*).
+  (`knowledge/gotchas.md` → *Docs builds need their own scratch path*).
 
 ## Phase 0 — Preconditions
 
@@ -271,6 +271,12 @@ deduped against `knowledge/`, written to the right file (gotchas / API notes
 a valid outcome. Exception: one or two small entries already authored during
 implementation may be committed inline instead — note the inline capture in
 the retro.
+
+Its report must include the `swept:` line — Phase 6 is the knowledge base's
+retirement trigger (the skill's step 5); a report without it means the sweep
+did not run. That applies to the inline-capture exception too: a delivery that
+touched `Makefile`, `Package.swift`, `.github/workflows/` or `.claude/` still
+owes the sweep, whoever wrote the entries.
 
 ## Phase 7 — Rubric verification (exit gate)
 

--- a/.claude/skills/review-changes/SKILL.md
+++ b/.claude/skills/review-changes/SKILL.md
@@ -75,7 +75,7 @@ processes contending on one `.build/.lock` — and if any of them builds docs, t
 `SWIFTCI_DOCC` manifest flip *invalidates* the others' build plans, so they redo
 each other's work in a cycle rather than merely queueing. Observed once as ~10
 `zsh` pipelines pinned at 100% long enough that the user killed them (see
-`knowledge/gotchas.md` → *`make build-docs` shares `.build`*).
+`knowledge/gotchas.md` → *Docs builds need their own scratch path*).
 
 If a finding genuinely cannot be settled without executing something, say so in
 the finding and let the caller run it — serially, once.

--- a/.claude/skills/review-knowledge/SKILL.md
+++ b/.claude/skills/review-knowledge/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: review-knowledge
+description: Audit the knowledge/ base for staleness, self-contradiction, and drift from its own retention policy — two independent adversarial critics verify every load-bearing claim against the current tree, cross-examine each other, and reach a consensus on if/what needs changing. Use periodically, after a run of deliveries that changed build config or target layout, or whenever you suspect the knowledge base has aged out of true.
+---
+
+# Review Knowledge
+
+Audit `knowledge/` against reality. A knowledge base is a **cache of currently-true
+facts** (`knowledge/README.md` → *Maintenance & retention*), and caches go stale
+silently: writes are engineered here (`/capture-knowledge`, `/deliver`'s capture
+phase) but retirements are not, so truth decays exactly where the code moves
+fastest — `Makefile`, `.github/workflows/ci.yml`, `Package.swift`, target layout,
+toolchain pins.
+
+Two independent adversarial critics audit it, cross-examine each other's findings,
+and converge on a consensus. You adjudicate only what survives disputed.
+
+> The base's own entries are the thing under suspicion. An entry that reads
+> confidently and cites a file is exactly the kind that goes stale unnoticed —
+> confidence is not currency here. **Verify against the tree or drop the claim.**
+
+## Agent Behaviour Contract
+
+The point of this skill: do these by default, without being reminded.
+
+1. **Two critics, two lenses, one Workflow.** Run the embedded `Workflow` below.
+   It fans out exactly two auditors in parallel, each pinned to the **`fable`**
+   model, then runs a **cross-examination** round where each sees the other's
+   findings. Invoking this skill is itself the opt-in to call `Workflow`.
+2. **Verify, never trust the prose.** Every finding must be checked against the
+   actual tree (`Read`/`Grep`/`Bash`) and cite `file:line`. A finding sourced only
+   from reading the knowledge base itself is inadmissible — that is the failure
+   mode being audited.
+3. **Critics are read-only.** They audit and report. They do not edit `knowledge/`,
+   do not fix anything, and do not open PRs. Applying is the conductor's job, after
+   the user approves.
+4. **"Nothing needs changing" is a real, respectable outcome.** A critic that
+   finds a file accurate must say so and name what it checked. Do not manufacture
+   findings to look thorough — a padded audit trains the next one to be ignored.
+5. **Adjudicate only genuine deadlock.** After cross-examination, findings both
+   critics confirm are consensus and need no debate from you. Resolve only what
+   remains disputed, with a stated rationale grounded in the tree.
+6. **Report before you fix.** Present the consensus, get the user's go-ahead, then
+   apply. Never silently rewrite the knowledge base on the strength of an audit.
+
+## Scope
+
+Everything under `knowledge/`:
+
+| File | What decay looks like here |
+| --- | --- |
+| `gotchas.md` | A trap that was fixed upstream but still reads as live; a tooling pin, path, or filter that moved; three generations of truth accreted into one entry. |
+| `tmdb-api-notes.md` | A live-API behaviour that changed; a field that is no longer nullable; a claim never verified against a real response. |
+| `decisions/` | Numbering collisions; a status still saying "targets X" after X shipped; an ADR superseded in fact with no forward link; the index out of sync. |
+| `delivery-retros.md` | Over its ~12-entry rolling window; prose whose lesson is already folded into a skill (spent — distil it). |
+| `skill-improvement-log.md` | A `deferred`/`rejected` entry whose "Reconsider when" condition has **already been met**. This is the highest-cost staleness in the base: the recurring-pattern scan reads this file as dedup memory, so a stale entry actively misinforms it. |
+| `breaking-backlog.md` | An item that shipped, or one whose "breaking" premise no longer holds. |
+| `README.md` | The stated policy no longer matching what the files actually do. |
+
+Also in scope: **contradictions with `CLAUDE.md`**. When the base and `CLAUDE.md`
+disagree, determine which is right from the tree — the base is often the one that
+already diagnosed the truth, and nobody propagated it upstream.
+
+## Run the audit (Workflow)
+
+Two auditors run as a single `Workflow` so the **`fable`** model is guaranteed per
+agent and each verdict is schema-validated rather than free-text. No `args` are
+needed — the scope is the repository itself.
+
+```javascript
+export const meta = {
+  name: 'review-knowledge-critics',
+  description: 'Two adversarial Fable critics audit the knowledge base, then cross-examine',
+  phases: [
+    { title: 'Audit', detail: 'two fable critics, one per lens' },
+    { title: 'Cross-examine', detail: 'each critic tries to refute the other' },
+  ],
+  model: 'fable',
+}
+
+const SEVERITY = `Grade by CONSEQUENCE IF THE ENTRY IS TRUSTED AS WRITTEN, not by your confidence:
+- critical: acting on this entry causes real harm or wasted work — it states a falsehood about the current tree, contradicts another entry, or (in skill-improvement-log.md) misinforms the dedup scan that reads it as memory.
+- major: materially misleading — a stale path/pin/filter, an ADR status or number defect, a policy the base states but does not follow, a missing cross-reference that hides a correction.
+- minor: hygiene — ordering, duplication, a cosmetic defect, a window one entry over.
+If unsure whether a finding is real, set "confidence" to low/medium and say so in the claim — do NOT inflate or deflate severity to express doubt.`
+
+const LENSES = [
+  {
+    key: 'accuracy',
+    title: 'Accuracy & Staleness',
+    brief: `Assume the knowledge base is lying to you. For every load-bearing factual claim, check it against the CURRENT tree and flag what no longer holds. Prioritise claims about things that move: Makefile targets and variables, .github/workflows/ci.yml (toolchain pins, job names, lint scopes, test filters), Package.swift (targets, dependencies, exclude lists), test-target layout and file locations, swiftlint/swiftformat pins, and live-API behaviours. Hunt specifically for: entries describing a FIXED problem as still live; entries that contradict EACH OTHER; entries that contradict CLAUDE.md; and entries that have accreted several generations of truth instead of being rewritten to the present. Read git log for the PRs an entry cites — an entry whose fix shipped should have been retired.`,
+  },
+  {
+    key: 'structure',
+    title: 'Structure, Policy Compliance & Gaps',
+    brief: `Audit the base against its OWN stated rules in knowledge/README.md (rolling windows, retire-what-is-untrue, ADR immutability and superseding, do-not-pre-split, dated grep-friendly headings) and against knowledge/decisions/README.md (numbering, status upkeep). Hunt for: duplicate or out-of-order headings, numbering collisions, index drift, broken or missing cross-references, orphaned files, statuses that lag reality, entries filed under the wrong file, and windows that have drifted. Then ask what is MISSING: a decision made but never recorded as an ADR, a recurring trap with no entry, a deferred item with no trigger that would ever surface it. Check the base applies its own hygiene rules TO ITSELF.`,
+  },
+]
+
+const FINDING_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    lens: { type: 'string' },
+    verdict: { type: 'string', enum: ['healthy', 'needs-fixes', 'materially-stale'] },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          id: { type: 'string', description: 'short stable slug, e.g. "xcode-pin-stale"' },
+          severity: { type: 'string', enum: ['critical', 'major', 'minor'] },
+          confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+          claim: { type: 'string', description: 'one-line statement of the defect' },
+          knowledgeLocation: { type: 'string', description: 'the knowledge/ file:line at fault' },
+          evidence: { type: 'string', description: 'how you VERIFIED it against the tree — the file:line or command whose output proves the entry wrong' },
+          fix: { type: 'string', description: 'the concrete change: rewrite / retire / renumber / relocate, and to what' },
+        },
+        required: ['id', 'severity', 'confidence', 'claim', 'knowledgeLocation', 'evidence', 'fix'],
+      },
+    },
+    verifiedAccurate: { type: 'string', description: 'load-bearing claims you checked that ARE still true — say what you checked and how' },
+  },
+  required: ['lens', 'verdict', 'findings'],
+}
+
+const REBUTTAL_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    assessments: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          id: { type: 'string', description: "the other critic's finding id" },
+          position: { type: 'string', enum: ['confirm', 'refute', 'amend'] },
+          reasoning: { type: 'string', description: 'evidence from the tree — not an opinion' },
+          amendedSeverity: { type: 'string', enum: ['critical', 'major', 'minor'], description: 'only when position is amend' },
+        },
+        required: ['id', 'position', 'reasoning'],
+      },
+    },
+    missedByBoth: { type: 'string', description: 'anything the other report made you realise BOTH of you missed' },
+  },
+  required: ['assessments'],
+}
+
+const READONLY = `You are READ-ONLY. Read the repo freely (Read/Grep/Bash for git log, grep, ls) but do NOT edit any file, do not fix anything, and do not run builds or tests (slow and unnecessary). `
+
+phase('Audit')
+const audits = await parallel(LENSES.map((lens) => () =>
+  agent(
+    `You are an ADVERSARIAL auditor of the engineering knowledge base at knowledge/ in this repo, working the "${lens.title}" lens.\n\n` +
+    `${lens.brief}\n\n` +
+    `${READONLY}\n\n` +
+    `EVERY finding must be VERIFIED against the current tree and cite the evidence that proves it — the file:line or command output that contradicts the entry. A finding derived only from reading the knowledge base is inadmissible; that credulity is the exact failure mode you are auditing. Equally: do NOT manufacture findings to look thorough. If a file is accurate, say so in "verifiedAccurate" and name what you checked.\n\n` +
+    `SEVERITY RUBRIC:\n${SEVERITY}`,
+    { label: `audit:${lens.key}`, phase: 'Audit', model: 'fable', effort: 'high', schema: FINDING_SCHEMA }
+  ).then((v) => v && { ...v, lens: lens.title, key: lens.key })
+))
+
+const live = audits.filter(Boolean)
+if (live.length < 2) {
+  log(`WARNING: only ${live.length} of 2 auditors returned — cross-examination skipped, treat the result as unreconciled`)
+  return { audits: live, rebuttals: [], degraded: true }
+}
+
+phase('Cross-examine')
+const rebuttals = await parallel(live.map((mine, i) => () => {
+  const theirs = live[1 - i]
+  return agent(
+    `You audited this knowledge base through the "${mine.lens}" lens. Another independent auditor worked the "${theirs.lens}" lens. Your job now is to CROSS-EXAMINE their findings — try to refute each one.\n\n` +
+    `Their findings:\n${JSON.stringify(theirs.findings, null, 2)}\n\n` +
+    `For each, independently verify it against the tree and take a position: "confirm" (you checked, it holds), "refute" (you checked, it is wrong or the entry is actually fine — say what they misread), or "amend" (real, but the severity or the proposed fix is wrong — give the corrected one).\n\n` +
+    `Default to REFUTE when the evidence is thin. A finding that cannot be independently reproduced from the tree should not survive into the consensus. Do not confirm out of collegiality.\n\n` +
+    `${READONLY}\n\n` +
+    `Finally, in "missedByBoth", note anything their report made you realise you BOTH missed.`,
+    { label: `cross:${mine.key}`, phase: 'Cross-examine', model: 'fable', effort: 'high', schema: REBUTTAL_SCHEMA }
+  ).then((r) => r && { by: mine.lens, ...r })
+}))
+
+return { audits: live, rebuttals: rebuttals.filter(Boolean) }
+```
+
+To iterate on the script, edit the file path the `Workflow` tool returns and
+re-invoke with `{ scriptPath }` rather than resending it.
+
+## Reach the consensus
+
+The critics have already done the reconciling work — read it, don't redo it:
+
+1. **Consensus findings** — raised by one critic and **confirmed** by the other.
+   These are settled. Do not re-litigate them; carry them at the confirmed
+   severity (or the amended one, if the cross-examiner amended and justified it).
+2. **Refuted findings** — dropped. Record them in the report as *raised and
+   refuted*, with the refutation's reasoning, so the next audit doesn't re-raise
+   them cold.
+3. **Disputed** — a finding whose rebuttal is itself unconvincing (asserts rather
+   than evidences). **This is the only place you adjudicate.** Verify it yourself
+   against the tree and make the call, stating what you checked.
+4. **`missedByBoth`** — fold in anything either critic surfaced here; verify it
+   yourself first, since by definition neither audited it properly.
+5. **If a critic died** (`degraded: true`), say so plainly. A single unreconciled
+   audit is a weaker result, not an equivalent one — offer to re-run.
+
+Present a consensus table: finding · severity · agreement (confirmed / adjudicated
+/ refuted) · the fix. Then state the **verdict for the base as a whole**, and be
+willing to conclude *no changes needed*.
+
+## Apply — only after the user agrees
+
+Present the consensus and **stop**. On the go-ahead:
+
+- Group the fixes into one PR unless the user says otherwise. Branch off `main`
+  first — never edit on `main` (`CLAUDE.md` → *Branching*).
+- **Rewrite to the present tense, don't append corrections.** The retention policy
+  is describe-the-present: an entry that has accreted "…update: actually…" layers
+  should be rewritten as one entry that states what is true now. Git history is
+  the archive.
+- **Retire, don't hedge.** When a trap was fixed upstream, delete the entry. Keep
+  only the part that is still load-bearing (typically: the invariant somebody must
+  maintain so it doesn't come back).
+- ADR corrections are exempt from immutability: fixing a stale status, a broken
+  link, or a numbering collision is not a change of mind. A change of *decision*
+  still needs a new ADR that supersedes the old one.
+- If the audit found a **class** of staleness rather than instances, fix the
+  trigger too — an audit that only patches entries guarantees the next audit finds
+  the same class again.
+
+Close with what changed, what was deliberately left, and anything needing a human
+call.
+
+## Relationship to other skills
+
+- **`/capture-knowledge`** writes entries; this skill retires them. They are the
+  two halves of keeping the base a cache rather than an archive.
+- **`/deliver`** runs `/capture-knowledge` pre-PR, and its capture phase carries
+  the **targeted** staleness sweep (when a diff touches build config, re-check the
+  entries citing it). This skill is the **untargeted, periodic** counterpart — it
+  catches decay no single delivery's diff would have pointed at.
+- **`/review-plan`** is the same adversarial-critics-then-consensus shape applied
+  to a plan instead of the knowledge base.

--- a/.claude/skills/review-knowledge/SKILL.md
+++ b/.claude/skills/review-knowledge/SKILL.md
@@ -54,7 +54,7 @@ Everything under `knowledge/`:
 | `decisions/` | Numbering collisions; a status still saying "targets X" after X shipped; an ADR superseded in fact with no forward link; the index out of sync. |
 | `delivery-retros.md` | Over its ~12-entry rolling window; prose whose lesson is already folded into a skill (spent — distil it). |
 | `skill-improvement-log.md` | A `deferred`/`rejected` entry whose "Reconsider when" condition has **already been met**. This is the highest-cost staleness in the base: the recurring-pattern scan reads this file as dedup memory, so a stale entry actively misinforms it. |
-| `breaking-backlog.md` | An item that shipped, or one whose "breaking" premise no longer holds. |
+| `next-major.md` | An item that shipped, or one whose "breaking" premise no longer holds. It is a **queue**: anything still listed after its major version tagged is a process failure, not a backlog item. |
 | `README.md` | The stated policy no longer matching what the files actually do. |
 
 Also in scope: **contradictions with `CLAUDE.md`**. When the base and `CLAUDE.md`
@@ -172,8 +172,9 @@ phase('Cross-examine')
 const rebuttals = await parallel(live.map((mine, i) => () => {
   const theirs = live[1 - i]
   return agent(
-    `You audited this knowledge base through the "${mine.lens}" lens. Another independent auditor worked the "${theirs.lens}" lens. Your job now is to CROSS-EXAMINE their findings — try to refute each one.\n\n` +
-    `Their findings:\n${JSON.stringify(theirs.findings, null, 2)}\n\n` +
+    `An audit of this knowledge base was run through the "${mine.lens}" lens — those findings are YOURS, reproduced below. Another independent auditor worked the "${theirs.lens}" lens. Your job now is to CROSS-EXAMINE their findings — try to refute each one.\n\n` +
+    `YOUR findings (the "${mine.lens}" lens):\n${JSON.stringify(mine.findings, null, 2)}\n\n` +
+    `THEIR findings (the "${theirs.lens}" lens), which you must assess:\n${JSON.stringify(theirs.findings, null, 2)}\n\n` +
     `For each, independently verify it against the tree and take a position: "confirm" (you checked, it holds), "refute" (you checked, it is wrong or the entry is actually fine — say what they misread), or "amend" (real, but the severity or the proposed fix is wrong — give the corrected one).\n\n` +
     `Default to REFUTE when the evidence is thin. A finding that cannot be independently reproduced from the tree should not survive into the consensus. Do not confirm out of collegiality.\n\n` +
     `${READONLY}\n\n` +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<!-- Adding a new major-version ([X.0.0]) section? Read
+     knowledge/next-major.md first — it lists approved breaking changes
+     waiting for exactly this bump. Ship them or consciously re-defer. -->
+
 ## [19.0.0] - 2026-07-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,7 +400,9 @@ Structural pattern for a new service:
    (e.g. `TMDbMovieService`).
 2. Models in `Domain/Models/` conform to `Codable`, `Equatable`, `Hashable`,
    `Sendable`.
-3. Register in `TMDbFactory.swift`; expose via `TMDbClient.swift`.
+3. Construct and expose the service in `TMDbClient.swift`'s private init.
+   `TMDbFactory` vends only shared plumbing (`makeServiceDependencies`,
+   `httpClient(wrapping:)`) — services are **not** registered there.
 4. Unit tests with JSON fixtures (`Tests/TMDbTests/Resources/`) **and** integration
    tests (`Tests/TMDbIntegrationTests/`).
 

--- a/README.md
+++ b/README.md
@@ -533,6 +533,7 @@ that automate the development workflow. Invoke any of them with `/<name>`.
 | `/implement-plan` | Implement the plan test-first (Canon TDD) until the test list is empty |
 | `/review-changes` | Review the working-tree changes — one reviewer, or a parallel fan-out with adversarial verification for large diffs |
 | `/capture-knowledge` | Record durable learnings (gotchas, API quirks, ADRs) into `knowledge/` |
+| `/review-knowledge` | Audit `knowledge/` for staleness with two adversarial critics that cross-examine and reach a consensus |
 | `/pr` | Create a pull request (`/format` → `make ci` → review → open) |
 | `/watch-pr` | Watch the PR: resolve review threads, fix failing checks, optionally merge |
 | `/review-pr-threads` | Resolve the PR's unresolved review threads in one sweep |

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -15,11 +15,17 @@ this directory; the detail lives here and is read on demand.
 | [`tmdb-api-notes.md`](tmdb-api-notes.md) | Behaviours of the **live TMDb API** discovered while implementing (nullable/absent fields, undocumented quirks, response-shape surprises). |
 | [`delivery-retros.md`](delivery-retros.md) | A short retrospective per feature delivered via `/deliver` (written pre-PR so it rides the delivery's own PR) — what worked, friction, deviations, one improvement. |
 | [`skill-improvement-log.md`](skill-improvement-log.md) | Decisions on every skill-improvement proposal from `/deliver`'s wrap-up recurring-pattern scan (applied / deferred / rejected), so the scan doesn't re-propose settled calls. |
+| [`next-major.md`](next-major.md) | **Breaking-change backlog** — approved-in-principle changes waiting for a major version bump. Consulted when a `[X.0.0]` CHANGELOG section is opened (a sentinel there points here) and whenever a plan already contains a breaking change. |
 
 ## How to use it
 
 - **Before solving a non-trivial problem**, skim the relevant file — the answer
   may already be here.
+- **Cite the PR, not the issue.** A bare `#NNN` is ambiguous — this repo's
+  numbers interleave issues and PRs (`#392` is the issue, `#397` the PR that
+  closed it; likewise `#395`/`#398`, `#391`/`#401`). An entry describing *work
+  that was done* should name the **PR**; name the issue only when the issue
+  itself is the subject.
 - **After learning something durable** (a gotcha, an API quirk, a decision),
   record it here in the same change — ideally via `/capture-knowledge`, which
   runs automatically before a PR in the `/deliver` pipeline.
@@ -53,7 +59,14 @@ age differently:
   the past.
 - **ADRs** (`decisions/`) are one immutable file per decision — don't edit an
   Accepted ADR; **supersede** it with a new one that links back. This already
-  scales; no window needed.
+  scales; no window needed. [`decisions/README.md`](decisions/README.md) is the
+  index: take the next number from it, and keep the Status column true (an
+  unreleased `CHANGELOG` section is **not** a release — only a tag is).
+  Correcting a stale status, a broken link, or a numbering error is not a change
+  of mind and needs no supersession.
+- **`next-major.md`** is a **queue, not a log** — an entry leaves it when the
+  change ships or is rejected outright. It is read at release time, so an entry
+  that lingers past a major bump is a bug in the process, not a backlog item.
 - **Don't pre-split a file.** Split a section into its own file only when it
   genuinely dominates (e.g. `gotchas.md` → `gotchas/tooling.md`), mirroring the
   project's "promote a boundary only when the pain shows up" rule. The dated `###`

--- a/knowledge/decisions/0006-tmdbtesting-public-target.md
+++ b/knowledge/decisions/0006-tmdbtesting-public-target.md
@@ -5,7 +5,7 @@
 - **Deciders:** Adam Young
 
 > **Amended in part by [ADR-0010](0010-tmdb-intelligence-product.md)
-> (2026-07-06, shipped in 19.0.0).** The decision below still holds for the
+> (2026-07-06, in the unreleased 19.0.0).** The decision below still holds for the
 > `TMDb` service mocks, but the natural-language-search doubles it describes
 > (`MockNaturalLanguageSearchService`, `SearchPlan.sample`) no longer ship in
 > `TMDbTesting` — they moved to the `TMDbIntelligenceTesting` product when the

--- a/knowledge/decisions/0006-tmdbtesting-public-target.md
+++ b/knowledge/decisions/0006-tmdbtesting-public-target.md
@@ -4,6 +4,13 @@
 - **Date:** 2026-06-23
 - **Deciders:** Adam Young
 
+> **Amended in part by [ADR-0010](0010-tmdb-intelligence-product.md)
+> (2026-07-06, shipped in 19.0.0).** The decision below still holds for the
+> `TMDb` service mocks, but the natural-language-search doubles it describes
+> (`MockNaturalLanguageSearchService`, `SearchPlan.sample`) no longer ship in
+> `TMDbTesting` — they moved to the `TMDbIntelligenceTesting` product when the
+> intelligence features were extracted. Read the two together.
+
 ## Context
 
 Apps depending on `TMDb` had no supported way to test their own code against the

--- a/knowledge/decisions/0007-document-existing-response-caching.md
+++ b/knowledge/decisions/0007-document-existing-response-caching.md
@@ -54,4 +54,3 @@ they interact and how to tune or disable the `URLCache` (supply a custom
 - **Expose a config knob to size/disable `URLCache`.** Deferred: the existing
   custom-`HTTPClient` escape hatch already covers tuning/disabling; a dedicated
   knob can be added later if demand appears.
-</content>

--- a/knowledge/decisions/0010-tmdb-intelligence-product.md
+++ b/knowledge/decisions/0010-tmdb-intelligence-product.md
@@ -1,6 +1,6 @@
 # ADR-0010: Extract on-device intelligence into a `TMDbIntelligence` product
 
-- **Status:** Accepted
+- **Status:** Accepted (in 19.0.0, unreleased)
 - **Date:** 2026-07-06
 - **Deciders:** Adam Young
 

--- a/knowledge/decisions/0011-duration-for-runtime.md
+++ b/knowledge/decisions/0011-duration-for-runtime.md
@@ -1,6 +1,6 @@
 # ADR-0011: Represent runtimes as `Duration`, bridging integer minutes at the wire boundary
 
-- **Status:** Accepted
+- **Status:** Accepted (in 19.0.0, unreleased)
 - **Date:** 2026-07-24
 - **Deciders:** Adam Young (with Claude Code)
 

--- a/knowledge/decisions/0012-structured-tmdberror-context.md
+++ b/knowledge/decisions/0012-structured-tmdberror-context.md
@@ -1,6 +1,6 @@
 # ADR-0012: Enrich `TMDbError` with structured context
 
-- **Status:** Accepted (targets 19.0.0)
+- **Status:** Accepted (shipped in 19.0.0)
 - **Date:** 2026-07-24
 - **Deciders:** Adam Young
 

--- a/knowledge/decisions/0012-structured-tmdberror-context.md
+++ b/knowledge/decisions/0012-structured-tmdberror-context.md
@@ -1,6 +1,6 @@
 # ADR-0012: Enrich `TMDbError` with structured context
 
-- **Status:** Accepted (shipped in 19.0.0)
+- **Status:** Accepted (in 19.0.0, unreleased)
 - **Date:** 2026-07-24
 - **Deciders:** Adam Young
 

--- a/knowledge/decisions/0013-cached-image-url-resolver.md
+++ b/knowledge/decisions/0013-cached-image-url-resolver.md
@@ -1,6 +1,6 @@
 # ADR-0013: Cache the image configuration in an actor behind `client.images`
 
-- **Status:** Accepted (targets 19.x)
+- **Status:** Accepted (in 19.0.0, unreleased)
 - **Date:** 2026-07-27
 - **Deciders:** Adam Young
 

--- a/knowledge/decisions/0014-subagent-model-tiers.md
+++ b/knowledge/decisions/0014-subagent-model-tiers.md
@@ -1,4 +1,4 @@
-# ADR-0010: Model-tier policy for skills and subagents
+# ADR-0014: Model-tier policy for skills and subagents
 
 - **Status:** Accepted
 - **Date:** 2026-07-06

--- a/knowledge/decisions/README.md
+++ b/knowledge/decisions/README.md
@@ -1,0 +1,38 @@
+# Architecture Decision Records
+
+One file per non-obvious design decision, with its rationale. Start from
+[`0000-template.md`](0000-template.md).
+
+**Numbering:** the next ADR takes the number after the highest in the table below
+— check the table, not a directory listing, before naming a file. (Two ADRs were
+once both numbered `0010`; the model-tier one was renumbered to `0014` by the
+2026-07-28 audit. This index exists so that cannot recur.)
+
+**Immutability:** an `Accepted` ADR is not edited to reflect a later change of
+mind — write a new one and mark the old **Superseded by [ADR-XXXX]**, with a
+forward link in the superseded file and a back link in the new one. Correcting a
+factual error, a stale status, or a broken link is *not* a change of mind and is
+always fair game.
+
+## Index
+
+| # | Decision | Date | Status |
+| --- | --- | --- | --- |
+| [0001](0001-error-mapping-api-client.md) | Centralise API error mapping in an `ErrorMappingAPIClient` decorator | 2024 | Accepted (shipped in 18.0.0) |
+| [0002](0002-changes-auto-pagination-adapter.md) | Auto-pagination for Changes adapts `ChangedIDCollection`, excludes detail endpoints | 2026-06-18 | Accepted |
+| [0003](0003-opt-in-pagination-prefetch.md) | Opt-in next-page prefetch holds an unstructured `Task` on a value-type iterator | 2026-06-18 | Accepted |
+| [0004](0004-service-parameter-name-convention.md) | Service method parameter-name convention (`<entity>ID`) | 2026-06-18 | Accepted |
+| [0005](0005-authenticated-session-additive-overloads.md) | `AuthenticatedSession` via additive extension overloads | 2026-06-18 | Accepted |
+| [0006](0006-tmdbtesting-public-target.md) | Ship a public `TMDbTesting` target (spy+stub mocks + real-data samples) | 2026-06-23 | Accepted (amended in part by [0010](0010-tmdb-intelligence-product.md)) |
+| [0007](0007-document-existing-response-caching.md) | Document existing response caching instead of building a custom on-disk cache | 2026-06-24 | Accepted |
+| [0008](0008-percent-encode-url-path-segments.md) | Percent-encode user-supplied URL path segments with the RFC 3986 unreserved set | 2026-06-24 | Accepted |
+| [0009](0009-github-mcp-over-gh-cli.md) | Use the GitHub MCP (not the `gh` CLI) in the local skills | 2026-06-25 | Accepted |
+| [0010](0010-tmdb-intelligence-product.md) | Extract on-device intelligence into a `TMDbIntelligence` product | 2026-07-06 | Accepted (shipped in 19.0.0) |
+| [0011](0011-duration-for-runtime.md) | Represent runtimes as `Duration`, bridging integer minutes at the wire boundary | 2026-07-24 | Accepted (shipped in 19.0.0) |
+| [0012](0012-structured-tmdberror-context.md) | Enrich `TMDbError` with structured context | 2026-07-24 | Accepted (shipped in 19.0.0) |
+| [0013](0013-cached-image-url-resolver.md) | Cache the image configuration in an actor behind `client.images` | 2026-07-27 | Accepted (targets 19.x, merged unreleased) |
+| [0014](0014-subagent-model-tiers.md) | Model-tier policy for skills and subagents | 2026-07-06 | Accepted |
+
+> **Keep the Status column true.** "Targets X" becomes "shipped in X" when the
+> release tags — see [`../breaking-backlog.md`](../breaking-backlog.md), which the
+> release process reads.

--- a/knowledge/decisions/README.md
+++ b/knowledge/decisions/README.md
@@ -27,12 +27,13 @@ always fair game.
 | [0007](0007-document-existing-response-caching.md) | Document existing response caching instead of building a custom on-disk cache | 2026-06-24 | Accepted |
 | [0008](0008-percent-encode-url-path-segments.md) | Percent-encode user-supplied URL path segments with the RFC 3986 unreserved set | 2026-06-24 | Accepted |
 | [0009](0009-github-mcp-over-gh-cli.md) | Use the GitHub MCP (not the `gh` CLI) in the local skills | 2026-06-25 | Accepted |
-| [0010](0010-tmdb-intelligence-product.md) | Extract on-device intelligence into a `TMDbIntelligence` product | 2026-07-06 | Accepted (shipped in 19.0.0) |
-| [0011](0011-duration-for-runtime.md) | Represent runtimes as `Duration`, bridging integer minutes at the wire boundary | 2026-07-24 | Accepted (shipped in 19.0.0) |
-| [0012](0012-structured-tmdberror-context.md) | Enrich `TMDbError` with structured context | 2026-07-24 | Accepted (shipped in 19.0.0) |
+| [0010](0010-tmdb-intelligence-product.md) | Extract on-device intelligence into a `TMDbIntelligence` product | 2026-07-06 | Accepted (in 19.0.0, unreleased) |
+| [0011](0011-duration-for-runtime.md) | Represent runtimes as `Duration`, bridging integer minutes at the wire boundary | 2026-07-24 | Accepted (in 19.0.0, unreleased) |
+| [0012](0012-structured-tmdberror-context.md) | Enrich `TMDbError` with structured context | 2026-07-24 | Accepted (in 19.0.0, unreleased) |
 | [0013](0013-cached-image-url-resolver.md) | Cache the image configuration in an actor behind `client.images` | 2026-07-27 | Accepted (targets 19.x, merged unreleased) |
 | [0014](0014-subagent-model-tiers.md) | Model-tier policy for skills and subagents | 2026-07-06 | Accepted |
 
-> **Keep the Status column true.** "Targets X" becomes "shipped in X" when the
-> release tags — see [`../breaking-backlog.md`](../breaking-backlog.md), which the
-> release process reads.
+> **Keep the Status column true.** "In X, unreleased" becomes "shipped in X" when
+> X is **tagged** — a `CHANGELOG.md` section is not a release. For breaking changes
+> still waiting on a major bump, see [`../next-major.md`](../next-major.md), which
+> the release process reads.

--- a/knowledge/decisions/README.md
+++ b/knowledge/decisions/README.md
@@ -30,7 +30,7 @@ always fair game.
 | [0010](0010-tmdb-intelligence-product.md) | Extract on-device intelligence into a `TMDbIntelligence` product | 2026-07-06 | Accepted (in 19.0.0, unreleased) |
 | [0011](0011-duration-for-runtime.md) | Represent runtimes as `Duration`, bridging integer minutes at the wire boundary | 2026-07-24 | Accepted (in 19.0.0, unreleased) |
 | [0012](0012-structured-tmdberror-context.md) | Enrich `TMDbError` with structured context | 2026-07-24 | Accepted (in 19.0.0, unreleased) |
-| [0013](0013-cached-image-url-resolver.md) | Cache the image configuration in an actor behind `client.images` | 2026-07-27 | Accepted (targets 19.x, merged unreleased) |
+| [0013](0013-cached-image-url-resolver.md) | Cache the image configuration in an actor behind `client.images` | 2026-07-27 | Accepted (in 19.0.0, unreleased) |
 | [0014](0014-subagent-model-tiers.md) | Model-tier policy for skills and subagents | 2026-07-06 | Accepted |
 
 > **Keep the Status column true.** "In X, unreleased" becomes "shipped in X" when

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -252,7 +252,8 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
   settled pre-plan via `AskUserQuestion`), `review-changes` and
   `security-review` self-skipped, `/capture-knowledge` returned nothing (the
   sole candidate was already documented inside the `capture-knowledge` skill
-  itself); ADR-0010 (model tiers) authored inline in Phase 3.
+  itself); ADR-0014 (model tiers, originally numbered 0010) authored inline in
+  Phase 3.
 - **Worked:** the plan-time Explore cross-reference sweep pre-scoped the prose
   blast radius — spotting that "delegates to a Haiku subagent" prose stays
   *true* after the refactor (the runner agent **is** Haiku) cut the edit list
@@ -458,33 +459,6 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
   manually, not by the sub-skills. Flagging this avoids confusion when `/pr` visibly
   runs `gh pr create` while the diff says otherwise.
 
-## 2026-06-24 — 🔧 Add entry/exit criteria and auto-start to /deliver (#365) · lite
-
-- **Phases / skills:** phases 0–6; `pr, watch-pr`. Skipped `/review-plan` (lite +
-  plan approved via ExitPlanMode this session); skipped `/implement-plan`
-  (markdown-only — no TDD test list); skipped code review + security review (no
-  Swift changed).
-- **Worked:** the fast-gate detector caught this as docs/config-only correctly —
-  only `make lint-markdown` ran locally, CI resolved in under 2 minutes. Deriving
-  the changes directly from the conversation (Looper article → gap analysis →
-  plan) kept the plan tight and the edits focused. The three changes (entry gate,
-  Phase 3.6, Contract §8) landed cleanly in one commit with no review friction.
-- **Friction:** the auto-start behaviour (Contract §8) can only be captured in the
-  skill itself and memory — there's no harness hook that fires on ExitPlanMode
-  approval, so it relies on the model reading the contract. That's a soft guarantee.
-- **Deviations:** Plan had no formal acceptance criteria (the first delivery under
-  the new entry gate!) — the circular dependency was noted and the Verification
-  section stood in. Phase 3.6 was accordingly a no-op for this run.
-- **One improvement:** the entry gate prompts for ACs but doesn't suggest a format
-  or example in context — the prompt could include a one-line example inline
-  ("e.g. 'Given X, when Y, then Z'") to reduce back-and-forth.
-- **Gotcha — `reviewThreads` is not a valid `gh pr view --json` field.** Adding it
-  causes `gh` to error with empty stdout; any JSON parsing then fails with
-  `JSONDecodeError: Expecting value: line 1 column 1`. Thread data must be fetched
-  via `gh api graphql` — `/review-pr-threads` already does this correctly. Added a
-  guard note to `watch-pr/SKILL.md §0`. Do not add `reviewThreads` (or `comments`)
-  to `gh pr view --json` calls.
-
 ## Archive (distilled)
 
 Older entries condensed per the rolling window (`knowledge/README.md` →
@@ -492,6 +466,7 @@ Older entries condensed per the rolling window (`knowledge/README.md` →
 
 | Date | PR | Weight | Outcome |
 | --- | --- | --- | --- |
+| 2026-06-24 | #365 | lite | Entry/exit criteria + auto-start for `/deliver`. The docs/config fast-gate correctly classified it (CI green in under 2 min). Lasting lesson: auto-start on `ExitPlanMode` approval is a **soft guarantee** — no harness hook fires on it, so it depends on the model reading the contract. First delivery under the new AC entry gate, and the plan had no formal ACs (circular dependency, noted); its "one improvement" — put an inline `Given X, when Y, then Z` example in the gate prompt — still stands. Its `reviewThreads`/`gh pr view --json` gotcha was superseded by #366 (the MCP migration removed the call) and is deliberately not carried forward. |
 | 2026-06-24 | #364 | lite | Percent-encode URL path segments + validate `String` IDs (ADR-0008). The security review's end-to-end trace through `urlFromPath`'s `URLComponents` round-trip is what made the fix trustworthy (and found the `%2F`→`/` decode, correctly bounded as path-only on a locked host). Lesson that became skill policy: for "fix every instance of pattern X", do **one type-driven enumeration of all sites up front** — here the planning grep, `/security-review`, code review, and `claude-review` each found a *different subset*. |
 | 2026-06-24 | #363 | lite (docs-led) | Documented the existing response caching instead of building it: challenging the premise mid-plan (`curl -D-` showed every GET returns `Cache-Control`/`ETag`, so the default `URLCache` already provides — and beats — the requested opt-in cache) turned a feature build into a docs PR + ADR-0007. A single `code-reviewer` caught a High that both `make build-docs` and `markdownlint` missed: stray `</content>`/`</invoke>` tags the `Write` tool leaked into the article tail. Fourth entry asking for a docs/config-only fast gate, widened here to "no semantic Swift change" so doc-comment-only `.swift` diffs qualify. |
 | 2026-06-24 | #361 | lite | Missing discover filter params; single-`code-reviewer` converged 0/0/0 (existing no-op-mutation guard test made the dropped-field risk in the ~30-arg `copy()` helpers trivial to cover). Two recurring traps: edits landing in `main` not the worktree (source `Read` pre-`EnterWorktree` → stale paths; now the Phase 1 `git status` checkpoint), and a stale "ready" call — verify every required check is `COMPLETED`+`SUCCESS` on the current tip, and rule out a pending required check before blaming a review rule on `BLOCKED`. |

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -1,8 +1,48 @@
 # Gotchas & Lookups
 
 Implementation quirks, tooling traps, and things that needed a lookup to resolve.
-Newest at the top. Keep each entry short and dated; link an ADR if a decision came
-out of it.
+Within each section, **dated entries are newest-first** and undated evergreen
+conventions sit at the bottom. Keep each entry short and dated; link an ADR if a
+decision came out of it.
+
+## False green — the recurring failure family
+
+A signal only proves what it measures. The costliest recurring mistake in
+this project is accepting a passing signal as evidence of a claim it does not
+measure. Before letting any green close a loop — "implementation done",
+"ready to merge", "the API supports this", "the guarantee holds" — ask:
+**would this signal look any different if the thing I'm claiming were
+broken?** If not, it is not evidence; find the check that discriminates.
+
+Instances, each with its countermeasure:
+
+- **Green build of the wrong tree** — edits landed in the main checkout while
+  the pristine worktree built green with baseline test counts (#361); the
+  tooling-runner built the main checkout instead of the worktree (#397, fixed
+  in #399). *Check: `git status` shows your diff in the tree that built.*
+- **Pipe summary vs process exit** — `swift build` can exit 1 while `xcsift`
+  exits 0, and toon `errors[]` can list a benign diagnostic on a passing
+  build. *Check: the `pipefail` exit status is the verdict (see Tooling).*
+- **Debug-green vs release-broken** — a `@testable import` in a non-test
+  target passed debug, `--build-tests`, 2868 unit and 291 integration tests;
+  only `swift build -c release` failed (#398). *Check: run the release build
+  before declaring done — now a `/deliver` Phase 3 checkpoint (#400).*
+- **"No failures" while a required check was still running** — a stale
+  "ready" call read absence-of-red as green (#361). *Check: every required
+  check is `COMPLETED` + `SUCCESS` on the current tip.*
+- **HTTP 200 on an ignored query parameter** — TMDb returns 200 for bogus
+  discover parameters (see `tmdb-api-notes.md`). *Check: assert the response
+  content changed, never just the status.*
+- **A test asserting a guarantee it cannot observe** — the memoising-actor
+  gate test passed while unable to see joining callers: green by coincidence,
+  flaky by construction (#401). *Check: make the assertion fail once (break
+  the code or the input) before trusting its green.*
+
+The same discipline applies to this knowledge base: an entry that reads
+confidently is not thereby true. `/review-knowledge` audits it against the tree.
+
+When an instance's countermeasure becomes tooling-enforced, its bullet may be
+retired; the family heading stays.
 
 ## Tooling
 
@@ -48,9 +88,32 @@ serialised (40 suites carry `.integrationGate`, a global semaphore), so 300 live
 tests run one at a time. That is long wall-clock by design, not contention —
 don't "fix" it.
 
+### A new target with a `.docc` catalog must be added to `Package.swift`'s exclude list
+
+*2026-07-24 (#396; re-hit in #398).* The DocC plugin loads only under
+`SWIFTCI_DOCC=1` (`make build-docs`). Outside a docs build nothing claims the
+`.docc` catalogs, so `Package.swift`'s `else` branch `exclude`s each one —
+**enumerated per target** (four today). Since Swift 6.4 / Xcode 27,
+`-Xswiftc -warnings-as-errors` promotes the resulting "unhandled files"
+package-load warning to an error, so a target whose catalog is missing from
+that list fails **every** `make` build/test/release target — locally and in
+CI (both pin Xcode 27) — with:
+
+```text
+error: 'TMDb': found 1 file(s) which are unhandled; explicitly declare them
+as resources or exclude from the target
+```
+
+- **Adding a target with a DocC catalog ⇒ extend the `exclude` block in the
+  same change.** #398 added two catalogs, rebased cleanly onto #396, and
+  compiled green under plain `swift build` — only `make ci` caught the
+  omission, because the error needs `-warnings-as-errors`.
+- `make build-docs` is unaffected either way — it sets `SWIFTCI_DOCC=1`, so
+  the plugin handles the catalogs.
+
 ### A non-test target can never `@testable import` — it breaks `swift build -c release` only
 
-*2026-07-24 (#395).* Sharing test fixtures between two test targets needs a
+*2026-07-24 (#398).* Sharing test fixtures between two test targets needs a
 **regular** `.target` (SwiftPM does not let a `.testTarget` depend on another
 `.testTarget`). But a regular target is in the **default build graph**, and
 `@testable import TMDb` requires `TMDb` to be compiled with `-enable-testing`,
@@ -84,6 +147,30 @@ jobs. **Debug-green proves nothing here; run the release build.**
   belongs in whichever test target `@testable`-imports it. Promoting such a type
   cascades into member-level access (memberwise inits, nested types) — usually
   not worth it.
+
+### The build/test tooling-runner runs in the main checkout, not the active worktree
+
+*2026-07-24.* During a `/deliver` in a worktree, the `tooling-runner` (Haiku)
+subagent behind `/build` / `/build-for-testing` / `/test` / `/integration-test` —
+and Agent-tool subagents generally — execute in the **main checkout**, not the
+worktree the conductor switched into. So `make test` spawned that way builds
+`main`'s pristine sources, **misses the worktree's committed changes**, and
+(compounded by the toon `errors[]` quirk below) misreports. **Detect it:** the
+run's `.build/last-*.log` lands under the **main checkout** and the worktree's
+`.build/` has none — or, when the worktree adds a *new* suite, the run reports
+**"no matching test cases found"** for a `--filter` naming suites that plainly
+exist (observed 2026-07-24, #392).
+
+**Fixed 2026-07-24** — the four skills now pass `Package directory: <absolute
+CWD>` in the task, and `tooling-runner` refuses to run without it, verifies
+`Package.swift` is there, uses `make -C "<dir>"` with absolute log paths, and
+echoes the directory it used. So the failure mode is now an explicit error
+rather than a plausible-looking wrong answer. **If you see a runner report
+without a `Directory:` line, it predates the fix — treat its result as
+untrusted** and re-run. The manual fallback (`swift build --build-tests`, then
+`swift test --skip-build --scratch-path .build --filter
+"TMDbTests|TMDbTestingTests"` directly via `Bash`, which does run in the
+worktree CWD) still works if you need it.
 
 ### `EnterWorktree` no longer uses the requested name as the branch name
 
@@ -144,7 +231,7 @@ in isolation.
   `generate-documentation --warnings-as-errors` **without `--target`**, i.e.
   across *all* targets, so a second target's doc-link errors fail the build.
 
-> **Update (2026-07-24, PR for #395):** this is **conditional on how the docs
+> **Update (2026-07-24, #398):** this is **conditional on how the docs
 > are built**. Once the build passes `--enable-experimental-combined-documentation`
 > with every doc-bearing target listed (as `documentation.yml` and
 > `make generate-docs` now do), the module-qualified form **does** resolve:
@@ -183,30 +270,6 @@ Either way: **verify `git status` shows your diff *in the worktree*** (and the m
 checkout stayed clean) before trusting a green run. To rescue edits already made on
 `main`: `git -C <main> stash` then `git -C <worktree> stash pop` (stash is shared
 across worktrees).
-
-### The build/test tooling-runner runs in the main checkout, not the active worktree
-
-*2026-07-24.* During a `/deliver` in a worktree, the `tooling-runner` (Haiku)
-subagent behind `/build` / `/build-for-testing` / `/test` / `/integration-test` —
-and Agent-tool subagents generally — execute in the **main checkout**, not the
-worktree the conductor switched into. So `make test` spawned that way builds
-`main`'s pristine sources, **misses the worktree's committed changes**, and
-(compounded by the toon `errors[]` quirk below) misreports. **Detect it:** the
-run's `.build/last-*.log` lands under the **main checkout** and the worktree's
-`.build/` has none — or, when the worktree adds a *new* suite, the run reports
-**"no matching test cases found"** for a `--filter` naming suites that plainly
-exist (observed 2026-07-24, #392).
-
-**Fixed 2026-07-24** — the four skills now pass `Package directory: <absolute
-CWD>` in the task, and `tooling-runner` refuses to run without it, verifies
-`Package.swift` is there, uses `make -C "<dir>"` with absolute log paths, and
-echoes the directory it used. So the failure mode is now an explicit error
-rather than a plausible-looking wrong answer. **If you see a runner report
-without a `Directory:` line, it predates the fix — treat its result as
-untrusted** and re-run. The manual fallback (`swift build --build-tests`, then
-`swift test --skip-build --scratch-path .build --filter
-"TMDbTests|TMDbTestingTests"` directly via `Bash`, which does run in the
-worktree CWD) still works if you need it.
 
 ### swiftlint `file_length` / `type_body_length` — split into a `+Feature` extension file
 
@@ -266,80 +329,22 @@ members). Every time, `swift build` / `make build-tests` reported **0 errors /
   `curl -fsSL https://github.com/nicklockwood/SwiftFormat/releases/download/0.61.1/swiftformat.zip`,
   unzip, and `install` the binary to `~/.local/bin/swiftformat`.
 
-### Xcode 27 / Swift 6.4 makes the `.docc` unhandled-file warning **fatal** — `make ci` fails locally, CI is green
-
-*2026-07-24.* On a toolchain **newer than the CI pin** (local Xcode 27.0 /
-Swift 6.4 vs CI's `Xcode_26.6`), SwiftPM promotes the package-load "unhandled
-files" warning for the two `.docc` catalogs into an **error** whenever
-`-Xswiftc -warnings-as-errors` is passed:
-
-```text
-error: 'TMDb': found 1 file(s) which are unhandled; explicitly declare them as
-resources or exclude from the target
-    …/Sources/TMDb/TMDb.docc
-```
-
-Consequences and how to read it:
-
-- **It is `swift build` failing, not xcsift.** `swift build … -Xswiftc
-  -warnings-as-errors` exits **1** while `xcsift` exits **0** (check with
-  `pipestatus`). Don't blame the formatter, and don't "fix" it by dropping
-  `--Werror`.
-- **It breaks `make build`, `make test`, `make build-release` — hence `make ci`
-  — locally**, on a clean checkout, with an empty diff. Plain `swift build
-  --build-tests` (no `-warnings-as-errors`) still exits 0, and `make build-docs`
-  is unaffected (it sets `SWIFTCI_DOCC=1`, which loads the plugin and *handles*
-  the catalogs). `SWIFTCI_DOCC=1` does **not** rescue the other targets.
-- **CI is unaffected** — `.github/workflows/ci.yml` pins
-  `DEVELOPER_DIR=/Applications/Xcode_26.6.app`, where the same flag leaves it a
-  warning. So a local `make ci` failure whose *only* error is these two lines is
-  a **toolchain-drift artifact, not a regression**: verify with the commands CI
-  actually runs (`swift build --build-tests -Xswiftc -warnings-as-errors`,
-  `swift test --filter "TMDbTests|TMDbTestingTests"`, `make build-docs`,
-  `make lint`, `make lint-markdown`) and let the PR's CI be the gate.
-- **A real fix**, if it starts biting: declare the catalogs explicitly in
-  `Package.swift` (e.g. `resources: [.copy("TMDb.docc")]`) or `exclude` them when
-  the plugin isn't loaded — but that touches the DocC build, so verify
-  `make build-docs` still passes.
-
-### `make` build/test targets pipe through xcsift with `pipefail`
+### `make` build/test targets pipe through xcsift — the exit status is the verdict, not the summary
 
 - macOS targets pipe compiler/test output through `xcsift`; the Makefile sets
-  `set -o pipefail`, so a non-zero exit from `swift build`/`swift test` propagates
-  through the pipe. A subagent checking exit status can trust it.
+  `set -o pipefail`, so a non-zero exit from `swift build`/`swift test`
+  propagates through the pipe. **Trust the pipeline's exit status over any
+  rendering of its output** — the two can disagree in both directions:
+  `xcsift` itself exits 0 on input whose producer failed (check `pipestatus`
+  when debugging the pipe itself), and its `-f toon` `errors[…]` array can
+  carry a benign package-load diagnostic with `null,null` coordinates while
+  the build exited 0 — a subagent keying off that array once reported a
+  passing build as failed.
 - Install with `brew install xcsift`. Local builds use `xcsift -f toon` (TOON
-  format); CI builds use `xcsift -f github-actions` (GitHub annotations).
+  format); CI uses `xcsift -f github-actions` (GitHub annotations).
 - Build targets pass `--Werror` (warnings-as-errors) and `2>&1` (compiler
-  diagnostics are emitted on stderr). **Linux/Docker targets do not use xcsift.**
-- **The `.docc` "unhandled file" warning** — `swift build`/`make build-tests` emit
-  `'<pkg>': found 1 file(s) which are unhandled … Sources/TMDb/TMDb.docc` (and the
-  `TMDbTesting.docc` twin) because the DocC plugin only loads under
-  `SWIFTCI_DOCC=1` (see `Package.swift`), so outside a docs build SwiftPM sees the
-  catalogs as unhandled. **Whether it is fatal depends on the toolchain — see
-  the entry below.** On the CI-pinned toolchain it stays a package-load warning
-  and the build **exits 0** ("Build complete!").
-  But xcsift's `-f toon` output lists it under `errors[…]{file,line,message}` with
-  `null,null` coordinates, so a Haiku `/build-for-testing` subagent that keys off
-  that array (instead of the exit status) will wrongly report the build as
-  **failed**. Re-check the actual exit code before believing it.
-- **Resolved in #396 — and it needs maintaining.** `Package.swift` now
-  `exclude`s each `.docc` catalog when `SWIFTCI_DOCC != 1` (the "real fix"
-  suggested above), so `make ci` passes again on Xcode 27. **That list is
-  enumerated per target: adding a new target with a DocC catalog means adding it
-  to the `exclude` block, or the failure comes straight back for every `make`
-  build/test/release target.** Hit during #395, which added
-  `TMDbIntelligence.docc` and `TMDbIntelligenceTesting.docc` — the rebase onto
-  #396 compiled fine and only `make ci` caught the omission.
-
-  **Beta-toolchain caveat (Swift 6.4 / macOS 27, Xcode 27):** on this toolchain
-  `swift build --build-tests -Xswiftc -warnings-as-errors` now **exits 1** on the
-  same `.docc` diagnostic, so `make build-tests` / `make test` / `make ci` fail
-  locally even though the code is clean (plain `swift build` — no `--build-tests`,
-  no `-Werror` — still exits 0). Workaround while on the beta: build tests
-  **without** `-Werror` (`swift build --build-tests`) and run them via `swift test
-  --skip-build`; to still catch real warnings, build with `-Werror` and require
-  `… 2>&1 | grep 'error:' | grep -v unhandled` to be empty. `make build-docs` is
-  unaffected — it sets `SWIFTCI_DOCC=1`, so the plugin handles the catalogs.
+  diagnostics are emitted on stderr). **Linux/Docker targets do not use
+  xcsift.**
 
 ### The `xcode-tools` MCP only exists inside Xcode
 
@@ -354,7 +359,12 @@ Consequences and how to read it:
 - There is **no `GetBuildLog` tool** — for build-error detail inside Xcode use
   `mcp__xcode-tools__XcodeRefreshCodeIssuesInFile` on the flagged file(s).
 
-### FoundationModels can't build for watchOS under Xcode 27 beta 2 (CoreImage)
+### FoundationModels can't build for watchOS under Xcode 27 beta (CoreImage)
+
+*Undated original; still open as of 2026-07-28 on Xcode 27.0 build `27A5228h` (a
+seed build). **Transient by nature — re-probe and delete once a GM toolchain
+ships**; a watchOS build is the only way to confirm, so it was not re-run during
+the 2026-07-28 audit.*
 
 - Building the package for a **watchOS** destination
   (`xcodebuild -scheme TMDb -destination 'generic/platform=watchOS Simulator'`)
@@ -376,6 +386,41 @@ Consequences and how to read it:
 
 ## Testing
 
+### An `async let` binding cannot be captured by `#expect(throws:)`
+
+*2026-07-27 (#391).* Awaiting an `async let` inside the `#expect(throws:)`
+closure fails to compile:
+
+```text
+error: capturing 'async let' variables is not supported
+```
+
+Use an explicit `Task {}` handle instead and await its `.value` inside the macro
+— `let caller = Task { try await store.foo() }`, then
+`await #expect(throws: TMDbError.unknown) { _ = try await caller.value }`. A
+plain `let` task handle is capturable; the `async let` binding is not.
+
+### `Date(iso8601:)` is not visible to `TMDbIntegrationTests`
+
+*2026-06-24, path updated 2026-07-28.* The `Date(iso8601: "…")` convenience
+initialiser lives in `Tests/TMDbTestFixtures/TestUtils/Date+ISO8601.swift` — the
+**shared fixtures target**, which the unit-test targets get via
+`@_exported import TMDbTestFixtures`. **`TMDbIntegrationTests` does not depend on
+it** (`Package.swift`: its dependencies are `["TMDb", "TMDbIntelligence"]`), so
+the helper is unavailable there. Using it in an integration test fails to compile
+with a misleading *"argument passed to call that takes no arguments"* (Swift
+resolves `Date(...)` to the argument-less `Date()`).
+
+The integration target has no date-from-string helper; build dates there with
+`Date(timeIntervalSince1970:)` (the existing convention, e.g. the
+`video.publishedAt` assertions). This only surfaces when the **integration**
+target compiles, so `/integration-test` catches it; a unit-only check may not.
+
+> Originally filed as "exists only in the `TMDbTests` target". The helper moved
+> to the shared fixtures target in the #398 extraction; the **conclusion**
+> was unaffected, which is exactly why the stale path survived so long — the
+> advice still worked, so nobody re-read the reasoning.
+
 ### Model-decode equality tests: build the expected value directly, not from an over-populated mock
 
 *2026-06-19.* `Network` is `Equatable` over **all six** stored properties
@@ -394,6 +439,15 @@ fields.
 - Generalises to **any** `Equatable` model whose `*+Mocks` helper over-populates
   optional fields: a mock is for convenience construction, not for asserting
   decode equality against a sparse fixture.
+
+### Integration tests need live-API env vars, and can fail transiently
+
+- `make integration-test` requires `TMDB_API_KEY` / `TMDB_USERNAME` /
+  `TMDB_PASSWORD` (injected via `.claude/settings.local.json`). A missing var is
+  a **precondition** failure, not a test failure.
+- They hit the **live** API, so HTTP 429 / timeout / network are possible — a
+  truncated log with no assertion failure is likely transient, not a code bug.
+  Use `/diagnose-integration-failure` to attribute a failure.
 
 ## Public API
 
@@ -621,55 +675,3 @@ in a '@Sendable' closure"*.
 - **Lesson:** before wrapping a service method in any `@Sendable` closure
   (auto-pagination, `Task {}`, etc.), check that every captured **public** type is
   `Sendable`; don't assume a simple value enum already is.
-
-## Testing
-
-### An `async let` binding cannot be captured by `#expect(throws:)`
-
-*2026-07-27 (#391).* Awaiting an `async let` inside the `#expect(throws:)`
-closure fails to compile:
-
-```text
-error: capturing 'async let' variables is not supported
-```
-
-Use an explicit `Task {}` handle instead and await its `.value` inside the macro
-— `let caller = Task { try await store.foo() }`, then
-`await #expect(throws: TMDbError.unknown) { _ = try await caller.value }`. A
-plain `let` task handle is capturable; the `async let` binding is not.
-
-### Integration tests need live-API env vars, and can fail transiently
-
-- `make integration-test` requires `TMDB_API_KEY` / `TMDB_USERNAME` /
-  `TMDB_PASSWORD` (injected via `.claude/settings.local.json`). A missing var is
-  a **precondition** failure, not a test failure.
-- They hit the **live** API, so HTTP 429 / timeout / network are possible — a
-  truncated log with no assertion failure is likely transient, not a code bug.
-  Use `/diagnose-integration-failure` to attribute a failure.
-
-### Fixtures must exercise every decoder branch
-
-- A custom `Decodable` with per-property branches (e.g. `append_to_response`
-  optionals) needs a fixture covering **all** branches, plus a "without appended
-  data" test asserting the optionals are `nil`. Untested branches hide bugs.
-
-### `Date(iso8601:)` is not visible to `TMDbIntegrationTests`
-
-*2026-06-24, path updated 2026-07-28.* The `Date(iso8601: "…")` convenience
-initialiser lives in `Tests/TMDbTestFixtures/TestUtils/Date+ISO8601.swift` — the
-**shared fixtures target**, which the unit-test targets get via
-`@_exported import TMDbTestFixtures`. **`TMDbIntegrationTests` does not depend on
-it** (`Package.swift`: its dependencies are `["TMDb", "TMDbIntelligence"]`), so
-the helper is unavailable there. Using it in an integration test fails to compile
-with a misleading *"argument passed to call that takes no arguments"* (Swift
-resolves `Date(...)` to the argument-less `Date()`).
-
-The integration target has no date-from-string helper; build dates there with
-`Date(timeIntervalSince1970:)` (the existing convention, e.g. the
-`video.publishedAt` assertions). This only surfaces when the **integration**
-target compiles, so `/integration-test` catches it; a unit-only check may not.
-
-> Originally filed as "exists only in the `TMDbTests` target". The helper moved
-> to the shared fixtures target in the #395/#398 extraction; the **conclusion**
-> was unaffected, which is exactly why the stale path survived so long — the
-> advice still worked, so nobody re-read the reasoning.

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -653,15 +653,23 @@ plain `let` task handle is capturable; the `async let` binding is not.
   optionals) needs a fixture covering **all** branches, plus a "without appended
   data" test asserting the optionals are `nil`. Untested branches hide bugs.
 
-### `Date(iso8601:)` test helper exists only in the `TMDbTests` target
+### `Date(iso8601:)` is not visible to `TMDbIntegrationTests`
 
-*2026-06-24.* The `Date(iso8601: "…")` convenience initialiser is defined in
-`Tests/TMDbTests/TestUtils/Date+ISO8601.swift`, which belongs to the **`TMDbTests`**
-(unit) target only — it is **not** visible to **`TMDbIntegrationTests`**. Using it
-in an integration test fails to compile with a misleading *"argument passed to call
-that takes no arguments"* (Swift resolves `Date(...)` to the argument-less
-`Date()`). The integration target has no date-from-string helper; build dates there
-with `Date(timeIntervalSince1970:)` (the existing convention, e.g. the `video.publishedAt`
-assertions). This only surfaces when the **integration** target compiles, so a
-`make test` that builds all targets — or `/integration-test` — catches it; a
-unit-only check may not.
+*2026-06-24, path updated 2026-07-28.* The `Date(iso8601: "…")` convenience
+initialiser lives in `Tests/TMDbTestFixtures/TestUtils/Date+ISO8601.swift` — the
+**shared fixtures target**, which the unit-test targets get via
+`@_exported import TMDbTestFixtures`. **`TMDbIntegrationTests` does not depend on
+it** (`Package.swift`: its dependencies are `["TMDb", "TMDbIntelligence"]`), so
+the helper is unavailable there. Using it in an integration test fails to compile
+with a misleading *"argument passed to call that takes no arguments"* (Swift
+resolves `Date(...)` to the argument-less `Date()`).
+
+The integration target has no date-from-string helper; build dates there with
+`Date(timeIntervalSince1970:)` (the existing convention, e.g. the
+`video.publishedAt` assertions). This only surfaces when the **integration**
+target compiles, so `/integration-test` catches it; a unit-only check may not.
+
+> Originally filed as "exists only in the `TMDbTests` target". The helper moved
+> to the shared fixtures target in the #395/#398 extraction; the **conclusion**
+> was unaffected, which is exactly why the stale path survived so long — the
+> advice still worked, so nobody re-read the reasoning.

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -2,8 +2,10 @@
 
 Implementation quirks, tooling traps, and things that needed a lookup to resolve.
 Within each section, **dated entries are newest-first** and undated evergreen
-conventions sit at the bottom. Keep each entry short and dated; link an ADR if a
-decision came out of it.
+conventions sit at the bottom. Keep each entry short, and **date every entry
+that records an observation** (an undated entry can never be aged out); link an
+ADR if a decision came out of it. Cite the **PR** that did the work, not the
+issue — see `README.md`.
 
 ## False green — the recurring failure family
 
@@ -96,8 +98,8 @@ don't "fix" it.
 **enumerated per target** (four today). Since Swift 6.4 / Xcode 27,
 `-Xswiftc -warnings-as-errors` promotes the resulting "unhandled files"
 package-load warning to an error, so a target whose catalog is missing from
-that list fails **every** `make` build/test/release target — locally and in
-CI (both pin Xcode 27) — with:
+that list fails **every** `make` build/test/release target — in CI (which pins
+`Xcode_27.0`) and locally on any Xcode 27 toolchain — with:
 
 ```text
 error: 'TMDb': found 1 file(s) which are unhandled; explicitly declare them
@@ -159,7 +161,7 @@ worktree the conductor switched into. So `make test` spawned that way builds
 run's `.build/last-*.log` lands under the **main checkout** and the worktree's
 `.build/` has none — or, when the worktree adds a *new* suite, the run reports
 **"no matching test cases found"** for a `--filter` naming suites that plainly
-exist (observed 2026-07-24, #392).
+exist (observed 2026-07-24, #397).
 
 **Fixed 2026-07-24** — the four skills now pass `Package directory: <absolute
 CWD>` in the task, and `tooling-runner` refuses to run without it, verifies
@@ -388,7 +390,7 @@ the 2026-07-28 audit.*
 
 ### An `async let` binding cannot be captured by `#expect(throws:)`
 
-*2026-07-27 (#391).* Awaiting an `async let` inside the `#expect(throws:)`
+*2026-07-27 (#401).* Awaiting an `async let` inside the `#expect(throws:)`
 closure fails to compile:
 
 ```text
@@ -518,7 +520,6 @@ the documented signature. (We initially mis-scoped the `<entity>ID` rename as
 breaking; it isn't.) See [ADR-0004](decisions/0004-service-parameter-name-convention.md).
 
 ## Networking
-
 ### `URL(string:)` on Apple platforms rejects almost nothing — probe before testing a rejection
 
 *2026-07-24.* Trying to test the `TMDbAPIError.invalidURL` branch (thrown when
@@ -536,22 +537,6 @@ emoji, invalid percent-escapes (`%zz`), `<>`, `\`, `^`, `|`.
   strings) before writing any test that depends on `URL(string:)` returning
   `nil`; the behaviour changed with the swift-foundation rewrite and intuitions
   from older Foundation are wrong.
-
-### Bearer-token clients share one credential-free `URLCache` key space
-
-- `TMDbClient(bearerToken:)` (v4 auth) sends the token as an
-  `Authorization: Bearer` header, so — unlike `api_key` mode — the credential is
-  **not** in the request URL. That's the point (keys stay out of logs/proxies),
-  but it means the process-wide default `URLCache` (and the opt-in
-  `CacheHTTPClient`, which keys on `request.url.absoluteString`) no longer
-  partitions cache entries by credential. Two bearer clients with **different**
-  tokens in one process can therefore serve each other cache hits.
-- This is **benign today**: the affected v3 `GET` endpoints return app-level
-  public data identical across tokens, and user-specific requests carry
-  `session_id` in the URL (distinct cache keys, and `CacheHTTPClient` bypasses
-  session requests entirely). It would only matter if TMDb started returning
-  token-specific data on an otherwise-public GET — worth remembering before
-  relying on per-token cache isolation.
 
 ### `URLComponents` path round-trip in `TMDbAPIClient.urlFromPath` decodes `%2F`
 
@@ -575,11 +560,27 @@ separator. That residual is path-only — `urlFromPath` force-overrides
 (no SSRF). If you ever need to neutralise `/` too, encode after the round-trip
 (set `percentEncodedPath`) rather than relying on the segment encoder alone.
 
+### Bearer-token clients share one credential-free `URLCache` key space
+
+- `TMDbClient(bearerToken:)` (v4 auth) sends the token as an
+  `Authorization: Bearer` header, so — unlike `api_key` mode — the credential is
+  **not** in the request URL. That's the point (keys stay out of logs/proxies),
+  but it means the process-wide default `URLCache` (and the opt-in
+  `CacheHTTPClient`, which keys on `request.url.absoluteString`) no longer
+  partitions cache entries by credential. Two bearer clients with **different**
+  tokens in one process can therefore serve each other cache hits.
+- This is **benign today**: the affected v3 `GET` endpoints return app-level
+  public data identical across tokens, and user-specific requests carry
+  `session_id` in the URL (distinct cache keys, and `CacheHTTPClient` bypasses
+  session requests entirely). It would only matter if TMDb started returning
+  token-specific data on an otherwise-public GET — worth remembering before
+  relying on per-token cache isolation.
+
 ## Swift concurrency
 
 ### Writing a `Task {}` body inside an actor: typed throws and the missing `await`
 
-*2026-07-27 (#391).* Two compiler rules bite together when an actor stores an
+*2026-07-27 (#401).* Two compiler rules bite together when an actor stores an
 unstructured `Task` and commits its result back to the actor (the memo in
 `APIConfigurationStore`).
 
@@ -607,7 +608,7 @@ same actor-isolated, suspension-free region as the task's completion.
 
 ### Testing a memoising actor: a caller that *joins* is invisible to the mock
 
-*2026-07-27 (#391).* When an actor de-duplicates concurrent work by sharing one
+*2026-07-27 (#401).* When an actor de-duplicates concurrent work by sharing one
 in-flight `Task`, only the **first** caller reaches the underlying mock or gate.
 Every later caller awaits the existing handle and never touches the double — so
 a `FetchGate`-style barrier cannot observe it, and a test that opens the gate and

--- a/knowledge/next-major.md
+++ b/knowledge/next-major.md
@@ -1,0 +1,60 @@
+# Next Major Version — Breaking-Change Backlog
+
+Changes that are approved in principle but **breaking**, so they wait for a
+major version bump. This file exists because deferred breaking changes
+previously lived only in rejection logs and API notes, and nothing consulted
+them at release time — they missed the 19.0.0 window as a result.
+
+**Read this when:** you open a `[X.0.0]` section in `CHANGELOG.md` (the
+sentinel comment there points here), or a plan already contains one breaking
+change (batch deliberately, or record why not).
+**Write to it** via `/capture-knowledge` whenever a fix is rejected or
+deferred *because* it is breaking. **Remove an entry when it ships** (the
+CHANGELOG records it) or is rejected outright (record that in
+`skill-improvement-log.md`).
+
+> **Status as of 2026-07-28: 19.0.0 is assembled but *not tagged*** — the
+> newest tag is `18.2.0` while `CHANGELOG.md` already carries a
+> `[19.0.0] - 2026-07-24` section. Everything below is therefore **still
+> eligible for 19.0.0**, not deferred to 20.0.0. That call is the
+> maintainer's; this note exists so it is made deliberately rather than by
+> the window closing unnoticed a second time.
+
+## Backlog
+
+### Make `Company.logoPath` optional (`URL?`)
+
+- **What:** `Company.logoPath` is `public let logoPath: URL` with a required
+  decode (`Sources/TMDb/Domain/Models/Company.swift:45,126`), so an absent,
+  `null`, or empty `logo_path` makes the **whole `Company` decode throw**.
+  TMDb does return logo-less production companies — a live decode-failure
+  risk, not a theoretical one. Fix: `URL?` with a guarded decode, matching
+  `Network.logoPath`. Note the asymmetry in the same decoder: `homepageURL`
+  *is* guarded (empty string → `nil`); only `logoPath` is unguarded.
+- **Why it waits:** property type + `init` parameter change — breaking.
+- **Source:** `tmdb-api-notes.md` → *`Company.logoPath` is a required decode*
+  (2026-06-30); `skill-improvement-log.md` → *Align `Network` to `Company`*
+  (rejected 2026-06-30).
+
+### Align the `Company`/`Network` model shapes deliberately
+
+- **What:** decide the canonical shape for the shared homepage-URL /
+  logo-path fields and apply it to both models (including whether
+  `Network.homepage` takes the `homepageURL` name). Do this together with the
+  `logoPath` change above — the 2026-06-30 audit rejected aligning them in
+  the *wrong* (non-optional) direction; the right direction is breaking.
+- **Why it waits:** public property renames — breaking.
+- **Source:** `skill-improvement-log.md` → *Align `Network` to `Company`*
+  (rejected 2026-06-30; "Reconsider when: a major-version bump…").
+
+### Revisit `TMDbError.invalidRating` inside a broader `TMDbError` review
+
+- **What:** the audit floated merging `.invalidRating` into `.badRequest` and
+  rejected it as a net-worse API (a precise typed case traded for a
+  stringly-typed one). If a major bump reopens `TMDbError` anyway, settle the
+  argument-validation error idiom once, as part of that review — never as a
+  standalone change.
+- **Why it waits:** removing/merging a public enum case — breaking, and only
+  worth doing inside a wider review.
+- **Source:** `skill-improvement-log.md` → *Error-idiom unification*
+  (rejected 2026-06-30).

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -536,7 +536,7 @@ two fields the dedup step keys on.
   CI is green on it. Both stem from the two gates having different scopes/caches.
 - **Decision:** originally **deferred** (the fix was a repo-config change, outside
   the Phase-6 scan's remit) and **closed as applied on 2026-07-28** — the two
-  scopes are now identical: `Makefile:46–48` and `.github/workflows/ci.yml:122`
+  scopes are now identical: `Makefile:47–49` and `.github/workflows/ci.yml:122`
   both lint `README.md`, `CLAUDE.md`, `**/*.docc/**/*.md`, `.claude/**/*.md`.
   The #347 half was already mitigated in `/pr` (the `--no-cache` re-lint step).
 - **Rationale:** a green CI sitting behind a red local `make ci` repeatedly cost

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -525,7 +525,7 @@ two fields the dedup step keys on.
   gate that's hard to skip, and explicitly covers the fan-out case this run missed.
 - **Reconsider when:** n/a (applied).
 
-### 2026-06-19 — Reconcile local `make ci` lint scope with CI · deferred
+### 2026-06-19 — Reconcile local `make ci` lint scope with CI · applied
 
 - **Pattern:** the local `make ci` lint gate and the authoritative GitHub CI lint
   gate disagree on what counts as a violation, so `make ci` mis-signals — twice
@@ -534,20 +534,18 @@ two fields the dedup step keys on.
   lints `.claude/**` and went **red** on `.claude/skills/deliver/SKILL.md:347`
   (MD028), but CI's markdown job (`ci.yml:120`) lints only `README.md` + docc, so
   CI is green on it. Both stem from the two gates having different scopes/caches.
-- **Decision:** **deferred** — surfaced to the user. The real fix is a **repo
-  config** change (narrow the Makefile `lint-markdown` to match `ci.yml`, *or* add
-  `.claude/**` to the CI markdown job and fix the pre-existing MD028), which is
-  outside the Phase-6 scan's remit (it edits SKILL.md files, not the Makefile/CI).
-  The #347 half is already mitigated in `/pr` (the `--no-cache` re-lint step).
-- **Rationale:** a green CI sitting behind a red local `make ci` repeatedly costs
-  a triage detour and risks a real local failure being dismissed as "just the
-  scope thing". But the fix belongs in `Makefile`/`ci.yml`, not a skill, so it
-  needs the user's call rather than an auto-applied skill edit.
-- **Reconsider when:** the user aligns the two scopes in repo config (then close
-  as applied), or the disagreement recurs a third time — at which point add an
-  explicit "local lint-markdown over-covers `.claude/**`; a red there on a file
-  not in your diff is a known local-only artifact" triage note to `/deliver`
-  Phase 4 and `/pr` step 4 (a skill-level mitigation that *is* in remit).
+- **Decision:** originally **deferred** (the fix was a repo-config change, outside
+  the Phase-6 scan's remit) and **closed as applied on 2026-07-28** — the two
+  scopes are now identical: `Makefile:46–48` and `.github/workflows/ci.yml:122`
+  both lint `README.md`, `CLAUDE.md`, `**/*.docc/**/*.md`, `.claude/**/*.md`.
+  The #347 half was already mitigated in `/pr` (the `--no-cache` re-lint step).
+- **Rationale:** a green CI sitting behind a red local `make ci` repeatedly cost
+  a triage detour and risked a real local failure being dismissed as "just the
+  scope thing". Aligning the two scopes in repo config removed the class.
+- **Reconsider when:** n/a (applied). *Closed retroactively by the 2026-07-28
+  knowledge-base audit — the closure condition had been met by an earlier config
+  change and nobody came back to close it. A stale `deferred` in this file is a
+  live defect: the scan reads it as the current state of a settled question.*
 
 ### 2026-06-18 — Telemetry (phases completed + skills invoked) in retro · applied
 

--- a/knowledge/tmdb-api-notes.md
+++ b/knowledge/tmdb-api-notes.md
@@ -58,6 +58,31 @@ runs its `endpointPath` through `EndpointPathRedactor` (see
 [ADR-0012](decisions/0012-structured-tmdberror-context.md)); redaction keys off
 the **first** path component so `/authentication/guest_session/new` is untouched.
 
+## Rate limiting
+
+### v3 GET responses expose **no** `X-RateLimit-*` headers — you cannot budget against them
+
+*2026-07-28, `/3/movie/{movie_id}`.* A successful v3 GET returns only
+`server`, `cache-control`, `etag` (and an `age` when CDN-cached). There is **no**
+`X-RateLimit-Limit` / `-Remaining` / `-Reset`, so a client has no way to see how
+close it is to a limit, and no header to drive pre-emptive throttling. A burst of
+12 back-to-back requests returned no `429`, consistent with TMDb having retired
+its old 40-requests-per-10-seconds cap.
+
+Consequences for this package:
+
+- `RetryHTTPClient` and `HTTPResponse.retryAfterDuration` do parse and honour a
+  `Retry-After` header (capping it to `maxDelay` so a hostile `Retry-After:
+  86400` can't park the calling task) — but that path fires only *reactively*, on
+  a `429` we have never observed live. **Treat the 429 branch as unexercised
+  against the real API**; its unit tests are the only coverage.
+- Don't add "remaining quota" style API to the client — there is no source of
+  truth for it.
+- **Not reproduced:** an actual `429`, and therefore whether TMDb sends
+  `Retry-After` with it at all (the header is assumed, not confirmed). Deliberately
+  not pursued — inducing one means abusing the live API. If a real `429` is ever
+  captured in the wild, record its headers here.
+
 ## Discover
 
 ### `discover/movie` has *two* distinct release-date filters


### PR DESCRIPTION
## Summary

Two independent reviews audited `knowledge/` and converged on 13 findings; all
13 are fixed here, plus a new `/review-knowledge` skill so the audit is
repeatable.

The root cause behind most of them: the knowledge base has an **engineered write
path** (`/capture-knowledge`, `/deliver` Phase 6) but **no retirement path**. So
truth decayed exactly where the code moves fastest — `Makefile`, `ci.yml`,
`Package.swift`, target layout. #396, #398 and #402 each changed those files, and
nothing swept `knowledge/` for entries citing them.

Every factual claim added here was verified against the tree. Two claims raised
during the work turned out to be wrong and were corrected before landing (see
*Corrections* below).

## Changes

**New — the retirement trigger (the root-cause fix):**

- 🔧 `/capture-knowledge` step 5 is now a **diff-driven sweep**: grep the diff for
  infra files, grep *all* of `knowledge/` for entries citing them, reconcile each,
  and report a `swept:` line. It explicitly **bans appending "Resolved in #NNN"**
  to a stale entry — that is precisely how the `.docc` gotcha came to contradict
  itself across three generations of edits.
- 🔧 `/deliver` Phase 6 requires the `swept:` line, including under the
  inline-capture exception.

**New — `/review-knowledge` skill:**

- ✨ Two adversarial **Fable** critics audit `knowledge/` in parallel (accuracy /
  staleness, and structure / policy compliance), then **cross-examine** each
  other's findings before the conductor adjudicates only what stays disputed.
  Critics are read-only; applying needs the user's go-ahead. Findings must cite
  the `file:line` that *disproves* the entry — a finding sourced from reading the
  knowledge base is inadmissible, since that credulity is the failure mode being
  audited. "Nothing needs changing" is an explicitly valid outcome.

**New — `knowledge/next-major.md`:**

- ✨ A breaking-change queue, with an HTML-comment **sentinel in `CHANGELOG.md`**
  as its read trigger — cutting a major requires editing that file, so the queue
  gets read. Seeded with `Company.logoPath` (a live decode-failure risk) and two
  deferred rejections.

**Retired / rewritten (`knowledge/gotchas.md`):**

- 📝 **Deleted** the "Xcode 27 makes the `.docc` warning fatal" entry — three of
  its claims are false now (CI pins `Xcode_27.0`, and its proposed fix shipped in
  #396).
- 📝 **Replaced** the self-contradicting xcsift entry (which said both "Resolved
  in #396" and "still fails locally") with two entries that describe the present.
- 📝 New **"False green"** doctrine section naming the failure family both reviews
  found unnamed — green build of the wrong tree, pipe-summary vs exit code,
  debug-green vs release-broken, "no failures" vs a running check, HTTP 200 on an
  ignored parameter, a test asserting what it cannot observe — each with its
  countermeasure.
- 📝 Merged the duplicate `## Testing` section; every section now reads
  dated-newest-first with undated conventions last.

**Corrected:**

- 📝 `CLAUDE.md`: services are constructed in `TMDbClient`'s private init, not
  "registered in `TMDbFactory.swift`" (#401's retro diagnosed this; nobody
  propagated it).
- 📝 ADR-0010 collision → renumbered to **ADR-0014**; both numbers were live in
  prose. New `decisions/README.md` index makes recurrence impossible.
- 📝 All four 19.0.0 ADRs now read *"Accepted (in 19.0.0, unreleased)"* — a
  CHANGELOG section is not a release.
- 📝 A stale `deferred` in `skill-improvement-log.md` closed as applied; that file
  is the recurring-scan's dedup memory, so a stale entry actively misinforms it.
- 📝 Three skills cited a gotcha by a title #402 renamed.
- 📝 `tooling-runner` told the Haiku runner to treat the `.docc` diagnostic as a
  benign **PASS**. Post-#396 that is inverted — it now only appears when a target
  is missing from the `exclude` list, which is **fatal**.
- 📝 `</content>` tag stripped from ADR-0007 — the exact defect the gotcha written
  in that same delivery warns about.

**Documentation:**

- 📚 New live-API section on rate limiting: TMDb exposes **no** `X-RateLimit-*`
  headers (verified live), so the `429`/`Retry-After` branch is unexercised
  against the real API. Recorded as unverified rather than assumed.
- 📚 Citation convention: `#392`/`#397`, `#395`/`#398` and `#391`/`#401` are
  issue/PR pairs — cite the **PR** that did the work.

## Corrections made during the work

- "19.0.0 shipped" — **wrong**. `CHANGELOG.md` has a `[19.0.0]` section but the
  newest tag is `18.2.0`. The three `next-major.md` entries are therefore still
  **eligible for 19.0.0**; that call is yours, and the file says so.
- "#395 is a phantom PR" — **wrong**. It is a real *issue* ("Execute ADR-0010"),
  closed by PR #398. The citations were valid but ambiguous, so they were
  normalised rather than deleted.

## Benefits

- **Staleness has a fix, not just a symptom** — the sweep runs on every delivery
  that touches build config, which is where decay actually comes from.
- **The base stops contradicting itself** — entries describe the present; git
  history is the archive.
- **Deferred breaking changes resurface** at exactly the moment they can ship.
- **Repeatable** — `/review-knowledge` re-runs this audit on demand.

## Note

`knowledge/**` is deliberately outside `make lint-markdown` scope (documented in
`/capture-knowledge`), so these files have no CI gate — all checks here were run
by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013buB3reHTt1iq66zEtZGhq