### PR TITLE
🔧 Grade the rubric before capturing knowledge in /deliver

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -18,8 +18,8 @@ picks up from there.
 
 ```text
 you approve the plan ─▶ /deliver ─▶ entry gate (ACs?) ─▶ worktree ─▶ [review-plan] ─▶
-  implement ─▶ code-review + fix ─▶ security-review + fix ─▶ capture ─▶
-  rubric check (ACs met?) ─▶ retro (pre-PR) ─▶ /pr reviewed ─▶ /watch-pr ─▶
+  implement ─▶ code-review + fix ─▶ security-review + fix ─▶
+  rubric check (ACs met?) ─▶ capture ─▶ retro (pre-PR) ─▶ /pr reviewed ─▶ /watch-pr ─▶
   GATE: ready-to-merge ─▶ wrap-up (wiki + recurring-pattern scan)
   ▲ the only hard stop
   … then, when the PR actually merges (maybe a later session): teardown (Phase 12)
@@ -56,7 +56,7 @@ Non-negotiable. Do these by default, without being reminded.
    keeps one ledger sub-tree per deliverable.
 7. **Jot knowledge candidates the moment a learning occurs** (a lookup, a
    gotcha, a live-API surprise, a non-obvious decision) — one line each
-   (`<category>: <gist> [where]`), in the ledger. Phase 6 curates them;
+   (`<category>: <gist> [where]`), in the ledger. Phase 7 curates them;
    reconstruction later loses the best material.
 8. **Auto-start after plan-mode approval.** `ExitPlanMode` approval IS the
    start signal — invoke `/deliver` immediately; pause first only if
@@ -115,7 +115,7 @@ implementation = separate `/deliver` sessions.)
   full stop. The conductor owns it.* Concretely:
   - Only the conductor and the `tooling-runner` it spawns may build. **Reviewer,
     security and grader subagents must be told not to build** — their prompts
-    say so, and `/review-changes` and Phase 7 above already carry that
+    say so, and `/review-changes` and Phase 6 above already carry that
     instruction.
   - **Never run two analysis phases concurrently.** Phase 4 and Phase 5 read the
     same commits and feel independent, so "run the security review while the
@@ -150,9 +150,9 @@ implementation = separate `/deliver` sessions.)
 - **Entry gate — acceptance criteria required.** Plans are expected as
   *"As a \<user-type\> I want \<feature\> so that \<reason\>"* + acceptance
   criteria. Extract the ACs verbatim as
-  the **delivery rubric** (consumed in Phase 7) into the ledger. Absent →
+  the **delivery rubric** (consumed in Phase 6) into the ledger. Absent →
   stop and ask for them ("Given X, when Y, then Z") — don't enter the
-  worktree. **Auto:** panel — proceed rubric-less (Phase 7 no-ops) vs stop.
+  worktree. **Auto:** panel — proceed rubric-less (Phase 6 no-ops) vs stop.
 - **Read the plan's content into context now** — `EnterWorktree` switches CWD
   (clearing the plans cache), and a fresh worktree lacks uncommitted local
   files; the plan must travel in the conversation.
@@ -261,24 +261,7 @@ stop even in auto**. This is the pipeline's **only** security gate (CI has no
 SAST). Surfaces that bite:
 [`references/review-loops.md`](references/review-loops.md).
 
-## Phase 6 — Capture learnings
-
-Invoke **`/capture-knowledge`**, passing the ledger's knowledge-candidates
-list as the skill argument (`$ARGUMENTS` — it travels with the call even
-after compaction). It curates: durable, non-obvious, reusable items only,
-deduped against `knowledge/`, written to the right file (gotchas / API notes
-/ an ADR). Before `/pr`, so the notes ride the same PR. Capturing nothing is
-a valid outcome. Exception: one or two small entries already authored during
-implementation may be committed inline instead — note the inline capture in
-the retro.
-
-Its report must include the `swept:` line — Phase 6 is the knowledge base's
-retirement trigger (the skill's step 5); a report without it means the sweep
-did not run. That applies to the inline-capture exception too: a delivery that
-touched `Makefile`, `Package.swift`, `.github/workflows/` or `.claude/` still
-owes the sweep, whoever wrote the entries.
-
-## Phase 7 — Rubric verification (exit gate)
+## Phase 6 — Rubric verification (exit gate)
 
 Take the rubric (Phase 0 ACs) from the ledger; none extracted → skip. How it
 is graded depends on weight:
@@ -306,6 +289,23 @@ Satisfied → mark off. Not → fix test-first, commit, re-verify (full weight:
 re-run the grader); a gap needing a plan change is noted in the PR
 description. *"Did we build what the plan said?"*, not *"did the build
 pass?"*.
+
+## Phase 7 — Capture learnings
+
+Invoke **`/capture-knowledge`**, passing the ledger's knowledge-candidates
+list as the skill argument (`$ARGUMENTS` — it travels with the call even
+after compaction). It curates: durable, non-obvious, reusable items only,
+deduped against `knowledge/`, written to the right file (gotchas / API notes
+/ an ADR). Runs **after** the rubric gate, so a grading failure that changes the design cannot invalidate an entry already committed; still before `/pr`, so the notes ride the same PR. Capturing nothing is
+a valid outcome. Exception: one or two small entries already authored during
+implementation may be committed inline instead — note the inline capture in
+the retro.
+
+Its report must include the `swept:` line — Phase 7 is the knowledge base's
+retirement trigger (the skill's step 5); a report without it means the sweep
+did not run. That applies to the inline-capture exception too: a delivery that
+touched `Makefile`, `Package.swift`, `.github/workflows/` or `.claude/` still
+owes the sweep, whoever wrote the entries.
 
 ## Phase 8 — Write the retrospective (pre-PR)
 

--- a/.claude/skills/deliver/references/auto-and-async.md
+++ b/.claude/skills/deliver/references/auto-and-async.md
@@ -32,7 +32,7 @@ unattended run must still be reviewable.
 
 **Panel decision points** (marked **Auto:** in `SKILL.md`):
 
-- Phase 0 — missing acceptance criteria: proceed without a rubric (Phase 7
+- Phase 0 — missing acceptance criteria: proceed without a rubric (Phase 6
   becomes a no-op) vs stop.
 - Phase 2 — a plan-review blocker that is *not* data-loss/breaking: proceed
   vs stop. (Data-loss/breaking = hard stop, never delegated.)

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,35 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-07-28 — Grade the rubric *before* capturing knowledge (#404) · applied
+
+- **Pattern:** a **single** occurrence, logged deliberately — the third time
+  this log has broken its own ≥2-recurrence bar (cf. the #398 release build and
+  the #357 adversarial-drop rule). In #404 the capture phase ran first and
+  committed a `tmdb-api-notes.md` entry whose whole argument was that
+  `Company.Parent` did **not** need an empty-string guard. The next phase's
+  independent grader then failed AC6 precisely because `Company.Parent` threw
+  on an empty string, the design changed, and the just-committed entry had to
+  be rewritten inside the same delivery. Capture records what was decided;
+  running it before the last gate that can *change* the decision guarantees the
+  occasional rewrite — and risks shipping a knowledge entry that contradicts
+  the code it describes, which is the exact decay #403 had just finished
+  cleaning out of the base.
+- **Decision:** **applied.** Swapped the two phases in
+  `.claude/skills/deliver/SKILL.md`: **Phase 6 is now Rubric verification** and
+  **Phase 7 is Capture learnings**, with the header diagram, the four
+  cross-references, and `references/auto-and-async.md` updated to match. Phase 7
+  gains one sentence stating *why* it runs after the gate. Ordering is the only
+  change — neither phase's content or contract is otherwise altered.
+- **Rationale:** free to do, and it removes a whole class of rework rather than
+  the one instance. Capture is the pipeline's memory; it should observe the
+  final state of the delivery, not an intermediate one. Waiting for a second
+  occurrence would mean knowingly shipping another self-contradicting entry to
+  earn evidence already in hand.
+- **Reconsider when:** n/a (applied). Note for readers of older entries: retros
+  and log entries before 2026-07-28 refer to capture as "Phase 6" and grading as
+  "Phase 7" — that was the numbering at the time.
+
 ### 2026-07-25 — `/deliver` Phase 3 must run a release build before declaring done (#398) · applied
 
 - **Pattern:** a **single** occurrence, not a recurrence — logged deliberately.


### PR DESCRIPTION
## Summary

Swaps `/deliver` **Phase 6** and **Phase 7**: rubric verification now runs
*before* `/capture-knowledge`, not after.

This came out of #404's retrospective. There, capture ran first and committed a
`tmdb-api-notes.md` entry whose entire argument was that `Company.Parent` did
**not** need an empty-string guard. The independent grader then failed AC6 for
exactly that reason, the design changed, and the just-committed entry had to be
rewritten inside the same delivery.

The failure mode is structural, not a one-off: capture records *what was
decided*, so running it before the last gate that can **change** the decision
guarantees the occasional rewrite — and risks shipping a knowledge entry that
contradicts the code it describes. That is precisely the decay #403 had just
finished clearing out of the base, reintroduced by the pipeline's own ordering.

## Changes

**Skill:**

- 🔧 `.claude/skills/deliver/SKILL.md` — Phase 6 is now *Rubric verification
  (exit gate)*, Phase 7 is *Capture learnings*. The header diagram, the four
  cross-references (`Phase 6 curates them`, `Phase 7 above`, `consumed in Phase
  7`, `Phase 7 no-ops`) and `references/auto-and-async.md` all follow.
- 🔧 Phase 7 gains one sentence saying *why* it now runs after the gate, so the
  ordering is self-documenting rather than incidental.

**Ordering is the only change** — neither phase's content, contract, weight
split, or `swept:` requirement is otherwise altered.

**Documentation:**

- 📚 Decision recorded in `knowledge/skill-improvement-log.md` in the five-field
  format, including a note that retros and log entries dated before 2026-07-28
  refer to capture as "Phase 6" and grading as "Phase 7" — that was the
  numbering at the time.

## Notes for review

- **Single occurrence, logged deliberately.** This is the third time the log has
  broken its own ≥2-recurrence bar, and for the same reason as the other two
  (#398's release-build checkpoint, #357's adversarial-drop rule): the fix is
  free, and the failure class is already evidenced. Waiting for a second
  incident would mean knowingly shipping another self-contradicting entry to
  earn evidence we already have.
- `CLAUDE.md`'s pipeline summary is deliberately untouched — it lists the
  *skills* invoked, and the rubric grade is not a skill, so it remains accurate.

Docs/config only — no Swift, so the code-review and security gates self-skip and
the local gate is `make lint-markdown` (passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013buB3reHTt1iq66zEtZGhq