### PR TITLE
🔧 Prepare the 19.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      knowledge/next-major.md first — it lists approved breaking changes
      waiting for exactly this bump. Ship them or consciously re-defer. -->
 
-## [19.0.0] - 2026-07-28
+## [19.0.0] - 2026-07-29
 
 ### Added
 
@@ -164,6 +164,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `PersonService.personChanges(startDate:endDate:page:)` — use
   `PersonService.changes(startDate:endDate:page:)` instead.
 
+[19.0.0]: https://github.com/adamayoung/TMDb/releases/tag/19.0.0
+[18.2.0]: https://github.com/adamayoung/TMDb/releases/tag/18.2.0
 [18.1.0]: https://github.com/adamayoung/TMDb/releases/tag/18.1.0
 [18.0.1]: https://github.com/adamayoung/TMDb/releases/tag/18.0.1
 [18.0.0]: https://github.com/adamayoung/TMDb/releases/tag/18.0.0

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ let package = Package(
   name: "MyProject",
 
   dependencies: [
-    .package(url: "https://github.com/adamayoung/TMDb.git", from: "18.0.0")
+    .package(url: "https://github.com/adamayoung/TMDb.git", from: "19.0.0")
   ],
 
   targets: [

--- a/knowledge/decisions/0006-tmdbtesting-public-target.md
+++ b/knowledge/decisions/0006-tmdbtesting-public-target.md
@@ -5,7 +5,7 @@
 - **Deciders:** Adam Young
 
 > **Amended in part by [ADR-0010](0010-tmdb-intelligence-product.md)
-> (2026-07-06, in the unreleased 19.0.0).** The decision below still holds for the
+> (2026-07-06, shipped in 19.0.0).** The decision below still holds for the
 > `TMDb` service mocks, but the natural-language-search doubles it describes
 > (`MockNaturalLanguageSearchService`, `SearchPlan.sample`) no longer ship in
 > `TMDbTesting` — they moved to the `TMDbIntelligenceTesting` product when the

--- a/knowledge/decisions/0010-tmdb-intelligence-product.md
+++ b/knowledge/decisions/0010-tmdb-intelligence-product.md
@@ -1,6 +1,6 @@
 # ADR-0010: Extract on-device intelligence into a `TMDbIntelligence` product
 
-- **Status:** Accepted (in 19.0.0, unreleased)
+- **Status:** Accepted (shipped in 19.0.0)
 - **Date:** 2026-07-06
 - **Deciders:** Adam Young
 

--- a/knowledge/decisions/0011-duration-for-runtime.md
+++ b/knowledge/decisions/0011-duration-for-runtime.md
@@ -1,6 +1,6 @@
 # ADR-0011: Represent runtimes as `Duration`, bridging integer minutes at the wire boundary
 
-- **Status:** Accepted (in 19.0.0, unreleased)
+- **Status:** Accepted (shipped in 19.0.0)
 - **Date:** 2026-07-24
 - **Deciders:** Adam Young (with Claude Code)
 

--- a/knowledge/decisions/0012-structured-tmdberror-context.md
+++ b/knowledge/decisions/0012-structured-tmdberror-context.md
@@ -1,6 +1,6 @@
 # ADR-0012: Enrich `TMDbError` with structured context
 
-- **Status:** Accepted (in 19.0.0, unreleased)
+- **Status:** Accepted (shipped in 19.0.0)
 - **Date:** 2026-07-24
 - **Deciders:** Adam Young
 

--- a/knowledge/decisions/0013-cached-image-url-resolver.md
+++ b/knowledge/decisions/0013-cached-image-url-resolver.md
@@ -1,6 +1,6 @@
 # ADR-0013: Cache the image configuration in an actor behind `client.images`
 
-- **Status:** Accepted (in 19.0.0, unreleased)
+- **Status:** Accepted (shipped in 19.0.0)
 - **Date:** 2026-07-27
 - **Deciders:** Adam Young
 

--- a/knowledge/decisions/README.md
+++ b/knowledge/decisions/README.md
@@ -27,10 +27,10 @@ always fair game.
 | [0007](0007-document-existing-response-caching.md) | Document existing response caching instead of building a custom on-disk cache | 2026-06-24 | Accepted |
 | [0008](0008-percent-encode-url-path-segments.md) | Percent-encode user-supplied URL path segments with the RFC 3986 unreserved set | 2026-06-24 | Accepted |
 | [0009](0009-github-mcp-over-gh-cli.md) | Use the GitHub MCP (not the `gh` CLI) in the local skills | 2026-06-25 | Accepted |
-| [0010](0010-tmdb-intelligence-product.md) | Extract on-device intelligence into a `TMDbIntelligence` product | 2026-07-06 | Accepted (in 19.0.0, unreleased) |
-| [0011](0011-duration-for-runtime.md) | Represent runtimes as `Duration`, bridging integer minutes at the wire boundary | 2026-07-24 | Accepted (in 19.0.0, unreleased) |
-| [0012](0012-structured-tmdberror-context.md) | Enrich `TMDbError` with structured context | 2026-07-24 | Accepted (in 19.0.0, unreleased) |
-| [0013](0013-cached-image-url-resolver.md) | Cache the image configuration in an actor behind `client.images` | 2026-07-27 | Accepted (in 19.0.0, unreleased) |
+| [0010](0010-tmdb-intelligence-product.md) | Extract on-device intelligence into a `TMDbIntelligence` product | 2026-07-06 | Accepted (shipped in 19.0.0) |
+| [0011](0011-duration-for-runtime.md) | Represent runtimes as `Duration`, bridging integer minutes at the wire boundary | 2026-07-24 | Accepted (shipped in 19.0.0) |
+| [0012](0012-structured-tmdberror-context.md) | Enrich `TMDbError` with structured context | 2026-07-24 | Accepted (shipped in 19.0.0) |
+| [0013](0013-cached-image-url-resolver.md) | Cache the image configuration in an actor behind `client.images` | 2026-07-27 | Accepted (shipped in 19.0.0) |
 | [0014](0014-subagent-model-tiers.md) | Model-tier policy for skills and subagents | 2026-07-06 | Accepted |
 
 > **Keep the Status column true.** "In X, unreleased" becomes "shipped in X" when

--- a/knowledge/next-major.md
+++ b/knowledge/next-major.md
@@ -13,15 +13,11 @@ deferred *because* it is breaking. **Remove an entry when it ships** (the
 CHANGELOG records it) or is rejected outright (record that in
 `skill-improvement-log.md`).
 
-> **Status as of 2026-07-28: 19.0.0 is assembled but *not tagged*** — the
-> newest tag is `18.2.0` while `CHANGELOG.md` already carries a `[19.0.0]`
-> section. Everything below is therefore **still eligible for 19.0.0**, not
-> deferred to 20.0.0. That call is the maintainer's; this note exists so it is
-> made deliberately rather than by the window closing unnoticed a second time.
->
-> **First use of this file worked:** the `Company.logoPath` fix shipped into the
-> 19.0.0 window on 2026-07-28 because this queue was read, one day after it was
-> written. Remove the status note once 19.0.0 is tagged.
+> **This file has earned its keep once.** It was written on 2026-07-27 and read
+> on 2026-07-28, while 19.0.0 was assembled but still untagged — which is the
+> only reason the `Company.logoPath` decode bug (#404) made that release instead
+> of waiting for 20.0.0. The next window is **20.0.0**; everything below is
+> queued for it.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

Pre-tag housekeeping for 19.0.0. All four items must land **before** the tag,
because a tag snapshots the tree — anything the repo says about 19.0.0 at that
commit is frozen into it permanently.

## Changes

**The one with user impact:**

- 🔧 `README.md` — the install snippet said `from: "18.0.0"`. SemVer resolves
  that to `>=18.0.0, <19.0.0`, so **anyone following the README would not have
  resolved to 19.0.0 at all**. Now `from: "19.0.0"`.

**Release record:**

- 📝 `CHANGELOG.md` — date the `[19.0.0]` section `2026-07-29`, and add the
  missing release link definitions for `[19.0.0]` **and** `[18.2.0]`. The
  version headings use reference-link syntax, but only `18.1.0` / `18.0.1` /
  `18.0.0` had definitions — 18.2.0's was missed last release too, so both were
  rendering as literal brackets.

**Metadata the tag would otherwise freeze as wrong:**

- 📝 `knowledge/next-major.md` — drop the *"19.0.0 is assembled but **not
  tagged**"* status note. Left in place, the tagged tree would insist 19.0.0 is
  unreleased. Replaced with the durable point: the file was written on 07-27 and
  read on 07-28, which is the only reason #404's decode bug made this release
  rather than waiting for 20.0.0. Next window is 20.0.0.
- 📝 ADRs **0010**, **0011**, **0012**, **0013** and ADR-0006's amendment note
  move from *"in 19.0.0, unreleased"* to *"shipped in 19.0.0"*, in both the ADR
  files and the `decisions/README.md` index.

The policy statements that *explain* the unreleased/shipped distinction
(`knowledge/README.md`, `decisions/README.md` footer) are deliberately left
alone — those are the rule, not a stale status.

## Verified, no action needed

- **Platform requirements unchanged** — macOS 13 / iOS 16 / watchOS 9 / tvOS 16
  / visionOS 1, swift-tools 6.0. #396 touched `Package.swift` but was CI-only,
  so there is no requirement change to document.
- **The CHANGELOG covers every user-facing commit** since `18.2.0`
  (`TMDbError` context, `TMDbIntelligence`, `Duration` runtimes, `client.images`,
  Company nullability). The other ten commits are tooling, skills and docs.
- **No workflow triggers on a tag push** — `documentation.yml` is
  branch/PR-triggered, so tagging starts nothing that needs watching.

Docs-only — no Swift, so the code-review and security gates self-skip; local
gate is `make lint-markdown` (passing).

**After this merges:** tag `19.0.0` on `main` and publish the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013buB3reHTt1iq66zEtZGhq