### PR TITLE
🐛 Make Company logo path and origin country optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      knowledge/next-major.md first — it lists approved breaking changes
      waiting for exactly this bump. Ship them or consciously re-defer. -->
 
-## [19.0.0] - 2026-07-24
+## [19.0.0] - 2026-07-28
 
 ### Added
+
+- `Company` and `Company.Parent` now conform to `LogoImageProviding`, so
+  `logoURL(using:size:)` works on them as it already does on `Network`,
+  `ProductionCompany` and `WatchProvider`. Previously blocked only by
+  `logoPath` being non-optional.
 
 - `ImageService`, exposed as `TMDbClient.images`, resolving a model's image
   path to a fully qualified URL in one call:
@@ -34,6 +39,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.unknown`.
 
 ### Changed
+
+- **Breaking:** `Company.logoPath` is now `URL?` and `Company.originCountry` is
+  now `String?`, and `Company.Parent.logoPath` is now `URL?`. TMDb returns
+  `null` for these fields on many production companies (roughly 1 in 6 sampled
+  for `logo_path`), which previously made the **entire `Company` decode throw** —
+  `details(forCompany:)` failed outright for companies such as Time Warner
+  (id 128) and Paramount Pictures (id 4, whose parent company has no logo).
+  Migration: unwrap before use, e.g. `company.logoPath.map { ... }` or
+  `if let logoPath = company.logoPath`. Note the encoded JSON now omits
+  `logo_path` / `origin_country` when they are `nil`, rather than always
+  emitting them.
 
 - **Breaking:** `TMDbError`'s `badRequest`, `unauthorised`, `forbidden`,
   `notFound`, `tooManyRequests` and `serverError` cases now carry a

--- a/Sources/TMDb/Domain/Models/Company.swift
+++ b/Sources/TMDb/Domain/Models/Company.swift
@@ -183,3 +183,33 @@ public extension Company {
     }
 
 }
+
+extension Company.Parent {
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case logoPath
+    }
+
+    ///
+    /// Creates a new instance by decoding from the given decoder.
+    ///
+    /// This initializer throws an error if reading from the decoder fails, or
+    /// if the data read is corrupted or otherwise invalid.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    ///
+    /// - Throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested
+    /// type.
+    /// - Throws: `DecodingError.keyNotFound` if self does not have an entry for the given key.
+    ///
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.id = try container.decode(Company.ID.self, forKey: .id)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.logoPath = try container.decodeNonEmptyURLIfPresent(forKey: .logoPath)
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/Company.swift
+++ b/Sources/TMDb/Domain/Models/Company.swift
@@ -203,6 +203,7 @@ extension Company.Parent {
     /// - Throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested
     /// type.
     /// - Throws: `DecodingError.keyNotFound` if self does not have an entry for the given key.
+    /// - Throws: `DecodingError.valueNotFound` if self has a null entry for the given key.
     ///
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/TMDb/Domain/Models/Company.swift
+++ b/Sources/TMDb/Domain/Models/Company.swift
@@ -40,14 +40,19 @@ public struct Company: Identifiable, Codable, Equatable, Hashable, Sendable {
     ///
     /// Company's logo path.
     ///
+    /// `nil` when the company has no logo — TMDb returns a `null` `logo_path`
+    /// for many production companies.
+    ///
     /// To generate a full URL see <doc:/TMDb/GeneratingImageURLs>.
     ///
-    public let logoPath: URL
+    public let logoPath: URL?
 
     ///
     /// Origin country.
     ///
-    public let originCountry: String
+    /// `nil` when TMDb has no origin country recorded for the company.
+    ///
+    public let originCountry: String?
 
     ///
     /// Parent company.
@@ -73,8 +78,8 @@ public struct Company: Identifiable, Codable, Equatable, Hashable, Sendable {
         description: String,
         headquarters: String,
         homepageURL: URL? = nil,
-        logoPath: URL,
-        originCountry: String,
+        logoPath: URL? = nil,
+        originCountry: String? = nil,
         parentCompany: Parent? = nil
     ) {
         self.id = id
@@ -123,8 +128,8 @@ extension Company {
         self.description = try container.decode(String.self, forKey: .description)
         self.headquarters = try container.decode(String.self, forKey: .headquarters)
         self.homepageURL = try container.decodeNonEmptyURLIfPresent(forKey: .homepageURL)
-        self.logoPath = try container.decode(URL.self, forKey: .logoPath)
-        self.originCountry = try container.decode(String.self, forKey: .originCountry)
+        self.logoPath = try container.decodeNonEmptyURLIfPresent(forKey: .logoPath)
+        self.originCountry = try container.decodeIfPresent(String.self, forKey: .originCountry)
         self.parentCompany = try container.decodeIfPresent(Parent.self, forKey: .parentCompany)
     }
 
@@ -150,9 +155,12 @@ public extension Company {
         ///
         /// Company's logo path.
         ///
+        /// `nil` when the parent company has no logo — TMDb returns a `null`
+        /// `logo_path` for many production companies.
+        ///
         /// To generate a full URL see <doc:/TMDb/GeneratingImageURLs>.
         ///
-        public let logoPath: URL
+        public let logoPath: URL?
 
         ///
         /// Creates a parent company object.
@@ -165,7 +173,7 @@ public extension Company {
         public init(
             id: Company.ID,
             name: String,
-            logoPath: URL
+            logoPath: URL? = nil
         ) {
             self.id = id
             self.name = name

--- a/Sources/TMDb/Domain/Models/ImageProviding+Conformances.swift
+++ b/Sources/TMDb/Domain/Models/ImageProviding+Conformances.swift
@@ -46,6 +46,8 @@ extension CreditPerson: ProfileImageProviding {}
 extension ProductionCompany: LogoImageProviding {}
 extension Network: LogoImageProviding {}
 extension WatchProvider: LogoImageProviding {}
+extension Company: LogoImageProviding {}
+extension Company.Parent: LogoImageProviding {}
 
 // MARK: - StillImageProviding
 

--- a/Sources/TMDbTesting/Samples/Company+Sample.swift
+++ b/Sources/TMDbTesting/Samples/Company+Sample.swift
@@ -18,8 +18,7 @@ public extension Company {
             description: "",
             headquarters: "San Francisco, California",
             homepageURL: URL(string: "https://www.lucasfilm.com"),
-            logoPath: URL(string: "/tlVSws0RvvtPBwViUyOFAO0vcQS.png")
-                ?? URL(fileURLWithPath: "/"),
+            logoPath: URL(string: "/tlVSws0RvvtPBwViUyOFAO0vcQS.png"),
             originCountry: "US",
             parentCompany: nil
         )

--- a/Tests/TMDbIntegrationTests/CompanyIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/CompanyIntegrationTests.swift
@@ -33,6 +33,33 @@ struct CompanyIntegrationTests {
         #expect(company.name == "LuckyChap Entertainment")
     }
 
+    @Test("details for a company with no logo")
+    func detailsForCompanyWithoutLogo() async throws {
+        // Time Warner — TMDb returns null for both logo_path and origin_country.
+        // Asserting only that the decode succeeds: whether this company has a
+        // logo is contributor-editable live data, so asserting `logoPath == nil`
+        // would go red on a data edit rather than on a regression. The nil
+        // mapping itself is locked by the fixture-driven unit tests.
+        let companyID = 128
+
+        let company = try await companyService.details(forCompany: companyID)
+
+        #expect(company.id == companyID)
+        #expect(company.name == "Time Warner")
+    }
+
+    @Test("details for a company whose parent has no logo")
+    func detailsForCompanyWhoseParentHasNoLogo() async throws {
+        // Paramount Pictures — its parent_company (Viacom International) has a
+        // null logo_path, which previously made the whole Company decode throw.
+        let companyID = 4
+
+        let company = try await companyService.details(forCompany: companyID)
+
+        #expect(company.id == companyID)
+        #expect(company.parentCompany != nil)
+    }
+
     @Test("alternativeNames")
     func alternativeNames() async throws {
         let companyID = 82968

--- a/Tests/TMDbTestFixtures/Mocks/Models/Company+Mocks.swift
+++ b/Tests/TMDbTestFixtures/Mocks/Models/Company+Mocks.swift
@@ -17,9 +17,8 @@ package extension Company {
         description: String = "Some description",
         headquarters: String = "San Francisco, California",
         homepageURL: URL? = URL(string: "https://www.lucasfilm.com"),
-        // swiftlint:disable:next force_unwrapping
-        logoPath: URL = URL(string: "/o86DbpburjxrqAzEDhXZcyE8pDb.png")!,
-        originCountry: String = "US",
+        logoPath: URL? = URL(string: "/o86DbpburjxrqAzEDhXZcyE8pDb.png"),
+        originCountry: String? = "US",
         parentCompany: Company.Parent? = nil
     ) -> Company {
         Company(
@@ -35,8 +34,7 @@ package extension Company {
     }
 
     static var lucasfilm: Company {
-        // swiftlint:disable:next force_unwrapping
-        let logoPath = URL(string: "/o86DbpburjxrqAzEDhXZcyE8pDb.png")!
+        let logoPath = URL(string: "/o86DbpburjxrqAzEDhXZcyE8pDb.png")
         return Company.mock(
             id: 1,
             name: "Lucasfilm Ltd.",

--- a/Tests/TMDbTests/Domain/Models/CompanyTests.swift
+++ b/Tests/TMDbTests/Domain/Models/CompanyTests.swift
@@ -84,13 +84,28 @@ struct CompanyTests {
     }
 
     @Test(
+        "JSON decoding of Company when parent company's logo path is an empty string",
+        .tags(.decoding)
+    )
+    func decodeCompanyWhenParentCompanyLogoPathIsEmptyString() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            Company.self,
+            fromResource: "company-empty-parent-logo"
+        )
+
+        let parentCompany = try #require(result.parentCompany)
+        #expect(parentCompany.logoPath == nil)
+    }
+
+    @Test(
         "JSON encoding of Company round-trips",
         .tags(.encoding),
         arguments: [
             "company",
             "company-null-logo",
             "company-null-parent-logo",
-            "company-empty-logo"
+            "company-empty-logo",
+            "company-empty-parent-logo"
         ]
     )
     func encodeCompanyRoundTrips(resource: String) throws {

--- a/Tests/TMDbTests/Domain/Models/CompanyTests.swift
+++ b/Tests/TMDbTests/Domain/Models/CompanyTests.swift
@@ -98,6 +98,24 @@ struct CompanyTests {
     }
 
     @Test(
+        "JSON decoding of Company when the logo path keys are absent",
+        .tags(.decoding)
+    )
+    func decodeCompanyWhenLogoPathKeysAreAbsent() throws {
+        // TMDb always sends these keys, so this covers the decoder's
+        // key-absent branch defensively rather than a shape seen in the wild.
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            Company.self,
+            fromResource: "company-absent-logo"
+        )
+
+        #expect(result.logoPath == nil)
+        #expect(result.originCountry == nil)
+        let parentCompany = try #require(result.parentCompany)
+        #expect(parentCompany.logoPath == nil)
+    }
+
+    @Test(
         "JSON encoding of Company round-trips",
         .tags(.encoding),
         arguments: [
@@ -105,7 +123,8 @@ struct CompanyTests {
             "company-null-logo",
             "company-null-parent-logo",
             "company-empty-logo",
-            "company-empty-parent-logo"
+            "company-empty-parent-logo",
+            "company-absent-logo"
         ]
     )
     func encodeCompanyRoundTrips(resource: String) throws {

--- a/Tests/TMDbTests/Domain/Models/CompanyTests.swift
+++ b/Tests/TMDbTests/Domain/Models/CompanyTests.swift
@@ -83,19 +83,26 @@ struct CompanyTests {
         #expect(parentCompany.logoPath == nil)
     }
 
-    @Test("JSON encoding of Company round-trips", .tags(.decoding))
-    func encodeCompanyRoundTrips() throws {
-        for resource in ["company", "company-null-logo", "company-null-parent-logo"] {
-            let decoded = try JSONDecoder.theMovieDatabase.decode(
-                Company.self,
-                fromResource: resource
-            )
+    @Test(
+        "JSON encoding of Company round-trips",
+        .tags(.encoding),
+        arguments: [
+            "company",
+            "company-null-logo",
+            "company-null-parent-logo",
+            "company-empty-logo"
+        ]
+    )
+    func encodeCompanyRoundTrips(resource: String) throws {
+        let decoded = try JSONDecoder.theMovieDatabase.decode(
+            Company.self,
+            fromResource: resource
+        )
 
-            let data = try JSONEncoder.theMovieDatabase.encode(decoded)
-            let roundTripped = try JSONDecoder.theMovieDatabase.decode(Company.self, from: data)
+        let data = try JSONEncoder.theMovieDatabase.encode(decoded)
+        let roundTripped = try JSONDecoder.theMovieDatabase.decode(Company.self, from: data)
 
-            #expect(roundTripped == decoded, "round-trip changed \(resource)")
-        }
+        #expect(roundTripped == decoded)
     }
 
 }

--- a/Tests/TMDbTests/Domain/Models/CompanyTests.swift
+++ b/Tests/TMDbTests/Domain/Models/CompanyTests.swift
@@ -14,18 +14,18 @@ struct CompanyTests {
 
     @Test("JSON decoding of Company", .tags(.decoding))
     func decodeCompany() throws {
-        let company = try Company(
+        let company = Company(
             id: 3,
             name: "Pixar",
             description: "",
             headquarters: "Emeryville, California",
             homepageURL: URL(string: "http://www.pixar.com"),
-            logoPath: #require(URL(string: "/1TjvGVDMYsj6JBxOAkUHpPEwLf7.png")),
+            logoPath: URL(string: "/1TjvGVDMYsj6JBxOAkUHpPEwLf7.png"),
             originCountry: "US",
             parentCompany: Company.Parent(
                 id: 2,
                 name: "Walt Disney Pictures",
-                logoPath: #require(URL(string: "/wdrCwmRnLFJhEoH8GSfymY85KHT.png"))
+                logoPath: URL(string: "/wdrCwmRnLFJhEoH8GSfymY85KHT.png")
             )
         )
 
@@ -42,6 +42,60 @@ struct CompanyTests {
         #expect(parentCompany.id == company.parentCompany?.id)
         #expect(parentCompany.name == company.parentCompany?.name)
         #expect(parentCompany.logoPath == company.parentCompany?.logoPath)
+    }
+
+    @Test("JSON decoding of Company when logo path and origin country are null", .tags(.decoding))
+    func decodeCompanyWhenLogoPathAndOriginCountryAreNull() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            Company.self,
+            fromResource: "company-null-logo"
+        )
+
+        #expect(result.id == 128)
+        #expect(result.name == "Time Warner")
+        #expect(result.logoPath == nil)
+        #expect(result.originCountry == nil)
+        #expect(result.parentCompany == nil)
+    }
+
+    @Test("JSON decoding of Company when logo path is an empty string", .tags(.decoding))
+    func decodeCompanyWhenLogoPathIsEmptyString() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            Company.self,
+            fromResource: "company-empty-logo"
+        )
+
+        #expect(result.logoPath == nil)
+    }
+
+    @Test("JSON decoding of Company when parent company's logo path is null", .tags(.decoding))
+    func decodeCompanyWhenParentCompanyLogoPathIsNull() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            Company.self,
+            fromResource: "company-null-parent-logo"
+        )
+
+        #expect(result.logoPath != nil)
+        #expect(result.originCountry == "US")
+        let parentCompany = try #require(result.parentCompany)
+        #expect(parentCompany.id == 5308)
+        #expect(parentCompany.name == "Viacom International")
+        #expect(parentCompany.logoPath == nil)
+    }
+
+    @Test("JSON encoding of Company round-trips", .tags(.decoding))
+    func encodeCompanyRoundTrips() throws {
+        for resource in ["company", "company-null-logo", "company-null-parent-logo"] {
+            let decoded = try JSONDecoder.theMovieDatabase.decode(
+                Company.self,
+                fromResource: resource
+            )
+
+            let data = try JSONEncoder.theMovieDatabase.encode(decoded)
+            let roundTripped = try JSONDecoder.theMovieDatabase.decode(Company.self, from: data)
+
+            #expect(roundTripped == decoded, "round-trip changed \(resource)")
+        }
     }
 
 }

--- a/Tests/TMDbTests/Domain/Models/ImageProvidingTests.swift
+++ b/Tests/TMDbTests/Domain/Models/ImageProvidingTests.swift
@@ -70,6 +70,41 @@ struct ImageProvidingTests {
         #expect(logoURL == URL(string: "https://image.tmdb.org/t/p/w154/logo.jpg"))
     }
 
+    @Test("Company logo URL")
+    func companyLogoURL() throws {
+        let logoPath = try #require(URL(string: "/logo.jpg"))
+        let company = Company(
+            id: 1,
+            name: "Company",
+            description: "",
+            headquarters: "",
+            logoPath: logoPath
+        )
+
+        let logoURL = company.logoURL(using: configuration, size: .width(154))
+
+        #expect(logoURL == URL(string: "https://image.tmdb.org/t/p/w154/logo.jpg"))
+    }
+
+    @Test("Company logo URL is nil when the company has no logo")
+    func companyLogoURLWhenLogoPathIsNil() {
+        let company = Company(id: 1, name: "Company", description: "", headquarters: "")
+
+        let logoURL = company.logoURL(using: configuration, size: .width(154))
+
+        #expect(logoURL == nil)
+    }
+
+    @Test("Company.Parent logo URL")
+    func companyParentLogoURL() throws {
+        let logoPath = try #require(URL(string: "/logo.jpg"))
+        let parent = Company.Parent(id: 1, name: "Parent", logoPath: logoPath)
+
+        let logoURL = parent.logoURL(using: configuration, size: .width(154))
+
+        #expect(logoURL == URL(string: "https://image.tmdb.org/t/p/w154/logo.jpg"))
+    }
+
     @Test("TVEpisode still URL")
     func tvEpisodeStillURL() throws {
         let stillPath = try #require(URL(string: "/still.jpg"))

--- a/Tests/TMDbTests/Domain/Models/ImageProvidingTests.swift
+++ b/Tests/TMDbTests/Domain/Models/ImageProvidingTests.swift
@@ -105,6 +105,15 @@ struct ImageProvidingTests {
         #expect(logoURL == URL(string: "https://image.tmdb.org/t/p/w154/logo.jpg"))
     }
 
+    @Test("Company.Parent logo URL is nil when the parent has no logo")
+    func companyParentLogoURLWhenLogoPathIsNil() {
+        let parent = Company.Parent(id: 1, name: "Parent")
+
+        let logoURL = parent.logoURL(using: configuration, size: .width(154))
+
+        #expect(logoURL == nil)
+    }
+
     @Test("TVEpisode still URL")
     func tvEpisodeStillURL() throws {
         let stillPath = try #require(URL(string: "/still.jpg"))

--- a/Tests/TMDbTests/Resources/json/company-absent-logo.json
+++ b/Tests/TMDbTests/Resources/json/company-absent-logo.json
@@ -1,0 +1,11 @@
+{
+    "description": "",
+    "headquarters": "",
+    "homepage": "",
+    "id": 128,
+    "name": "Time Warner",
+    "parent_company": {
+        "name": "Viacom International",
+        "id": 5308
+    }
+}

--- a/Tests/TMDbTests/Resources/json/company-empty-logo.json
+++ b/Tests/TMDbTests/Resources/json/company-empty-logo.json
@@ -1,0 +1,10 @@
+{
+    "description": "",
+    "headquarters": "",
+    "homepage": "",
+    "id": 128,
+    "logo_path": "",
+    "name": "Time Warner",
+    "origin_country": null,
+    "parent_company": null
+}

--- a/Tests/TMDbTests/Resources/json/company-empty-parent-logo.json
+++ b/Tests/TMDbTests/Resources/json/company-empty-parent-logo.json
@@ -1,0 +1,14 @@
+{
+    "description": "",
+    "headquarters": "Hollywood, California",
+    "homepage": "https://www.paramountpictures.com/movies",
+    "id": 4,
+    "logo_path": "/jay6WcMgagAklUt7i9Euwj1pzTF.png",
+    "name": "Paramount Pictures",
+    "origin_country": "US",
+    "parent_company": {
+        "name": "Viacom International",
+        "id": 5308,
+        "logo_path": ""
+    }
+}

--- a/Tests/TMDbTests/Resources/json/company-null-logo.json
+++ b/Tests/TMDbTests/Resources/json/company-null-logo.json
@@ -1,0 +1,10 @@
+{
+    "description": "",
+    "headquarters": "",
+    "homepage": "",
+    "id": 128,
+    "logo_path": null,
+    "name": "Time Warner",
+    "origin_country": null,
+    "parent_company": null
+}

--- a/Tests/TMDbTests/Resources/json/company-null-parent-logo.json
+++ b/Tests/TMDbTests/Resources/json/company-null-parent-logo.json
@@ -1,0 +1,14 @@
+{
+    "description": "",
+    "headquarters": "Hollywood, California",
+    "homepage": "https://www.paramountpictures.com/movies",
+    "id": 4,
+    "logo_path": "/jay6WcMgagAklUt7i9Euwj1pzTF.png",
+    "name": "Paramount Pictures",
+    "origin_country": "US",
+    "parent_company": {
+        "name": "Viacom International",
+        "id": 5308,
+        "logo_path": null
+    }
+}

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,7 +14,7 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
-## 2026-07-28 — 🐛 Company logo path & origin country optional (`fix/company-logo-path-optional`) · full
+## 2026-07-28 — 🐛 Company logo path & origin country optional (#404) · full
 
 - **Phases / skills:** 0–8 pre-PR; full weight (breaking public API +
   `Decodable`). `consulted:` next-major.md (the source), tmdb-api-notes

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,6 +14,56 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-07-28 — 🐛 Company logo path & origin country optional (`fix/company-logo-path-optional`) · full
+
+- **Phases / skills:** 0–8 pre-PR; full weight (breaking public API +
+  `Decodable`). `consulted:` next-major.md (the source), tmdb-api-notes
+  *Company.logoPath required decode*, gotchas *False green*. `/review-plan`
+  (3 Opus critics) → **1 blocker + 9 findings**. `/implement-plan` inline,
+  test-first. `/review-changes` 5-dimension fan-out + adversarial verify →
+  **0 Critical/High/Medium, 2 Low**, both applied, 0 dropped by verification.
+  `/security-review` → 0 findings ≥ conf-8. Independent grader → **6/7 ACs,
+  AC6 not met**, fixed and re-graded to met.
+- **Worked — the queue fired on its first real use.** `next-major.md` was
+  written on 2026-07-27 and consulted on 2026-07-28; the fix reached the
+  still-untagged 19.0.0 window instead of waiting for 20.0.0. The whole point
+  of that file, validated one day later.
+- **Worked — two independent checks each caught something the other didn't.**
+  My type-driven sweep found `Company.Parent.logoPath` (a second instance,
+  invisible because `Parent`'s decode is synthesized). The plan critics found
+  the **blocker**: `Company.originCountry` is the same bug on the same records,
+  so shipping `logoPath` alone would have left Time Warner throwing — and my
+  own AC1 integration test failing. Verified independently before accepting:
+  5 of 54 sampled companies.
+- **Worked — sampling beat spot-checking.** One `curl` showed
+  `logo_path: null` and nearly ended the investigation. Sampling 54 companies
+  took a minute and produced the field/nullability matrix that proved
+  `origin_country` was in scope and `description`/`headquarters` were not —
+  the difference between a correct fix and a subset.
+- **Friction — I adjudicated a 2–1 critic split wrongly, and the grader caught
+  it.** Two critics wanted `Company.Parent` to guard empty strings; one called
+  it speculative. I sided with the one, citing 0/54 observed empty strings.
+  That produced an asymmetry *inside one type* — `Company.logoPath` mapped
+  `""` → `nil` while `Company.Parent.logoPath` still threw — i.e. the exact
+  bug this delivery exists to remove, one level down. **Lesson: "matches the
+  siblings" and "consistent within the type" can conflict, and within-the-type
+  wins;** an unobserved value ranks the risk, it doesn't close the case.
+- **Friction — I nearly shipped a knowledge entry contradicting my own code.**
+  The api-note written in Phase 6 argued *against* guarding `Parent`; the
+  Phase 7 fix reversed that, and the note had to be rewritten in the same
+  delivery. Capture-before-grade is the wrong order when grading can still
+  change the design.
+- **Deviations:** (a) scope grew from one field to three plus a
+  `LogoImageProviding` conformance — the blocker forced two, and all three
+  critics independently asked for the conformance (it was blocked *only* by
+  the non-optional type). (b) Fixtures for the empty/absent cases are
+  hand-built, not live captures: TMDb always sends these keys, so those
+  decoder branches have no real-world sample. Flagged in-test.
+- **One improvement:** **`/deliver` should run the rubric grader before
+  `/capture-knowledge`, not after.** Phase 7 changed the design this run, which
+  invalidated a Phase 6 entry that had already been committed. Ordering
+  capture after grading costs nothing and removes the rewrite.
+
 ## 2026-07-27 — ✨ Cached image URL resolver, `client.images` (#401) · full
 
 - **Phases / skills:** 0–8 pre-PR; full weight (new public service + actor,
@@ -423,42 +473,6 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
   interruptions actually bite" condition now holds), or have `/deliver` re-create
   the ledger after an `EnterWorktree`/reconnect.
 
-## 2026-06-25 — 🔧 Use the GitHub MCP instead of the gh CLI in the skills (#366) · lite
-
-- **Phases / skills:** phases 0–6; `pr, watch-pr` (both dogfooded the new MCP path).
-  Skipped `/review-plan` as a *skill* (the plan already got a 3-critic adversarial
-  pass earlier in the session, pre-`/deliver`); skipped `/implement-plan` (markdown
-  only — no TDD list); skipped code review (no Swift) and the automated
-  `/security-review` (diff is 100% markdown — `.md` is excluded; the only
-  security-relevant artifact, the `mcp__github__*` permission, is gitignored and out
-  of the PR — reviewed by reasoning instead, parity with `Bash(gh:*)`, ADR-0009).
-- **Worked:** the migration was **dogfooded end-to-end** — PR opened via
-  `mcp__github__create_pull_request`, readiness verified positively via
-  `get`/`get_check_runs`/`get_review_comments`, and the blocking wait used the
-  *retained* `gh pr checks --watch`. The pre-implementation 3-critic plan review paid
-  off: it caught two **BLOCKERs** before any edit — the review-reply mapping gap
-  (`add_reply_to_pull_request_comment` needs a REST comment id `get_review_comments`
-  doesn't expose → reply stays on `gh`) and the wrong method name (`rerun_failed_jobs`,
-  not "rerun-failed"). Path-aware CI resolved the docs-only PR in ~1 min.
-- **Friction — the MCP registration detour cost real time.** Enabling the `actions`
-  toolset, the user repointed the single `github` server to `…/mcp/x/actions`, whose
-  **exclusive** path silently dropped the default PR toolset — `pull_request_read`
-  etc. vanished mid-implementation, needing diagnosis + two reconnect cycles before
-  `…/mcp/x/all` fixed it. Now an ADR + `gotchas.md` entry.
-- **Deviations:** (1) the owner/repo "single source" decision surfaced *mid-edit*
-  from a user question, not in the plan — it should have been a planned design point
-  (it forced re-touching four already-edited files). (2) Captured knowledge **inline**
-  (ADR-0009 + gotchas) rather than invoking `/capture-knowledge`, since the ADR was
-  written during implementation. (3) This PR **supersedes** #365's
-  `reviewThreads`/`gh pr view --json` gotcha — watch-pr §0 no longer calls
-  `gh pr view` at all, so that guard was adapted to the MCP (`get_review_comments`).
-- **One improvement:** when a delivery edits the *very skills the pipeline runs*
-  (`/pr`, `/watch-pr`, `/deliver`), `/deliver` should note up front that the skill
-  **registry loads from the main checkout**, so the in-session skills keep the *old*
-  behaviour until merge — the change can only be dogfooded by the conductor acting
-  manually, not by the sub-skills. Flagging this avoids confusion when `/pr` visibly
-  runs `gh pr create` while the diff says otherwise.
-
 ## Archive (distilled)
 
 Older entries condensed per the rolling window (`knowledge/README.md` →
@@ -466,6 +480,7 @@ Older entries condensed per the rolling window (`knowledge/README.md` →
 
 | Date | PR | Weight | Outcome |
 | --- | --- | --- | --- |
+| 2026-06-25 | #366 | lite | Migrated the skills from the `gh` CLI to the GitHub MCP (ADR-0009), dogfooded end-to-end. The 3-critic plan review paid for itself pre-edit: it caught that `add_reply_to_pull_request_comment` needs a REST comment id `get_review_comments` doesn't expose (so thread replies stay on `gh`), and a wrong method name. Real cost was a registration detour — the hosted `/x/<toolset>` paths are **exclusive**, so pointing at `/x/actions` silently dropped the default PR toolset mid-implementation; `/x/all` fixed it. Lesson that generalises: when a delivery edits the very skills the pipeline runs, the skill registry loads from the main checkout, so the change can only be dogfooded by the conductor acting manually until merge. |
 | 2026-06-24 | #365 | lite | Entry/exit criteria + auto-start for `/deliver`. The docs/config fast-gate correctly classified it (CI green in under 2 min). Lasting lesson: auto-start on `ExitPlanMode` approval is a **soft guarantee** — no harness hook fires on it, so it depends on the model reading the contract. First delivery under the new AC entry gate, and the plan had no formal ACs (circular dependency, noted); its "one improvement" — put an inline `Given X, when Y, then Z` example in the gate prompt — still stands. Its `reviewThreads`/`gh pr view --json` gotcha was superseded by #366 (the MCP migration removed the call) and is deliberately not carried forward. |
 | 2026-06-24 | #364 | lite | Percent-encode URL path segments + validate `String` IDs (ADR-0008). The security review's end-to-end trace through `urlFromPath`'s `URLComponents` round-trip is what made the fix trustworthy (and found the `%2F`→`/` decode, correctly bounded as path-only on a locked host). Lesson that became skill policy: for "fix every instance of pattern X", do **one type-driven enumeration of all sites up front** — here the planning grep, `/security-review`, code review, and `claude-review` each found a *different subset*. |
 | 2026-06-24 | #363 | lite (docs-led) | Documented the existing response caching instead of building it: challenging the premise mid-plan (`curl -D-` showed every GET returns `Cache-Control`/`ETag`, so the default `URLCache` already provides — and beats — the requested opt-in cache) turned a feature build into a docs PR + ADR-0007. A single `code-reviewer` caught a High that both `make build-docs` and `markdownlint` missed: stray `</content>`/`</invoke>` tags the `Write` tool leaked into the article tail. Fourth entry asking for a docs/config-only fast gate, widened here to "no semantic Swift change" so doc-comment-only `.swift` diffs qualify. |

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -48,6 +48,19 @@ retired; the family heading stays.
 
 ## Tooling
 
+### Removing a force-unwrap orphans its `swiftlint:disable` — `--strict` then fails
+
+*2026-07-28 (#404).* Making a property optional let two
+`URL(string: …)!` force-unwraps in `Company+Mocks.swift` become plain optionals.
+Each was preceded by `// swiftlint:disable:next force_unwrapping`; with the `!`
+gone those comments suppress nothing, and `make ci` runs `swiftlint --strict`,
+under which **`superfluous_disable_command` is an error**. The build and the
+whole test suite stay green — this fails only at the lint gate.
+
+**When you delete a `!` or a `try!`, delete its `disable` comment in the same
+edit**, and grep the file for orphans (`grep -n "disable:next" <file>`). Same
+applies in reverse to `file_length` / `type_body_length` disables after a split.
+
 ### Docs builds need their own scratch path — sharing one invalidates the other
 
 *2026-07-27 (#401, fixed in #402).* `Package.swift` branches on `SWIFTCI_DOCC`:
@@ -388,6 +401,30 @@ the 2026-07-28 audit.*
 
 ## Testing
 
+### Sweeping for a decode bug: sweep the *failure class*, not the property name
+
+*2026-07-28 (#404).* Fixing `Company.logoPath`'s required decode, a
+type-driven sweep for `let logoPath: URL` found two sites — the property and
+the nested `Company.Parent`. It felt complete. It wasn't: `Company.originCountry`
+is the *same bug* in a different property, and the very records that return
+`logo_path: null` also return `origin_country: null` — so the fix would have
+shipped with its own integration test still failing.
+
+- **The sweep key was wrong.** "Every `logoPath: URL`" is a *name* sweep. The
+  real class is **"every required decode on a model whose API returns sparse
+  records"** — enumerate the model's `try container.decode(` lines and check
+  each against real responses, rather than grepping the field you already know
+  about.
+- **Nested types hide instances.** `Company.Parent` has no `init(from:)` of its
+  own, so its required decode is *synthesized* and invisible to a grep for
+  `container.decode`. A file with one custom decoder can still have several
+  decoding types — count the types, not the decoders.
+- **Sample the population, don't spot-check.** One `curl` of an affected record
+  showed `logo_path: null` and stopped the investigation there. Sampling 54
+  companies took a minute and produced the whole field/nullability matrix (see
+  `tmdb-api-notes.md`) — which is what proved `origin_country` was in scope and
+  `description`/`headquarters` were not.
+
 ### An `async let` binding cannot be captured by `#expect(throws:)`
 
 *2026-07-27 (#401).* Awaiting an `async let` inside the `#expect(throws:)`
@@ -520,6 +557,7 @@ the documented signature. (We initially mis-scoped the `<entity>ID` rename as
 breaking; it isn't.) See [ADR-0004](decisions/0004-service-parameter-name-convention.md).
 
 ## Networking
+
 ### `URL(string:)` on Apple platforms rejects almost nothing — probe before testing a rejection
 
 *2026-07-24.* Trying to test the `TMDbAPIError.invalidURL` branch (thrown when

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -401,6 +401,32 @@ the 2026-07-28 audit.*
 
 ## Testing
 
+### Guard consistently within a type, even for a value the API never sends
+
+*2026-07-28 (#404).* Making `Company.logoPath` optional, the question was whether
+the nested `Company.Parent.logoPath` needed the same empty-string guard. The
+evidence said no: a 54-company sample found `logo_path` was `""` **zero** times,
+and no sibling logo model (`ProductionCompany`, `WatchProvider`, `Network`)
+guards it. So `Company` got `decodeNonEmptyURLIfPresent` (free — it already had
+a custom decoder) and `Parent` was left synthesized.
+
+That was the wrong cut. It produced an **asymmetry inside a single type**:
+`Company.logoPath` mapped `""` → `nil` while `Company.Parent.logoPath` still
+threw `DecodingError.dataCorrupted: Invalid URL string` on it — the very failure
+the change existed to remove, surviving one level down. The independent rubric
+grader caught it; three plan critics had split 2–1 on it beforehand.
+
+- **"Matches the siblings" and "consistent within the type" can conflict.**
+  When they do, prefer *within the type* — a reader of `Company.swift` sees both
+  properties at once and cannot explain why they differ, whereas the
+  cross-model difference is invisible in practice.
+- **"The API never sends it" ranks the risk, it doesn't close the case.** It is
+  a reason not to build elaborate machinery; it is not a reason to leave two
+  neighbouring properties behaving differently for the same input.
+- A nested type with synthesized `Decodable` needs its **own** `CodingKeys` +
+  `init(from:)` to use the helper — roughly 15 lines. That was the real cost
+  being weighed, and it was worth paying.
+
 ### Sweeping for a decode bug: sweep the *failure class*, not the property name
 
 *2026-07-28 (#404).* Fixing `Company.logoPath`'s required decode, a

--- a/knowledge/next-major.md
+++ b/knowledge/next-major.md
@@ -14,36 +14,31 @@ CHANGELOG records it) or is rejected outright (record that in
 `skill-improvement-log.md`).
 
 > **Status as of 2026-07-28: 19.0.0 is assembled but *not tagged*** — the
-> newest tag is `18.2.0` while `CHANGELOG.md` already carries a
-> `[19.0.0] - 2026-07-24` section. Everything below is therefore **still
-> eligible for 19.0.0**, not deferred to 20.0.0. That call is the
-> maintainer's; this note exists so it is made deliberately rather than by
-> the window closing unnoticed a second time.
+> newest tag is `18.2.0` while `CHANGELOG.md` already carries a `[19.0.0]`
+> section. Everything below is therefore **still eligible for 19.0.0**, not
+> deferred to 20.0.0. That call is the maintainer's; this note exists so it is
+> made deliberately rather than by the window closing unnoticed a second time.
+>
+> **First use of this file worked:** the `Company.logoPath` fix shipped into the
+> 19.0.0 window on 2026-07-28 because this queue was read, one day after it was
+> written. Remove the status note once 19.0.0 is tagged.
 
 ## Backlog
 
-### Make `Company.logoPath` optional (`URL?`)
+### Align the `Company`/`Network` model shapes deliberately — *partially shipped*
 
-- **What:** `Company.logoPath` is `public let logoPath: URL` with a required
-  decode (`Sources/TMDb/Domain/Models/Company.swift:45,126`), so an absent,
-  `null`, or empty `logo_path` makes the **whole `Company` decode throw**.
-  TMDb does return logo-less production companies — a live decode-failure
-  risk, not a theoretical one. Fix: `URL?` with a guarded decode, matching
-  `Network.logoPath`. Note the asymmetry in the same decoder: `homepageURL`
-  *is* guarded (empty string → `nil`); only `logoPath` is unguarded.
-- **Why it waits:** property type + `init` parameter change — breaking.
-- **Source:** `tmdb-api-notes.md` → *`Company.logoPath` is a required decode*
-  (2026-06-30); `skill-improvement-log.md` → *Align `Network` to `Company`*
-  (rejected 2026-06-30).
-
-### Align the `Company`/`Network` model shapes deliberately
-
-- **What:** decide the canonical shape for the shared homepage-URL /
-  logo-path fields and apply it to both models (including whether
-  `Network.homepage` takes the `homepageURL` name). Do this together with the
-  `logoPath` change above — the 2026-06-30 audit rejected aligning them in
-  the *wrong* (non-optional) direction; the right direction is breaking.
-- **Why it waits:** public property renames — breaking.
+- **Shipped in 19.0.0 (2026-07-28):** the *nullability* half. `Company.logoPath`
+  → `URL?`, `Company.originCountry` → `String?`, `Company.Parent.logoPath` →
+  `URL?`, bringing `Company` into line with `Network`'s optionality. This also
+  closed the separate "Make `Company.logoPath` optional" entry, which is
+  removed. Plan review caught that `originCountry` throws on exactly the same
+  records, so shipping `logoPath` alone would not have fixed the bug.
+- **Consciously re-deferred:** the *naming* half — renaming `Network.homepage`
+  to `homepageURL` for parity with `Company.homepageURL`. Deliberately left out
+  of 19.0.0: it is a pure rename with no correctness benefit, and bundling it
+  would have widened a bug-fix PR into a cosmetic breaking change. It buys
+  nothing that waiting does not.
+- **Why it still waits:** public property rename — breaking.
 - **Source:** `skill-improvement-log.md` → *Align `Network` to `Company`*
   (rejected 2026-06-30; "Reconsider when: a major-version bump…").
 

--- a/knowledge/tmdb-api-notes.md
+++ b/knowledge/tmdb-api-notes.md
@@ -166,10 +166,13 @@ guessed:
   `logo_path` and `origin_country`. Don't assume sparse records are edge cases.
 - **The two null-bearing fields are exactly the two that were modelled as
   required**, so `details(forCompany:)` threw for those companies until 19.0.0.
-- The `""`/`null` split is the useful part: `homepage` needs the
-  empty-string→nil guard (`decodeNonEmptyURLIfPresent`) because it *is* `""` 23
-  times; `logo_path` never is, so a plain optional decode suffices for it. Guard
-  where the API actually produces the value, not everywhere symmetrically.
+- The `""`/`null` split tells you where a guard is *load-bearing*: `homepage`
+  needs `decodeNonEmptyURLIfPresent` because it genuinely *is* `""` 23 times;
+  for `logo_path` the guard is belt-and-braces, since the API never sent one.
+  **Both `Company.logoPath` and `Company.Parent.logoPath` guard it anyway** —
+  see the gotcha *Guard consistently within a type*: an unobserved value is a
+  reason to rank the risk low, not a reason to leave one property of a type
+  behaving differently from its neighbour.
 
 ### Verify optionality against real responses, not assumptions
 

--- a/knowledge/tmdb-api-notes.md
+++ b/knowledge/tmdb-api-notes.md
@@ -147,6 +147,30 @@ status code alone proves nothing.
 
 ## Field nullability
 
+### `/company/{id}`: `logo_path` and `origin_country` are frequently `null`
+
+*2026-07-28, `/3/company/{company_id}`, 54-company sample.* Measured, not
+guessed:
+
+| field | `null` | `""` | notes |
+| --- | --- | --- | --- |
+| `logo_path` | **9** (17%) | 0 | never an empty string |
+| `origin_country` | **5** (9%) | 0 | |
+| `parent_company.logo_path` | **2 of 8** | 0 | parents are sparse too |
+| `description` | 0 | 53 | empty, never null |
+| `headquarters` | 0 | 12 | empty, never null |
+| `homepage` | 0 | 23 | empty, never null |
+
+- The nulls hit **prominent** companies, not obscure ones — Time Warner (128)
+  and Viacom International (5308, Paramount's parent) return `null` for *both*
+  `logo_path` and `origin_country`. Don't assume sparse records are edge cases.
+- **The two null-bearing fields are exactly the two that were modelled as
+  required**, so `details(forCompany:)` threw for those companies until 19.0.0.
+- The `""`/`null` split is the useful part: `homepage` needs the
+  empty-string→nil guard (`decodeNonEmptyURLIfPresent`) because it *is* `""` 23
+  times; `logo_path` never is, so a plain optional decode suffices for it. Guard
+  where the API actually produces the value, not everywhere symmetrically.
+
 ### Verify optionality against real responses, not assumptions
 
 - A property should be optional (`?`) only if the API can return `null` or omit

--- a/knowledge/tmdb-api-notes.md
+++ b/knowledge/tmdb-api-notes.md
@@ -154,23 +154,6 @@ status code alone proves nothing.
   before deciding — the docs aren't always accurate about which fields are
   guaranteed.
 
-### `Company.logoPath` is a required decode — latent throw if `logo_path` is absent
-
-*2026-06-30, `/3/company/{company_id}`.* `Company.logoPath` is non-optional
-(`public let logoPath: URL`) and decoded with a **required**
-`try container.decode(URL.self, forKey: .logoPath)`
-(`Sources/TMDb/Domain/Models/Company.swift`), so an absent, `null`, or empty
-`logo_path` makes the **whole `Company` decode throw**. TMDb does return
-logo-less production companies, so this is a real latent failure, not theoretical.
-Note the asymmetry in the *same* decoder: `homepageURL` **is** guarded (empty
-string → `nil`, with the comment "URL decoding will fail with an empty string"),
-and the sibling `Network.logoPath` is correctly `URL?` — only `Company.logoPath`
-is unguarded. **Fixing it means making `logoPath` optional (`URL?`), a breaking
-public-API change** (property type + `init` parameter), so it is deferred to a
-deliberate major version rather than patched ad hoc. Until then, treat a company
-with no logo as a known decode-failure risk. (Surfaced in the 2026-06-30
-standardization audit.)
-
 ## Changes endpoints
 
 ### `changes/movie|tv|person` list responses are large and carry an unmodelled `softcore` field


### PR DESCRIPTION
## Summary

`client.companies.details(forCompany:)` **throws today** for real, commonly
fetched companies. `Company` modelled `logo_path` and `origin_country` as
required decodes, but TMDb returns `null` for both on a large minority of
records — so the *entire* `Company` decode fails.

Verified live across a 54-company sample before implementing:

| field | `null` | `""` |
| --- | --- | --- |
| `logo_path` | **9** (17%) | 0 |
| `origin_country` | **5** (9%) | 0 |
| `parent_company.logo_path` | **2 of 8** | 0 |
| `description` / `headquarters` / `homepage` | 0 | empty strings only |

The nulls hit prominent companies, not obscure ones — **Time Warner** (id 128)
and **Paramount Pictures** (id 4, whose parent Viacom International has no logo)
both fail on `main`.

This is a deliberate **breaking** change riding the unreleased 19.0.0, taken
from `knowledge/next-major.md`. That queue was written yesterday and consulted
today — its first real use.

## Changes

**Fix:**

- 🐛 `Company.logoPath` → `URL?`, decoded with `decodeNonEmptyURLIfPresent`
  (the helper `homepageURL` already uses, so `""` also maps to `nil`).
- 🐛 `Company.originCountry` → `String?`, decoded with `decodeIfPresent`,
  matching `Network.originCountry`.
- 🐛 `Company.Parent.logoPath` → `URL?`, with its own `CodingKeys` +
  `init(from:)` so it guards `""` identically to its containing type.

**Scope beyond the original entry** — both additions were forced by review, not
chosen:

- The backlog entry named only `logoPath`. A type-driven sweep found
  `Company.Parent` (invisible to a grep, because its decode is synthesized),
  and **plan review found the blocker**: `originCountry` fails on *the same
  records*, so fixing `logoPath` alone would have left Time Warner throwing —
  and this PR's own integration test failing.

**New API:**

- ✨ `Company` and `Company.Parent` conform to `LogoImageProviding`, so
  `logoURL(using:size:)` works as it already does on `Network`,
  `ProductionCompany` and `WatchProvider`. This was blocked *only* by
  `logoPath` being non-optional; all three plan critics asked for it.

**Tests:**

- ✅ Six fixtures covering present / null / empty / absent for both `Company`
  and its nested parent, plus a parameterized encode round-trip over all of
  them. Fixtures for the real-world cases are captured from actual API
  responses (ids 128 and 4); the empty/absent fixtures are hand-built and
  labelled as such, since TMDb always sends those keys.
- ✅ Integration tests assert the decode **succeeds**, not that `logoPath` is
  `nil` — whether a company has a logo is contributor-editable live data, so a
  value assertion would go red on a data edit rather than a regression (and
  redden the scheduled run, which auto-opens PRs). The nil mapping is locked by
  the fixture tests.

**Cleanup the type change unblocked:**

- ♻️ Dropped a `?? URL(fileURLWithPath: "/")` fallback in `Company+Sample` and
  two force-unwraps in `Company+Mocks` — along with their now-superfluous
  `swiftlint:disable` comments, which `--strict` would otherwise have turned
  into `superfluous_disable_command` errors at the gate.

**Documentation:**

- 📚 CHANGELOG Breaking entry under `[19.0.0]` with a migration note, including
  that the encoded JSON now omits these keys when `nil`.
- 📚 `knowledge/tmdb-api-notes.md`: the stale "required decode" note is deleted
  and replaced with the measured nullability table above.
- 📚 `knowledge/next-major.md`: entry closed; the coupled `Network.homepage`
  rename explicitly re-deferred rather than silently orphaned.

## Benefits

- **Fixes a live bug** — a whole `Company` no longer fails because it has no
  logo.
- **Consistent with siblings** — `Company` now matches `Network` /
  `ProductionCompany` optionality.
- **Closes the class, not one instance** — all three affected fields fixed
  together, verified against a sampled population rather than one spot-check.

## Notes for review

- The `""`-handling on `Company.Parent` was a **corrected mistake**. I first
  left `Parent` synthesized to match `ProductionCompany`/`WatchProvider`, citing
  zero observed empty strings. The independent rubric grader caught that this
  left an asymmetry *inside one type*: `Company.logoPath` mapped `""` → `nil`
  while `Company.Parent.logoPath` still threw. Consistency within the type won.
- `description` / `headquarters` are deliberately **not** touched: 0 nulls in
  54 samples (empty strings only, which decode fine), so widening the breaking
  surface there would be speculative.

Gates: `make ci` green — 2,911 unit tests, 302 integration tests,
`swift build -c release` exit 0, `swiftlint --strict --no-cache` 0 violations,
docs build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013buB3reHTt1iq66zEtZGhq