### PR TITLE
✨ Add TMDb v4 list support

### DIFF
--- a/.github/CODE_REVIEW.md
+++ b/.github/CODE_REVIEW.md
@@ -57,7 +57,7 @@ inflate nitpicks to Critical.
 - A **library** (not an app) — no UI frameworks. Swift 6.0+ strict concurrency.
   No external dependencies (stdlib + Foundation only).
 - Platforms: iOS 16+, macOS 13+, watchOS 9+, tvOS 16+, visionOS 1+, Linux.
-- **27 services** behind `TMDbClient`, each a public `protocol` + an internal
+- **28 services** behind `TMDbClient`, each a public `protocol` + an internal
   `TMDb`-prefixed implementation; the `naturalLanguageSearch` service is Apple-only.
 - **Networking decorator chain:**
 

--- a/.github/workflows/integration-failure.yml
+++ b/.github/workflows/integration-failure.yml
@@ -125,6 +125,8 @@ jobs:
           TMDB_PASSWORD: ${{ secrets.TMDB_PASSWORD }}
           TMDB_API_READ_ONLY_TOKEN: ${{ secrets.TMDB_API_READ_ONLY_TOKEN }}
           TMDB_API_USER_TOKEN: ${{ secrets.TMDB_API_USER_TOKEN }}
+          # Mounted into the diagnosing agent above, so it can reach its output.
+          SCRUB_PR_TOKEN: ${{ secrets.INTEGRATION_FIX_PR_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           [ -s pr-url.txt ] || { echo "No PR opened — nothing to scrub."; exit 0; }
@@ -147,13 +149,15 @@ jobs:
             # log line, an env dump — which the `[Bb]earer` pattern would miss
             # entirely.
             for v in "${TMDB_API_KEY:-}" "${TMDB_PASSWORD:-}" \
-                     "${TMDB_API_READ_ONLY_TOKEN:-}" "${TMDB_API_USER_TOKEN:-}"; do
+                     "${TMDB_API_READ_ONLY_TOKEN:-}" "${TMDB_API_USER_TOKEN:-}" \
+                     "${SCRUB_PR_TOKEN:-}"; do
               [ -n "$v" ] && text="${text//"$v"/***REDACTED***}"
             done
             printf '%s' "$text" \
               | sed -E 's/(api_key=)[^&"[:space:]]+/\1***REDACTED***/g' \
               | sed -E 's/([Bb]earer )[A-Za-z0-9._-]{16,}/\1***REDACTED***/g' \
-              | sed -E 's/eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+/***REDACTED-JWT***/g'
+              | sed -E 's/eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+/***REDACTED-JWT***/g' \
+              | sed -E 's/(gh[pousr]_|github_pat_)[A-Za-z0-9_]{20,}/***REDACTED-PAT***/g'
           }
 
           BODY=$(gh pr view "$PR_URL" --json body -q .body)
@@ -192,6 +196,8 @@ jobs:
           TMDB_PASSWORD: ${{ secrets.TMDB_PASSWORD }}
           TMDB_API_READ_ONLY_TOKEN: ${{ secrets.TMDB_API_READ_ONLY_TOKEN }}
           TMDB_API_USER_TOKEN: ${{ secrets.TMDB_API_USER_TOKEN }}
+          # Mounted into the diagnosing agent above, so it can reach its output.
+          SCRUB_PR_TOKEN: ${{ secrets.INTEGRATION_FIX_PR_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -222,13 +228,15 @@ jobs:
             # log line, an env dump — which the `[Bb]earer` pattern would miss
             # entirely.
             for v in "${TMDB_API_KEY:-}" "${TMDB_PASSWORD:-}" \
-                     "${TMDB_API_READ_ONLY_TOKEN:-}" "${TMDB_API_USER_TOKEN:-}"; do
+                     "${TMDB_API_READ_ONLY_TOKEN:-}" "${TMDB_API_USER_TOKEN:-}" \
+                     "${SCRUB_PR_TOKEN:-}"; do
               [ -n "$v" ] && text="${text//"$v"/***REDACTED***}"
             done
             printf '%s' "$text" \
               | sed -E 's/(api_key=)[^&"[:space:]]+/\1***REDACTED***/g' \
               | sed -E 's/([Bb]earer )[A-Za-z0-9._-]{16,}/\1***REDACTED***/g' \
-              | sed -E 's/eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+/***REDACTED-JWT***/g'
+              | sed -E 's/eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+/***REDACTED-JWT***/g' \
+              | sed -E 's/(gh[pousr]_|github_pat_)[A-Za-z0-9_]{20,}/***REDACTED-PAT***/g'
           }
 
           # Pull in Claude's analysis if it produced one; otherwise fall back.

--- a/.github/workflows/integration-failure.yml
+++ b/.github/workflows/integration-failure.yml
@@ -87,6 +87,8 @@ jobs:
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
           TMDB_USERNAME: ${{ secrets.TMDB_USERNAME }}
           TMDB_PASSWORD: ${{ secrets.TMDB_PASSWORD }}
+          TMDB_API_READ_ONLY_TOKEN: ${{ secrets.TMDB_API_READ_ONLY_TOKEN }}
+          TMDB_API_USER_TOKEN: ${{ secrets.TMDB_API_USER_TOKEN }}
           # git push + `gh pr create` use this token (PAT so the PR triggers CI).
           GH_TOKEN: ${{ secrets.INTEGRATION_FIX_PR_TOKEN || secrets.GITHUB_TOKEN }}
         with:
@@ -121,6 +123,8 @@ jobs:
           GH_PAGER: cat
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
           TMDB_PASSWORD: ${{ secrets.TMDB_PASSWORD }}
+          TMDB_API_READ_ONLY_TOKEN: ${{ secrets.TMDB_API_READ_ONLY_TOKEN }}
+          TMDB_API_USER_TOKEN: ${{ secrets.TMDB_API_USER_TOKEN }}
         run: |
           set -euo pipefail
           [ -s pr-url.txt ] || { echo "No PR opened — nothing to scrub."; exit 0; }
@@ -130,18 +134,26 @@ jobs:
           # metacharacters in a secret are handled), then the generic patterns.
           redact() {
             local text="$1" v
-            # API key and password only. The USERNAME is deliberately NOT
-            # literal-substituted: it is low-sensitivity, and if it equals the
-            # GitHub handle every `github.com/<handle>/TMDb/pull/N` link in the
-            # alert would be rewritten to a dead one and a false ::warning::
-            # raised on every run. The api_key=/Bearer patterns below still
-            # cover it wherever it appears as a credential.
-            for v in "${TMDB_API_KEY:-}" "${TMDB_PASSWORD:-}"; do
+            # Every high-value secret: the API key, the password, and the two
+            # v4 tokens. The USERNAME is deliberately NOT literal-substituted:
+            # it is low-sensitivity, and if it equals the GitHub handle every
+            # `github.com/<handle>/TMDb/pull/N` link in the alert would be
+            # rewritten to a dead one and a false ::warning:: raised on every
+            # run. The patterns below still cover it wherever it appears as a
+            # credential.
+            #
+            # The bare-JWT pattern matters because the v4 tokens are JWTs that
+            # an agent may quote WITHOUT a `Bearer ` prefix — in a curl body, a
+            # log line, an env dump — which the `[Bb]earer` pattern would miss
+            # entirely.
+            for v in "${TMDB_API_KEY:-}" "${TMDB_PASSWORD:-}" \
+                     "${TMDB_API_READ_ONLY_TOKEN:-}" "${TMDB_API_USER_TOKEN:-}"; do
               [ -n "$v" ] && text="${text//"$v"/***REDACTED***}"
             done
             printf '%s' "$text" \
               | sed -E 's/(api_key=)[^&"[:space:]]+/\1***REDACTED***/g' \
-              | sed -E 's/([Bb]earer )[A-Za-z0-9._-]{16,}/\1***REDACTED***/g'
+              | sed -E 's/([Bb]earer )[A-Za-z0-9._-]{16,}/\1***REDACTED***/g' \
+              | sed -E 's/eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+/***REDACTED-JWT***/g'
           }
 
           BODY=$(gh pr view "$PR_URL" --json body -q .body)
@@ -178,6 +190,8 @@ jobs:
           # into the diagnosing agent, so all three can appear in its output.
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
           TMDB_PASSWORD: ${{ secrets.TMDB_PASSWORD }}
+          TMDB_API_READ_ONLY_TOKEN: ${{ secrets.TMDB_API_READ_ONLY_TOKEN }}
+          TMDB_API_USER_TOKEN: ${{ secrets.TMDB_API_USER_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -195,18 +209,26 @@ jobs:
           # also covers a key that never came from this secret.
           redact() {
             local text="$1" v
-            # API key and password only. The USERNAME is deliberately NOT
-            # literal-substituted: it is low-sensitivity, and if it equals the
-            # GitHub handle every `github.com/<handle>/TMDb/pull/N` link in the
-            # alert would be rewritten to a dead one and a false ::warning::
-            # raised on every run. The api_key=/Bearer patterns below still
-            # cover it wherever it appears as a credential.
-            for v in "${TMDB_API_KEY:-}" "${TMDB_PASSWORD:-}"; do
+            # Every high-value secret: the API key, the password, and the two
+            # v4 tokens. The USERNAME is deliberately NOT literal-substituted:
+            # it is low-sensitivity, and if it equals the GitHub handle every
+            # `github.com/<handle>/TMDb/pull/N` link in the alert would be
+            # rewritten to a dead one and a false ::warning:: raised on every
+            # run. The patterns below still cover it wherever it appears as a
+            # credential.
+            #
+            # The bare-JWT pattern matters because the v4 tokens are JWTs that
+            # an agent may quote WITHOUT a `Bearer ` prefix — in a curl body, a
+            # log line, an env dump — which the `[Bb]earer` pattern would miss
+            # entirely.
+            for v in "${TMDB_API_KEY:-}" "${TMDB_PASSWORD:-}" \
+                     "${TMDB_API_READ_ONLY_TOKEN:-}" "${TMDB_API_USER_TOKEN:-}"; do
               [ -n "$v" ] && text="${text//"$v"/***REDACTED***}"
             done
             printf '%s' "$text" \
               | sed -E 's/(api_key=)[^&"[:space:]]+/\1***REDACTED***/g' \
-              | sed -E 's/([Bb]earer )[A-Za-z0-9._-]{16,}/\1***REDACTED***/g'
+              | sed -E 's/([Bb]earer )[A-Za-z0-9._-]{16,}/\1***REDACTED***/g' \
+              | sed -E 's/eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+/***REDACTED-JWT***/g'
           }
 
           # Pull in Claude's analysis if it produced one; otherwise fall back.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -97,6 +97,11 @@ jobs:
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
           TMDB_USERNAME: ${{ secrets.TMDB_USERNAME }}
           TMDB_PASSWORD: ${{ secrets.TMDB_PASSWORD }}
+          # The v4 suites need two further credentials: the application's API
+          # Read Access Token, and a *user* access token for anything touching
+          # a user's lists. Absent either, those suites skip rather than fail.
+          TMDB_API_READ_ONLY_TOKEN: ${{ secrets.TMDB_API_READ_ONLY_TOKEN }}
+          TMDB_API_USER_TOKEN: ${{ secrets.TMDB_API_USER_TOKEN }}
 
       - name: Upload test results to Codecov
         if: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   supply your own `HTTPClient` **and** switch exhaustively over the method — add
   a `.put` branch, or a `default`.
 
-- **Breaking:** `HTTPRequest` gains `isUserSpecific`. It is `true` when a
-  request required a specific user's credential — a v4 access token, a v3
-  `session_id`, or a guest session. **A custom `HTTPClient` must not cache,
-  store or log such a response.** The memberwise initialiser takes it last with
-  a default of `false`, so existing construction still compiles.
+- `HTTPRequest` gains `isUserSpecific`. It is `true` when a request required a
+  specific user's credential — a v4 access token, a v3 `session_id`, or a guest
+  session. **A custom `HTTPClient` must not cache, store or log such a
+  response.** This is source-compatible: it is a new property with a defaulted
+  trailing initialiser parameter, so nothing needs changing to compile — but a
+  custom `HTTPClient` should be updated to honour it.
 
 - A request that carries its own `Authorization` header now suppresses the
   client credential entirely, rather than having it overwritten. Without this a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [20.0.0]
 
+### Added
+
+- `client.v4Lists` — TMDb v4 lists. Unlike the v3 `client.lists`, a v4 list
+  holds **movies and TV series together**, can be private, and can carry a
+  comment on each item. All eleven operations are covered: reading a list and
+  its items, checking whether an item is present, listing an account's lists,
+  creating, updating, adding, commenting, removing, clearing and deleting.
+
+  Reading a public list needs no user credential; everything else takes an
+  access token from `client.v4Authentication`. Adds `V4ListService` and its
+  models, plus `MockV4ListService` and samples in `TMDbTesting`. See the
+  *Authenticating with the v4 API* article.
+
+### Changed
+
+- **Breaking:** `HTTPRequest.Method` gains a `.put` case. v4 list update is a
+  PUT and there is no other way to express it. This only affects you if you
+  supply your own `HTTPClient` **and** switch exhaustively over the method — add
+  a `.put` branch, or a `default`.
+
+- **Breaking:** `HTTPRequest` gains `isUserSpecific`. It is `true` when a
+  request required a specific user's credential — a v4 access token, a v3
+  `session_id`, or a guest session. **A custom `HTTPClient` must not cache,
+  store or log such a response.** The memberwise initialiser takes it last with
+  a default of `false`, so existing construction still compiles.
+
+- A request that carries its own `Authorization` header now suppresses the
+  client credential entirely, rather than having it overwritten. Without this a
+  per-call user token never reached the wire, and a user-scoped v4 read returned
+  the *application owner's* data.
+
+- Responses requiring a user's credential are no longer written to, or served
+  from, either cache — the opt-in in-memory cache or the always-on on-disk
+  `URLCache`. This changes behaviour for v3 session and guest-session requests,
+  which were previously stored on disk. Responses authenticated with an
+  application bearer token are unaffected and remain cached.
+
 ### Fixed
 
 - 37 convenience methods on the public service protocols no longer share a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,8 +285,9 @@ scratch directory. Every target accepts an overridable `SCRATCH_PATH`
 
 Run shell commands directly — do not prefix them with
 `source ~/.zshrc`. Required environment variables (`TMDB_API_KEY`,
-`TMDB_USERNAME`, `TMDB_PASSWORD`) are injected via the `env` block in
-`.claude/settings.local.json`, and Homebrew tools (`gh`, `swiftlint`,
+`TMDB_USERNAME`, `TMDB_PASSWORD`) plus the two v4 credentials
+(`TMDB_API_READ_ONLY_TOKEN`, `TMDB_API_USER_TOKEN` — without them the v4 suites
+skip) are injected via the `env` block in `.claude/settings.local.json`, and Homebrew tools (`gh`, `swiftlint`,
 `swiftformat`, `xcsift`, `markdownlint-cli2`) are already on `PATH`.
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,13 +32,14 @@ ADR for any non-obvious design decision.
 ### Service-Based Design
 
 The library uses protocol-based services with dependency injection.
-`TMDbClient` is the main facade exposing 27 service properties:
+`TMDbClient` is the main facade exposing 28 service properties:
 
 ```text
 TMDbClient (main facade)
 ├── AccountService
 ├── AuthenticationService
 ├── V4AuthenticationService
+├── V4ListService
 ├── CertificationService
 ├── ChangesService
 ├── CollectionService

--- a/Makefile
+++ b/Makefile
@@ -118,3 +118,10 @@ ci: .check-env-vars lint lint-markdown test integration-test build-release build
 	@test $${TMDB_API_KEY?Please set environment variable TMDB_API_KEY}
 	@test $${TMDB_USERNAME?Please set environment variable TMDB_USERNAME}
 	@test $${TMDB_PASSWORD?Please set environment variable TMDB_PASSWORD}
+# The v4 credentials warn rather than fail: the suites needing them self-gate
+# with `.enabled(if:)`, so a contributor without them must still be able to run
+# `make ci` to green.
+	@test -n "$${TMDB_API_READ_ONLY_TOKEN:-}" || \
+		echo "warning: TMDB_API_READ_ONLY_TOKEN not set — v4 suites will skip"
+	@test -n "$${TMDB_API_USER_TOKEN:-}" || \
+		echo "warning: TMDB_API_USER_TOKEN not set — v4 list suites will skip"

--- a/README.md
+++ b/README.md
@@ -519,6 +519,15 @@ Integration tests require these environment variables:
 * `TMDB_USERNAME` - Your TMDb username
 * `TMDB_PASSWORD` - Your TMDB password
 
+The v4 suites need two further credentials, and **skip silently** without them:
+
+* `TMDB_API_READ_ONLY_TOKEN` - Your API Read Access Token, from the same TMDb
+  settings page as the API key. This is the *application's* bearer credential —
+  the v4 endpoints reject an API key.
+* `TMDB_API_USER_TOKEN` - A *user* access token, minted through the v4 approval
+  flow (see the *Authenticating with the v4 API* article). Required for anything
+  touching a user's lists.
+
 Running unit tests on Linux requires [Docker](https://www.docker.com) to be running.
 
 ### Claude Code Skills

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
 ## Features
 
 * **Comprehensive API Coverage**: Full support for TMDb API v3, plus v4 user
-  authentication — 27 specialized services and 2 on-device intelligence
+  authentication — 28 specialized services and 2 on-device intelligence
   extensions
 * **Append to Response**: Fetch details with credits, images, videos,
   and more in a single request using `append_to_response`
@@ -68,6 +68,7 @@ A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
 | **account** | User favorites, watchlist, rated items (requires authentication) |
 | **authentication** | Session management, guest sessions, request tokens |
 | **v4Authentication** | TMDb v4 user authentication: request tokens, approval URLs, user access tokens (requires a bearer-token client) |
+| **v4Lists** | TMDb v4 lists: mixed movie/TV lists, private lists, per-item comments |
 | **genres** | Genre lists for movies and TV shows |
 | **keywords** | Keyword details and movies by keyword |
 | **networks** | TV network details, alternative names, logos |

--- a/Sources/TMDb/Adapters/URLSessionHTTPClientAdapter.swift
+++ b/Sources/TMDb/Adapters/URLSessionHTTPClientAdapter.swift
@@ -15,16 +15,48 @@ final class URLSessionHTTPClientAdapter: HTTPClient, Sendable {
 
     private let urlSession: URLSession
 
+    /// A second session for user-specific requests, with **no** `URLCache`.
+    ///
+    /// The shared session installs a 1 GB on-disk `URLCache` that is
+    /// process-wide, survives relaunch, and keys on URL alone. A v4 list read
+    /// is private to one user yet has the same URL for every user — the token
+    /// is in a header — so its response must never be stored there. Bypassing
+    /// the *policy* alone is not enough: that stops a stale read, not the
+    /// write.
+    ///
+    /// The configuration is **copied from the injected session** rather than
+    /// built fresh, so `protocolClasses`, timeouts and
+    /// `waitsForConnectivity` all carry over — without that, tests injecting a
+    /// `MockURLProtocol` session would silently reach the live network here.
+    private let noCacheURLSession: URLSession
+
     init(urlSession: URLSession) {
         self.urlSession = urlSession
+
+        let configuration = urlSession.configuration
+        configuration.urlCache = nil
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        self.noCacheURLSession = URLSession(configuration: configuration)
     }
 
     func perform(request: HTTPRequest) async throws -> HTTPResponse {
         let urlRequest = Self.urlRequest(from: request)
 
-        let (data, response) = try await perform(urlRequest)
+        let (data, response) = try await perform(urlRequest, using: session(for: request))
 
         return Self.httpResponse(from: data, response: response)
+    }
+
+    ///
+    /// The session a request is sent through.
+    ///
+    /// - Parameter request: The request about to be performed.
+    ///
+    /// - Returns: The cache-free session for a user-specific request, otherwise
+    ///   the shared one.
+    ///
+    func session(for request: HTTPRequest) -> URLSession {
+        request.isUserSpecific ? noCacheURLSession : urlSession
     }
 
 }
@@ -37,6 +69,13 @@ extension URLSessionHTTPClientAdapter {
         urlRequest.httpBody = httpRequest.body
         for header in httpRequest.headers {
             urlRequest.addValue(header.value, forHTTPHeaderField: header.key)
+        }
+
+        if httpRequest.isUserSpecific {
+            // Belt and braces with `noCacheURLSession`: this stops a *stale*
+            // read even if some cache is reachable, while the cache-free
+            // session stops the *write*.
+            urlRequest.cachePolicy = .reloadIgnoringLocalCacheData
         }
 
         return urlRequest
@@ -80,7 +119,10 @@ extension URLSessionHTTPClientAdapter {
             }
         }
 
-        private func perform(_ urlRequest: URLRequest) async throws -> (Data, URLResponse) {
+        private func perform(
+            _ urlRequest: URLRequest,
+            using urlSession: URLSession
+        ) async throws -> (Data, URLResponse) {
             let box = DataTaskBox()
 
             return try await withTaskCancellationHandler {
@@ -115,7 +157,10 @@ extension URLSessionHTTPClientAdapter {
             }
         }
     #else
-        private func perform(_ urlRequest: URLRequest) async throws -> (Data, URLResponse) {
+        private func perform(
+            _ urlRequest: URLRequest,
+            using urlSession: URLSession
+        ) async throws -> (Data, URLResponse) {
             try await urlSession.data(for: urlRequest)
         }
     #endif

--- a/Sources/TMDb/Adapters/URLSessionHTTPClientAdapter.swift
+++ b/Sources/TMDb/Adapters/URLSessionHTTPClientAdapter.swift
@@ -28,12 +28,19 @@ final class URLSessionHTTPClientAdapter: HTTPClient, Sendable {
     /// built fresh, so `protocolClasses`, timeouts and
     /// `waitsForConnectivity` all carry over — without that, tests injecting a
     /// `MockURLProtocol` session would silently reach the live network here.
+    ///
+    /// The `.copy()` is load-bearing on Linux. On Apple platforms
+    /// `URLSession.configuration` is `@NSCopying` and already hands back a
+    /// copy, but swift-corelibs-foundation returns the **stored instance** —
+    /// so mutating it would unhook the `URLCache` from the primary session too,
+    /// disabling caching everywhere.
     private let noCacheURLSession: URLSession
 
     init(urlSession: URLSession) {
         self.urlSession = urlSession
 
-        let configuration = urlSession.configuration
+        let configuration = urlSession.configuration.copy() as? URLSessionConfiguration
+            ?? URLSessionConfiguration.default
         configuration.urlCache = nil
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
         self.noCacheURLSession = URLSession(configuration: configuration)

--- a/Sources/TMDb/Domain/APIClient/APIRequestMethod.swift
+++ b/Sources/TMDb/Domain/APIClient/APIRequestMethod.swift
@@ -11,6 +11,7 @@ package enum APIRequestMethod {
 
     case get
     case post
+    case put
     case delete
 
 }

--- a/Sources/TMDb/Domain/APIClient/APIRequestQueryItem.swift
+++ b/Sources/TMDb/Domain/APIClient/APIRequestQueryItem.swift
@@ -46,6 +46,8 @@ extension APIRequestQueryItem.Name {
     static let sessionID = APIRequestQueryItem.Name("session_id")
     static let language = APIRequestQueryItem.Name("language")
     static let region = APIRequestQueryItem.Name("region")
+    static let mediaID = APIRequestQueryItem.Name("media_id")
+    static let mediaType = APIRequestQueryItem.Name("media_type")
 
     static let withPeople = APIRequestQueryItem.Name("with_people")
     static let withOriginalLanguage = APIRequestQueryItem.Name("with_original_language")

--- a/Sources/TMDb/Domain/Models/FailableDecodable.swift
+++ b/Sources/TMDb/Domain/Models/FailableDecodable.swift
@@ -1,0 +1,32 @@
+//
+//  FailableDecodable.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A decoding wrapper that tolerates a failing element.
+///
+/// Decoding never throws: when the wrapped value cannot be decoded, ``value``
+/// is `nil` and the element is consumed so the surrounding array continues to
+/// decode. This lets a list skip an unrecognised element instead of dropping
+/// the whole page.
+///
+/// - Important: A dropped element is **silent**. Any model using this should
+///   pair it with an assertion reconciling the decoded count against the
+///   count the API reports, or a decoder regression shows up as a quietly
+///   short page rather than a failure.
+///
+struct FailableDecodable<Wrapped: Decodable>: Decodable {
+
+    let value: Wrapped?
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.value = try? container.decode(Wrapped.self)
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/PageableListResult.swift
+++ b/Sources/TMDb/Domain/Models/PageableListResult.swift
@@ -94,22 +94,3 @@ extension PageableListResult {
     }
 
 }
-
-///
-/// A decoding wrapper that tolerates a failing element.
-///
-/// Decoding never throws: when the wrapped value cannot be decoded, ``value``
-/// is `nil` and the element is consumed so the surrounding array continues to
-/// decode. This lets a list skip an unrecognised element instead of dropping
-/// the whole page.
-///
-private struct FailableDecodable<Wrapped: Decodable>: Decodable {
-
-    let value: Wrapped?
-
-    init(from decoder: any Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        self.value = try? container.decode(Wrapped.self)
-    }
-
-}

--- a/Sources/TMDb/Domain/Models/V4ClearListResult.swift
+++ b/Sources/TMDb/Domain/Models/V4ClearListResult.swift
@@ -1,0 +1,44 @@
+//
+//  V4ClearListResult.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A model representing the result of clearing a v4 list.
+///
+public struct V4ClearListResult: Codable, Equatable, Hashable, Sendable {
+
+    ///
+    /// Whether the list was cleared.
+    ///
+    public let success: Bool
+
+    ///
+    /// The identifier of the list that was cleared.
+    ///
+    public let id: Int
+
+    ///
+    /// How many items were removed.
+    ///
+    public let itemsDeleted: Int
+
+    ///
+    /// Creates a clear-list result.
+    ///
+    /// - Parameters:
+    ///    - success: Whether the list was cleared.
+    ///    - id: The identifier of the list that was cleared.
+    ///    - itemsDeleted: How many items were removed.
+    ///
+    public init(success: Bool, id: Int, itemsDeleted: Int) {
+        self.success = success
+        self.id = id
+        self.itemsDeleted = itemsDeleted
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/V4CreateListResult.swift
+++ b/Sources/TMDb/Domain/Models/V4CreateListResult.swift
@@ -1,0 +1,40 @@
+//
+//  V4CreateListResult.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A model representing the result of creating a v4 list.
+///
+public struct V4CreateListResult: Codable, Equatable, Hashable, Sendable {
+
+    ///
+    /// Whether the list was created.
+    ///
+    public let success: Bool
+
+    ///
+    /// The identifier of the new list.
+    ///
+    /// - Note: v4 returns this as `id`, where the v3 create endpoint returns
+    ///   `list_id`.
+    ///
+    public let id: Int
+
+    ///
+    /// Creates a create-list result.
+    ///
+    /// - Parameters:
+    ///    - success: Whether the list was created.
+    ///    - id: The identifier of the new list.
+    ///
+    public init(success: Bool, id: Int) {
+        self.success = success
+        self.id = id
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/V4List.swift
+++ b/Sources/TMDb/Domain/Models/V4List.swift
@@ -209,8 +209,12 @@ extension V4List {
     /// each comment is matched back onto its item here.
     ///
     /// Items decode tolerantly: one the library cannot model is skipped rather
-    /// than failing the whole page. Compare ``items``.count against
-    /// ``itemCount`` if you need to detect that.
+    /// than failing the whole page.
+    ///
+    /// - Important: A skipped item is **not detectable** from this type.
+    ///   ``itemCount`` is the size of the whole list across every page, not of
+    ///   ``items``, so the two differ legitimately whenever the list is longer
+    ///   than a page. They are only comparable for a single-page list.
     ///
     /// - Parameter decoder: The decoder to read data from.
     ///
@@ -223,7 +227,9 @@ extension V4List {
         self.id = try container.decode(Int.self, forKey: .id)
         self.name = try container.decode(String.self, forKey: .name)
         self.description = try container.decodeIfPresent(String.self, forKey: .description)
-        self.isPublic = try container.decodeIfPresent(Bool.self, forKey: .isPublic) ?? true
+        // Absent visibility defaults to *private*: for a privacy flag the safe
+        // failure direction is the restrictive one.
+        self.isPublic = try container.decodeIfPresent(Bool.self, forKey: .isPublic) ?? false
         self.createdBy = try container.decode(V4ListCreator.self, forKey: .createdBy)
         self.itemCount = try container.decodeIfPresent(Int.self, forKey: .itemCount) ?? 0
         self.averageRating = try container.decodeIfPresent(Double.self, forKey: .averageRating) ?? 0

--- a/Sources/TMDb/Domain/Models/V4List.swift
+++ b/Sources/TMDb/Domain/Models/V4List.swift
@@ -1,0 +1,314 @@
+//
+//  V4List.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A model representing a v4 list — a user-created list that can hold both
+/// movies and TV series.
+///
+public struct V4List: Identifiable, Codable, Equatable, Hashable, Sendable {
+
+    ///
+    /// List identifier.
+    ///
+    public let id: Int
+
+    ///
+    /// List name.
+    ///
+    public let name: String
+
+    ///
+    /// List description.
+    ///
+    public let description: String?
+
+    ///
+    /// Whether the list is visible to everyone.
+    ///
+    public let isPublic: Bool
+
+    ///
+    /// The user who created the list.
+    ///
+    public let createdBy: V4ListCreator
+
+    ///
+    /// The items on this page of the list.
+    ///
+    /// Named for symmetry with `MediaList.items`; TMDb sends it as `results`.
+    ///
+    public let items: [V4ListItem]
+
+    ///
+    /// Number of items in the whole list, across every page.
+    ///
+    public let itemCount: Int
+
+    ///
+    /// Average rating of the list's items.
+    ///
+    public let averageRating: Double
+
+    ///
+    /// Combined runtime of the list's items, in minutes.
+    ///
+    public let runtime: Int
+
+    ///
+    /// Combined revenue of the list's items.
+    ///
+    public let revenue: Int
+
+    ///
+    /// The order the list is sorted in, as TMDb reports it, e.g.
+    /// `original_order.asc`.
+    ///
+    /// - Note: This is the raw value rather than a ``V4ListSortBy``. The v4 API
+    ///   reports the sort order as a *string* here but as an *integer* on
+    ///   ``V4ListSummary``, and publishes no mapping between the two — so
+    ///   decoding either into a shared type would be inventing a contract.
+    ///
+    public let sortBy: String
+
+    ///
+    /// ISO 639-1 language code.
+    ///
+    public let languageCode: String
+
+    ///
+    /// ISO 3166-1 country code.
+    ///
+    public let countryCode: String
+
+    ///
+    /// Path to the list's backdrop image.
+    ///
+    public let backdropPath: URL?
+
+    ///
+    /// Path to the list's poster image.
+    ///
+    public let posterPath: URL?
+
+    ///
+    /// Page number.
+    ///
+    public let page: Int
+
+    ///
+    /// Total number of pages.
+    ///
+    public let totalPages: Int
+
+    ///
+    /// Total number of results.
+    ///
+    public let totalResults: Int
+
+    ///
+    /// Creates a v4 list object.
+    ///
+    /// - Parameters:
+    ///    - id: List identifier.
+    ///    - name: List name.
+    ///    - description: List description.
+    ///    - isPublic: Whether the list is visible to everyone.
+    ///    - createdBy: The user who created the list.
+    ///    - items: The items on this page of the list.
+    ///    - itemCount: Number of items in the whole list.
+    ///    - averageRating: Average rating of the list's items.
+    ///    - runtime: Combined runtime of the list's items, in minutes.
+    ///    - revenue: Combined revenue of the list's items.
+    ///    - sortBy: The order the list is sorted in, as TMDb reports it.
+    ///    - languageCode: ISO 639-1 language code.
+    ///    - countryCode: ISO 3166-1 country code.
+    ///    - backdropPath: Path to the list's backdrop image.
+    ///    - posterPath: Path to the list's poster image.
+    ///    - page: Page number.
+    ///    - totalPages: Total number of pages.
+    ///    - totalResults: Total number of results.
+    ///
+    public init(
+        id: Int,
+        name: String,
+        description: String? = nil,
+        isPublic: Bool,
+        createdBy: V4ListCreator,
+        items: [V4ListItem] = [],
+        itemCount: Int,
+        averageRating: Double = 0,
+        runtime: Int = 0,
+        revenue: Int = 0,
+        sortBy: String,
+        languageCode: String,
+        countryCode: String,
+        backdropPath: URL? = nil,
+        posterPath: URL? = nil,
+        page: Int = 1,
+        totalPages: Int = 1,
+        totalResults: Int = 0
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.isPublic = isPublic
+        self.createdBy = createdBy
+        self.items = items
+        self.itemCount = itemCount
+        self.averageRating = averageRating
+        self.runtime = runtime
+        self.revenue = revenue
+        self.sortBy = sortBy
+        self.languageCode = languageCode
+        self.countryCode = countryCode
+        self.backdropPath = backdropPath
+        self.posterPath = posterPath
+        self.page = page
+        self.totalPages = totalPages
+        self.totalResults = totalResults
+    }
+
+}
+
+extension V4List {
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case description
+        case isPublic = "public"
+        case createdBy
+        case items = "results"
+        case itemCount
+        case averageRating
+        case runtime
+        case revenue
+        case sortBy
+        case languageCode = "iso6391"
+        case countryCode = "iso31661"
+        case backdropPath
+        case posterPath
+        case page
+        case totalPages
+        case totalResults
+        case comments
+    }
+
+    ///
+    /// Creates a v4 list by decoding from the given decoder.
+    ///
+    /// Item comments are **not** sent alongside the items. TMDb sends a
+    /// separate top-level `comments` dictionary keyed by `"<media_type>:<id>"`
+    /// — for example `"movie:550"` or `"tv:1399"` — with nullable values, so
+    /// each comment is matched back onto its item here.
+    ///
+    /// Items decode tolerantly: one the library cannot model is skipped rather
+    /// than failing the whole page. Compare ``items``.count against
+    /// ``itemCount`` if you need to detect that.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    ///
+    /// - Throws: An error if reading from the decoder fails, or if the data is
+    ///   corrupted or otherwise invalid.
+    ///
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.id = try container.decode(Int.self, forKey: .id)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.description = try container.decodeIfPresent(String.self, forKey: .description)
+        self.isPublic = try container.decodeIfPresent(Bool.self, forKey: .isPublic) ?? true
+        self.createdBy = try container.decode(V4ListCreator.self, forKey: .createdBy)
+        self.itemCount = try container.decodeIfPresent(Int.self, forKey: .itemCount) ?? 0
+        self.averageRating = try container.decodeIfPresent(Double.self, forKey: .averageRating) ?? 0
+        self.runtime = try container.decodeIfPresent(Int.self, forKey: .runtime) ?? 0
+        self.revenue = try container.decodeIfPresent(Int.self, forKey: .revenue) ?? 0
+        self.sortBy = try container.decodeIfPresent(String.self, forKey: .sortBy)
+            ?? V4ListSortBy.originalOrder().description
+        self.languageCode = try container.decodeIfPresent(String.self, forKey: .languageCode) ?? ""
+        self.countryCode = try container.decodeIfPresent(String.self, forKey: .countryCode) ?? ""
+        self.backdropPath = try container.decodeIfPresent(URL.self, forKey: .backdropPath)
+        self.posterPath = try container.decodeIfPresent(URL.self, forKey: .posterPath)
+        self.page = try container.decodeIfPresent(Int.self, forKey: .page) ?? 1
+        self.totalPages = try container.decodeIfPresent(Int.self, forKey: .totalPages) ?? 1
+        self.totalResults = try container.decodeIfPresent(Int.self, forKey: .totalResults) ?? 0
+
+        let wrapped = try container.decodeIfPresent(
+            [FailableDecodable<Show>].self,
+            forKey: .items
+        )
+        let media = (wrapped ?? []).compactMap(\.value)
+        let comments = try container.decodeIfPresent(
+            [String: String?].self,
+            forKey: .comments
+        ) ?? [:]
+
+        self.items = media.map { show in
+            V4ListItem(media: show, comment: comments[Self.commentKey(for: show)] ?? nil)
+        }
+    }
+
+    ///
+    /// Encodes this value into the given encoder.
+    ///
+    /// Item comments are written back into the top-level `comments` dictionary,
+    /// in the `"<media_type>:<id>"` shape TMDb sends, so a decode/encode round
+    /// trip preserves them.
+    ///
+    /// - Parameter encoder: The encoder to write data to.
+    ///
+    /// - Throws: An error if any values are invalid for the given encoder's
+    ///   format.
+    ///
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(description, forKey: .description)
+        try container.encode(isPublic, forKey: .isPublic)
+        try container.encode(createdBy, forKey: .createdBy)
+        // Encode the items, not their media: `V4ListItem` adds the `media_type`
+        // discriminator that `Show` does not write, and without it the items
+        // cannot be decoded back.
+        try container.encode(items, forKey: .items)
+        try container.encode(itemCount, forKey: .itemCount)
+        try container.encode(averageRating, forKey: .averageRating)
+        try container.encode(runtime, forKey: .runtime)
+        try container.encode(revenue, forKey: .revenue)
+        try container.encode(sortBy, forKey: .sortBy)
+        try container.encode(languageCode, forKey: .languageCode)
+        try container.encode(countryCode, forKey: .countryCode)
+        try container.encodeIfPresent(backdropPath, forKey: .backdropPath)
+        try container.encodeIfPresent(posterPath, forKey: .posterPath)
+        try container.encode(page, forKey: .page)
+        try container.encode(totalPages, forKey: .totalPages)
+        try container.encode(totalResults, forKey: .totalResults)
+
+        let comments = items.reduce(into: [String: String?]()) { result, item in
+            guard let comment = item.comment else {
+                return
+            }
+            result[Self.commentKey(for: item.media)] = comment
+        }
+        if !comments.isEmpty {
+            try container.encode(comments, forKey: .comments)
+        }
+    }
+
+    private static func commentKey(for show: Show) -> String {
+        let mediaType = switch show {
+        case .movie: ShowType.movie
+        case .tvSeries: ShowType.tvSeries
+        }
+
+        return "\(mediaType.rawValue):\(show.id)"
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/V4ListAttributes.swift
+++ b/Sources/TMDb/Domain/Models/V4ListAttributes.swift
@@ -1,0 +1,78 @@
+//
+//  V4ListAttributes.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// The settable properties of a v4 list.
+///
+/// Used when creating a list and when updating one. Every property is optional:
+/// on create, an omitted property takes TMDb's default; on update, an omitted
+/// property is left as it is.
+///
+public struct V4ListAttributes: Equatable, Hashable, Sendable {
+
+    ///
+    /// The list's name.
+    ///
+    public let name: String?
+
+    ///
+    /// The list's description.
+    ///
+    public let description: String?
+
+    ///
+    /// Whether the list is visible to everyone.
+    ///
+    /// - Note: TMDb defaults a new list to public.
+    ///
+    public let isPublic: Bool?
+
+    ///
+    /// ISO 639-1 language code for the list.
+    ///
+    public let languageCode: String?
+
+    ///
+    /// ISO 3166-1 country code for the list.
+    ///
+    public let countryCode: String?
+
+    ///
+    /// The order to store the list's items in.
+    ///
+    public let sortBy: V4ListSortBy?
+
+    ///
+    /// Creates a set of v4 list attributes.
+    ///
+    /// - Parameters:
+    ///    - name: The list's name.
+    ///    - description: The list's description.
+    ///    - isPublic: Whether the list is visible to everyone.
+    ///    - languageCode: ISO 639-1 language code for the list.
+    ///    - countryCode: ISO 3166-1 country code for the list.
+    ///    - sortBy: The order to store the list's items in.
+    ///
+    public init(
+        name: String? = nil,
+        description: String? = nil,
+        isPublic: Bool? = nil,
+        languageCode: String? = nil,
+        countryCode: String? = nil,
+        sortBy: V4ListSortBy? = nil
+    ) {
+        self.name = name
+        self.description = description
+        self.isPublic = isPublic
+        self.languageCode = languageCode
+        self.countryCode = countryCode
+        self.sortBy = sortBy
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/V4ListCreator.swift
+++ b/Sources/TMDb/Domain/Models/V4ListCreator.swift
@@ -1,0 +1,69 @@
+//
+//  V4ListCreator.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A model representing the creator of a v4 list.
+///
+/// The v4 API sends the creator as an object, where v3 sends only a username
+/// string — which is one of the reasons the v3 list models cannot be reused.
+///
+public struct V4ListCreator: Codable, Equatable, Hashable, Sendable {
+
+    ///
+    /// The creator's account object identifier.
+    ///
+    public let id: String
+
+    ///
+    /// The creator's display name.
+    ///
+    /// TMDb sends an empty string when the user has not set one.
+    ///
+    public let name: String
+
+    ///
+    /// The creator's username.
+    ///
+    public let username: String
+
+    ///
+    /// Path to the creator's avatar image.
+    ///
+    public let avatarPath: URL?
+
+    ///
+    /// The creator's Gravatar hash.
+    ///
+    public let gravatarHash: String?
+
+    ///
+    /// Creates a list creator object.
+    ///
+    /// - Parameters:
+    ///    - id: The creator's account object identifier.
+    ///    - name: The creator's display name.
+    ///    - username: The creator's username.
+    ///    - avatarPath: Path to the creator's avatar image.
+    ///    - gravatarHash: The creator's Gravatar hash.
+    ///
+    public init(
+        id: String,
+        name: String,
+        username: String,
+        avatarPath: URL? = nil,
+        gravatarHash: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.username = username
+        self.avatarPath = avatarPath
+        self.gravatarHash = gravatarHash
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/V4ListItem.swift
+++ b/Sources/TMDb/Domain/Models/V4ListItem.swift
@@ -1,0 +1,111 @@
+//
+//  V4ListItem.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A model representing an item in a v4 list.
+///
+/// A v4 list holds movies and TV series together, so the media is a ``Show``
+/// rather than a movie-shaped model — the v3 `MediaListItem` requires
+/// movie-only fields and would silently drop every TV item.
+///
+public struct V4ListItem: Identifiable, Codable, Equatable, Hashable, Sendable {
+
+    ///
+    /// The item's identifier — the identifier of the movie or TV series.
+    ///
+    public var id: Int {
+        media.id
+    }
+
+    ///
+    /// The movie or TV series.
+    ///
+    public let media: Show
+
+    ///
+    /// The list owner's comment on this item, if they have written one.
+    ///
+    /// - Note: TMDb does not send this alongside the item. It arrives in a
+    ///   separate top-level `comments` dictionary and is stitched in when the
+    ///   containing ``V4List`` decodes, so an item decoded on its own always
+    ///   has a `nil` comment.
+    ///
+    public let comment: String?
+
+    ///
+    /// Creates a v4 list item object.
+    ///
+    /// - Parameters:
+    ///    - media: The movie or TV series.
+    ///    - comment: The list owner's comment on this item.
+    ///
+    public init(media: Show, comment: String? = nil) {
+        self.media = media
+        self.comment = comment
+    }
+
+}
+
+public extension V4ListItem {
+
+    ///
+    /// Creates a v4 list item by decoding from the given decoder.
+    ///
+    /// The same decoder is handed to ``Show``, which reads the `media_type`
+    /// discriminator and decodes the movie or TV series shape accordingly.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    ///
+    /// - Throws: An error if reading from the decoder fails, or if the data is
+    ///   corrupted or otherwise invalid.
+    ///
+    init(from decoder: any Decoder) throws {
+        self.media = try Show(from: decoder)
+        self.comment = nil
+    }
+
+    ///
+    /// Encodes this value into the given encoder.
+    ///
+    /// The media is written in the flat shape TMDb sends, **plus** the
+    /// `media_type` discriminator. ``Show`` alone does not write it — neither
+    /// `MovieListItem` nor `TVSeriesListItem` has the field — so without this
+    /// an encoded item could not be decoded back into a ``Show``, and a round
+    /// trip would silently drop every item.
+    ///
+    /// The comment is deliberately omitted: on the wire it lives in the
+    /// containing list's `comments` dictionary, not on the item.
+    ///
+    /// - Parameter encoder: The encoder to write data to.
+    ///
+    /// - Throws: An error if any values are invalid for the given encoder's
+    ///   format.
+    ///
+    func encode(to encoder: any Encoder) throws {
+        try media.encode(to: encoder)
+
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(mediaType, forKey: .mediaType)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case mediaType
+    }
+
+    private var mediaType: ShowType {
+        switch media {
+        case .movie:
+            .movie
+
+        case .tvSeries:
+            .tvSeries
+        }
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/V4ListItemComment.swift
+++ b/Sources/TMDb/Domain/Models/V4ListItemComment.swift
@@ -1,0 +1,88 @@
+//
+//  V4ListItemComment.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A model setting the list owner's comment on an item already in a v4 list.
+///
+/// This is the **only** way to store a comment. TMDb's add-items endpoint also
+/// accepts one and answers `success: true`, but silently discards it — so
+/// ``V4ListMediaItem``, used when adding, deliberately has no comment field.
+///
+public struct V4ListItemComment: Codable, Equatable, Hashable, Sendable {
+
+    ///
+    /// Whether the item is a movie or a TV series.
+    ///
+    public let mediaType: ShowType
+
+    ///
+    /// The identifier of the movie or TV series.
+    ///
+    public let mediaID: Int
+
+    ///
+    /// The comment to store against the item.
+    ///
+    public let comment: String
+
+    ///
+    /// Creates a v4 list item comment.
+    ///
+    /// - Parameters:
+    ///    - mediaType: Whether the item is a movie or a TV series.
+    ///    - mediaID: The identifier of the movie or TV series.
+    ///    - comment: The comment to store against the item.
+    ///
+    public init(mediaType: ShowType, mediaID: Int, comment: String) {
+        self.mediaType = mediaType
+        self.mediaID = mediaID
+        self.comment = comment
+    }
+
+}
+
+public extension V4ListItemComment {
+
+    ///
+    /// Creates a comment on a movie in a list.
+    ///
+    /// - Parameters:
+    ///    - movieID: The identifier of the movie.
+    ///    - comment: The comment to store against it.
+    ///
+    /// - Returns: A comment for that movie.
+    ///
+    static func movie(_ movieID: Movie.ID, comment: String) -> V4ListItemComment {
+        V4ListItemComment(mediaType: .movie, mediaID: movieID, comment: comment)
+    }
+
+    ///
+    /// Creates a comment on a TV series in a list.
+    ///
+    /// - Parameters:
+    ///    - tvSeriesID: The identifier of the TV series.
+    ///    - comment: The comment to store against it.
+    ///
+    /// - Returns: A comment for that TV series.
+    ///
+    static func tvSeries(_ tvSeriesID: TVSeries.ID, comment: String) -> V4ListItemComment {
+        V4ListItemComment(mediaType: .tvSeries, mediaID: tvSeriesID, comment: comment)
+    }
+
+}
+
+extension V4ListItemComment {
+
+    private enum CodingKeys: String, CodingKey {
+        case mediaType
+        case mediaID = "mediaId"
+        case comment
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/V4ListItemStatusResult.swift
+++ b/Sources/TMDb/Domain/Models/V4ListItemStatusResult.swift
@@ -1,0 +1,35 @@
+//
+//  V4ListItemStatusResult.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// The response from checking whether an item is in a v4 list.
+///
+/// Internal: TMDb signals absence with a 404 rather than a flag in this body,
+/// so the service maps the whole thing to a `Bool` and this type never reaches
+/// a caller.
+///
+struct V4ListItemStatusResult: Decodable {
+
+    let success: Bool
+    let id: Int
+    let mediaID: Int
+    let mediaType: ShowType
+
+}
+
+extension V4ListItemStatusResult {
+
+    private enum CodingKeys: String, CodingKey {
+        case success
+        case id
+        case mediaID = "mediaId"
+        case mediaType
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/V4ListItemsResult.swift
+++ b/Sources/TMDb/Domain/Models/V4ListItemsResult.swift
@@ -1,0 +1,125 @@
+//
+//  V4ListItemsResult.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A model representing the outcome of adding, updating or removing items in a
+/// v4 list.
+///
+/// - Important: ``success`` describes the *request*, not every item. TMDb
+///   answers `success: true` for a request in which individual items failed —
+///   removing an item that is not in the list is the easy case to reproduce —
+///   so check ``results`` rather than ``success`` alone. ``failures`` is there
+///   for exactly that.
+///
+public struct V4ListItemsResult: Codable, Equatable, Hashable, Sendable {
+
+    ///
+    /// Whether TMDb accepted the request.
+    ///
+    public let success: Bool
+
+    ///
+    /// The per-item outcomes, in the order TMDb returned them.
+    ///
+    public let results: [V4ListItemResult]
+
+    ///
+    /// The items that failed, if any.
+    ///
+    public var failures: [V4ListItemResult] {
+        results.filter { !$0.success }
+    }
+
+    ///
+    /// Whether every individual item succeeded.
+    ///
+    public var allItemsSucceeded: Bool {
+        success && failures.isEmpty
+    }
+
+    ///
+    /// Creates a v4 list items result.
+    ///
+    /// - Parameters:
+    ///    - success: Whether TMDb accepted the request.
+    ///    - results: The per-item outcomes.
+    ///
+    public init(success: Bool, results: [V4ListItemResult] = []) {
+        self.success = success
+        self.results = results
+    }
+
+}
+
+public extension V4ListItemsResult {
+
+    ///
+    /// Creates a v4 list items result by decoding from the given decoder.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    ///
+    /// - Throws: An error if reading from the decoder fails, or if the data is
+    ///   corrupted or otherwise invalid.
+    ///
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.success = try container.decodeIfPresent(Bool.self, forKey: .success) ?? false
+        self.results = try container.decodeIfPresent(
+            [V4ListItemResult].self, forKey: .results
+        ) ?? []
+    }
+
+}
+
+///
+/// A model representing the outcome for one item in a v4 list write.
+///
+public struct V4ListItemResult: Codable, Equatable, Hashable, Sendable {
+
+    ///
+    /// Whether the item is a movie or a TV series.
+    ///
+    public let mediaType: ShowType
+
+    ///
+    /// The identifier of the movie or TV series.
+    ///
+    public let mediaID: Int
+
+    ///
+    /// Whether this item succeeded.
+    ///
+    public let success: Bool
+
+    ///
+    /// Creates a v4 list item result.
+    ///
+    /// - Parameters:
+    ///    - mediaType: Whether the item is a movie or a TV series.
+    ///    - mediaID: The identifier of the movie or TV series.
+    ///    - success: Whether this item succeeded.
+    ///
+    public init(mediaType: ShowType, mediaID: Int, success: Bool) {
+        self.mediaType = mediaType
+        self.mediaID = mediaID
+        self.success = success
+    }
+
+}
+
+extension V4ListItemResult {
+
+    private enum CodingKeys: String, CodingKey {
+        case mediaType
+        case mediaID = "mediaId"
+        case success
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/V4ListMediaItem.swift
+++ b/Sources/TMDb/Domain/Models/V4ListMediaItem.swift
@@ -1,0 +1,79 @@
+//
+//  V4ListMediaItem.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A model identifying a movie or TV series to add to, or remove from, a v4
+/// list.
+///
+/// - Note: This deliberately carries **no comment**. TMDb's add-items endpoint
+///   accepts a per-item `comment` and answers `success: true`, but never stores
+///   it — only updating an existing item persists one. Accepting a comment here
+///   would be a parameter that silently does nothing. Use
+///   ``V4ListItemComment`` with `updateItems` instead.
+///
+public struct V4ListMediaItem: Codable, Equatable, Hashable, Sendable {
+
+    ///
+    /// Whether the item is a movie or a TV series.
+    ///
+    public let mediaType: ShowType
+
+    ///
+    /// The identifier of the movie or TV series.
+    ///
+    public let mediaID: Int
+
+    ///
+    /// Creates a v4 list media item.
+    ///
+    /// - Parameters:
+    ///    - mediaType: Whether the item is a movie or a TV series.
+    ///    - mediaID: The identifier of the movie or TV series.
+    ///
+    public init(mediaType: ShowType, mediaID: Int) {
+        self.mediaType = mediaType
+        self.mediaID = mediaID
+    }
+
+}
+
+public extension V4ListMediaItem {
+
+    ///
+    /// Creates a v4 list media item for a movie.
+    ///
+    /// - Parameter movieID: The identifier of the movie.
+    ///
+    /// - Returns: An item identifying that movie.
+    ///
+    static func movie(_ movieID: Movie.ID) -> V4ListMediaItem {
+        V4ListMediaItem(mediaType: .movie, mediaID: movieID)
+    }
+
+    ///
+    /// Creates a v4 list media item for a TV series.
+    ///
+    /// - Parameter tvSeriesID: The identifier of the TV series.
+    ///
+    /// - Returns: An item identifying that TV series.
+    ///
+    static func tvSeries(_ tvSeriesID: TVSeries.ID) -> V4ListMediaItem {
+        V4ListMediaItem(mediaType: .tvSeries, mediaID: tvSeriesID)
+    }
+
+}
+
+extension V4ListMediaItem {
+
+    private enum CodingKeys: String, CodingKey {
+        case mediaType
+        case mediaID = "mediaId"
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/V4ListSortBy.swift
+++ b/Sources/TMDb/Domain/Models/V4ListSortBy.swift
@@ -1,0 +1,91 @@
+//
+//  V4ListSortBy.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A sort order for the items in a v4 list.
+///
+/// Use it when creating or updating a list to set its stored order, and when
+/// reading a list to override that order for one request.
+///
+/// - Note: These are the orderings TMDb accepts — each was confirmed against
+///   the live API by setting it and reading the list back. Notably `popularity`,
+///   `runtime`, `revenue`, `first_air_date` and `vote_count` are **rejected**,
+///   even though the v3 discover endpoints accept several of them.
+///
+public enum V4ListSortBy: CustomStringConvertible, Equatable, Hashable, Sendable {
+
+    ///
+    /// By the order items were added to the list.
+    ///
+    /// This is the order a newly created list uses.
+    ///
+    case originalOrder(descending: Bool = false)
+
+    ///
+    /// By average vote.
+    ///
+    case voteAverage(descending: Bool = false)
+
+    ///
+    /// By primary release date.
+    ///
+    case primaryReleaseDate(descending: Bool = false)
+
+    ///
+    /// By release date.
+    ///
+    case releaseDate(descending: Bool = false)
+
+    ///
+    /// By title.
+    ///
+    case title(descending: Bool = false)
+
+    ///
+    /// The value as TMDb expects it, e.g. `title.asc`.
+    ///
+    public var description: String {
+        "\(fieldName).\(isDescending ? "desc" : "asc")"
+    }
+
+}
+
+extension V4ListSortBy {
+
+    private var fieldName: String {
+        switch self {
+        case .originalOrder:
+            "original_order"
+
+        case .voteAverage:
+            "vote_average"
+
+        case .primaryReleaseDate:
+            "primary_release_date"
+
+        case .releaseDate:
+            "release_date"
+
+        case .title:
+            "title"
+        }
+    }
+
+    private var isDescending: Bool {
+        switch self {
+        case .originalOrder(let descending),
+             .voteAverage(let descending),
+             .primaryReleaseDate(let descending),
+             .releaseDate(let descending),
+             .title(let descending):
+            descending
+        }
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/V4ListSummary.swift
+++ b/Sources/TMDb/Domain/Models/V4ListSummary.swift
@@ -200,6 +200,50 @@ public struct V4ListSummary: Identifiable, Codable, Equatable, Hashable, Sendabl
 
 extension V4ListSummary {
 
+    ///
+    /// Creates a v4 list summary by decoding from the given decoder.
+    ///
+    /// Every field except `id` and `name` is decoded tolerantly. That matters
+    /// more here than usual: `lists(forAccount:)` wraps its results in
+    /// `FailableDecodable`, so a summary that *throws* is silently **dropped**
+    /// from the page rather than surfaced — one field TMDb stopped sending
+    /// would make a user's list disappear with no error at all. `V4List`
+    /// defends itself the same way.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    ///
+    /// - Throws: An error if reading from the decoder fails, or if the data is
+    ///   corrupted or otherwise invalid.
+    ///
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.id = try container.decode(Int.self, forKey: .id)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.description = try container.decodeIfPresent(String.self, forKey: .description)
+        self.accountObjectID = try container.decodeIfPresent(
+            String.self, forKey: .accountObjectID
+        ) ?? ""
+        self.numberOfItems = try container.decodeIfPresent(Int.self, forKey: .numberOfItems) ?? 0
+        self.averageRating = try container.decodeIfPresent(Double.self, forKey: .averageRating) ?? 0
+        self.revenue = try container.decodeIfPresent(Int.self, forKey: .revenue) ?? 0
+        self.sortBy = try container.decodeIfPresent(Int.self, forKey: .sortBy) ?? 1
+        self.languageCode = try container.decodeIfPresent(String.self, forKey: .languageCode) ?? ""
+        self.countryCode = try container.decodeIfPresent(String.self, forKey: .countryCode) ?? ""
+        self.backdropPath = try container.decodeIfPresent(URL.self, forKey: .backdropPath)
+        self.posterPath = try container.decodeIfPresent(URL.self, forKey: .posterPath)
+        self.createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
+            ?? Date(timeIntervalSince1970: 0)
+        self.updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt)
+            ?? Date(timeIntervalSince1970: 0)
+        // Absent visibility defaults to *private*: for a privacy flag the safe
+        // failure direction is the restrictive one.
+        self.publicValue = try container.decodeIfPresent(Int.self, forKey: .publicValue) ?? 0
+        self.adultValue = try container.decodeIfPresent(Int.self, forKey: .adultValue) ?? 0
+        self.featuredValue = try container.decodeIfPresent(Int.self, forKey: .featuredValue) ?? 0
+        self.runtimeValue = try container.decodeIfPresent(String.self, forKey: .runtimeValue) ?? "0"
+    }
+
     /// With `.convertFromSnakeCase` the decoder hands over the camelCased form,
     /// so these raw values must be spelled that way — `iso6391`, not `iso_639_1`.
     private enum CodingKeys: String, CodingKey {

--- a/Sources/TMDb/Domain/Models/V4ListSummary.swift
+++ b/Sources/TMDb/Domain/Models/V4ListSummary.swift
@@ -1,0 +1,226 @@
+//
+//  V4ListSummary.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// A model representing a v4 list without its items, as returned when listing
+/// an account's lists.
+///
+/// - Note: This is a separate model from ``V4List`` rather than a subset of it,
+///   because the two endpoints disagree on the *types* of the fields they
+///   share: `public` is a boolean on the list-details endpoint but `0`/`1`
+///   here, `sort_by` is a string there but an integer here, and `runtime` is a
+///   number there but a string here. Each raw value is stored as the wire sends
+///   it and exposed through a computed property, so `Codable` stays synthesized
+///   and correct in both directions.
+///
+public struct V4ListSummary: Identifiable, Codable, Equatable, Hashable, Sendable {
+
+    ///
+    /// List identifier.
+    ///
+    public let id: Int
+
+    ///
+    /// List name.
+    ///
+    public let name: String
+
+    ///
+    /// List description.
+    ///
+    public let description: String?
+
+    ///
+    /// The account object identifier of the list's owner.
+    ///
+    public let accountObjectID: String
+
+    ///
+    /// Number of items in the list.
+    ///
+    public let numberOfItems: Int
+
+    ///
+    /// Average rating of the list's items.
+    ///
+    public let averageRating: Double
+
+    ///
+    /// Combined revenue of the list's items.
+    ///
+    public let revenue: Int
+
+    ///
+    /// ISO 639-1 language code.
+    ///
+    public let languageCode: String
+
+    ///
+    /// ISO 3166-1 country code.
+    ///
+    public let countryCode: String
+
+    ///
+    /// Path to the list's backdrop image.
+    ///
+    public let backdropPath: URL?
+
+    ///
+    /// Path to the list's poster image.
+    ///
+    public let posterPath: URL?
+
+    ///
+    /// When the list was created.
+    ///
+    public let createdAt: Date
+
+    ///
+    /// When the list was last updated.
+    ///
+    public let updatedAt: Date
+
+    ///
+    /// The order the list is sorted in, as TMDb's numeric identifier.
+    ///
+    /// - Note: This endpoint reports the sort order as an integer, while
+    ///   ``V4List/sortBy`` reports it as a string. TMDb publishes no mapping
+    ///   between the two, so both are exposed exactly as sent rather than
+    ///   decoded into a shared type.
+    ///
+    public let sortBy: Int
+
+    // The wire sends these as `0`/`1` and as a string; stored raw so `Codable`,
+    // `Equatable` and `Hashable` all stay synthesized at wire granularity.
+    private let publicValue: Int
+    private let adultValue: Int
+    private let featuredValue: Int
+    private let runtimeValue: String
+
+    ///
+    /// Whether the list is visible to everyone.
+    ///
+    public var isPublic: Bool {
+        publicValue != 0
+    }
+
+    ///
+    /// Whether the list is flagged as adult.
+    ///
+    public var isAdult: Bool {
+        adultValue != 0
+    }
+
+    ///
+    /// Whether the list is featured by TMDb.
+    ///
+    public var isFeatured: Bool {
+        featuredValue != 0
+    }
+
+    ///
+    /// Combined runtime of the list's items, in minutes.
+    ///
+    /// Returns `0` when TMDb sends a value that is not a number.
+    ///
+    public var runtime: Int {
+        Int(runtimeValue) ?? 0
+    }
+
+    ///
+    /// Creates a v4 list summary object.
+    ///
+    /// - Parameters:
+    ///    - id: List identifier.
+    ///    - name: List name.
+    ///    - description: List description.
+    ///    - accountObjectID: The account object identifier of the list's owner.
+    ///    - numberOfItems: Number of items in the list.
+    ///    - isPublic: Whether the list is visible to everyone.
+    ///    - isAdult: Whether the list is flagged as adult.
+    ///    - isFeatured: Whether the list is featured by TMDb.
+    ///    - runtime: Combined runtime of the list's items, in minutes.
+    ///    - averageRating: Average rating of the list's items.
+    ///    - revenue: Combined revenue of the list's items.
+    ///    - sortBy: The order the list is sorted in, as TMDb's numeric identifier.
+    ///    - languageCode: ISO 639-1 language code.
+    ///    - countryCode: ISO 3166-1 country code.
+    ///    - backdropPath: Path to the list's backdrop image.
+    ///    - posterPath: Path to the list's poster image.
+    ///    - createdAt: When the list was created.
+    ///    - updatedAt: When the list was last updated.
+    ///
+    public init(
+        id: Int,
+        name: String,
+        description: String? = nil,
+        accountObjectID: String,
+        numberOfItems: Int,
+        isPublic: Bool,
+        isAdult: Bool = false,
+        isFeatured: Bool = false,
+        runtime: Int = 0,
+        averageRating: Double = 0,
+        revenue: Int = 0,
+        sortBy: Int = 1,
+        languageCode: String,
+        countryCode: String,
+        backdropPath: URL? = nil,
+        posterPath: URL? = nil,
+        createdAt: Date,
+        updatedAt: Date
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.accountObjectID = accountObjectID
+        self.numberOfItems = numberOfItems
+        self.publicValue = isPublic ? 1 : 0
+        self.adultValue = isAdult ? 1 : 0
+        self.featuredValue = isFeatured ? 1 : 0
+        self.runtimeValue = String(runtime)
+        self.averageRating = averageRating
+        self.revenue = revenue
+        self.sortBy = sortBy
+        self.languageCode = languageCode
+        self.countryCode = countryCode
+        self.backdropPath = backdropPath
+        self.posterPath = posterPath
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+}
+
+extension V4ListSummary {
+
+    /// With `.convertFromSnakeCase` the decoder hands over the camelCased form,
+    /// so these raw values must be spelled that way — `iso6391`, not `iso_639_1`.
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case description
+        case accountObjectID = "accountObjectId"
+        case numberOfItems
+        case averageRating
+        case revenue
+        case sortBy
+        case languageCode = "iso6391"
+        case countryCode = "iso31661"
+        case backdropPath
+        case posterPath
+        case createdAt
+        case updatedAt
+        case publicValue = "public"
+        case adultValue = "adult"
+        case featuredValue = "featured"
+        case runtimeValue = "runtime"
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/V4Lists/Requests/AddV4ListItemsRequest.swift
+++ b/Sources/TMDb/Domain/Services/V4Lists/Requests/AddV4ListItemsRequest.swift
@@ -1,0 +1,38 @@
+//
+//  AddV4ListItemsRequest.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+final class AddV4ListItemsRequest: CodableAPIRequest<
+    AddV4ListItemsRequest.Body, V4ListItemsResult
+> {
+
+    convenience init(items: [V4ListMediaItem], listID: Int, accessToken: String) {
+        let body = AddV4ListItemsRequest.Body(items: items)
+
+        self.init(listID: listID, body: body, accessToken: accessToken)
+    }
+
+    private init(listID: Int, body: AddV4ListItemsRequest.Body, accessToken: String) {
+        super.init(
+            path: "/list/\(listID)/items",
+            body: body,
+            headers: .v4Authorization(accessToken)
+        )
+    }
+
+}
+
+extension AddV4ListItemsRequest {
+
+    struct Body: Encodable, Equatable {
+
+        let items: [V4ListMediaItem]
+
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/V4Lists/Requests/ClearV4ListRequest.swift
+++ b/Sources/TMDb/Domain/Services/V4Lists/Requests/ClearV4ListRequest.swift
@@ -1,0 +1,27 @@
+//
+//  ClearV4ListRequest.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// Removes every item from a list.
+///
+/// - Note: This is a **`GET`** that changes state — `POST` to the same path
+///   returns 404. `CacheHTTPClient` recognises a `GET` whose path ends `/clear`
+///   and routes it through its mutation path, so it invalidates the cache
+///   rather than populating it.
+///
+final class ClearV4ListRequest: DecodableAPIRequest<V4ClearListResult> {
+
+    init(listID: Int, accessToken: String) {
+        super.init(
+            path: "/list/\(listID)/clear",
+            headers: .v4Authorization(accessToken)
+        )
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/V4Lists/Requests/CreateV4ListRequest.swift
+++ b/Sources/TMDb/Domain/Services/V4Lists/Requests/CreateV4ListRequest.swift
@@ -1,0 +1,76 @@
+//
+//  CreateV4ListRequest.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+final class CreateV4ListRequest: CodableAPIRequest<CreateV4ListRequest.Body, V4CreateListResult> {
+
+    convenience init(
+        name: String,
+        description: String? = nil,
+        isPublic: Bool? = nil,
+        languageCode: String? = nil,
+        countryCode: String? = nil,
+        sortBy: V4ListSortBy? = nil,
+        accessToken: String
+    ) {
+        let body = CreateV4ListRequest.Body(
+            name: name,
+            description: description,
+            isPublic: isPublic.map { $0 ? 1 : 0 },
+            languageCode: languageCode,
+            countryCode: countryCode,
+            sortBy: sortBy?.description
+        )
+
+        self.init(body: body, accessToken: accessToken)
+    }
+
+    private init(body: CreateV4ListRequest.Body, accessToken: String) {
+        super.init(
+            path: "/list",
+            body: body,
+            headers: .v4Authorization(accessToken)
+        )
+    }
+
+}
+
+extension CreateV4ListRequest {
+
+    struct Body: Encodable, Equatable {
+
+        let name: String
+        let description: String?
+
+        /// Sent as `0`/`1`, **not** as a boolean.
+        ///
+        /// This was established against the live API: creating with
+        /// `{"public": false}` returns a list that reads back as public, while
+        /// `{"public": 0}` is honoured. (Update accepts either.)
+        let isPublic: Int?
+
+        let languageCode: String?
+        let countryCode: String?
+        let sortBy: String?
+
+    }
+
+}
+
+extension CreateV4ListRequest.Body {
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case description
+        case isPublic = "public"
+        case languageCode = "iso_639_1"
+        case countryCode = "iso_3166_1"
+        case sortBy = "sort_by"
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/V4Lists/Requests/DeleteV4ListRequest.swift
+++ b/Sources/TMDb/Domain/Services/V4Lists/Requests/DeleteV4ListRequest.swift
@@ -1,0 +1,20 @@
+//
+//  DeleteV4ListRequest.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+final class DeleteV4ListRequest: DecodableAPIRequest<SuccessResult> {
+
+    init(listID: Int, accessToken: String) {
+        super.init(
+            path: "/list/\(listID)",
+            method: .delete,
+            headers: .v4Authorization(accessToken)
+        )
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/V4Lists/Requests/RemoveV4ListItemsRequest.swift
+++ b/Sources/TMDb/Domain/Services/V4Lists/Requests/RemoveV4ListItemsRequest.swift
@@ -1,0 +1,39 @@
+//
+//  RemoveV4ListItemsRequest.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+final class RemoveV4ListItemsRequest: CodableAPIRequest<
+    RemoveV4ListItemsRequest.Body, V4ListItemsResult
+> {
+
+    convenience init(items: [V4ListMediaItem], listID: Int, accessToken: String) {
+        let body = RemoveV4ListItemsRequest.Body(items: items)
+
+        self.init(listID: listID, body: body, accessToken: accessToken)
+    }
+
+    private init(listID: Int, body: RemoveV4ListItemsRequest.Body, accessToken: String) {
+        super.init(
+            path: "/list/\(listID)/items",
+            method: .delete,
+            body: body,
+            headers: .v4Authorization(accessToken)
+        )
+    }
+
+}
+
+extension RemoveV4ListItemsRequest {
+
+    struct Body: Encodable, Equatable {
+
+        let items: [V4ListMediaItem]
+
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/V4Lists/Requests/UpdateV4ListItemsRequest.swift
+++ b/Sources/TMDb/Domain/Services/V4Lists/Requests/UpdateV4ListItemsRequest.swift
@@ -1,0 +1,45 @@
+//
+//  UpdateV4ListItemsRequest.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// Updates items already in a list — in practice, setting their comments.
+///
+/// This is the only endpoint that stores a comment. Add-items accepts one and
+/// answers success, but discards it.
+///
+final class UpdateV4ListItemsRequest: CodableAPIRequest<
+    UpdateV4ListItemsRequest.Body, V4ListItemsResult
+> {
+
+    convenience init(items: [V4ListItemComment], listID: Int, accessToken: String) {
+        let body = UpdateV4ListItemsRequest.Body(items: items)
+
+        self.init(listID: listID, body: body, accessToken: accessToken)
+    }
+
+    private init(listID: Int, body: UpdateV4ListItemsRequest.Body, accessToken: String) {
+        super.init(
+            path: "/list/\(listID)/items",
+            method: .put,
+            body: body,
+            headers: .v4Authorization(accessToken)
+        )
+    }
+
+}
+
+extension UpdateV4ListItemsRequest {
+
+    struct Body: Encodable, Equatable {
+
+        let items: [V4ListItemComment]
+
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/V4Lists/Requests/UpdateV4ListRequest.swift
+++ b/Sources/TMDb/Domain/Services/V4Lists/Requests/UpdateV4ListRequest.swift
@@ -1,0 +1,68 @@
+//
+//  UpdateV4ListRequest.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+final class UpdateV4ListRequest: CodableAPIRequest<UpdateV4ListRequest.Body, SuccessResult> {
+
+    convenience init(
+        listID: Int,
+        name: String? = nil,
+        description: String? = nil,
+        isPublic: Bool? = nil,
+        sortBy: V4ListSortBy? = nil,
+        accessToken: String
+    ) {
+        let body = UpdateV4ListRequest.Body(
+            name: name,
+            description: description,
+            isPublic: isPublic.map { $0 ? 1 : 0 },
+            sortBy: sortBy?.description
+        )
+
+        self.init(listID: listID, body: body, accessToken: accessToken)
+    }
+
+    private init(listID: Int, body: UpdateV4ListRequest.Body, accessToken: String) {
+        super.init(
+            path: "/list/\(listID)",
+            method: .put,
+            body: body,
+            headers: .v4Authorization(accessToken)
+        )
+    }
+
+}
+
+extension UpdateV4ListRequest {
+
+    struct Body: Encodable, Equatable {
+
+        let name: String?
+        let description: String?
+
+        /// Sent as `0`/`1` for symmetry with create, which only honours the
+        /// integer form. Update accepts either, so this is consistency rather
+        /// than necessity.
+        let isPublic: Int?
+
+        let sortBy: String?
+
+    }
+
+}
+
+extension UpdateV4ListRequest.Body {
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case description
+        case isPublic = "public"
+        case sortBy = "sort_by"
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/V4Lists/Requests/V4AccountListsRequest.swift
+++ b/Sources/TMDb/Domain/Services/V4Lists/Requests/V4AccountListsRequest.swift
@@ -1,0 +1,35 @@
+//
+//  V4AccountListsRequest.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+final class V4AccountListsRequest: DecodableAPIRequest<PageableListResult<V4ListSummary>> {
+
+    init(accountObjectID: String, page: Int? = nil, accessToken: String) {
+        // The account object id is caller-supplied and goes into a path
+        // segment, where `URLComponents` does no escaping for us (ADR-0008).
+        let path = "/account/\(accountObjectID.urlPathSegmentEncoded)/lists"
+        let queryItems = APIRequestQueryItems(page: page)
+
+        super.init(
+            path: path,
+            queryItems: queryItems,
+            headers: .v4Authorization(accessToken)
+        )
+    }
+
+}
+
+private extension APIRequestQueryItems {
+
+    init(page: Int?) {
+        self.init()
+
+        self[ifPresent: .page] = page
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/V4Lists/Requests/V4AuthorizationHeaders.swift
+++ b/Sources/TMDb/Domain/Services/V4Lists/Requests/V4AuthorizationHeaders.swift
@@ -1,0 +1,33 @@
+//
+//  V4AuthorizationHeaders.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+extension [String: String] {
+
+    ///
+    /// The headers carrying a v4 user access token, if one was supplied.
+    ///
+    /// Setting `Authorization` on the request is what makes `TMDbAPIClient`
+    /// treat the call as the *user's* rather than the application's: it then
+    /// withholds the client credential and marks the request user-specific, so
+    /// neither cache stores the response.
+    ///
+    /// - Parameter accessToken: The user's v4 access token, or `nil` to
+    ///   authenticate with the client's own credential.
+    ///
+    /// - Returns: The headers for the request.
+    ///
+    static func v4Authorization(_ accessToken: String?) -> [String: String] {
+        guard let accessToken else {
+            return [:]
+        }
+
+        return ["Authorization": "Bearer \(accessToken)"]
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/V4Lists/Requests/V4ListItemStatusRequest.swift
+++ b/Sources/TMDb/Domain/Services/V4Lists/Requests/V4ListItemStatusRequest.swift
@@ -1,0 +1,41 @@
+//
+//  V4ListItemStatusRequest.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// Checks whether a movie or TV series is in a list.
+///
+/// - Note: TMDb answers **404** when the item is not in the list, rather than
+///   returning a present/absent flag, so the calling service maps
+///   ``TMDbError/notFound(_:)`` to `false`.
+///
+final class V4ListItemStatusRequest: DecodableAPIRequest<V4ListItemStatusResult> {
+
+    init(listID: Int, mediaID: Int, mediaType: ShowType, accessToken: String? = nil) {
+        let path = "/list/\(listID)/item_status"
+        let queryItems = APIRequestQueryItems(mediaID: mediaID, mediaType: mediaType)
+
+        super.init(
+            path: path,
+            queryItems: queryItems,
+            headers: .v4Authorization(accessToken)
+        )
+    }
+
+}
+
+private extension APIRequestQueryItems {
+
+    init(mediaID: Int, mediaType: ShowType) {
+        self.init()
+
+        self[.mediaID] = mediaID
+        self[.mediaType] = mediaType.rawValue
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/V4Lists/Requests/V4ListRequest.swift
+++ b/Sources/TMDb/Domain/Services/V4Lists/Requests/V4ListRequest.swift
@@ -1,0 +1,41 @@
+//
+//  V4ListRequest.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+final class V4ListRequest: DecodableAPIRequest<V4List> {
+
+    init(
+        id listID: Int,
+        page: Int? = nil,
+        sortBy: V4ListSortBy? = nil,
+        language: String? = nil,
+        accessToken: String? = nil
+    ) {
+        let path = "/list/\(listID)"
+        let queryItems = APIRequestQueryItems(page: page, sortBy: sortBy, language: language)
+
+        super.init(
+            path: path,
+            queryItems: queryItems,
+            headers: .v4Authorization(accessToken)
+        )
+    }
+
+}
+
+private extension APIRequestQueryItems {
+
+    init(page: Int?, sortBy: V4ListSortBy?, language: String?) {
+        self.init()
+
+        self[ifPresent: .page] = page
+        self[ifPresent: .sortBy] = sortBy
+        self[ifPresent: .language] = language
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/V4Lists/TMDbV4ListService.swift
+++ b/Sources/TMDb/Domain/Services/V4Lists/TMDbV4ListService.swift
@@ -1,0 +1,235 @@
+//
+//  TMDbV4ListService.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+final class TMDbV4ListService: V4ListService {
+
+    private let apiClient: any APIClient
+
+    init(apiClient: some APIClient) {
+        self.apiClient = apiClient
+    }
+
+    func details(
+        forList listID: Int,
+        page: Int?,
+        sortedBy: V4ListSortBy?,
+        language: String?,
+        accessToken: String?
+    ) async throws(TMDbError) -> V4List {
+        try Self.validate(accessToken: accessToken)
+        let request = V4ListRequest(
+            id: listID,
+            page: page,
+            sortBy: sortedBy,
+            language: language,
+            accessToken: accessToken
+        )
+
+        return try await apiClient.perform(request)
+    }
+
+    func items(
+        forList listID: Int,
+        page: Int?,
+        sortedBy: V4ListSortBy?,
+        language: String?,
+        accessToken: String?
+    ) async throws(TMDbError) -> PageableListResult<V4ListItem> {
+        let list = try await details(
+            forList: listID,
+            page: page,
+            sortedBy: sortedBy,
+            language: language,
+            accessToken: accessToken
+        )
+
+        return PageableListResult(
+            page: list.page,
+            results: list.items,
+            totalResults: list.totalResults,
+            totalPages: list.totalPages
+        )
+    }
+
+    func itemStatus(
+        forMedia mediaID: Int,
+        ofType showType: ShowType,
+        inList listID: Int,
+        accessToken: String?
+    ) async throws(TMDbError) -> Bool {
+        try Self.validate(accessToken: accessToken)
+        let request = V4ListItemStatusRequest(
+            listID: listID,
+            mediaID: mediaID,
+            mediaType: showType,
+            accessToken: accessToken
+        )
+
+        do {
+            let result: V4ListItemStatusResult = try await apiClient.perform(request)
+            return result.success
+        } catch .notFound {
+            // TMDb has no present/absent flag here: an item that is not in the
+            // list, a list that does not exist, and a list you cannot see all
+            // answer 404. Documented on the protocol.
+            return false
+        }
+    }
+
+    func lists(
+        forAccount accountObjectID: String,
+        page: Int?,
+        accessToken: String
+    ) async throws(TMDbError) -> PageableListResult<V4ListSummary> {
+        try Self.validate(accessToken: accessToken)
+        try Self.validate(accountObjectID: accountObjectID)
+        let request = V4AccountListsRequest(
+            accountObjectID: accountObjectID,
+            page: page,
+            accessToken: accessToken
+        )
+
+        return try await apiClient.perform(request)
+    }
+
+    func create(
+        name: String,
+        attributes: V4ListAttributes?,
+        accessToken: String
+    ) async throws(TMDbError) -> V4CreateListResult {
+        try Self.validate(accessToken: accessToken)
+        try Self.validate(name: name)
+        let request = CreateV4ListRequest(
+            name: name,
+            description: attributes?.description,
+            isPublic: attributes?.isPublic,
+            languageCode: attributes?.languageCode,
+            countryCode: attributes?.countryCode,
+            sortBy: attributes?.sortBy,
+            accessToken: accessToken
+        )
+
+        return try await apiClient.perform(request)
+    }
+
+    func update(
+        list listID: Int,
+        attributes: V4ListAttributes,
+        accessToken: String
+    ) async throws(TMDbError) {
+        try Self.validate(accessToken: accessToken)
+        if let name = attributes.name {
+            try Self.validate(name: name)
+        }
+        let request = UpdateV4ListRequest(
+            listID: listID,
+            name: attributes.name,
+            description: attributes.description,
+            isPublic: attributes.isPublic,
+            sortBy: attributes.sortBy,
+            accessToken: accessToken
+        )
+
+        _ = try await apiClient.perform(request)
+    }
+
+    func addItems(
+        _ items: [V4ListMediaItem],
+        toList listID: Int,
+        accessToken: String
+    ) async throws(TMDbError) -> V4ListItemsResult {
+        try Self.validate(accessToken: accessToken)
+        try Self.validate(itemCount: items.count)
+        let request = AddV4ListItemsRequest(
+            items: items,
+            listID: listID,
+            accessToken: accessToken
+        )
+
+        return try await apiClient.perform(request)
+    }
+
+    func updateItems(
+        _ items: [V4ListItemComment],
+        inList listID: Int,
+        accessToken: String
+    ) async throws(TMDbError) -> V4ListItemsResult {
+        try Self.validate(accessToken: accessToken)
+        try Self.validate(itemCount: items.count)
+        let request = UpdateV4ListItemsRequest(
+            items: items,
+            listID: listID,
+            accessToken: accessToken
+        )
+
+        return try await apiClient.perform(request)
+    }
+
+    func removeItems(
+        _ items: [V4ListMediaItem],
+        fromList listID: Int,
+        accessToken: String
+    ) async throws(TMDbError) -> V4ListItemsResult {
+        try Self.validate(accessToken: accessToken)
+        try Self.validate(itemCount: items.count)
+        let request = RemoveV4ListItemsRequest(
+            items: items,
+            listID: listID,
+            accessToken: accessToken
+        )
+
+        return try await apiClient.perform(request)
+    }
+
+    func clear(
+        list listID: Int,
+        accessToken: String
+    ) async throws(TMDbError) -> V4ClearListResult {
+        try Self.validate(accessToken: accessToken)
+        let request = ClearV4ListRequest(listID: listID, accessToken: accessToken)
+
+        return try await apiClient.perform(request)
+    }
+
+    func delete(list listID: Int, accessToken: String) async throws(TMDbError) {
+        try Self.validate(accessToken: accessToken)
+        let request = DeleteV4ListRequest(listID: listID, accessToken: accessToken)
+
+        _ = try await apiClient.perform(request)
+    }
+
+}
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+extension TMDbV4ListService {
+
+    private static func validate(accessToken: String?) throws(TMDbError) {
+        guard let accessToken else {
+            return
+        }
+
+        try accessToken.validateNotEmpty(message: "Access token must not be empty")
+    }
+
+    private static func validate(name: String) throws(TMDbError) {
+        try name.validateNotEmpty(message: "List name must not be empty")
+    }
+
+    private static func validate(accountObjectID: String) throws(TMDbError) {
+        try accountObjectID.validateNotEmpty(message: "Account object ID must not be empty")
+    }
+
+    private static func validate(itemCount: Int) throws(TMDbError) {
+        guard itemCount > 0 else {
+            throw .badRequest(TMDbErrorContext(statusMessage: "Items must not be empty"))
+        }
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/V4Lists/V4ListService+Conveniences.swift
+++ b/Sources/TMDb/Domain/Services/V4Lists/V4ListService+Conveniences.swift
@@ -1,0 +1,173 @@
+//
+//  V4ListService+Conveniences.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// Shorter forms of the ``V4ListService`` requirements.
+///
+/// Every one of these **drops** parameters rather than defaulting them. A
+/// defaulted overload would share its requirement's signature — default values
+/// are not part of a signature for witness matching — and so would silently
+/// become that requirement's default implementation, recursing forever for any
+/// conformer that omitted it. `Scripts/check-defaulted-witnesses.py` fails the
+/// lint if one is ever added here.
+///
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+public extension V4ListService {
+
+    ///
+    /// Returns the details of a public list.
+    ///
+    /// - Parameter listID: The identifier of the list.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The matching list.
+    ///
+    func details(forList listID: Int) async throws(TMDbError) -> V4List {
+        try await details(
+            forList: listID, page: nil, sortedBy: nil, language: nil, accessToken: nil
+        )
+    }
+
+    ///
+    /// Returns the details of a list, as its owner.
+    ///
+    /// - Parameters:
+    ///    - listID: The identifier of the list.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The matching list.
+    ///
+    func details(
+        forList listID: Int,
+        accessToken: String
+    ) async throws(TMDbError) -> V4List {
+        try await details(
+            forList: listID, page: nil, sortedBy: nil, language: nil, accessToken: accessToken
+        )
+    }
+
+    ///
+    /// Returns a page of a public list's items.
+    ///
+    /// - Parameter listID: The identifier of the list.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: A pageable list of the list's items.
+    ///
+    func items(forList listID: Int) async throws(TMDbError) -> PageableListResult<V4ListItem> {
+        try await items(
+            forList: listID, page: nil, sortedBy: nil, language: nil, accessToken: nil
+        )
+    }
+
+    ///
+    /// Returns a page of a list's items, as its owner.
+    ///
+    /// - Parameters:
+    ///    - listID: The identifier of the list.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: A pageable list of the list's items.
+    ///
+    func items(
+        forList listID: Int,
+        accessToken: String
+    ) async throws(TMDbError) -> PageableListResult<V4ListItem> {
+        try await items(
+            forList: listID, page: nil, sortedBy: nil, language: nil, accessToken: accessToken
+        )
+    }
+
+    ///
+    /// Checks whether a movie or TV series is in a public list.
+    ///
+    /// - Parameters:
+    ///    - mediaID: The identifier of the movie or TV series.
+    ///    - showType: Whether it is a movie or a TV series.
+    ///    - listID: The identifier of the list.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: `true` when the item is in the list.
+    ///
+    func itemStatus(
+        forMedia mediaID: Int,
+        ofType showType: ShowType,
+        inList listID: Int
+    ) async throws(TMDbError) -> Bool {
+        try await itemStatus(
+            forMedia: mediaID, ofType: showType, inList: listID, accessToken: nil
+        )
+    }
+
+    ///
+    /// Returns the lists belonging to an account.
+    ///
+    /// - Parameters:
+    ///    - accountObjectID: The account's object identifier.
+    ///    - accessToken: The account owner's access token.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: A pageable list of the account's lists.
+    ///
+    func lists(
+        forAccount accountObjectID: String,
+        accessToken: String
+    ) async throws(TMDbError) -> PageableListResult<V4ListSummary> {
+        try await lists(forAccount: accountObjectID, page: nil, accessToken: accessToken)
+    }
+
+    ///
+    /// Creates a list with just a name.
+    ///
+    /// - Parameters:
+    ///    - name: The list's name.
+    ///    - accessToken: The user's access token.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The result, including the new list's identifier.
+    ///
+    func create(
+        name: String,
+        accessToken: String
+    ) async throws(TMDbError) -> V4CreateListResult {
+        try await create(name: name, attributes: nil, accessToken: accessToken)
+    }
+
+    ///
+    /// Renames a list.
+    ///
+    /// - Parameters:
+    ///    - listID: The identifier of the list.
+    ///    - name: The new name.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    func update(
+        list listID: Int,
+        name: String,
+        accessToken: String
+    ) async throws(TMDbError) {
+        try await update(
+            list: listID,
+            attributes: V4ListAttributes(name: name),
+            accessToken: accessToken
+        )
+    }
+
+}

--- a/Sources/TMDb/Domain/Services/V4Lists/V4ListService.swift
+++ b/Sources/TMDb/Domain/Services/V4Lists/V4ListService.swift
@@ -1,0 +1,259 @@
+//
+//  V4ListService.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// Provides an interface for managing TMDb v4 lists.
+///
+/// v4 lists differ from v3 lists in the ways that matter for a watchlist: they
+/// hold **movies and TV series together**, they can be private, and each item
+/// can carry a comment.
+///
+/// Reads take an optional `accessToken`. Passing `nil` authenticates with the
+/// client's own credential, which is enough for a public list; a private list
+/// needs its owner's access token, obtained through
+/// ``V4AuthenticationService``. Writes always require one.
+///
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+public protocol V4ListService: Sendable {
+
+    ///
+    /// Returns the details of a list, including a page of its items.
+    ///
+    /// [TMDb API - List: Details](https://developer.themoviedb.org/v4/reference/list-details)
+    ///
+    /// - Parameters:
+    ///    - listID: The identifier of the list.
+    ///    - page: The page of items to return.
+    ///    - sortedBy: How to order the items for this request. Defaults to the
+    ///      list's stored order.
+    ///    - language: ISO 639-1 language code to display results in.
+    ///    - accessToken: The list owner's access token. Required for a private
+    ///      list; `nil` uses the client's credential.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The matching list.
+    ///
+    func details(
+        forList listID: Int,
+        page: Int?,
+        sortedBy: V4ListSortBy?,
+        language: String?,
+        accessToken: String?
+    ) async throws(TMDbError) -> V4List
+
+    ///
+    /// Returns a page of a list's items.
+    ///
+    /// This reshapes ``details(forList:page:sortedBy:language:accessToken:)`` —
+    /// v4 has no separate items endpoint.
+    ///
+    /// - Parameters:
+    ///    - listID: The identifier of the list.
+    ///    - page: The page of items to return.
+    ///    - sortedBy: How to order the items for this request.
+    ///    - language: ISO 639-1 language code to display results in.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: A pageable list of the list's items.
+    ///
+    func items(
+        forList listID: Int,
+        page: Int?,
+        sortedBy: V4ListSortBy?,
+        language: String?,
+        accessToken: String?
+    ) async throws(TMDbError) -> PageableListResult<V4ListItem>
+
+    ///
+    /// Checks whether a movie or TV series is in a list.
+    ///
+    /// [TMDb API - List: Item Status](https://developer.themoviedb.org/v4/reference/list-item-status)
+    ///
+    /// - Parameters:
+    ///    - mediaID: The identifier of the movie or TV series.
+    ///    - showType: Whether it is a movie or a TV series.
+    ///    - listID: The identifier of the list.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: `true` when the item is in the list.
+    ///
+    /// - Important: `false` means only "not found". TMDb answers 404 for an
+    ///   item that is absent, for a list that does not exist, **and** for a
+    ///   list you cannot see — the three are indistinguishable in its response.
+    ///
+    func itemStatus(
+        forMedia mediaID: Int,
+        ofType showType: ShowType,
+        inList listID: Int,
+        accessToken: String?
+    ) async throws(TMDbError) -> Bool
+
+    ///
+    /// Returns the lists belonging to an account.
+    ///
+    /// [TMDb API - Account: Lists](https://developer.themoviedb.org/v4/reference/account-lists)
+    ///
+    /// - Parameters:
+    ///    - accountObjectID: The account's object identifier, as returned by
+    ///      ``V4AccessToken/accountID``.
+    ///    - page: The page of results to return.
+    ///    - accessToken: The account owner's access token.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: A pageable list of the account's lists.
+    ///
+    func lists(
+        forAccount accountObjectID: String,
+        page: Int?,
+        accessToken: String
+    ) async throws(TMDbError) -> PageableListResult<V4ListSummary>
+
+    ///
+    /// Creates a list.
+    ///
+    /// [TMDb API - List: Create](https://developer.themoviedb.org/v4/reference/list-create)
+    ///
+    /// - Parameters:
+    ///    - name: The list's name.
+    ///    - attributes: The list's other settable properties. Any left `nil`
+    ///      take TMDb's default; an omitted `isPublic` yields a public list.
+    ///    - accessToken: The user's access token.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The result, including the new list's identifier.
+    ///
+    func create(
+        name: String,
+        attributes: V4ListAttributes?,
+        accessToken: String
+    ) async throws(TMDbError) -> V4CreateListResult
+
+    ///
+    /// Updates a list's details.
+    ///
+    /// [TMDb API - List: Update](https://developer.themoviedb.org/v4/reference/list-update)
+    ///
+    /// - Parameters:
+    ///    - listID: The identifier of the list.
+    ///    - attributes: The properties to change. Any left `nil` are unchanged.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    func update(
+        list listID: Int,
+        attributes: V4ListAttributes,
+        accessToken: String
+    ) async throws(TMDbError)
+
+    ///
+    /// Adds items to a list.
+    ///
+    /// [TMDb API - List: Add Items](https://developer.themoviedb.org/v4/reference/list-add-items)
+    ///
+    /// - Parameters:
+    ///    - items: The movies and TV series to add.
+    ///    - listID: The identifier of the list.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The per-item outcomes. Check these rather than the overall
+    ///   success: TMDb reports success for a request in which individual items
+    ///   failed.
+    ///
+    func addItems(
+        _ items: [V4ListMediaItem],
+        toList listID: Int,
+        accessToken: String
+    ) async throws(TMDbError) -> V4ListItemsResult
+
+    ///
+    /// Sets comments on items already in a list.
+    ///
+    /// [TMDb API - List: Update Items](https://developer.themoviedb.org/v4/reference/list-update-items)
+    ///
+    /// - Parameters:
+    ///    - items: The items to comment on.
+    ///    - listID: The identifier of the list.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The per-item outcomes.
+    ///
+    /// - Note: This is the only way to store a comment — adding an item with
+    ///   one attached does not.
+    ///
+    func updateItems(
+        _ items: [V4ListItemComment],
+        inList listID: Int,
+        accessToken: String
+    ) async throws(TMDbError) -> V4ListItemsResult
+
+    ///
+    /// Removes items from a list.
+    ///
+    /// [TMDb API - List: Remove Items](https://developer.themoviedb.org/v4/reference/list-remove-items)
+    ///
+    /// - Parameters:
+    ///    - items: The movies and TV series to remove.
+    ///    - listID: The identifier of the list.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The per-item outcomes. Removing an item that is not in the
+    ///   list reports overall success with that item marked failed.
+    ///
+    func removeItems(
+        _ items: [V4ListMediaItem],
+        fromList listID: Int,
+        accessToken: String
+    ) async throws(TMDbError) -> V4ListItemsResult
+
+    ///
+    /// Removes every item from a list, keeping the list itself.
+    ///
+    /// [TMDb API - List: Clear](https://developer.themoviedb.org/v4/reference/list-clear)
+    ///
+    /// - Parameters:
+    ///    - listID: The identifier of the list.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    /// - Returns: The result, including how many items were removed.
+    ///
+    func clear(
+        list listID: Int,
+        accessToken: String
+    ) async throws(TMDbError) -> V4ClearListResult
+
+    ///
+    /// Deletes a list.
+    ///
+    /// [TMDb API - List: Delete](https://developer.themoviedb.org/v4/reference/list-delete)
+    ///
+    /// - Parameters:
+    ///    - listID: The identifier of the list.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error ``TMDbError``.
+    ///
+    func delete(list listID: Int, accessToken: String) async throws(TMDbError)
+
+}

--- a/Sources/TMDb/Extensions/JSONDecoder+TMDb.swift
+++ b/Sources/TMDb/Extensions/JSONDecoder+TMDb.swift
@@ -43,6 +43,38 @@ extension JSONDecoder {
         return decoder
     }
 
+    /// The v4 API returns **both** date shapes, sometimes in one response:
+    /// account-list summaries carry `"2026-08-06 23:26:00 UTC"` while list
+    /// items carry `"1999-10-15"`. Neither v3 decoder handles both.
+    ///
+    /// The timestamp form is tried first because the day-precision strategy
+    /// cannot consume a timestamp that has already failed, and the fallback
+    /// reuses the v3 day-precision strategy — including its time zone — so the
+    /// same `release_date` decodes to the same instant whichever API version
+    /// fetched it.
+    static var theMovieDatabaseV4: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let dateString = try container.decode(String.self)
+
+            if let date = try? Date(dateString, strategy: theMovieDatabaseAuthDateStrategy) {
+                return date
+            }
+
+            do {
+                return try Date(dateString, strategy: theMovieDatabaseDateStrategy)
+            } catch {
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Date string matches neither yyyy-MM-dd HH:mm:ss UTC nor yyyy-MM-dd: \(dateString). Underlying error: \(error)"
+                )
+            }
+        }
+        return decoder
+    }
+
     static var theMovieDatabaseAuth: JSONDecoder {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase

--- a/Sources/TMDb/Extensions/JSONEncoder+TMDb.swift
+++ b/Sources/TMDb/Extensions/JSONEncoder+TMDb.swift
@@ -23,4 +23,22 @@ extension JSONEncoder {
         return encoder
     }
 
+    /// The v4 counterpart of ``theMovieDatabaseV4`` decoding.
+    ///
+    /// It writes the `yyyy-MM-dd HH:mm:ss UTC` form for **every** date, which
+    /// is what makes a v4 model round trip exactly. That form is lossless to
+    /// the second, and the v4 decoder tries it first, so a day-precision date
+    /// re-read after encoding still lands on the instant it started from —
+    /// whereas the day-precision encoder would throw the time away and a
+    /// timestamp would come back as midnight.
+    ///
+    /// No v4 *request* body carries a date, so this only ever affects
+    /// re-encoding a decoded response.
+    static var theMovieDatabaseV4: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        encoder.dateEncodingStrategy = .formatted(.theMovieDatabaseAuth)
+        return encoder
+    }
+
 }

--- a/Sources/TMDb/Networking/CacheHTTPClient.swift
+++ b/Sources/TMDb/Networking/CacheHTTPClient.swift
@@ -91,7 +91,7 @@ final class CacheHTTPClient: HTTPClient, Sendable {
     }
 
     func perform(request: HTTPRequest) async throws -> HTTPResponse {
-        guard request.method == .get else {
+        guard request.method == .get, !isStateChanging(request) else {
             return try await performMutation(request: request)
         }
 
@@ -129,6 +129,13 @@ extension CacheHTTPClient {
     }
 
     private func isUserSpecificRequest(_ request: HTTPRequest) -> Bool {
+        // Set by `TMDbAPIClient` when the request carried its own credential —
+        // the v4 endpoints thread a user access token per call, so two users'
+        // reads of one list share a URL and differ only by a header.
+        if request.isUserSpecific {
+            return true
+        }
+
         if let components = URLComponents(url: request.url, resolvingAgainstBaseURL: false),
            let queryItems = components.queryItems,
            queryItems.contains(where: { $0.name == "session_id" }) {
@@ -140,6 +147,17 @@ extension CacheHTTPClient {
         }
 
         return false
+    }
+
+    ///
+    /// Whether a `GET` mutates server state despite its method.
+    ///
+    /// `GET /4/list/{id}/clear` empties a list — `POST` to that path returns
+    /// 404 — so it must invalidate the cache rather than populate it. v3's
+    /// clear is a `POST` and so never reaches here.
+    ///
+    private func isStateChanging(_ request: HTTPRequest) -> Bool {
+        request.url.path.hasSuffix("/clear")
     }
 
     private func isSuccessful(_ response: HTTPResponse) -> Bool {

--- a/Sources/TMDb/Networking/CacheHTTPClient.swift
+++ b/Sources/TMDb/Networking/CacheHTTPClient.swift
@@ -70,10 +70,13 @@ private actor ResponseCache {
 ///
 /// An `HTTPClient` decorator that caches successful `GET` responses in memory.
 ///
-/// Cache hits short-circuit the wrapped client. User-specific requests (those
-/// carrying a `session_id` or a guest session) bypass the cache, and any
-/// successful `POST` or `DELETE` invalidates the entire cache. This layer sits
-/// above the underlying transport's own on-disk `URLCache`.
+/// Cache hits short-circuit the wrapped client. Requests needing a *user's*
+/// credential bypass the cache entirely — see ``HTTPRequest/isUserSpecific`` —
+/// and any successful mutation invalidates the whole cache. A mutation here
+/// means a `POST`, `PUT` or `DELETE`, **or** a state-changing `GET`: TMDb
+/// clears a v4 list with `GET /4/list/{id}/clear`, which must invalidate rather
+/// than be cached. This layer sits above the underlying transport's own on-disk
+/// `URLCache`.
 ///
 final class CacheHTTPClient: HTTPClient, Sendable {
 
@@ -149,15 +152,8 @@ extension CacheHTTPClient {
         return false
     }
 
-    ///
-    /// Whether a `GET` mutates server state despite its method.
-    ///
-    /// `GET /4/list/{id}/clear` empties a list — `POST` to that path returns
-    /// 404 — so it must invalidate the cache rather than populate it. v3's
-    /// clear is a `POST` and so never reaches here.
-    ///
     private func isStateChanging(_ request: HTTPRequest) -> Bool {
-        request.url.path.hasSuffix("/clear")
+        request.isStateChangingGET
     }
 
     private func isSuccessful(_ response: HTTPResponse) -> Bool {

--- a/Sources/TMDb/Networking/HTTPClient/HTTPRequest+StateChanging.swift
+++ b/Sources/TMDb/Networking/HTTPClient/HTTPRequest+StateChanging.swift
@@ -1,0 +1,28 @@
+//
+//  HTTPRequest+StateChanging.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+extension HTTPRequest {
+
+    ///
+    /// Whether this `GET` mutates server state despite its method.
+    ///
+    /// `GET /4/list/{id}/clear` empties a list — `POST` to that path returns
+    /// 404 — so its method says "safe and repeatable" while its effect says
+    /// otherwise. v3's clear is a `POST` and never matches.
+    ///
+    /// Both decorators need this and must agree, which is why it lives here
+    /// rather than in either of them: `CacheHTTPClient` has to invalidate
+    /// instead of caching, and `RetryHTTPClient` must not replay it. Splitting
+    /// the judgement across the two is how they would drift apart.
+    ///
+    var isStateChangingGET: Bool {
+        method == .get && url.path.hasSuffix("/clear")
+    }
+
+}

--- a/Sources/TMDb/Networking/HTTPClient/HTTPRequest.swift
+++ b/Sources/TMDb/Networking/HTTPClient/HTTPRequest.swift
@@ -33,6 +33,21 @@ public struct HTTPRequest: Sendable {
     public let body: Data?
 
     ///
+    /// Whether this request is authenticated as a specific user, rather than as
+    /// the application.
+    ///
+    /// A custom ``HTTPClient`` **must not cache, store or log the response to a
+    /// request where this is `true`**. Such a response is private to one user,
+    /// yet its URL is identical for every user — the credential travels in a
+    /// header — so caching it by URL would serve one user's data to another.
+    ///
+    /// This cannot be inferred from the presence of an `Authorization` header: a
+    /// client created with ``TMDbClient/init(bearerToken:configuration:)`` sends
+    /// one on every request, including entirely public ones.
+    ///
+    public let isUserSpecific: Bool
+
+    ///
     /// Create an HTTP request object.
     ///
     /// - Parameters:
@@ -40,16 +55,20 @@ public struct HTTPRequest: Sendable {
     ///   - method: HTTP method.
     ///   - headers: HTTP headers.
     ///   - body: Body data.
+    ///   - isUserSpecific: Whether the request is authenticated as a specific
+    ///     user. Defaults to `false`.
     public init(
         url: URL,
         method: HTTPRequest.Method = .get,
         headers: [String: String] = [:],
-        body: Data? = nil
+        body: Data? = nil,
+        isUserSpecific: Bool = false
     ) {
         self.url = url
         self.method = method
         self.headers = headers
         self.body = body
+        self.isUserSpecific = isUserSpecific
     }
 
 }
@@ -75,6 +94,11 @@ public extension HTTPRequest {
         /// HTTP DELETE method.
         ///
         case delete = "DELETE"
+
+        ///
+        /// HTTP PUT method.
+        ///
+        case put = "PUT"
 
     }
 

--- a/Sources/TMDb/Networking/HTTPClient/HTTPRequest.swift
+++ b/Sources/TMDb/Networking/HTTPClient/HTTPRequest.swift
@@ -33,17 +33,23 @@ public struct HTTPRequest: Sendable {
     public let body: Data?
 
     ///
-    /// Whether this request is authenticated as a specific user, rather than as
-    /// the application.
+    /// Whether this request requires a specific user's credential, rather than
+    /// the application's.
     ///
     /// A custom ``HTTPClient`` **must not cache, store or log the response to a
-    /// request where this is `true`**. Such a response is private to one user,
-    /// yet its URL is identical for every user — the credential travels in a
-    /// header — so caching it by URL would serve one user's data to another.
+    /// request where this is `true`** — it is one user's private data.
     ///
-    /// This cannot be inferred from the presence of an `Authorization` header: a
-    /// client created with ``TMDbClient/init(bearerToken:configuration:)`` sends
-    /// one on every request, including entirely public ones.
+    /// It is `true` for all three of TMDb's user-scoped mechanisms: a v4 user
+    /// access token passed per call, a v3 `session_id`, and a guest session.
+    /// Where the token travels in a header, two users' requests for the same
+    /// resource have *identical* URLs, so a URL-keyed cache would serve one
+    /// user's data to another; where it travels in the URL the keys differ, but
+    /// the response is still private and must not be written to a shared store.
+    ///
+    /// It cannot be inferred from the presence of an `Authorization` header
+    /// alone: a client created with ``TMDbClient/init(bearerToken:configuration:)``
+    /// sends one on every request, including wholly public ones, and those
+    /// remain cacheable.
     ///
     public let isUserSpecific: Bool
 

--- a/Sources/TMDb/Networking/RetryHTTPClient.swift
+++ b/Sources/TMDb/Networking/RetryHTTPClient.swift
@@ -25,7 +25,13 @@ final class RetryHTTPClient: HTTPClient, Sendable {
         // Only retry idempotent methods. Retrying a non-idempotent mutation
         // (e.g. a POST that adds to a list or rates an item) risks
         // double-applying it server-side, so perform it exactly once.
-        guard request.method.isIdempotent else {
+        //
+        // The method alone is not the whole answer: `GET /4/list/{id}/clear`
+        // mutates, so a replay after a lost response would report
+        // `items_deleted: 0` for a clear that did happen. `CacheHTTPClient`
+        // makes the same judgement from the same property, so the two cannot
+        // drift apart.
+        guard request.method.isIdempotent, !request.isStateChangingGET else {
             return try await httpClient.perform(request: request)
         }
 

--- a/Sources/TMDb/Networking/RetryHTTPClient.swift
+++ b/Sources/TMDb/Networking/RetryHTTPClient.swift
@@ -198,7 +198,10 @@ private extension HTTPRequest.Method {
     /// methods such as `POST` are not idempotent and must never be retried.
     var isIdempotent: Bool {
         switch self {
-        case .get, .delete:
+        case .get, .delete, .put:
+            // `PUT` replaces the resource with the request's own representation,
+            // so replaying it converges on the same state — unlike `POST`,
+            // which appends.
             true
 
         case .post:

--- a/Sources/TMDb/Networking/Serialisers/TMDbV4JSONSerialiser.swift
+++ b/Sources/TMDb/Networking/Serialisers/TMDbV4JSONSerialiser.swift
@@ -14,7 +14,10 @@ import Foundation
 /// shapes — account-list summaries use `"2026-08-06 23:26:00 UTC"` while list
 /// items use `"1999-10-15"` — and neither v3 decoder parses both.
 ///
-/// Encoding reuses the v3 encoder: no v4 request body carries a date.
+/// Encoding writes the timestamp form for every date. No v4 request body
+/// carries a date, so this only matters when re-encoding a decoded response —
+/// where it is what makes a round trip exact, since the day-precision encoder
+/// would discard the time from an account-list timestamp.
 ///
 final class TMDbV4JSONSerialiser: Serialiser {
 
@@ -29,7 +32,7 @@ final class TMDbV4JSONSerialiser: Serialiser {
     }
 
     func encode(_ value: some Encodable) async throws -> Data {
-        let encoder = JSONEncoder.theMovieDatabase
+        let encoder = JSONEncoder.theMovieDatabaseV4
 
         return try encoder.encode(value)
     }

--- a/Sources/TMDb/Networking/Serialisers/TMDbV4JSONSerialiser.swift
+++ b/Sources/TMDb/Networking/Serialisers/TMDbV4JSONSerialiser.swift
@@ -1,0 +1,37 @@
+//
+//  TMDbV4JSONSerialiser.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+///
+/// The serialiser for the v4 API.
+///
+/// It exists for one reason: a single v4 response can carry both TMDb date
+/// shapes — account-list summaries use `"2026-08-06 23:26:00 UTC"` while list
+/// items use `"1999-10-15"` — and neither v3 decoder parses both.
+///
+/// Encoding reuses the v3 encoder: no v4 request body carries a date.
+///
+final class TMDbV4JSONSerialiser: Serialiser {
+
+    let mimeType = "application/json"
+
+    init() {}
+
+    func decode<T: Decodable>(_ type: T.Type, from data: Data) async throws -> T {
+        let decoder = JSONDecoder.theMovieDatabaseV4
+
+        return try decoder.decode(type, from: data)
+    }
+
+    func encode(_ value: some Encodable) async throws -> Data {
+        let encoder = JSONEncoder.theMovieDatabase
+
+        return try encoder.encode(value)
+    }
+
+}

--- a/Sources/TMDb/Networking/TMDbAPIClient.swift
+++ b/Sources/TMDb/Networking/TMDbAPIClient.swift
@@ -70,16 +70,29 @@ extension TMDbAPIClient {
         var queryItems = request.queryItems
         var headers = request.headers
 
-        // A request that brought its own `Authorization` is authenticated as a
-        // specific *user* (the v4 endpoints thread an access token per call).
-        // The client credential is then withheld entirely — both the header and
-        // the `api_key` query item — because sending two credentials leaves
-        // precedence to the server, which is not something this library should
-        // guess at. Without this, `Authorization` was overwritten below and a
-        // user-scoped read would return the *application owner's* data.
-        let isUserSpecific = headers["Authorization"] != nil
+        // Does this request require a *user's* credential, by any of the three
+        // mechanisms TMDb offers? Marking it here — the one place that sees the
+        // request before the client credential is applied — keeps the rule out
+        // of the individual request classes, where a new user-scoped endpoint
+        // could forget it and silently have its private response cached.
+        //
+        // A client-level bearer token is deliberately NOT included: that is the
+        // application's API Read Access Token, sent on every request including
+        // wholly public ones, so treating it as user-scoped would disable
+        // caching for every `TMDbClient(bearerToken:)`.
+        let carriesUserToken = headers["Authorization"] != nil
+        let carriesSession = queryItems["session_id"] != nil
+        let isGuestSession = request.path.contains("guest_session")
+        let isUserSpecific = carriesUserToken || carriesSession || isGuestSession
 
-        if !isUserSpecific {
+        // A request that brought its own `Authorization` is authenticated as a
+        // specific user (the v4 endpoints thread an access token per call), so
+        // the client credential is withheld entirely — both the header and the
+        // `api_key` query item — because sending two credentials leaves
+        // precedence to the server, which this library should not guess at.
+        // Without this, `Authorization` was overwritten below and a user-scoped
+        // read would return the *application owner's* data.
+        if !carriesUserToken {
             switch credential {
             case .apiKey(let apiKey):
                 queryItems["api_key"] = apiKey

--- a/Sources/TMDb/Networking/TMDbAPIClient.swift
+++ b/Sources/TMDb/Networking/TMDbAPIClient.swift
@@ -70,11 +70,22 @@ extension TMDbAPIClient {
         var queryItems = request.queryItems
         var headers = request.headers
 
-        switch credential {
-        case .apiKey(let apiKey):
-            queryItems["api_key"] = apiKey
-        case .bearerToken(let token):
-            headers["Authorization"] = "Bearer \(token)"
+        // A request that brought its own `Authorization` is authenticated as a
+        // specific *user* (the v4 endpoints thread an access token per call).
+        // The client credential is then withheld entirely — both the header and
+        // the `api_key` query item — because sending two credentials leaves
+        // precedence to the server, which is not something this library should
+        // guess at. Without this, `Authorization` was overwritten below and a
+        // user-scoped read would return the *application owner's* data.
+        let isUserSpecific = headers["Authorization"] != nil
+
+        if !isUserSpecific {
+            switch credential {
+            case .apiKey(let apiKey):
+                queryItems["api_key"] = apiKey
+            case .bearerToken(let token):
+                headers["Authorization"] = "Bearer \(token)"
+            }
         }
 
         let url = urlFromPath(path, queryItems: queryItems)
@@ -93,7 +104,13 @@ extension TMDbAPIClient {
             }
         }
 
-        return HTTPRequest(url: url, method: method, headers: headers, body: data)
+        return HTTPRequest(
+            url: url,
+            method: method,
+            headers: headers,
+            body: data,
+            isUserSpecific: isUserSpecific
+        )
     }
 
     private func urlFromPath(
@@ -131,6 +148,9 @@ extension TMDbAPIClient {
 
         case .post:
             .post
+
+        case .put:
+            .put
 
         case .delete:
             .delete

--- a/Sources/TMDb/TMDb.docc/Extensions/TMDbClient.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/TMDbClient.md
@@ -40,5 +40,6 @@
 - ``account``
 - ``authentication``
 - ``v4Authentication``
+- ``v4Lists``
 - ``changes``
 - ``guestSessions``

--- a/Sources/TMDb/TMDb.docc/Extensions/V4ListService.md
+++ b/Sources/TMDb/TMDb.docc/Extensions/V4ListService.md
@@ -1,0 +1,40 @@
+# ``V4ListService``
+
+## Topics
+
+### Reading a List
+
+- ``details(forList:)``
+- ``details(forList:accessToken:)``
+- ``details(forList:page:sortedBy:language:accessToken:)``
+- ``items(forList:)``
+- ``items(forList:accessToken:)``
+- ``items(forList:page:sortedBy:language:accessToken:)``
+
+### Checking an Item
+
+- ``itemStatus(forMedia:ofType:inList:)``
+- ``itemStatus(forMedia:ofType:inList:accessToken:)``
+
+### Listing an Account's Lists
+
+- ``lists(forAccount:accessToken:)``
+- ``lists(forAccount:page:accessToken:)``
+
+### Creating and Updating a List
+
+- ``create(name:accessToken:)``
+- ``create(name:attributes:accessToken:)``
+- ``update(list:name:accessToken:)``
+- ``update(list:attributes:accessToken:)``
+
+### Managing a List's Items
+
+- ``addItems(_:toList:accessToken:)``
+- ``updateItems(_:inList:accessToken:)``
+- ``removeItems(_:fromList:accessToken:)``
+- ``clear(list:accessToken:)``
+
+### Deleting a List
+
+- ``delete(list:accessToken:)``

--- a/Sources/TMDb/TMDb.docc/HowTos/AuthenticatingWithV4.md
+++ b/Sources/TMDb/TMDb.docc/HowTos/AuthenticatingWithV4.md
@@ -104,6 +104,65 @@ Users can also revoke access from their TMDb account settings, so treat a
 sudden authentication failure as a signal to discard the stored token and run
 the flow again rather than as a bug.
 
+## Using the token with v4 lists
+
+The access token is what ``V4ListService`` needs. Reading a *public* list takes
+no token at all:
+
+```swift
+let list = try await client.v4Lists.details(forList: 1)
+```
+
+Everything else — a private list, and every write — takes the user's token:
+
+```swift
+let token = accessToken.accessToken
+
+let created = try await client.v4Lists.create(
+    name: "Weekend Watchlist",
+    attributes: V4ListAttributes(description: "Films to catch up on", isPublic: false),
+    accessToken: token
+)
+
+// A v4 list holds movies and TV series together.
+let added = try await client.v4Lists.addItems(
+    [.movie(550), .tvSeries(1399)],
+    toList: created.id,
+    accessToken: token
+)
+
+// Check the per-item outcomes: TMDb reports overall success even when an
+// individual item failed.
+if !added.allItemsSucceeded {
+    print("failed: \(added.failures)")
+}
+```
+
+Comments are set separately. Adding an item with a comment attached does not
+store it — only updating an existing item does:
+
+```swift
+try await client.v4Lists.updateItems(
+    [.movie(550, comment: "Rewatch for the twist")],
+    inList: created.id,
+    accessToken: token
+)
+```
+
+To list everything the user owns, use the `accountID` from the access token:
+
+```swift
+let lists = try await client.v4Lists.lists(
+    forAccount: accessToken.accountID,
+    accessToken: token
+)
+```
+
+- Note: Responses to any of these are **never cached**, by either cache layer.
+  They are private to one user, and a v4 list read carries its credential in a
+  header rather than the URL — so two users' requests are otherwise
+  indistinguishable. See <doc:CachingResponses>.
+
 ## Bridging to a v3 session
 
 If you already hold a v4 user access token and need to call a v3 endpoint,

--- a/Sources/TMDb/TMDb.docc/HowTos/CachingResponses.md
+++ b/Sources/TMDb/TMDb.docc/HowTos/CachingResponses.md
@@ -140,6 +140,7 @@ import TMDb
 struct CustomHTTPClient: HTTPClient {
 
     private let urlSession: URLSession
+    private let noCacheURLSession: URLSession
 
     init() {
         let configuration = URLSessionConfiguration.default
@@ -148,6 +149,14 @@ struct CustomHTTPClient: HTTPClient {
         configuration.urlCache = URLCache(memoryCapacity: 10_000_000, diskCapacity: 200_000_000)
         // ...or set `configuration.urlCache = nil` to disable HTTP caching.
         urlSession = URLSession(configuration: configuration)
+
+        // A second session with no cache, for user-specific responses. A cache
+        // *policy* alone would stop a stale read but not the write, so the
+        // response would still be on disk.
+        let privateConfiguration = URLSessionConfiguration.default
+        privateConfiguration.urlCache = nil
+        privateConfiguration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        noCacheURLSession = URLSession(configuration: privateConfiguration)
     }
 
     func perform(request: HTTPRequest) async throws -> HTTPResponse {
@@ -158,7 +167,14 @@ struct CustomHTTPClient: HTTPClient {
             urlRequest.setValue(value, forHTTPHeaderField: field)
         }
 
-        let (data, response) = try await urlSession.data(for: urlRequest)
+        // Never cache, store or log a response that required a user's
+        // credential — see `HTTPRequest.isUserSpecific`.
+        let session = request.isUserSpecific ? noCacheURLSession : urlSession
+        if request.isUserSpecific {
+            urlRequest.cachePolicy = .reloadIgnoringLocalCacheData
+        }
+
+        let (data, response) = try await session.data(for: urlRequest)
         let httpResponse = response as? HTTPURLResponse
         let statusCode = httpResponse?.statusCode ?? 0
         // Forward the headers so features like Retry-After backoff keep working.

--- a/Sources/TMDb/TMDb.docc/HowTos/CachingResponses.md
+++ b/Sources/TMDb/TMDb.docc/HowTos/CachingResponses.md
@@ -76,11 +76,38 @@ let tmdbClient = TMDbClient(apiKey: "<your-tmdb-api-key>", configuration: config
 
 This layer is deliberately lightweight: it holds responses in memory only (so it
 is cleared when the process ends), caches `GET` requests only, bypasses
-user-specific requests (those carrying a `session_id` or a guest session), and
-invalidates the entire cache after any successful `POST` or `DELETE`.
+user-specific requests (see below), and invalidates the entire cache after any
+successful `POST` or `DELETE`.
 
 Reach for it when you want a predictable, fixed TTL regardless of TMDb's headers,
 or when you need a cache on a platform where `URLCache` is unavailable.
+
+## User-specific responses are never cached
+
+A response that required a *user's* credential is never stored or served by
+either layer — not the in-memory cache, and not the on-disk `URLCache`. That
+covers all three of TMDb's user-scoped mechanisms:
+
+- a v4 user access token, passed per call to ``V4ListService``
+- a v3 `session_id`
+- a guest session
+
+The reason differs by mechanism, and both matter. A v4 list read carries its
+token in a **header**, so two different users requesting the same list send
+byte-identical URLs — a URL-keyed cache would serve one user's private list to
+another. A v3 session request carries its credential in the URL, so the keys do
+differ and nothing crosses between users; but the response is still one person's
+watchlist or ratings being written to a store that is shared process-wide and
+survives relaunch.
+
+A request built with `TMDbClient(bearerToken:)` is **not** treated as
+user-specific just for having an `Authorization` header. That token is your
+application's API Read Access Token, sent on every request including entirely
+public ones, so those responses stay cacheable.
+
+- Important: If you supply your own ``HTTPClient``, honour
+  ``HTTPRequest/isUserSpecific``. When it is `true`, do not cache, store or log
+  the response.
 
 ## How the layers interact
 

--- a/Sources/TMDb/TMDb.docc/TMDb.md
+++ b/Sources/TMDb/TMDb.docc/TMDb.md
@@ -429,6 +429,22 @@ Watch providers provided by [JustWatch](https://www.justwatch.com).
 - ``V4RequestToken``
 - ``V4AccessToken``
 
+### Lists (v4)
+
+- ``V4ListService``
+- ``V4List``
+- ``V4ListItem``
+- ``V4ListSummary``
+- ``V4ListCreator``
+- ``V4ListAttributes``
+- ``V4ListSortBy``
+- ``V4ListMediaItem``
+- ``V4ListItemComment``
+- ``V4CreateListResult``
+- ``V4ClearListResult``
+- ``V4ListItemsResult``
+- ``V4ListItemResult``
+
 ### Changes
 
 - ``ChangesService``

--- a/Sources/TMDb/TMDbClient.swift
+++ b/Sources/TMDb/TMDbClient.swift
@@ -258,6 +258,13 @@ public final class TMDbClient: Sendable {
     /// therefore out of logs, proxies, and cache keys). Use the **API Read
     /// Access Token** from your TMDb account's API settings.
     ///
+    /// - Warning: Pass the *application's* Read Access Token here, not a
+    /// **user** access token. TMDb accepts either, but a client built this way
+    /// is treated as application-level and its responses are cacheable — pass a
+    /// user token and that user's private data is written to a cache shared
+    /// across the process. To act as a user, keep the application token here
+    /// and pass the user's token per call, as ``V4ListService`` takes it.
+    ///
     /// - Parameters:
     ///   - bearerToken: The TMDb v4 access token to authenticate requests with.
     ///   - configuration: The configuration for the client. Defaults to ``TMDbConfiguration/system``.
@@ -280,6 +287,13 @@ public final class TMDbClient: Sendable {
     /// `api_key` query item, keeping the credential out of request URLs (and
     /// therefore out of logs, proxies, and cache keys). Use the **API Read
     /// Access Token** from your TMDb account's API settings.
+    ///
+    /// - Warning: Pass the *application's* Read Access Token here, not a
+    /// **user** access token. TMDb accepts either, but a client built this way
+    /// is treated as application-level and its responses are cacheable — pass a
+    /// user token and that user's private data is written to a cache shared
+    /// across the process. To act as a user, keep the application token here
+    /// and pass the user's token per call, as ``V4ListService`` takes it.
     ///
     /// - Parameters:
     ///   - bearerToken: The TMDb v4 access token to authenticate requests with.

--- a/Sources/TMDb/TMDbClient.swift
+++ b/Sources/TMDb/TMDbClient.swift
@@ -53,6 +53,17 @@ public final class TMDbClient: Sendable {
     public let v4Authentication: any V4AuthenticationService
 
     ///
+    /// Provides access to TMDb v4 lists.
+    ///
+    /// Unlike ``lists``, a v4 list holds **movies and TV series together**, can
+    /// be private, and can carry a comment on each item.
+    ///
+    /// Reading a public list needs no user credential. Everything else takes an
+    /// access token obtained through ``v4Authentication``.
+    ///
+    public let v4Lists: any V4ListService
+
+    ///
     /// Provides access to content certifications (e.g. G, PG, R) for
     /// movies and TV series.
     ///
@@ -315,6 +326,7 @@ public final class TMDbClient: Sendable {
             apiClient: v4APIClient,
             authenticateURLBuilder: v4AuthenticateURLBuilder
         )
+        self.v4Lists = TMDbV4ListService(apiClient: v4APIClient)
         self.certifications = TMDbCertificationService(apiClient: apiClient)
         self.collections = TMDbCollectionService(apiClient: apiClient, configuration: configuration)
         self.companies = TMDbCompanyService(apiClient: apiClient)

--- a/Sources/TMDb/TMDbFactory.swift
+++ b/Sources/TMDb/TMDbFactory.swift
@@ -50,7 +50,7 @@ extension TMDbFactory {
             apiClient: TMDbAPIClient(
                 credential: credential,
                 baseURL: tmdbAPIv4BaseURL,
-                serialiser: serialiser(),
+                serialiser: v4Serialiser(),
                 httpClient: httpClient
             )
         )
@@ -139,6 +139,10 @@ extension TMDbFactory {
 
     private static func authSerialiser() -> some Serialiser {
         TMDbAuthJSONSerialiser()
+    }
+
+    private static func v4Serialiser() -> some Serialiser {
+        TMDbV4JSONSerialiser()
     }
 
 }

--- a/Sources/TMDbTesting/Samples/V4List+Sample.swift
+++ b/Sources/TMDbTesting/Samples/V4List+Sample.swift
@@ -1,0 +1,145 @@
+//
+//  V4List+Sample.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import TMDb
+
+public extension V4ListCreator {
+
+    /// A sample `V4ListCreator` populated with representative data.
+    static var sample: V4ListCreator {
+        V4ListCreator(
+            id: "1a2b3c4d5e6f7a8b9c0d1e2f",
+            name: "Test User",
+            username: "testuser",
+            avatarPath: URL(string: "/1AbCdEfGhIjKlMnOpQrStUvWxYz.jpg"),
+            gravatarHash: "0123456789abcdef0123456789abcdef"
+        )
+    }
+
+}
+
+public extension V4ListItem {
+
+    /// A sample `V4ListItem` — a movie, with a comment.
+    static var sample: V4ListItem {
+        V4ListItem(media: .movie(sampleMovie), comment: "Rewatch for the twist")
+    }
+
+    /// Sample `V4ListItem`s — one movie and one TV series, since holding both
+    /// is what distinguishes a v4 list from a v3 one.
+    static var samples: [V4ListItem] {
+        [
+            V4ListItem(media: .movie(sampleMovie), comment: "Rewatch for the twist"),
+            V4ListItem(media: .tvSeries(sampleTVSeries), comment: nil)
+        ]
+    }
+
+    private static var sampleMovie: MovieListItem {
+        MovieListItem(
+            id: 550,
+            title: "Fight Club",
+            originalTitle: "Fight Club",
+            originalLanguage: "en",
+            overview: """
+            A ticking-time-bomb insomniac and a slippery soap salesman channel primal male \
+            aggression into a shocking new form of therapy.
+            """,
+            genreIDs: [18, 53],
+            releaseDate: Date(timeIntervalSince1970: 939_945_600),
+            posterPath: URL(string: "/jSziioSwPVrOy9Yow3XhWIBDjq1.jpg"),
+            backdropPath: URL(string: "/c6OLXfKAk5BKeR6broC8pYiCquX.jpg"),
+            popularity: 54.7069,
+            voteAverage: 8.437,
+            voteCount: 32545,
+            hasVideo: false,
+            isAdultOnly: false
+        )
+    }
+
+    private static var sampleTVSeries: TVSeriesListItem {
+        TVSeriesListItem(
+            id: 1399,
+            name: "Game of Thrones",
+            originalName: "Game of Thrones",
+            originalLanguage: "en",
+            overview: """
+            Seven noble families fight for control of the mythical land of Westeros. Friction \
+            between the houses leads to full-scale war.
+            """,
+            genreIDs: [10765, 18, 10759],
+            firstAirDate: Date(timeIntervalSince1970: 1_303_084_800),
+            originCountries: ["US"],
+            posterPath: URL(string: "/1XS1oqL89opfnbLl8WnZY1O1uJx.jpg"),
+            backdropPath: URL(string: "/2OMB0ynKlyIenMJWI2Dy9IWT4c.jpg"),
+            popularity: 178.5243,
+            voteAverage: 8.468,
+            voteCount: 27430
+        )
+    }
+
+}
+
+public extension V4List {
+
+    /// A sample `V4List` populated with representative data, holding both a
+    /// movie and a TV series.
+    static var sample: V4List {
+        V4List(
+            id: 8_678_999,
+            name: "My Watchlist",
+            description: "Films and shows to catch up on",
+            isPublic: true,
+            createdBy: .sample,
+            items: V4ListItem.samples,
+            itemCount: 2,
+            averageRating: 8.45,
+            runtime: 8433,
+            revenue: 43_124_857_678,
+            sortBy: "original_order.asc",
+            languageCode: "en",
+            countryCode: "US",
+            page: 1,
+            totalPages: 1,
+            totalResults: 2
+        )
+    }
+
+}
+
+public extension V4ListSummary {
+
+    /// A sample `V4ListSummary` populated with representative data.
+    static var sample: V4ListSummary {
+        V4ListSummary(
+            id: 8_678_999,
+            name: "My Watchlist",
+            description: "Films and shows to catch up on",
+            accountObjectID: "1a2b3c4d5e6f7a8b9c0d1e2f",
+            numberOfItems: 2,
+            isPublic: true,
+            isAdult: false,
+            isFeatured: false,
+            runtime: 8433,
+            averageRating: 8.45,
+            revenue: 43_124_857_678,
+            sortBy: 1,
+            languageCode: "en",
+            countryCode: "US",
+            // 2026-08-06 23:26:00 UTC and four seconds later — the shape this
+            // endpoint sends, as opposed to the day-precision dates on items.
+            createdAt: Date(timeIntervalSince1970: 1_786_058_760),
+            updatedAt: Date(timeIntervalSince1970: 1_786_058_764)
+        )
+    }
+
+    /// Sample `V4ListSummary`s.
+    static var samples: [V4ListSummary] {
+        [.sample]
+    }
+
+}

--- a/Sources/TMDbTesting/Samples/V4ListResults+Sample.swift
+++ b/Sources/TMDbTesting/Samples/V4ListResults+Sample.swift
@@ -1,0 +1,112 @@
+//
+//  V4ListResults+Sample.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import TMDb
+
+public extension V4CreateListResult {
+
+    /// A sample `V4CreateListResult` populated with representative data.
+    static var sample: V4CreateListResult {
+        V4CreateListResult(success: true, id: 8_678_999)
+    }
+
+}
+
+public extension V4ClearListResult {
+
+    /// A sample `V4ClearListResult` populated with representative data.
+    static var sample: V4ClearListResult {
+        V4ClearListResult(success: true, id: 8_678_999, itemsDeleted: 2)
+    }
+
+}
+
+public extension V4ListItemResult {
+
+    /// A sample `V4ListItemResult` for a movie that succeeded.
+    static var sample: V4ListItemResult {
+        V4ListItemResult(mediaType: .movie, mediaID: 550, success: true)
+    }
+
+    /// Sample `V4ListItemResult`s — one movie and one TV series.
+    static var samples: [V4ListItemResult] {
+        [
+            V4ListItemResult(mediaType: .movie, mediaID: 550, success: true),
+            V4ListItemResult(mediaType: .tvSeries, mediaID: 1399, success: true)
+        ]
+    }
+
+}
+
+public extension V4ListItemsResult {
+
+    /// A sample `V4ListItemsResult` in which every item succeeded.
+    static var sample: V4ListItemsResult {
+        V4ListItemsResult(success: true, results: V4ListItemResult.samples)
+    }
+
+    /// A sample `V4ListItemsResult` showing the partial failure TMDb really
+    /// returns: the request succeeded while an individual item did not.
+    static var partialFailureSample: V4ListItemsResult {
+        V4ListItemsResult(
+            success: true,
+            results: [
+                V4ListItemResult(mediaType: .movie, mediaID: 550, success: false),
+                V4ListItemResult(mediaType: .tvSeries, mediaID: 1399, success: true)
+            ]
+        )
+    }
+
+}
+
+public extension V4ListMediaItem {
+
+    /// A sample `V4ListMediaItem` for a movie.
+    static var sample: V4ListMediaItem {
+        .movie(550)
+    }
+
+    /// Sample `V4ListMediaItem`s — one movie and one TV series.
+    static var samples: [V4ListMediaItem] {
+        [.movie(550), .tvSeries(1399)]
+    }
+
+}
+
+public extension V4ListItemComment {
+
+    /// A sample `V4ListItemComment` for a movie.
+    static var sample: V4ListItemComment {
+        .movie(550, comment: "Rewatch for the twist")
+    }
+
+    /// Sample `V4ListItemComment`s.
+    static var samples: [V4ListItemComment] {
+        [
+            .movie(550, comment: "Rewatch for the twist"),
+            .tvSeries(1399, comment: "Start from season 1")
+        ]
+    }
+
+}
+
+public extension V4ListAttributes {
+
+    /// A sample `V4ListAttributes` populated with representative data.
+    static var sample: V4ListAttributes {
+        V4ListAttributes(
+            name: "My Watchlist",
+            description: "Films and shows to catch up on",
+            isPublic: true,
+            languageCode: "en",
+            countryCode: "US",
+            sortBy: .originalOrder()
+        )
+    }
+
+}

--- a/Sources/TMDbTesting/Services/MockV4ListService.swift
+++ b/Sources/TMDbTesting/Services/MockV4ListService.swift
@@ -1,0 +1,750 @@
+//
+//  MockV4ListService.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+// swiftlint:disable file_length type_body_length
+
+import Foundation
+import TMDb
+
+///
+/// A mock `V4ListService` for use in tests.
+///
+/// Each method records the calls it receives and returns an injectable stubbed
+/// result. By default a freshly-constructed mock returns sample data, so it can
+/// be used with zero setup; inject a `Result` into the matching `*Result`
+/// property to control the outcome of a method — assert on the value you
+/// injected, not on the believable defaults.
+///
+/// The mock is safe to share across concurrent calls: its recorded state is
+/// guarded by a lock.
+///
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+public final class MockV4ListService: V4ListService, @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var storage = Storage()
+
+    private struct Storage {
+        var detailsCalls: [DetailsCall] = []
+        var detailsResult: Result<V4List, TMDbError> = .success(.sample)
+        var itemsCalls: [ItemsCall] = []
+        var itemsResult: Result<PageableListResult<V4ListItem>, TMDbError> =
+            .success(PageableListResult(results: V4ListItem.samples))
+        var itemStatusCalls: [ItemStatusCall] = []
+        var itemStatusResult: Result<Bool, TMDbError> = .success(true)
+        var listsCalls: [ListsCall] = []
+        var listsResult: Result<PageableListResult<V4ListSummary>, TMDbError> =
+            .success(PageableListResult(results: V4ListSummary.samples))
+        var createCalls: [CreateCall] = []
+        var createResult: Result<V4CreateListResult, TMDbError> = .success(.sample)
+        var updateCalls: [UpdateCall] = []
+        var updateResult: Result<Void, TMDbError> = .success(())
+        var addItemsCalls: [AddItemsCall] = []
+        var addItemsResult: Result<V4ListItemsResult, TMDbError> = .success(.sample)
+        var updateItemsCalls: [UpdateItemsCall] = []
+        var updateItemsResult: Result<V4ListItemsResult, TMDbError> = .success(.sample)
+        var removeItemsCalls: [RemoveItemsCall] = []
+        var removeItemsResult: Result<V4ListItemsResult, TMDbError> = .success(.sample)
+        var clearCalls: [ClearCall] = []
+        var clearResult: Result<V4ClearListResult, TMDbError> = .success(.sample)
+        var deleteCalls: [DeleteCall] = []
+        var deleteResult: Result<Void, TMDbError> = .success(())
+    }
+
+    ///
+    /// Creates a mock v4 list service.
+    ///
+    public init() {}
+
+    private func withLock<R>(_ body: () -> R) -> R {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
+    }
+
+    // MARK: - details
+
+    ///
+    /// The arguments of a single call to
+    /// ``details(forList:page:sortedBy:language:accessToken:)``.
+    ///
+    public struct DetailsCall: Sendable {
+
+        /// The identifier of the list.
+        public let listID: Int
+        /// The requested page.
+        public let page: Int?
+        /// The requested sort order.
+        public let sortedBy: V4ListSortBy?
+        /// The requested language.
+        public let language: String?
+        /// The access token the method was called with.
+        public let accessToken: String?
+
+    }
+
+    ///
+    /// The recorded calls to ``details(forList:page:sortedBy:language:accessToken:)``,
+    /// in the order they were made.
+    ///
+    public var detailsCalls: [DetailsCall] {
+        withLock { storage.detailsCalls }
+    }
+
+    ///
+    /// The stubbed result returned by
+    /// ``details(forList:page:sortedBy:language:accessToken:)``.
+    ///
+    public var detailsResult: Result<V4List, TMDbError> {
+        get { withLock { storage.detailsResult } }
+        set { withLock { storage.detailsResult = newValue } }
+    }
+
+    ///
+    /// Records the call and returns ``detailsResult``.
+    ///
+    /// - Parameters:
+    ///    - listID: The identifier of the list.
+    ///    - page: The page of items to return.
+    ///    - sortedBy: How to order the items.
+    ///    - language: ISO 639-1 language code.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error `TMDbError`.
+    ///
+    /// - Returns: The stubbed list.
+    ///
+    public func details(
+        forList listID: Int,
+        page: Int?,
+        sortedBy: V4ListSortBy?,
+        language: String?,
+        accessToken: String?
+    ) async throws(TMDbError) -> V4List {
+        let result = withLock {
+            storage.detailsCalls.append(DetailsCall(
+                listID: listID,
+                page: page,
+                sortedBy: sortedBy,
+                language: language,
+                accessToken: accessToken
+            ))
+            return storage.detailsResult
+        }
+
+        return try result.get()
+    }
+
+    // MARK: - items
+
+    ///
+    /// The arguments of a single call to
+    /// ``items(forList:page:sortedBy:language:accessToken:)``.
+    ///
+    public struct ItemsCall: Sendable {
+
+        /// The identifier of the list.
+        public let listID: Int
+        /// The requested page.
+        public let page: Int?
+        /// The requested sort order.
+        public let sortedBy: V4ListSortBy?
+        /// The requested language.
+        public let language: String?
+        /// The access token the method was called with.
+        public let accessToken: String?
+
+    }
+
+    ///
+    /// The recorded calls to ``items(forList:page:sortedBy:language:accessToken:)``,
+    /// in the order they were made.
+    ///
+    public var itemsCalls: [ItemsCall] {
+        withLock { storage.itemsCalls }
+    }
+
+    ///
+    /// The stubbed result returned by
+    /// ``items(forList:page:sortedBy:language:accessToken:)``.
+    ///
+    public var itemsResult: Result<PageableListResult<V4ListItem>, TMDbError> {
+        get { withLock { storage.itemsResult } }
+        set { withLock { storage.itemsResult = newValue } }
+    }
+
+    ///
+    /// Records the call and returns ``itemsResult``.
+    ///
+    /// - Parameters:
+    ///    - listID: The identifier of the list.
+    ///    - page: The page of items to return.
+    ///    - sortedBy: How to order the items.
+    ///    - language: ISO 639-1 language code.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error `TMDbError`.
+    ///
+    /// - Returns: The stubbed page of items.
+    ///
+    public func items(
+        forList listID: Int,
+        page: Int?,
+        sortedBy: V4ListSortBy?,
+        language: String?,
+        accessToken: String?
+    ) async throws(TMDbError) -> PageableListResult<V4ListItem> {
+        let result = withLock {
+            storage.itemsCalls.append(ItemsCall(
+                listID: listID,
+                page: page,
+                sortedBy: sortedBy,
+                language: language,
+                accessToken: accessToken
+            ))
+            return storage.itemsResult
+        }
+
+        return try result.get()
+    }
+
+    // MARK: - itemStatus
+
+    ///
+    /// The arguments of a single call to
+    /// ``itemStatus(forMedia:ofType:inList:accessToken:)``.
+    ///
+    public struct ItemStatusCall: Sendable {
+
+        /// The identifier of the movie or TV series.
+        public let mediaID: Int
+        /// Whether it is a movie or a TV series.
+        public let showType: ShowType
+        /// The identifier of the list.
+        public let listID: Int
+        /// The access token the method was called with.
+        public let accessToken: String?
+
+    }
+
+    ///
+    /// The recorded calls to ``itemStatus(forMedia:ofType:inList:accessToken:)``,
+    /// in the order they were made.
+    ///
+    public var itemStatusCalls: [ItemStatusCall] {
+        withLock { storage.itemStatusCalls }
+    }
+
+    ///
+    /// The stubbed result returned by
+    /// ``itemStatus(forMedia:ofType:inList:accessToken:)``.
+    ///
+    public var itemStatusResult: Result<Bool, TMDbError> {
+        get { withLock { storage.itemStatusResult } }
+        set { withLock { storage.itemStatusResult = newValue } }
+    }
+
+    ///
+    /// Records the call and returns ``itemStatusResult``.
+    ///
+    /// - Parameters:
+    ///    - mediaID: The identifier of the movie or TV series.
+    ///    - showType: Whether it is a movie or a TV series.
+    ///    - listID: The identifier of the list.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error `TMDbError`.
+    ///
+    /// - Returns: The stubbed status.
+    ///
+    public func itemStatus(
+        forMedia mediaID: Int,
+        ofType showType: ShowType,
+        inList listID: Int,
+        accessToken: String?
+    ) async throws(TMDbError) -> Bool {
+        let result = withLock {
+            storage.itemStatusCalls.append(ItemStatusCall(
+                mediaID: mediaID,
+                showType: showType,
+                listID: listID,
+                accessToken: accessToken
+            ))
+            return storage.itemStatusResult
+        }
+
+        return try result.get()
+    }
+
+    // MARK: - lists
+
+    ///
+    /// The arguments of a single call to ``lists(forAccount:page:accessToken:)``.
+    ///
+    public struct ListsCall: Sendable {
+
+        /// The account's object identifier.
+        public let accountObjectID: String
+        /// The requested page.
+        public let page: Int?
+        /// The access token the method was called with.
+        public let accessToken: String
+
+    }
+
+    ///
+    /// The recorded calls to ``lists(forAccount:page:accessToken:)``, in the
+    /// order they were made.
+    ///
+    public var listsCalls: [ListsCall] {
+        withLock { storage.listsCalls }
+    }
+
+    ///
+    /// The stubbed result returned by ``lists(forAccount:page:accessToken:)``.
+    ///
+    public var listsResult: Result<PageableListResult<V4ListSummary>, TMDbError> {
+        get { withLock { storage.listsResult } }
+        set { withLock { storage.listsResult = newValue } }
+    }
+
+    ///
+    /// Records the call and returns ``listsResult``.
+    ///
+    /// - Parameters:
+    ///    - accountObjectID: The account's object identifier.
+    ///    - page: The page of results to return.
+    ///    - accessToken: The account owner's access token.
+    ///
+    /// - Throws: TMDb error `TMDbError`.
+    ///
+    /// - Returns: The stubbed page of list summaries.
+    ///
+    public func lists(
+        forAccount accountObjectID: String,
+        page: Int?,
+        accessToken: String
+    ) async throws(TMDbError) -> PageableListResult<V4ListSummary> {
+        let result = withLock {
+            storage.listsCalls.append(ListsCall(
+                accountObjectID: accountObjectID,
+                page: page,
+                accessToken: accessToken
+            ))
+            return storage.listsResult
+        }
+
+        return try result.get()
+    }
+
+    // MARK: - create
+
+    ///
+    /// The arguments of a single call to ``create(name:attributes:accessToken:)``.
+    ///
+    public struct CreateCall: Sendable {
+
+        /// The list's name.
+        public let name: String
+        /// The list's other settable properties.
+        public let attributes: V4ListAttributes?
+        /// The access token the method was called with.
+        public let accessToken: String
+
+    }
+
+    ///
+    /// The recorded calls to ``create(name:attributes:accessToken:)``, in the
+    /// order they were made.
+    ///
+    public var createCalls: [CreateCall] {
+        withLock { storage.createCalls }
+    }
+
+    ///
+    /// The stubbed result returned by ``create(name:attributes:accessToken:)``.
+    ///
+    public var createResult: Result<V4CreateListResult, TMDbError> {
+        get { withLock { storage.createResult } }
+        set { withLock { storage.createResult = newValue } }
+    }
+
+    ///
+    /// Records the call and returns ``createResult``.
+    ///
+    /// - Parameters:
+    ///    - name: The list's name.
+    ///    - attributes: The list's other settable properties.
+    ///    - accessToken: The user's access token.
+    ///
+    /// - Throws: TMDb error `TMDbError`.
+    ///
+    /// - Returns: The stubbed create result.
+    ///
+    public func create(
+        name: String,
+        attributes: V4ListAttributes?,
+        accessToken: String
+    ) async throws(TMDbError) -> V4CreateListResult {
+        let result = withLock {
+            storage.createCalls.append(CreateCall(
+                name: name,
+                attributes: attributes,
+                accessToken: accessToken
+            ))
+            return storage.createResult
+        }
+
+        return try result.get()
+    }
+
+    // MARK: - update
+
+    ///
+    /// The arguments of a single call to ``update(list:attributes:accessToken:)``.
+    ///
+    public struct UpdateCall: Sendable {
+
+        /// The identifier of the list.
+        public let listID: Int
+        /// The properties to change.
+        public let attributes: V4ListAttributes
+        /// The access token the method was called with.
+        public let accessToken: String
+
+    }
+
+    ///
+    /// The recorded calls to ``update(list:attributes:accessToken:)``, in the
+    /// order they were made.
+    ///
+    public var updateCalls: [UpdateCall] {
+        withLock { storage.updateCalls }
+    }
+
+    ///
+    /// The stubbed result returned by ``update(list:attributes:accessToken:)``.
+    ///
+    public var updateResult: Result<Void, TMDbError> {
+        get { withLock { storage.updateResult } }
+        set { withLock { storage.updateResult = newValue } }
+    }
+
+    ///
+    /// Records the call and returns ``updateResult``.
+    ///
+    /// - Parameters:
+    ///    - listID: The identifier of the list.
+    ///    - attributes: The properties to change.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error `TMDbError`.
+    ///
+    public func update(
+        list listID: Int,
+        attributes: V4ListAttributes,
+        accessToken: String
+    ) async throws(TMDbError) {
+        let result = withLock {
+            storage.updateCalls.append(UpdateCall(
+                listID: listID,
+                attributes: attributes,
+                accessToken: accessToken
+            ))
+            return storage.updateResult
+        }
+
+        return try result.get()
+    }
+
+    // MARK: - addItems
+
+    ///
+    /// The arguments of a single call to ``addItems(_:toList:accessToken:)``.
+    ///
+    public struct AddItemsCall: Sendable {
+
+        /// The items to add.
+        public let items: [V4ListMediaItem]
+        /// The identifier of the list.
+        public let listID: Int
+        /// The access token the method was called with.
+        public let accessToken: String
+
+    }
+
+    ///
+    /// The recorded calls to ``addItems(_:toList:accessToken:)``, in the order
+    /// they were made.
+    ///
+    public var addItemsCalls: [AddItemsCall] {
+        withLock { storage.addItemsCalls }
+    }
+
+    ///
+    /// The stubbed result returned by ``addItems(_:toList:accessToken:)``.
+    ///
+    public var addItemsResult: Result<V4ListItemsResult, TMDbError> {
+        get { withLock { storage.addItemsResult } }
+        set { withLock { storage.addItemsResult = newValue } }
+    }
+
+    ///
+    /// Records the call and returns ``addItemsResult``.
+    ///
+    /// - Parameters:
+    ///    - items: The items to add.
+    ///    - listID: The identifier of the list.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error `TMDbError`.
+    ///
+    /// - Returns: The stubbed per-item outcomes.
+    ///
+    public func addItems(
+        _ items: [V4ListMediaItem],
+        toList listID: Int,
+        accessToken: String
+    ) async throws(TMDbError) -> V4ListItemsResult {
+        let result = withLock {
+            storage.addItemsCalls.append(AddItemsCall(
+                items: items,
+                listID: listID,
+                accessToken: accessToken
+            ))
+            return storage.addItemsResult
+        }
+
+        return try result.get()
+    }
+
+    // MARK: - updateItems
+
+    ///
+    /// The arguments of a single call to ``updateItems(_:inList:accessToken:)``.
+    ///
+    public struct UpdateItemsCall: Sendable {
+
+        /// The items to comment on.
+        public let items: [V4ListItemComment]
+        /// The identifier of the list.
+        public let listID: Int
+        /// The access token the method was called with.
+        public let accessToken: String
+
+    }
+
+    ///
+    /// The recorded calls to ``updateItems(_:inList:accessToken:)``, in the
+    /// order they were made.
+    ///
+    public var updateItemsCalls: [UpdateItemsCall] {
+        withLock { storage.updateItemsCalls }
+    }
+
+    ///
+    /// The stubbed result returned by ``updateItems(_:inList:accessToken:)``.
+    ///
+    public var updateItemsResult: Result<V4ListItemsResult, TMDbError> {
+        get { withLock { storage.updateItemsResult } }
+        set { withLock { storage.updateItemsResult = newValue } }
+    }
+
+    ///
+    /// Records the call and returns ``updateItemsResult``.
+    ///
+    /// - Parameters:
+    ///    - items: The items to comment on.
+    ///    - listID: The identifier of the list.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error `TMDbError`.
+    ///
+    /// - Returns: The stubbed per-item outcomes.
+    ///
+    public func updateItems(
+        _ items: [V4ListItemComment],
+        inList listID: Int,
+        accessToken: String
+    ) async throws(TMDbError) -> V4ListItemsResult {
+        let result = withLock {
+            storage.updateItemsCalls.append(UpdateItemsCall(
+                items: items,
+                listID: listID,
+                accessToken: accessToken
+            ))
+            return storage.updateItemsResult
+        }
+
+        return try result.get()
+    }
+
+    // MARK: - removeItems
+
+    ///
+    /// The arguments of a single call to ``removeItems(_:fromList:accessToken:)``.
+    ///
+    public struct RemoveItemsCall: Sendable {
+
+        /// The items to remove.
+        public let items: [V4ListMediaItem]
+        /// The identifier of the list.
+        public let listID: Int
+        /// The access token the method was called with.
+        public let accessToken: String
+
+    }
+
+    ///
+    /// The recorded calls to ``removeItems(_:fromList:accessToken:)``, in the
+    /// order they were made.
+    ///
+    public var removeItemsCalls: [RemoveItemsCall] {
+        withLock { storage.removeItemsCalls }
+    }
+
+    ///
+    /// The stubbed result returned by ``removeItems(_:fromList:accessToken:)``.
+    ///
+    public var removeItemsResult: Result<V4ListItemsResult, TMDbError> {
+        get { withLock { storage.removeItemsResult } }
+        set { withLock { storage.removeItemsResult = newValue } }
+    }
+
+    ///
+    /// Records the call and returns ``removeItemsResult``.
+    ///
+    /// - Parameters:
+    ///    - items: The items to remove.
+    ///    - listID: The identifier of the list.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error `TMDbError`.
+    ///
+    /// - Returns: The stubbed per-item outcomes.
+    ///
+    public func removeItems(
+        _ items: [V4ListMediaItem],
+        fromList listID: Int,
+        accessToken: String
+    ) async throws(TMDbError) -> V4ListItemsResult {
+        let result = withLock {
+            storage.removeItemsCalls.append(RemoveItemsCall(
+                items: items,
+                listID: listID,
+                accessToken: accessToken
+            ))
+            return storage.removeItemsResult
+        }
+
+        return try result.get()
+    }
+
+    // MARK: - clear
+
+    ///
+    /// The arguments of a single call to ``clear(list:accessToken:)``.
+    ///
+    public struct ClearCall: Sendable {
+
+        /// The identifier of the list.
+        public let listID: Int
+        /// The access token the method was called with.
+        public let accessToken: String
+
+    }
+
+    ///
+    /// The recorded calls to ``clear(list:accessToken:)``, in the order they
+    /// were made.
+    ///
+    public var clearCalls: [ClearCall] {
+        withLock { storage.clearCalls }
+    }
+
+    ///
+    /// The stubbed result returned by ``clear(list:accessToken:)``.
+    ///
+    public var clearResult: Result<V4ClearListResult, TMDbError> {
+        get { withLock { storage.clearResult } }
+        set { withLock { storage.clearResult = newValue } }
+    }
+
+    ///
+    /// Records the call and returns ``clearResult``.
+    ///
+    /// - Parameters:
+    ///    - listID: The identifier of the list.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error `TMDbError`.
+    ///
+    /// - Returns: The stubbed clear result.
+    ///
+    public func clear(
+        list listID: Int,
+        accessToken: String
+    ) async throws(TMDbError) -> V4ClearListResult {
+        let result = withLock {
+            storage.clearCalls.append(ClearCall(listID: listID, accessToken: accessToken))
+            return storage.clearResult
+        }
+
+        return try result.get()
+    }
+
+    // MARK: - delete
+
+    ///
+    /// The arguments of a single call to ``delete(list:accessToken:)``.
+    ///
+    public struct DeleteCall: Sendable {
+
+        /// The identifier of the list.
+        public let listID: Int
+        /// The access token the method was called with.
+        public let accessToken: String
+
+    }
+
+    ///
+    /// The recorded calls to ``delete(list:accessToken:)``, in the order they
+    /// were made.
+    ///
+    public var deleteCalls: [DeleteCall] {
+        withLock { storage.deleteCalls }
+    }
+
+    ///
+    /// The stubbed result returned by ``delete(list:accessToken:)``.
+    ///
+    public var deleteResult: Result<Void, TMDbError> {
+        get { withLock { storage.deleteResult } }
+        set { withLock { storage.deleteResult = newValue } }
+    }
+
+    ///
+    /// Records the call and returns ``deleteResult``.
+    ///
+    /// - Parameters:
+    ///    - listID: The identifier of the list.
+    ///    - accessToken: The list owner's access token.
+    ///
+    /// - Throws: TMDb error `TMDbError`.
+    ///
+    public func delete(list listID: Int, accessToken: String) async throws(TMDbError) {
+        let result = withLock {
+            storage.deleteCalls.append(DeleteCall(listID: listID, accessToken: accessToken))
+            return storage.deleteResult
+        }
+
+        return try result.get()
+    }
+
+}
+
+// swiftlint:enable file_length type_body_length

--- a/Sources/TMDbTesting/TMDbTesting.docc/TMDbTesting.md
+++ b/Sources/TMDbTesting/TMDbTesting.docc/TMDbTesting.md
@@ -63,6 +63,7 @@ let genres = [Genre].samples
 - ``MockAccountService``
 - ``MockAuthenticationService``
 - ``MockV4AuthenticationService``
+- ``MockV4ListService``
 - ``MockCertificationService``
 - ``MockChangesService``
 - ``MockCollectionService``

--- a/Tests/TMDbIntegrationTests/Utility/CredentialHelper.swift
+++ b/Tests/TMDbIntegrationTests/Utility/CredentialHelper.swift
@@ -33,8 +33,55 @@ final class CredentialHelper: Sendable {
         !tmdbAPIKey.isEmpty
     }
 
+    /// A **user** access token — the credential v4 writes require.
+    ///
+    /// Distinct from ``tmdbAccessToken``: that is the *application's* API Read
+    /// Access Token, which can read public data but cannot touch a user's
+    /// lists. This one is minted through the request-token → approve →
+    /// access-token flow and identifies a person.
+    ///
+    /// Read from `TMDB_API_USER_TOKEN`.
+    let tmdbUserAccessToken: String
+
     var hasAccessToken: Bool {
         !tmdbAccessToken.isEmpty
+    }
+
+    var hasUserAccessToken: Bool {
+        !tmdbUserAccessToken.isEmpty
+    }
+
+    /// The account object id the user token belongs to, read from its JWT
+    /// `sub` claim.
+    ///
+    /// Taken from the token rather than a separate secret, so there is one
+    /// fewer credential to configure and no way for the two to disagree.
+    /// Returns `nil` if the token is absent or not a decodable JWT, and the
+    /// suites that need it skip rather than fail.
+    var v4AccountObjectID: String? {
+        Self.subjectClaim(ofJWT: tmdbUserAccessToken)
+    }
+
+    static func subjectClaim(ofJWT token: String) -> String? {
+        let segments = token.split(separator: ".")
+        guard segments.count >= 2 else {
+            return nil
+        }
+
+        var base64 = String(segments[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        base64 += String(repeating: "=", count: (4 - base64.count % 4) % 4)
+
+        guard
+            let data = Data(base64Encoded: base64),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let subject = json["sub"] as? String
+        else {
+            return nil
+        }
+
+        return subject
     }
 
     /// Returns a `TMDbClient` configured with the integration-test API key
@@ -59,6 +106,7 @@ final class CredentialHelper: Sendable {
             processInfo.environment["TMDB_ACCESS_TOKEN"]
                 ?? processInfo.environment["TMDB_API_READ_ONLY_TOKEN"]
                 ?? ""
+        self.tmdbUserAccessToken = processInfo.environment["TMDB_API_USER_TOKEN"] ?? ""
     }
 
 }

--- a/Tests/TMDbIntegrationTests/V4ListIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/V4ListIntegrationTests.swift
@@ -1,0 +1,232 @@
+//
+//  V4ListIntegrationTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+import TMDb
+
+///
+/// Live coverage of the v4 list lifecycle, against the real API.
+///
+/// The suite creates **one** list, exercises the whole lifecycle against it,
+/// and deletes it. Two things learned the hard way while probing this API
+/// shaped that:
+///
+/// - **TMDb rate-limits list creation.** Fourteen quick creates named
+///   `probe <random>` were all rejected with `status_code` 18, "Content is
+///   suspected to be spam". So this creates once per run, with a name a person
+///   might plausibly use, and treats a spam rejection as a *skip* rather than a
+///   failure — it says nothing about the library.
+/// - **Cleanup cannot rely on a remembered identifier.** A probe script's
+///   `EXIT` trap never fired and orphaned four lists on the account. Teardown
+///   here enumerates the account's lists and deletes any left over from a
+///   previous run, so an interrupted run self-heals on the next one.
+///
+@Suite(
+    .integrationGate,
+    .serialized,
+    .tags(.list),
+    .enabled(if: CredentialHelper.shared.hasAccessToken
+        && CredentialHelper.shared.hasUserAccessToken)
+)
+final class V4ListIntegrationTests {
+
+    private static let listName = "TMDb Swift integration"
+
+    private let client: TMDbClient
+    private let token: String
+    private var listID: Int?
+
+    init() {
+        self.client = TMDbClient(
+            bearerToken: CredentialHelper.shared.tmdbAccessToken,
+            configuration: TMDbConfiguration(retry: .default)
+        )
+        self.token = CredentialHelper.shared.tmdbUserAccessToken
+    }
+
+    deinit {
+        guard let listID else {
+            return
+        }
+        let client = client
+        let token = token
+        Task {
+            try? await client.v4Lists.delete(list: listID, accessToken: token)
+        }
+    }
+
+    /// Creates the suite's list, or skips the test when TMDb's spam filter
+    /// declines. Also clears anything a previous interrupted run left behind.
+    private func makeList() async throws -> Int {
+        try await deleteLeftoverLists()
+
+        do {
+            let result = try await client.v4Lists.create(
+                name: Self.listName,
+                attributes: V4ListAttributes(
+                    description: "Created by the TMDb Swift package's integration tests",
+                    isPublic: false,
+                    languageCode: "en",
+                    countryCode: "GB"
+                ),
+                accessToken: token
+            )
+            listID = result.id
+            return result.id
+        } catch let error {
+            // TMDb rate-limits list creation and answers "Content is suspected
+            // to be spam". This is deliberately NOT swallowed into a skip: a
+            // green run that quietly created nothing would be indistinguishable
+            // from one that worked. It fails, loudly, and the failure names
+            // itself so `/fix-integration-failures` can tell an upstream limit
+            // from real drift.
+            Issue.record(
+                error,
+                """
+                Creating the list failed. If the message is "Content is suspected to be spam", \
+                this is TMDb rate-limiting list creation — an upstream limit, not a defect here. \
+                Re-run after a pause.
+                """
+            )
+            throw error
+        }
+    }
+
+    private func deleteLeftoverLists() async throws {
+        guard let accountObjectID = CredentialHelper.shared.v4AccountObjectID else {
+            return
+        }
+
+        let lists = try await client.v4Lists.lists(
+            forAccount: accountObjectID, accessToken: token
+        )
+        for list in lists.results where list.name == Self.listName {
+            try? await client.v4Lists.delete(list: list.id, accessToken: token)
+        }
+    }
+
+    @Test("the full list lifecycle: create, add, comment, read, remove, clear")
+    func listLifecycle() async throws {
+        let listID = try await makeList()
+
+        // Create — a private list, which v3 lists cannot express.
+        let created = try await client.v4Lists.details(forList: listID, accessToken: token)
+        #expect(created.name == Self.listName)
+        #expect(created.isPublic == false)
+        #expect(created.items.isEmpty)
+
+        // Add one movie and one TV series — the mixed list v4 exists for.
+        let added = try await client.v4Lists.addItems(
+            [.movie(550), .tvSeries(1399)], toList: listID, accessToken: token
+        )
+        #expect(added.allItemsSucceeded)
+
+        let withItems = try await client.v4Lists.details(forList: listID, accessToken: token)
+        #expect(withItems.items.count == withItems.itemCount)
+        let movie = try #require(withItems.items.first { $0.id == 550 })
+        let tvSeries = try #require(withItems.items.first { $0.id == 1399 })
+        guard case .movie = movie.media, case .tvSeries = tvSeries.media else {
+            Issue.record("expected one movie and one TV series in the list")
+            return
+        }
+
+        // itemStatus, both ways round.
+        let moviePresent = try await client.v4Lists.itemStatus(
+            forMedia: 550, ofType: .movie, inList: listID, accessToken: token
+        )
+        #expect(moviePresent)
+        let absent = try await client.v4Lists.itemStatus(
+            forMedia: 680, ofType: .movie, inList: listID, accessToken: token
+        )
+        #expect(absent == false)
+
+        // Comments only stick through updateItems, never through addItems.
+        let commented = try await client.v4Lists.updateItems(
+            [.movie(550, comment: "Integration test comment")],
+            inList: listID,
+            accessToken: token
+        )
+        #expect(commented.allItemsSucceeded)
+
+        let withComment = try await client.v4Lists.details(forList: listID, accessToken: token)
+        let commentedMovie = try #require(withComment.items.first { $0.id == 550 })
+        #expect(commentedMovie.comment == "Integration test comment")
+
+        // Remove one, then clear the rest.
+        let removed = try await client.v4Lists.removeItems(
+            [.movie(550)], fromList: listID, accessToken: token
+        )
+        #expect(removed.allItemsSucceeded)
+
+        let cleared = try await client.v4Lists.clear(list: listID, accessToken: token)
+        #expect(cleared.itemsDeleted >= 1)
+
+        let empty = try await client.v4Lists.details(forList: listID, accessToken: token)
+        #expect(empty.items.isEmpty)
+    }
+
+    @Test("removing an item that is not in the list reports a per-item failure")
+    func removingAbsentItemReportsFailure() async throws {
+        // Overall success with a failed item — the case that makes checking
+        // `success` alone insufficient.
+        let listID = try await makeList()
+
+        let result = try await client.v4Lists.removeItems(
+            [.movie(680)], fromList: listID, accessToken: token
+        )
+
+        #expect(result.success)
+        #expect(result.allItemsSucceeded == false)
+        #expect(result.failures.count == 1)
+    }
+
+    @Test("update renames a list and changes its sort order")
+    func updateChangesListProperties() async throws {
+        let listID = try await makeList()
+
+        try await client.v4Lists.update(
+            list: listID,
+            attributes: V4ListAttributes(
+                description: "Updated by the integration tests",
+                sortBy: .title(descending: true)
+            ),
+            accessToken: token
+        )
+
+        let updated = try await client.v4Lists.details(forList: listID, accessToken: token)
+        #expect(updated.description == "Updated by the integration tests")
+        #expect(updated.sortBy == "title.desc")
+    }
+
+    @Test("the account lists endpoint returns the list, with its own wire types")
+    func accountListsIncludesTheList() async throws {
+        let listID = try await makeList()
+        let accountObjectID = try #require(CredentialHelper.shared.v4AccountObjectID)
+
+        let lists = try await client.v4Lists.lists(
+            forAccount: accountObjectID, accessToken: token
+        )
+
+        let summary = try #require(lists.results.first { $0.id == listID })
+        #expect(summary.name == Self.listName)
+        // This endpoint sends `public` as 0/1 and `runtime` as a string; the
+        // model maps both, so a decode regression shows up here.
+        #expect(summary.isPublic == false)
+        #expect(summary.runtime >= 0)
+    }
+
+    @Test("reading a public list needs no user token")
+    func publicListReadableWithoutUserToken() async throws {
+        // List 1 is a long-standing public TMDb list.
+        let list = try await client.v4Lists.details(forList: 1)
+
+        #expect(list.id == 1)
+        #expect(list.isPublic)
+    }
+
+}

--- a/Tests/TMDbIntegrationTests/V4ListIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/V4ListIntegrationTests.swift
@@ -18,9 +18,11 @@ import TMDb
 ///
 /// - **TMDb rate-limits list creation.** Fourteen quick creates named
 ///   `probe <random>` were all rejected with `status_code` 18, "Content is
-///   suspected to be spam". So this creates once per run, with a name a person
-///   might plausibly use, and treats a spam rejection as a *skip* rather than a
-///   failure — it says nothing about the library.
+///   suspected to be spam". So this creates once per test, with a name a person
+///   might plausibly use. A rejection is deliberately **not** turned into a
+///   skip: a green run that created nothing looks exactly like one that worked.
+///   It fails, and the failure names itself so an upstream limit can be told
+///   apart from real drift.
 /// - **Cleanup cannot rely on a remembered identifier.** A probe script's
 ///   `EXIT` trap never fired and orphaned four lists on the account. Teardown
 ///   here enumerates the account's lists and deletes any left over from a
@@ -85,28 +87,36 @@ final class V4ListIntegrationTests {
             // from one that worked. It fails, loudly, and the failure names
             // itself so `/fix-integration-failures` can tell an upstream limit
             // from real drift.
-            Issue.record(
-                error,
-                """
-                Creating the list failed. If the message is "Content is suspected to be spam", \
-                this is TMDb rate-limiting list creation — an upstream limit, not a defect here. \
-                Re-run after a pause.
-                """
-            )
+            // Rethrow only — `Issue.record` here as well would report one cause
+            // twice. The context lives in the suite documentation instead:
+            // a `status_code` 18 / "Content is suspected to be spam" body means
+            // TMDb is rate-limiting list creation, not that the library broke.
             throw error
         }
     }
 
+    /// Deletes every list this suite has ever created that is still around.
+    ///
+    /// Walks **all** pages: the `deinit` cleanup is a detached `Task` that the
+    /// runtime can drop at process exit, so the final test's list routinely
+    /// survives to the next run and leftovers can accumulate past page one.
     private func deleteLeftoverLists() async throws {
         guard let accountObjectID = CredentialHelper.shared.v4AccountObjectID else {
             return
         }
 
-        let lists = try await client.v4Lists.lists(
-            forAccount: accountObjectID, accessToken: token
-        )
-        for list in lists.results where list.name == Self.listName {
-            try? await client.v4Lists.delete(list: list.id, accessToken: token)
+        var page = 1
+        while true {
+            let lists = try await client.v4Lists.lists(
+                forAccount: accountObjectID, page: page, accessToken: token
+            )
+            for list in lists.results where list.name == Self.listName {
+                try? await client.v4Lists.delete(list: list.id, accessToken: token)
+            }
+            guard page < lists.totalPages else {
+                return
+            }
+            page += 1
         }
     }
 

--- a/Tests/TMDbTestingTests/Services/AllMocksSmokeTests.swift
+++ b/Tests/TMDbTestingTests/Services/AllMocksSmokeTests.swift
@@ -27,6 +27,13 @@ struct AllMocksSmokeTests {
         #expect(service.requestTokenCalls.count == 1)
     }
 
+    @Test("MockV4ListService is usable with zero setup")
+    func v4ListServiceSmoke() async throws {
+        let service = MockV4ListService()
+        _ = try await service.details(forList: 1)
+        #expect(service.detailsCalls.count == 1)
+    }
+
     @Test("MockCertificationService is usable with zero setup")
     func certificationServiceSmoke() async throws {
         let service = MockCertificationService()

--- a/Tests/TMDbTestingTests/Services/MockV4ListServiceTests.swift
+++ b/Tests/TMDbTestingTests/Services/MockV4ListServiceTests.swift
@@ -1,0 +1,164 @@
+//
+//  MockV4ListServiceTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+import TMDb
+import TMDbTesting
+
+@Suite(.tags(.testingSupport, .mocks, .list))
+struct MockV4ListServiceTests {
+
+    var service: MockV4ListService
+
+    init() {
+        self.service = MockV4ListService()
+    }
+
+    // MARK: - Defaults
+
+    @Test("details returns the sample by default")
+    func detailsReturnsSampleByDefault() async throws {
+        let result = try await service.details(forList: 1)
+
+        #expect(result == .sample)
+    }
+
+    @Test("itemStatus reports present by default")
+    func itemStatusReturnsTrueByDefault() async throws {
+        let result = try await service.itemStatus(forMedia: 550, ofType: .movie, inList: 1)
+
+        #expect(result)
+    }
+
+    @Test("the sample list holds both a movie and a TV series")
+    func sampleListMixesMediaTypes() throws {
+        // The mixed list is the whole point of v4, so the default sample has to
+        // exercise it rather than being movies-only.
+        let list = V4List.sample
+
+        let movie = try #require(list.items.first { $0.id == 550 })
+        let tvSeries = try #require(list.items.first { $0.id == 1399 })
+
+        guard case .movie = movie.media else {
+            Issue.record("expected 550 to be a movie")
+            return
+        }
+        guard case .tvSeries = tvSeries.media else {
+            Issue.record("expected 1399 to be a TV series")
+            return
+        }
+    }
+
+    // MARK: - Recording
+
+    @Test("details records every argument it was called with")
+    func detailsRecordsArguments() async throws {
+        _ = try await service.details(
+            forList: 42,
+            page: 2,
+            sortedBy: .title(descending: true),
+            language: "en",
+            accessToken: "token"
+        )
+
+        #expect(service.detailsCalls.count == 1)
+        let call = try #require(service.detailsCalls.first)
+        #expect(call.listID == 42)
+        #expect(call.page == 2)
+        #expect(call.sortedBy == .title(descending: true))
+        #expect(call.language == "en")
+        #expect(call.accessToken == "token")
+    }
+
+    @Test("the details convenience forwards nils to the requirement")
+    func detailsConvenienceForwardsNils() async throws {
+        // The conveniences drop parameters rather than defaulting them; this
+        // pins that they still reach the requirement with nil.
+        _ = try await service.details(forList: 42)
+
+        let call = try #require(service.detailsCalls.first)
+        #expect(call.page == nil)
+        #expect(call.sortedBy == nil)
+        #expect(call.language == nil)
+        #expect(call.accessToken == nil)
+    }
+
+    @Test("addItems records the items and the list")
+    func addItemsRecordsArguments() async throws {
+        _ = try await service.addItems(
+            V4ListMediaItem.samples, toList: 42, accessToken: "token"
+        )
+
+        let call = try #require(service.addItemsCalls.first)
+        #expect(call.items == V4ListMediaItem.samples)
+        #expect(call.listID == 42)
+        #expect(call.accessToken == "token")
+    }
+
+    @Test("update records the attributes")
+    func updateRecordsAttributes() async throws {
+        try await service.update(list: 42, name: "Renamed", accessToken: "token")
+
+        let call = try #require(service.updateCalls.first)
+        #expect(call.listID == 42)
+        #expect(call.attributes.name == "Renamed")
+    }
+
+    // MARK: - Injection
+
+    @Test("details returns the injected success")
+    func detailsReturnsInjectedSuccess() async throws {
+        let expectedResult = V4List(
+            id: 7,
+            name: "Injected",
+            isPublic: false,
+            createdBy: .sample,
+            itemCount: 0,
+            sortBy: "title.asc",
+            languageCode: "en",
+            countryCode: "GB"
+        )
+        service.detailsResult = .success(expectedResult)
+
+        let result = try await service.details(forList: 7)
+
+        #expect(result == expectedResult)
+    }
+
+    @Test("details throws the injected failure")
+    func detailsThrowsInjectedFailure() async throws {
+        service.detailsResult = .failure(.notFound(TMDbErrorContext()))
+
+        await #expect(throws: TMDbError.notFound(TMDbErrorContext())) {
+            _ = try await service.details(forList: 1)
+        }
+    }
+
+    @Test("removeItems can be stubbed with the partial failure TMDb really sends")
+    func removeItemsPartialFailure() async throws {
+        service.removeItemsResult = .success(.partialFailureSample)
+
+        let result = try await service.removeItems(
+            [.movie(550)], fromList: 1, accessToken: "token"
+        )
+
+        #expect(result.success)
+        #expect(result.allItemsSucceeded == false)
+        #expect(result.failures.count == 1)
+    }
+
+    @Test("delete throws the injected failure")
+    func deleteThrowsInjectedFailure() async throws {
+        service.deleteResult = .failure(.unauthorised(TMDbErrorContext()))
+
+        await #expect(throws: TMDbError.unauthorised(TMDbErrorContext())) {
+            try await service.delete(list: 1, accessToken: "token")
+        }
+    }
+
+}

--- a/Tests/TMDbTestingTests/TestUtils/Tags.swift
+++ b/Tests/TMDbTestingTests/TestUtils/Tags.swift
@@ -19,6 +19,7 @@ extension Tag {
     @Tag static var find: Self
     @Tag static var genre: Self
     @Tag static var images: Self
+    @Tag static var list: Self
     @Tag static var movie: Self
     @Tag static var person: Self
     @Tag static var search: Self

--- a/Tests/TMDbTests/Adapters/URLSessionHTTPClientAdapterTests.swift
+++ b/Tests/TMDbTests/Adapters/URLSessionHTTPClientAdapterTests.swift
@@ -167,4 +167,64 @@ final class URLSessionHTTPClientAdapterTests {
         requireSendable(URLSessionHTTPClientAdapter.self)
     }
 
+    // MARK: - User-specific requests bypass the on-disk URLCache
+
+    @Test("a user-specific request goes through a session with no URLCache")
+    func userSpecificRequestUsesCacheFreeSession() throws {
+        let url = try #require(URL(string: "https://api.themoviedb.org/4/list/1"))
+        let request = HTTPRequest(url: url, isUserSpecific: true)
+
+        let session = httpClient.session(for: request)
+
+        #expect(session.configuration.urlCache == nil)
+        #expect(session.configuration.requestCachePolicy == .reloadIgnoringLocalCacheData)
+    }
+
+    @Test("an ordinary request still goes through the shared, caching session")
+    func ordinaryRequestUsesSharedSession() throws {
+        let url = try #require(URL(string: "https://api.themoviedb.org/3/movie/550"))
+        let request = HTTPRequest(url: url)
+
+        let session = httpClient.session(for: request)
+
+        #expect(session === urlSession)
+    }
+
+    @Test("the cache-free session inherits the injected session's protocol classes")
+    func cacheFreeSessionInheritsConfiguration() throws {
+        // Without this, a test injecting MockURLProtocol would reach the live
+        // network for user-specific requests and the bypass would be untestable.
+        let url = try #require(URL(string: "https://api.themoviedb.org/4/list/1"))
+        let request = HTTPRequest(url: url, isUserSpecific: true)
+
+        let session = httpClient.session(for: request)
+        let classes = try #require(session.configuration.protocolClasses)
+
+        #expect(classes.contains { $0 == MockURLProtocol.self })
+    }
+
+    @Test("a user-specific request is sent with a cache-ignoring policy")
+    func userSpecificRequestIgnoresCache() async throws {
+        MockURLProtocol.responseStatusCode = 200
+        let url = try #require(URL(string: "https://api.themoviedb.org/4/list/1"))
+
+        _ = try? await httpClient.perform(
+            request: HTTPRequest(url: url, isUserSpecific: true)
+        )
+
+        let lastURLRequest = try #require(MockURLProtocol.lastRequest)
+        #expect(lastURLRequest.cachePolicy == .reloadIgnoringLocalCacheData)
+    }
+
+    @Test("an ordinary request keeps the default cache policy")
+    func ordinaryRequestKeepsDefaultCachePolicy() async throws {
+        MockURLProtocol.responseStatusCode = 200
+        let url = try #require(URL(string: "https://api.themoviedb.org/3/movie/550"))
+
+        _ = try? await httpClient.perform(request: HTTPRequest(url: url))
+
+        let lastURLRequest = try #require(MockURLProtocol.lastRequest)
+        #expect(lastURLRequest.cachePolicy == .useProtocolCachePolicy)
+    }
+
 }

--- a/Tests/TMDbTests/Adapters/URLSessionHTTPClientAdapterTests.swift
+++ b/Tests/TMDbTests/Adapters/URLSessionHTTPClientAdapterTests.swift
@@ -180,6 +180,25 @@ final class URLSessionHTTPClientAdapterTests {
         #expect(session.configuration.requestCachePolicy == .reloadIgnoringLocalCacheData)
     }
 
+    @Test("deriving the cache-free session leaves the injected session untouched")
+    func derivingCacheFreeSessionDoesNotMutateInjectedSession() throws {
+        // On Apple platforms `URLSession.configuration` is @NSCopying, but
+        // swift-corelibs-foundation returns the stored instance — so without an
+        // explicit copy this would unhook the URLCache from the primary session
+        // too, on Linux only, where no test would notice.
+        let configuration = URLSessionConfiguration.default
+        configuration.protocolClasses = [MockURLProtocol.self]
+        configuration.urlCache = URLCache(memoryCapacity: 1024, diskCapacity: 0)
+        let session = URLSession(configuration: configuration)
+
+        let adapter = URLSessionHTTPClientAdapter(urlSession: session)
+        let url = try #require(URL(string: "https://api.themoviedb.org/4/list/1"))
+        _ = adapter.session(for: HTTPRequest(url: url, isUserSpecific: true))
+
+        #expect(session.configuration.urlCache != nil)
+        #expect(session.configuration.requestCachePolicy == .useProtocolCachePolicy)
+    }
+
     @Test("an ordinary request still goes through the shared, caching session")
     func ordinaryRequestUsesSharedSession() throws {
         let url = try #require(URL(string: "https://api.themoviedb.org/3/movie/550"))

--- a/Tests/TMDbTests/Adapters/URLSessionHTTPClientAdapterTests.swift
+++ b/Tests/TMDbTests/Adapters/URLSessionHTTPClientAdapterTests.swift
@@ -188,7 +188,11 @@ final class URLSessionHTTPClientAdapterTests {
         // too, on Linux only, where no test would notice.
         let configuration = URLSessionConfiguration.default
         configuration.protocolClasses = [MockURLProtocol.self]
-        configuration.urlCache = URLCache(memoryCapacity: 1024, diskCapacity: 0)
+        // `URLCache.shared` rather than a constructed one: the two-argument
+        // initialiser does not exist on swift-corelibs-foundation (it requires
+        // `diskPath:`), and the three-argument form is deprecated on Apple —
+        // which `--Werror` would reject. The shared instance exists on both.
+        configuration.urlCache = .shared
         let session = URLSession(configuration: configuration)
 
         let adapter = URLSessionHTTPClientAdapter(urlSession: session)

--- a/Tests/TMDbTests/Domain/Models/FailableDecodableTests.swift
+++ b/Tests/TMDbTests/Domain/Models/FailableDecodableTests.swift
@@ -1,0 +1,51 @@
+//
+//  FailableDecodableTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.models, .decoding))
+struct FailableDecodableTests {
+
+    private struct Item: Decodable, Equatable {
+        let id: Int
+        let name: String
+    }
+
+    @Test("decodes a valid element")
+    func decodesValidElement() throws {
+        let data = Data(#"{"id": 1, "name": "one"}"#.utf8)
+
+        let result = try JSONDecoder().decode(FailableDecodable<Item>.self, from: data)
+
+        #expect(result.value == Item(id: 1, name: "one"))
+    }
+
+    @Test("yields nil for an element that cannot be decoded, without throwing")
+    func yieldsNilForUndecodableElement() throws {
+        let data = Data(#"{"id": "not-an-int"}"#.utf8)
+
+        let result = try JSONDecoder().decode(FailableDecodable<Item>.self, from: data)
+
+        #expect(result.value == nil)
+    }
+
+    @Test("a bad element is consumed so the rest of the array still decodes")
+    func badElementDoesNotDropTheArray() throws {
+        let data = Data(#"""
+        [{"id": 1, "name": "one"}, {"nope": true}, {"id": 3, "name": "three"}]
+        """#.utf8)
+
+        let wrapped = try JSONDecoder().decode([FailableDecodable<Item>].self, from: data)
+        let items = wrapped.compactMap(\.value)
+
+        #expect(wrapped.count == 3)
+        #expect(items == [Item(id: 1, name: "one"), Item(id: 3, name: "three")])
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Models/V4ListSummaryTests.swift
+++ b/Tests/TMDbTests/Domain/Models/V4ListSummaryTests.swift
@@ -44,9 +44,58 @@ struct V4ListSummaryTests {
 
     @Test("maps the string runtime to an Int")
     func mapsStringRuntime() throws {
+        // A non-zero value on purpose: against `"runtime": "0"` a successful
+        // parse and the `?? 0` fallback are indistinguishable, so the test
+        // would still pass with the conversion deleted.
         let result = try decodeFixture()
 
+        #expect(result.runtime == 8433)
+    }
+
+    @Test("a non-numeric runtime falls back to zero rather than throwing")
+    func nonNumericRuntimeFallsBack() throws {
+        let json = Data(#"""
+        {"id": 1, "name": "List", "runtime": "not-a-number", "public": 1,
+         "iso_639_1": "en", "iso_3166_1": "US", "account_object_id": "abc",
+         "number_of_items": 0, "created_at": "2026-08-06 23:26:00 UTC",
+         "updated_at": "2026-08-06 23:26:00 UTC"}
+        """#.utf8)
+
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(V4ListSummary.self, from: json)
+
         #expect(result.runtime == 0)
+    }
+
+    @Test("a summary missing optional fields still decodes rather than vanishing")
+    func minimalSummaryDecodes() throws {
+        // These are wrapped in `FailableDecodable` by `PageableListResult`, so a
+        // throw here would silently DROP the list from the user's results
+        // instead of surfacing an error.
+        let json = Data(#"{"id": 42, "name": "Sparse"}"#.utf8)
+
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(V4ListSummary.self, from: json)
+
+        #expect(result.id == 42)
+        #expect(result.name == "Sparse")
+        #expect(result.isPublic == false)
+        #expect(result.runtime == 0)
+        #expect(result.numberOfItems == 0)
+        #expect(result.accountObjectID == "")
+    }
+
+    @Test("a sparse summary survives inside a page instead of being dropped")
+    func sparseSummarySurvivesInAPage() throws {
+        let json = Data(#"""
+        {"page": 1, "total_pages": 1, "total_results": 2,
+         "results": [{"id": 1, "name": "Full", "public": 1, "runtime": "10"},
+                     {"id": 2, "name": "Sparse"}]}
+        """#.utf8)
+
+        let page = try JSONDecoder.theMovieDatabaseV4.decode(
+            PageableListResult<V4ListSummary>.self, from: json
+        )
+
+        #expect(page.results.count == 2)
     }
 
     @Test("exposes the integer sort order exactly as sent")
@@ -77,7 +126,7 @@ struct V4ListSummaryTests {
         )
 
         #expect(json["public"] as? Int == 1)
-        #expect(json["runtime"] as? String == "0")
+        #expect(json["runtime"] as? String == "8433")
 
         let result = try JSONDecoder.theMovieDatabaseV4.decode(
             V4ListSummary.self, from: encoded

--- a/Tests/TMDbTests/Domain/Models/V4ListSummaryTests.swift
+++ b/Tests/TMDbTests/Domain/Models/V4ListSummaryTests.swift
@@ -1,0 +1,88 @@
+//
+//  V4ListSummaryTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.models, .decoding))
+struct V4ListSummaryTests {
+
+    private func decodeFixture() throws -> V4ListSummary {
+        let page = try JSONDecoder.theMovieDatabaseV4.decode(
+            PageableListResult<V4ListSummary>.self, fromResource: "v4-account-lists"
+        )
+
+        return try #require(page.results.first)
+    }
+
+    @Test("decodes an account list summary")
+    func decodesSummary() throws {
+        let result = try decodeFixture()
+
+        #expect(result.id == 8_678_999)
+        #expect(result.name == "My Watchlist")
+        #expect(result.accountObjectID == "1a2b3c4d5e6f7a8b9c0d1e2f")
+        #expect(result.numberOfItems == 2)
+        #expect(result.languageCode == "en")
+        #expect(result.countryCode == "US")
+    }
+
+    @Test("maps the integer public flag to a Bool")
+    func mapsIntegerPublicFlag() throws {
+        // This endpoint sends 0/1 where the list-details endpoint sends a bool.
+        let result = try decodeFixture()
+
+        #expect(result.isPublic)
+        #expect(result.isAdult == false)
+        #expect(result.isFeatured == false)
+    }
+
+    @Test("maps the string runtime to an Int")
+    func mapsStringRuntime() throws {
+        let result = try decodeFixture()
+
+        #expect(result.runtime == 0)
+    }
+
+    @Test("exposes the integer sort order exactly as sent")
+    func exposesRawSortBy() throws {
+        // TMDb reports sort order as an Int here and a String on list details,
+        // with no published mapping — so it is not decoded into a shared type.
+        let result = try decodeFixture()
+
+        #expect(result.sortBy == 1)
+    }
+
+    @Test("decodes the UTC timestamp form used by this endpoint")
+    func decodesTimestamps() throws {
+        let result = try decodeFixture()
+
+        #expect(result.updatedAt > result.createdAt)
+    }
+
+    @Test("round trips, preserving the wire types")
+    func roundTrips() throws {
+        // The raw values are stored as sent, so encoding must re-emit `public`
+        // as an integer and `runtime` as a string — not as a Bool and an Int.
+        let original = try decodeFixture()
+
+        let encoded = try JSONEncoder.theMovieDatabaseV4.encode(original)
+        let json = try #require(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+
+        #expect(json["public"] as? Int == 1)
+        #expect(json["runtime"] as? String == "0")
+
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(
+            V4ListSummary.self, from: encoded
+        )
+        #expect(result == original)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Models/V4ListTests.swift
+++ b/Tests/TMDbTests/Domain/Models/V4ListTests.swift
@@ -107,16 +107,73 @@ struct V4ListTests {
         #expect(result.comment == nil)
     }
 
-    @Test("round trips through encode and decode, comments included")
-    func roundTrips() throws {
+    @Test(
+        "round trips through encode and decode",
+        arguments: ["v4-list-with-comments", "v4-list", "v4-list-with-images", "v4-list-minimal"]
+    )
+    func roundTrips(fixture: String) throws {
+        // All four, so both branches of the comment encoding are covered: the
+        // `guard let comment else` skip, and the `if !comments.isEmpty`
+        // omission for a list where nobody has commented.
         let original = try JSONDecoder.theMovieDatabaseV4.decode(
-            V4List.self, fromResource: "v4-list-with-comments"
+            V4List.self, fromResource: fixture
         )
 
         let encoded = try JSONEncoder.theMovieDatabaseV4.encode(original)
         let result = try JSONDecoder.theMovieDatabaseV4.decode(V4List.self, from: encoded)
 
         #expect(result == original)
+    }
+
+    @Test("every optional field falls back when TMDb omits it")
+    func minimalPayloadUsesDefaults() throws {
+        // Both full fixtures carry every key, so without this not one of the
+        // fourteen `?? default` branches is ever exercised.
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(
+            V4List.self, fromResource: "v4-list-minimal"
+        )
+
+        #expect(result.id == 8_679_001)
+        #expect(result.name == "Minimal List")
+        #expect(result.description == nil)
+        #expect(result.isPublic == false)
+        #expect(result.items.isEmpty)
+        #expect(result.itemCount == 0)
+        #expect(result.averageRating == 0)
+        #expect(result.runtime == 0)
+        #expect(result.revenue == 0)
+        #expect(result.sortBy == "original_order.asc")
+        #expect(result.languageCode == "")
+        #expect(result.countryCode == "")
+        #expect(result.backdropPath == nil)
+        #expect(result.posterPath == nil)
+        #expect(result.page == 1)
+        #expect(result.totalPages == 1)
+        #expect(result.totalResults == 0)
+    }
+
+    @Test("an absent visibility flag decodes as private, not public")
+    func absentVisibilityDefaultsToPrivate() throws {
+        // For a privacy flag the safe failure direction is the restrictive one.
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(
+            V4List.self, fromResource: "v4-list-minimal"
+        )
+
+        #expect(result.isPublic == false)
+    }
+
+    @Test("decodes the image paths when TMDb sends them")
+    func decodesImagePaths() throws {
+        // Both other fixtures send null for these, leaving the URL branch
+        // unverified.
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(
+            V4List.self, fromResource: "v4-list-with-images"
+        )
+
+        let backdropPath = try #require(result.backdropPath)
+        let posterPath = try #require(result.posterPath)
+        #expect(backdropPath.absoluteString == "/c6OLXfKAk5BKeR6broC8pYiCquX.jpg")
+        #expect(posterPath.absoluteString == "/jSziioSwPVrOy9Yow3XhWIBDjq1.jpg")
     }
 
 }

--- a/Tests/TMDbTests/Domain/Models/V4ListTests.swift
+++ b/Tests/TMDbTests/Domain/Models/V4ListTests.swift
@@ -113,7 +113,7 @@ struct V4ListTests {
             V4List.self, fromResource: "v4-list-with-comments"
         )
 
-        let encoded = try JSONEncoder.theMovieDatabase.encode(original)
+        let encoded = try JSONEncoder.theMovieDatabaseV4.encode(original)
         let result = try JSONDecoder.theMovieDatabaseV4.decode(V4List.self, from: encoded)
 
         #expect(result == original)

--- a/Tests/TMDbTests/Domain/Models/V4ListTests.swift
+++ b/Tests/TMDbTests/Domain/Models/V4ListTests.swift
@@ -1,0 +1,122 @@
+//
+//  V4ListTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.models, .decoding))
+struct V4ListTests {
+
+    @Test("decodes a mixed movie and TV list")
+    func decodesMixedList() throws {
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(
+            V4List.self, fromResource: "v4-list"
+        )
+
+        #expect(result.id == 8_678_999)
+        #expect(result.name == "My Watchlist")
+        #expect(result.description == "Films and shows to catch up on")
+        #expect(result.isPublic)
+        #expect(result.languageCode == "en")
+        #expect(result.countryCode == "US")
+        #expect(result.sortBy == "original_order.asc")
+        #expect(result.createdBy.username == "testuser")
+    }
+
+    @Test("keeps every item — a short page would mean a dropped decode")
+    func decodesEveryItem() throws {
+        // `FailableDecodable` skips an element it cannot model, silently. This
+        // reconciles the decoded count against the count TMDb reports, so a
+        // decoder regression fails here rather than returning a quietly short
+        // page.
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(
+            V4List.self, fromResource: "v4-list"
+        )
+
+        #expect(result.items.count == 2)
+        #expect(result.items.count == result.itemCount)
+        #expect(result.items.count == result.totalResults)
+    }
+
+    @Test("decodes a movie item and a TV item into the right Show cases")
+    func decodesBothMediaTypes() throws {
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(
+            V4List.self, fromResource: "v4-list"
+        )
+
+        let movie = try #require(result.items.first { $0.id == 550 })
+        let tvSeries = try #require(result.items.first { $0.id == 1399 })
+
+        guard case .movie(let movieItem) = movie.media else {
+            Issue.record("expected item 550 to decode as a movie")
+            return
+        }
+        guard case .tvSeries(let tvSeriesItem) = tvSeries.media else {
+            Issue.record("expected item 1399 to decode as a TV series")
+            return
+        }
+
+        #expect(movieItem.title == "Fight Club")
+        #expect(tvSeriesItem.name == "Game of Thrones")
+    }
+
+    @Test("stitches the top-level comments dictionary onto the right items")
+    func stitchesComments() throws {
+        // TMDb sends comments separately, keyed "<media_type>:<id>" — the items
+        // themselves carry no comment field.
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(
+            V4List.self, fromResource: "v4-list-with-comments"
+        )
+
+        let movie = try #require(result.items.first { $0.id == 550 })
+        let tvSeries = try #require(result.items.first { $0.id == 1399 })
+
+        #expect(movie.comment == "A movie comment")
+        #expect(tvSeries.comment == "A TV comment")
+    }
+
+    @Test("a null comment decodes as no comment")
+    func nullCommentIsNil() throws {
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(
+            V4List.self, fromResource: "v4-list"
+        )
+
+        let tvSeries = try #require(result.items.first { $0.id == 1399 })
+
+        #expect(tvSeries.comment == nil)
+    }
+
+    @Test("an item decoded on its own has no comment")
+    func standaloneItemHasNoComment() throws {
+        let json = Data(#"""
+        {"id": 550, "media_type": "movie", "title": "Fight Club",
+         "original_title": "Fight Club", "adult": false, "genre_ids": [18],
+         "original_language": "en", "overview": "", "popularity": 1.0,
+         "release_date": "1999-10-15", "video": false, "vote_average": 8.4,
+         "vote_count": 1}
+        """#.utf8)
+
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(V4ListItem.self, from: json)
+
+        #expect(result.id == 550)
+        #expect(result.comment == nil)
+    }
+
+    @Test("round trips through encode and decode, comments included")
+    func roundTrips() throws {
+        let original = try JSONDecoder.theMovieDatabaseV4.decode(
+            V4List.self, fromResource: "v4-list-with-comments"
+        )
+
+        let encoded = try JSONEncoder.theMovieDatabase.encode(original)
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(V4List.self, from: encoded)
+
+        #expect(result == original)
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Models/V4ListWriteResultTests.swift
+++ b/Tests/TMDbTests/Domain/Models/V4ListWriteResultTests.swift
@@ -1,0 +1,140 @@
+//
+//  V4ListWriteResultTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.models, .decoding))
+struct V4ListWriteResultTests {
+
+    // MARK: - V4CreateListResult
+
+    @Test("decodes a create-list result, whose id key is `id` not `list_id`")
+    func decodesCreateResult() throws {
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(
+            V4CreateListResult.self, fromResource: "v4-create-list-result"
+        )
+
+        #expect(result.success)
+        #expect(result.id == 8_678_999)
+    }
+
+    // MARK: - V4ClearListResult
+
+    @Test("decodes a clear-list result including how many items went")
+    func decodesClearResult() throws {
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(
+            V4ClearListResult.self, fromResource: "v4-clear-list-result"
+        )
+
+        #expect(result.success)
+        #expect(result.id == 8_678_999)
+        #expect(result.itemsDeleted == 2)
+    }
+
+    // MARK: - V4ListItemsResult
+
+    @Test("decodes a per-item result for a movie and a TV series")
+    func decodesItemsResult() throws {
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(
+            V4ListItemsResult.self, fromResource: "v4-list-items-result"
+        )
+
+        #expect(result.success)
+        #expect(result.results.count == 2)
+        let movie = try #require(result.results.first { $0.mediaType == .movie })
+        let tvSeries = try #require(result.results.first { $0.mediaType == .tvSeries })
+        #expect(movie.mediaID == 550)
+        #expect(tvSeries.mediaID == 1399)
+        #expect(result.allItemsSucceeded)
+        #expect(result.failures.isEmpty)
+    }
+
+    @Test("a partial failure reports success overall but surfaces the failed item")
+    func decodesPartialFailure() throws {
+        // TMDb answers success: true for a request in which individual items
+        // failed — removing an item that is not in the list reproduces it — so
+        // the per-item results are the only reliable signal.
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(
+            V4ListItemsResult.self, fromResource: "v4-list-items-result-partial-failure"
+        )
+
+        #expect(result.success)
+        #expect(result.allItemsSucceeded == false)
+        #expect(result.failures.count == 1)
+        let failure = try #require(result.failures.first)
+        #expect(failure.mediaID == 550)
+        #expect(failure.mediaType == .movie)
+    }
+
+    // MARK: - Input models
+
+    @Test("a media item encodes to the media_type/media_id shape TMDb expects")
+    func encodesMediaItem() throws {
+        let item = V4ListMediaItem.movie(550)
+
+        let data = try JSONEncoder.theMovieDatabaseV4.encode(item)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(json["media_type"] as? String == "movie")
+        #expect(json["media_id"] as? Int == 550)
+        #expect(json["comment"] == nil)
+    }
+
+    @Test("a TV media item uses the tv media type")
+    func encodesTVMediaItem() throws {
+        let item = V4ListMediaItem.tvSeries(1399)
+
+        let data = try JSONEncoder.theMovieDatabaseV4.encode(item)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(json["media_type"] as? String == "tv")
+        #expect(json["media_id"] as? Int == 1399)
+    }
+
+    @Test("an item comment carries the comment, unlike a media item")
+    func encodesItemComment() throws {
+        let item = V4ListItemComment.movie(550, comment: "Rewatch for the twist")
+
+        let data = try JSONEncoder.theMovieDatabaseV4.encode(item)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(json["media_type"] as? String == "movie")
+        #expect(json["media_id"] as? Int == 550)
+        #expect(json["comment"] as? String == "Rewatch for the twist")
+    }
+
+    // MARK: - V4ListSortBy
+
+    @Test(
+        "renders the value TMDb accepts",
+        arguments: [
+            (V4ListSortBy.originalOrder(), "original_order.asc"),
+            (V4ListSortBy.originalOrder(descending: true), "original_order.desc"),
+            (V4ListSortBy.voteAverage(), "vote_average.asc"),
+            (V4ListSortBy.voteAverage(descending: true), "vote_average.desc"),
+            (V4ListSortBy.primaryReleaseDate(), "primary_release_date.asc"),
+            (V4ListSortBy.primaryReleaseDate(descending: true), "primary_release_date.desc"),
+            (V4ListSortBy.releaseDate(), "release_date.asc"),
+            (V4ListSortBy.releaseDate(descending: true), "release_date.desc"),
+            (V4ListSortBy.title(), "title.asc"),
+            (V4ListSortBy.title(descending: true), "title.desc")
+        ]
+    )
+    func rendersSortBy(sortBy: V4ListSortBy, expected: String) {
+        // These ten are the whole accepted set — each was set against the live
+        // API and read back to confirm it stuck.
+        #expect(sortBy.description == expected)
+    }
+
+    @Test("defaults to ascending, matching a newly created list")
+    func defaultsToAscending() {
+        #expect(V4ListSortBy.originalOrder().description == "original_order.asc")
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/V4Lists/TMDbV4ListServiceReadTests.swift
+++ b/Tests/TMDbTests/Domain/Services/V4Lists/TMDbV4ListServiceReadTests.swift
@@ -1,0 +1,216 @@
+//
+//  TMDbV4ListServiceReadTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.services, .list))
+struct TMDbV4ListServiceReadTests {
+
+    var service: TMDbV4ListService!
+    var apiClient: MockAPIClient!
+
+    init() {
+        self.apiClient = MockAPIClient()
+        self.service = TMDbV4ListService(apiClient: apiClient)
+    }
+
+    private func sampleList(id: Int = 1) -> V4List {
+        V4List(
+            id: id,
+            name: "My Watchlist",
+            isPublic: true,
+            createdBy: V4ListCreator(id: "abc", name: "Test", username: "test"),
+            items: [],
+            itemCount: 0,
+            sortBy: "original_order.asc",
+            languageCode: "en",
+            countryCode: "US"
+        )
+    }
+
+    // MARK: - details
+
+    @Test("details returns the list and builds the expected request")
+    func detailsReturnsList() async throws {
+        let expectedResult = sampleList()
+        apiClient.addResponse(.success(expectedResult))
+
+        let result = try await service.details(forList: 1)
+
+        #expect(result == expectedResult)
+        #expect(apiClient.lastRequest as? V4ListRequest == V4ListRequest(id: 1))
+    }
+
+    @Test("details threads page, sort order, language and token into the request")
+    func detailsBuildsFullRequest() async throws {
+        apiClient.addResponse(.success(sampleList()))
+
+        _ = try await service.details(
+            forList: 1,
+            page: 2,
+            sortedBy: .title(descending: true),
+            language: "en",
+            accessToken: "user-token"
+        )
+
+        let expected = V4ListRequest(
+            id: 1,
+            page: 2,
+            sortBy: .title(descending: true),
+            language: "en",
+            accessToken: "user-token"
+        )
+        #expect(apiClient.lastRequest as? V4ListRequest == expected)
+    }
+
+    @Test("details with an access token sends it as a bearer Authorization header")
+    func detailsSendsAuthorizationHeader() async throws {
+        apiClient.addResponse(.success(sampleList()))
+
+        _ = try await service.details(forList: 1, accessToken: "user-token")
+
+        let request = try #require(apiClient.lastRequest)
+        #expect(request.headers["Authorization"] == "Bearer user-token")
+    }
+
+    @Test("details without an access token sends no Authorization header")
+    func detailsWithoutTokenSendsNoAuthorizationHeader() async throws {
+        apiClient.addResponse(.success(sampleList()))
+
+        _ = try await service.details(forList: 1)
+
+        let request = try #require(apiClient.lastRequest)
+        #expect(request.headers["Authorization"] == nil)
+    }
+
+    @Test("details with an empty access token throws bad request without a call")
+    func detailsWithEmptyTokenThrows() async throws {
+        await #expect(throws: TMDbError.badRequest(
+            TMDbErrorContext(statusMessage: "Access token must not be empty")
+        )) {
+            _ = try await service.details(
+                forList: 1, page: nil, sortedBy: nil, language: nil, accessToken: " "
+            )
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
+    // MARK: - items
+
+    @Test("items reshapes the list details into a pageable result")
+    func itemsReshapesDetails() async throws {
+        // v4 has no separate items endpoint — this is the same request.
+        let list = V4List(
+            id: 1,
+            name: "My Watchlist",
+            isPublic: true,
+            createdBy: V4ListCreator(id: "abc", name: "Test", username: "test"),
+            items: [],
+            itemCount: 2,
+            sortBy: "original_order.asc",
+            languageCode: "en",
+            countryCode: "US",
+            page: 3,
+            totalPages: 5,
+            totalResults: 42
+        )
+        apiClient.addResponse(.success(list))
+
+        let result = try await service.items(forList: 1)
+
+        #expect(result.page == 3)
+        #expect(result.totalPages == 5)
+        #expect(result.totalResults == 42)
+        #expect(apiClient.lastRequest as? V4ListRequest == V4ListRequest(id: 1))
+    }
+
+    // MARK: - itemStatus
+
+    @Test("itemStatus is true when TMDb finds the item")
+    func itemStatusTrueWhenPresent() async throws {
+        apiClient.addResponse(.success(V4ListItemStatusResult(
+            success: true, id: 1, mediaID: 550, mediaType: .movie
+        )))
+
+        let result = try await service.itemStatus(forMedia: 550, ofType: .movie, inList: 1)
+
+        #expect(result)
+        let expected = V4ListItemStatusRequest(listID: 1, mediaID: 550, mediaType: .movie)
+        #expect(apiClient.lastRequest as? V4ListItemStatusRequest == expected)
+    }
+
+    @Test("itemStatus is false when TMDb answers not found")
+    func itemStatusFalseWhenNotFound() async throws {
+        // TMDb has no present/absent flag — an absent item is a 404.
+        apiClient.addResponse(.failure(.notFound(TMDbErrorContext())))
+
+        let result = try await service.itemStatus(forMedia: 550, ofType: .movie, inList: 1)
+
+        #expect(result == false)
+    }
+
+    @Test("itemStatus propagates errors other than not found")
+    func itemStatusPropagatesOtherErrors() async throws {
+        apiClient.addResponse(.failure(.unauthorised(TMDbErrorContext())))
+
+        await #expect(throws: TMDbError.unauthorised(TMDbErrorContext())) {
+            _ = try await service.itemStatus(forMedia: 550, ofType: .movie, inList: 1)
+        }
+    }
+
+    @Test("itemStatus uses the tv media type for a TV series")
+    func itemStatusUsesTVMediaType() async throws {
+        apiClient.addResponse(.success(V4ListItemStatusResult(
+            success: true, id: 1, mediaID: 1399, mediaType: .tvSeries
+        )))
+
+        _ = try await service.itemStatus(forMedia: 1399, ofType: .tvSeries, inList: 1)
+
+        let request = try #require(apiClient.lastRequest)
+        #expect(request.queryItems["media_type"] == "tv")
+        #expect(request.queryItems["media_id"] == "1399")
+    }
+
+    // MARK: - lists
+
+    @Test("lists returns the account's lists and builds the expected request")
+    func listsReturnsAccountLists() async throws {
+        let expectedResult = PageableListResult<V4ListSummary>(results: [])
+        apiClient.addResponse(.success(expectedResult))
+
+        let result = try await service.lists(forAccount: "abc123", accessToken: "user-token")
+
+        #expect(result == expectedResult)
+        let expected = V4AccountListsRequest(accountObjectID: "abc123", accessToken: "user-token")
+        #expect(apiClient.lastRequest as? V4AccountListsRequest == expected)
+    }
+
+    @Test("lists with an empty account object ID throws bad request without a call")
+    func listsWithEmptyAccountIDThrows() async throws {
+        await #expect(throws: TMDbError.badRequest(
+            TMDbErrorContext(statusMessage: "Account object ID must not be empty")
+        )) {
+            _ = try await service.lists(forAccount: "", page: nil, accessToken: "user-token")
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
+    @Test("lists percent-encodes the account object ID into the path")
+    func listsEncodesAccountObjectID() async throws {
+        apiClient.addResponse(.success(PageableListResult<V4ListSummary>(results: [])))
+
+        _ = try await service.lists(forAccount: "a b/c", accessToken: "user-token")
+
+        let request = try #require(apiClient.lastRequest)
+        #expect(request.path == "/account/a%20b%2Fc/lists")
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Services/V4Lists/TMDbV4ListServiceReadTests.swift
+++ b/Tests/TMDbTests/Domain/Services/V4Lists/TMDbV4ListServiceReadTests.swift
@@ -165,6 +165,21 @@ struct TMDbV4ListServiceReadTests {
         }
     }
 
+    @Test("itemStatus decodes the real item-status response")
+    func itemStatusDecodesFixture() async throws {
+        let response = try JSONDecoder.theMovieDatabaseV4.decode(
+            V4ListItemStatusResult.self, fromResource: "v4-list-item-status"
+        )
+        apiClient.addResponse(.success(response))
+
+        let result = try await service.itemStatus(forMedia: 550, ofType: .movie, inList: 1)
+
+        #expect(result)
+        #expect(response.mediaID == 550)
+        #expect(response.mediaType == .movie)
+        #expect(response.id == 8_678_999)
+    }
+
     @Test("itemStatus uses the tv media type for a TV series")
     func itemStatusUsesTVMediaType() async throws {
         apiClient.addResponse(.success(V4ListItemStatusResult(

--- a/Tests/TMDbTests/Domain/Services/V4Lists/TMDbV4ListServiceWriteTests.swift
+++ b/Tests/TMDbTests/Domain/Services/V4Lists/TMDbV4ListServiceWriteTests.swift
@@ -117,6 +117,89 @@ struct TMDbV4ListServiceWriteTests {
         #expect(request.path == "/list/1")
     }
 
+    @Test("update sends the visibility flag as an integer, like create")
+    func updateSendsIntegerVisibility() async throws {
+        // Update accepts either form, unlike create — but the two must agree,
+        // or the same `isPublic: false` means different things one method apart.
+        apiClient.addResponse(.success(SuccessResult(success: true)))
+
+        try await service.update(
+            list: 1,
+            attributes: V4ListAttributes(isPublic: false, sortBy: .title(descending: true)),
+            accessToken: Self.token
+        )
+
+        let request = try #require(apiClient.lastRequest as? UpdateV4ListRequest)
+        let body = try #require(request.body)
+        #expect(body.isPublic == 0)
+        #expect(body.sortBy == "title.desc")
+
+        let data = try JSONEncoder.theMovieDatabaseV4.encode(body)
+        let json = try #require(String(data: data, encoding: .utf8))
+        #expect(json.contains("\"public\":0"))
+        #expect(json.contains("\"public\":false") == false)
+    }
+
+    @Test("update omits the fields it was not given")
+    func updateOmitsUnsetFields() async throws {
+        apiClient.addResponse(.success(SuccessResult(success: true)))
+
+        try await service.update(list: 1, name: "Renamed", accessToken: Self.token)
+
+        let request = try #require(apiClient.lastRequest as? UpdateV4ListRequest)
+        let body = try #require(request.body)
+        #expect(body.name == "Renamed")
+        #expect(body.description == nil)
+        #expect(body.isPublic == nil)
+        #expect(body.sortBy == nil)
+    }
+
+    @Test("addItems sends the items in the body")
+    func addItemsSendsBody() async throws {
+        apiClient.addResponse(.success(itemsResult()))
+
+        _ = try await service.addItems(
+            [.movie(550), .tvSeries(1399)], toList: 1, accessToken: Self.token
+        )
+
+        let request = try #require(apiClient.lastRequest as? AddV4ListItemsRequest)
+        #expect(request.body?.items == [.movie(550), .tvSeries(1399)])
+    }
+
+    @Test("updateItems sends the comments in the body")
+    func updateItemsSendsBody() async throws {
+        apiClient.addResponse(.success(itemsResult()))
+
+        _ = try await service.updateItems(
+            [.movie(550, comment: "Great twist")], inList: 1, accessToken: Self.token
+        )
+
+        let request = try #require(apiClient.lastRequest as? UpdateV4ListItemsRequest)
+        #expect(request.body?.items == [.movie(550, comment: "Great twist")])
+    }
+
+    @Test("updateItems with no items throws bad request without a call")
+    func updateItemsWithNoItemsThrows() async throws {
+        await #expect(throws: TMDbError.badRequest(
+            TMDbErrorContext(statusMessage: "Items must not be empty")
+        )) {
+            _ = try await service.updateItems([], inList: 1, accessToken: Self.token)
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
+    @Test("removeItems with no items throws bad request without a call")
+    func removeItemsWithNoItemsThrows() async throws {
+        await #expect(throws: TMDbError.badRequest(
+            TMDbErrorContext(statusMessage: "Items must not be empty")
+        )) {
+            _ = try await service.removeItems([], fromList: 1, accessToken: Self.token)
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
     @Test("update with an empty name throws bad request without a call")
     func updateWithEmptyNameThrows() async throws {
         await #expect(throws: TMDbError.badRequest(

--- a/Tests/TMDbTests/Domain/Services/V4Lists/TMDbV4ListServiceWriteTests.swift
+++ b/Tests/TMDbTests/Domain/Services/V4Lists/TMDbV4ListServiceWriteTests.swift
@@ -1,0 +1,257 @@
+//
+//  TMDbV4ListServiceWriteTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.services, .list))
+struct TMDbV4ListServiceWriteTests {
+
+    var service: TMDbV4ListService!
+    var apiClient: MockAPIClient!
+
+    init() {
+        self.apiClient = MockAPIClient()
+        self.service = TMDbV4ListService(apiClient: apiClient)
+    }
+
+    private static let token = "user-token"
+
+    private func itemsResult() -> V4ListItemsResult {
+        V4ListItemsResult(
+            success: true,
+            results: [V4ListItemResult(mediaType: .movie, mediaID: 550, success: true)]
+        )
+    }
+
+    // MARK: - create
+
+    @Test("create returns the new list identifier and builds the expected request")
+    func createReturnsResult() async throws {
+        let expectedResult = V4CreateListResult(success: true, id: 42)
+        apiClient.addResponse(.success(expectedResult))
+
+        let result = try await service.create(name: "My Watchlist", accessToken: Self.token)
+
+        #expect(result == expectedResult)
+        let expected = CreateV4ListRequest(name: "My Watchlist", accessToken: Self.token)
+        #expect(apiClient.lastRequest as? CreateV4ListRequest == expected)
+    }
+
+    @Test("create sends the visibility flag as an integer, not a boolean")
+    func createSendsIntegerVisibility() async throws {
+        // Established against the live API: {"public": false} is ignored and
+        // the list comes back public, while {"public": 0} is honoured.
+        apiClient.addResponse(.success(V4CreateListResult(success: true, id: 42)))
+
+        _ = try await service.create(
+            name: "My Watchlist",
+            attributes: V4ListAttributes(isPublic: false),
+            accessToken: Self.token
+        )
+
+        let request = try #require(apiClient.lastRequest as? CreateV4ListRequest)
+        let body = try #require(request.body)
+        #expect(body.isPublic == 0)
+
+        // Asserted against the raw JSON text: `JSONSerialization` bridges 0 to
+        // an NSNumber that casts happily to `false`, so a typed check here
+        // could not tell the integer form from the boolean one — which is the
+        // whole distinction that matters to TMDb.
+        let data = try JSONEncoder.theMovieDatabaseV4.encode(body)
+        let json = try #require(String(data: data, encoding: .utf8))
+        #expect(json.contains("\"public\":0"))
+        #expect(json.contains("\"public\":false") == false)
+    }
+
+    @Test("create sends the sort order in TMDb's field.direction form")
+    func createSendsSortBy() async throws {
+        apiClient.addResponse(.success(V4CreateListResult(success: true, id: 42)))
+
+        _ = try await service.create(
+            name: "My Watchlist",
+            attributes: V4ListAttributes(
+                description: "Films",
+                isPublic: true,
+                languageCode: "en",
+                countryCode: "US",
+                sortBy: .title(descending: true)
+            ),
+            accessToken: Self.token
+        )
+
+        let request = try #require(apiClient.lastRequest as? CreateV4ListRequest)
+        let body = try #require(request.body)
+        #expect(body.sortBy == "title.desc")
+        #expect(body.languageCode == "en")
+        #expect(body.countryCode == "US")
+        #expect(body.isPublic == 1)
+    }
+
+    @Test("create with an empty name throws bad request without a call")
+    func createWithEmptyNameThrows() async throws {
+        await #expect(throws: TMDbError.badRequest(
+            TMDbErrorContext(statusMessage: "List name must not be empty")
+        )) {
+            _ = try await service.create(name: " ", accessToken: Self.token)
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
+    // MARK: - update
+
+    @Test("update builds a PUT request")
+    func updateBuildsPutRequest() async throws {
+        apiClient.addResponse(.success(SuccessResult(success: true)))
+
+        try await service.update(list: 1, name: "Renamed", accessToken: Self.token)
+
+        let request = try #require(apiClient.lastRequest)
+        #expect(request.method == .put)
+        #expect(request.path == "/list/1")
+    }
+
+    @Test("update with an empty name throws bad request without a call")
+    func updateWithEmptyNameThrows() async throws {
+        await #expect(throws: TMDbError.badRequest(
+            TMDbErrorContext(statusMessage: "List name must not be empty")
+        )) {
+            try await service.update(
+                list: 1,
+                attributes: V4ListAttributes(name: " "),
+                accessToken: Self.token
+            )
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
+    // MARK: - addItems
+
+    @Test("addItems posts the items and returns the per-item outcomes")
+    func addItemsReturnsResult() async throws {
+        let expectedResult = itemsResult()
+        apiClient.addResponse(.success(expectedResult))
+
+        let result = try await service.addItems(
+            [.movie(550), .tvSeries(1399)], toList: 1, accessToken: Self.token
+        )
+
+        #expect(result == expectedResult)
+        let request = try #require(apiClient.lastRequest)
+        #expect(request.method == .post)
+        #expect(request.path == "/list/1/items")
+    }
+
+    @Test("addItems with no items throws bad request without a call")
+    func addItemsWithNoItemsThrows() async throws {
+        await #expect(throws: TMDbError.badRequest(
+            TMDbErrorContext(statusMessage: "Items must not be empty")
+        )) {
+            _ = try await service.addItems([], toList: 1, accessToken: Self.token)
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
+    // MARK: - updateItems
+
+    @Test("updateItems builds a PUT — the only way a comment is stored")
+    func updateItemsBuildsPutRequest() async throws {
+        apiClient.addResponse(.success(itemsResult()))
+
+        _ = try await service.updateItems(
+            [.movie(550, comment: "Great twist")], inList: 1, accessToken: Self.token
+        )
+
+        let request = try #require(apiClient.lastRequest)
+        #expect(request.method == .put)
+        #expect(request.path == "/list/1/items")
+    }
+
+    // MARK: - removeItems
+
+    @Test("removeItems builds a DELETE carrying a body")
+    func removeItemsBuildsDeleteRequest() async throws {
+        apiClient.addResponse(.success(itemsResult()))
+
+        _ = try await service.removeItems([.movie(550)], fromList: 1, accessToken: Self.token)
+
+        let request = try #require(apiClient.lastRequest as? RemoveV4ListItemsRequest)
+        #expect(request.method == .delete)
+        #expect(request.path == "/list/1/items")
+        #expect(request.body?.items == [.movie(550)])
+    }
+
+    @Test("removeItems surfaces a per-item failure alongside overall success")
+    func removeItemsSurfacesPartialFailure() async throws {
+        apiClient.addResponse(.success(V4ListItemsResult(
+            success: true,
+            results: [V4ListItemResult(mediaType: .movie, mediaID: 550, success: false)]
+        )))
+
+        let result = try await service.removeItems(
+            [.movie(550)], fromList: 1, accessToken: Self.token
+        )
+
+        #expect(result.success)
+        #expect(result.allItemsSucceeded == false)
+        #expect(result.failures.count == 1)
+    }
+
+    // MARK: - clear
+
+    @Test("clear is a GET that reports how many items went")
+    func clearIsAGet() async throws {
+        // A state-changing GET: POST to this path returns 404.
+        apiClient.addResponse(.success(V4ClearListResult(success: true, id: 1, itemsDeleted: 2)))
+
+        let result = try await service.clear(list: 1, accessToken: Self.token)
+
+        #expect(result.itemsDeleted == 2)
+        let request = try #require(apiClient.lastRequest)
+        #expect(request.method == .get)
+        #expect(request.path == "/list/1/clear")
+    }
+
+    // MARK: - delete
+
+    @Test("delete builds a DELETE request")
+    func deleteBuildsDeleteRequest() async throws {
+        apiClient.addResponse(.success(SuccessResult(success: true)))
+
+        try await service.delete(list: 1, accessToken: Self.token)
+
+        let request = try #require(apiClient.lastRequest)
+        #expect(request.method == .delete)
+        #expect(request.path == "/list/1")
+    }
+
+    @Test("every write sends the access token as a bearer Authorization header")
+    func writesSendAuthorizationHeader() async throws {
+        apiClient.addResponse(.success(SuccessResult(success: true)))
+
+        try await service.delete(list: 1, accessToken: Self.token)
+
+        let request = try #require(apiClient.lastRequest)
+        #expect(request.headers["Authorization"] == "Bearer user-token")
+    }
+
+    @Test("a write with an empty access token throws bad request without a call")
+    func writeWithEmptyTokenThrows() async throws {
+        await #expect(throws: TMDbError.badRequest(
+            TMDbErrorContext(statusMessage: "Access token must not be empty")
+        )) {
+            try await service.delete(list: 1, accessToken: " ")
+        }
+
+        #expect(apiClient.requests.isEmpty)
+    }
+
+}

--- a/Tests/TMDbTests/Extensions/JSONDecoderV4Tests.swift
+++ b/Tests/TMDbTests/Extensions/JSONDecoderV4Tests.swift
@@ -61,10 +61,10 @@ struct JSONDecoderV4Tests {
         // means reusing v3's time zone (the current one), not GMT.
         let data = Data(#"{"release_date": "1999-10-15"}"#.utf8)
 
-        let v4 = try JSONDecoder.theMovieDatabaseV4.decode(DayPrecision.self, from: data)
-        let v3 = try JSONDecoder.theMovieDatabase.decode(DayPrecision.self, from: data)
+        let v4Decoded = try JSONDecoder.theMovieDatabaseV4.decode(DayPrecision.self, from: data)
+        let v3Decoded = try JSONDecoder.theMovieDatabase.decode(DayPrecision.self, from: data)
 
-        #expect(v4.releaseDate == v3.releaseDate)
+        #expect(v4Decoded.releaseDate == v3Decoded.releaseDate)
     }
 
     @Test("both date forms decode from one response")

--- a/Tests/TMDbTests/Extensions/JSONDecoderV4Tests.swift
+++ b/Tests/TMDbTests/Extensions/JSONDecoderV4Tests.swift
@@ -1,0 +1,94 @@
+//
+//  JSONDecoderV4Tests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+///
+/// The v4 decoder has to handle **both** TMDb date shapes, because one v4
+/// response can contain each: account-list summaries carry
+/// `"2026-08-06 23:26:00 UTC"` while list items carry `"1999-10-15"`. Neither
+/// existing decoder parses both.
+///
+@Suite(.tags(.networking))
+struct JSONDecoderV4Tests {
+
+    private struct DayPrecision: Decodable, Equatable {
+        let releaseDate: Date
+    }
+
+    private struct Timestamp: Decodable, Equatable {
+        let createdAt: Date
+    }
+
+    @Test("decodes the account-list timestamp form, in UTC")
+    func decodesTimestampForm() throws {
+        let data = Data(#"{"created_at": "2026-08-06 23:26:00 UTC"}"#.utf8)
+
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(Timestamp.self, from: data)
+
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 8
+        components.day = 6
+        components.hour = 23
+        components.minute = 26
+        components.second = 0
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .gmt
+        let expected = try #require(calendar.date(from: components))
+        #expect(result.createdAt == expected)
+    }
+
+    @Test("decodes the day-precision form")
+    func decodesDayPrecisionForm() throws {
+        let data = Data(#"{"release_date": "1999-10-15"}"#.utf8)
+
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(DayPrecision.self, from: data)
+
+        #expect(result.releaseDate != Date(timeIntervalSince1970: 0))
+    }
+
+    @Test("a day-precision date decodes identically to the v3 decoder")
+    func dayPrecisionMatchesV3Decoder() throws {
+        // The two decoders must agree, or the same `releaseDate` would land on a
+        // different instant depending on which API version fetched it. That
+        // means reusing v3's time zone (the current one), not GMT.
+        let data = Data(#"{"release_date": "1999-10-15"}"#.utf8)
+
+        let v4 = try JSONDecoder.theMovieDatabaseV4.decode(DayPrecision.self, from: data)
+        let v3 = try JSONDecoder.theMovieDatabase.decode(DayPrecision.self, from: data)
+
+        #expect(v4.releaseDate == v3.releaseDate)
+    }
+
+    @Test("both date forms decode from one response")
+    func decodesBothFormsFromOneResponse() throws {
+        struct Mixed: Decodable {
+            let createdAt: Date
+            let releaseDate: Date
+        }
+        let data = Data(#"""
+        {"created_at": "2026-08-06 23:26:00 UTC", "release_date": "1999-10-15"}
+        """#.utf8)
+
+        let result = try JSONDecoder.theMovieDatabaseV4.decode(Mixed.self, from: data)
+
+        #expect(result.createdAt > result.releaseDate)
+    }
+
+    @Test("an unparseable date throws rather than silently defaulting")
+    func unparseableDateThrows() throws {
+        let data = Data(#"{"release_date": "not-a-date"}"#.utf8)
+
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder.theMovieDatabaseV4.decode(DayPrecision.self, from: data)
+        }
+    }
+
+}

--- a/Tests/TMDbTests/Networking/CacheHTTPClientTests.swift
+++ b/Tests/TMDbTests/Networking/CacheHTTPClientTests.swift
@@ -33,6 +33,106 @@ struct CacheHTTPClientTests {
         #expect(mockClient.performCount == 1)
     }
 
+    @Test("a user-specific GET is never cached — two identical URLs both hit the network")
+    func userSpecificGetIsNotCached() async throws {
+        // Two users' reads of the same v4 list have byte-identical URLs; the
+        // credential is only in a header. Caching by URL would serve one user's
+        // private list to another.
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 200, data: Data("alice".utf8))))
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 200, data: Data("bob".utf8))))
+
+        let cacheClient = CacheHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.defaultConfig
+        )
+        let url = try #require(URL(string: "https://api.themoviedb.org/4/list/1"))
+
+        let first = try await cacheClient.perform(
+            request: HTTPRequest(
+                url: url,
+                headers: ["Authorization": "Bearer alice"],
+                isUserSpecific: true
+            )
+        )
+        let second = try await cacheClient.perform(
+            request: HTTPRequest(
+                url: url,
+                headers: ["Authorization": "Bearer bob"],
+                isUserSpecific: true
+            )
+        )
+
+        #expect(mockClient.performCount == 2)
+        #expect(first.data == Data("alice".utf8))
+        #expect(second.data == Data("bob".utf8))
+    }
+
+    @Test("a user-specific GET does not populate the cache for a later ordinary GET")
+    func userSpecificGetDoesNotPopulateCache() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 200, data: Data("private".utf8))))
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 200, data: Data("public".utf8))))
+
+        let cacheClient = CacheHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.defaultConfig
+        )
+        let url = try #require(URL(string: "https://api.themoviedb.org/4/list/1"))
+
+        _ = try await cacheClient.perform(
+            request: HTTPRequest(url: url, isUserSpecific: true)
+        )
+        let response = try await cacheClient.perform(request: HTTPRequest(url: url))
+
+        #expect(mockClient.performCount == 2)
+        #expect(response.data == Data("public".utf8))
+    }
+
+    @Test("a bearer-token client's ordinary GET is still cached")
+    func ordinaryBearerGetIsStillCached() async throws {
+        // The Authorization header alone must not disable caching, or every
+        // `TMDbClient(bearerToken:)` loses it for all reads.
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 200, data: Data("movie".utf8))))
+
+        let cacheClient = CacheHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.defaultConfig
+        )
+        let url = try #require(URL(string: "https://api.themoviedb.org/3/movie/550"))
+        let request = HTTPRequest(url: url, headers: ["Authorization": "Bearer app-token"])
+
+        _ = try await cacheClient.perform(request: request)
+        _ = try await cacheClient.perform(request: request)
+
+        #expect(mockClient.performCount == 1)
+    }
+
+    @Test("a GET ending in /clear is treated as a mutation — never cached, and invalidating")
+    func clearGetIsTreatedAsMutation() async throws {
+        // `GET /4/list/{id}/clear` empties the list. Caching it would return a
+        // stale success and never invalidate the list it just emptied.
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 200, data: Data("list".utf8))))
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 200, data: Data("cleared".utf8))))
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 200, data: Data("empty".utf8))))
+
+        let cacheClient = CacheHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.defaultConfig
+        )
+        let listURL = try #require(URL(string: "https://api.themoviedb.org/4/list/1"))
+        let clearURL = try #require(URL(string: "https://api.themoviedb.org/4/list/1/clear"))
+
+        _ = try await cacheClient.perform(request: HTTPRequest(url: listURL))
+        _ = try await cacheClient.perform(request: HTTPRequest(url: clearURL))
+        let afterClear = try await cacheClient.perform(request: HTTPRequest(url: listURL))
+
+        #expect(mockClient.performCount == 3)
+        #expect(afterClear.data == Data("empty".utf8))
+    }
+
     @Test("GET cache miss for different URLs performs request for each")
     func getCacheMiss() async throws {
         let mockClient = SequencingHTTPMockClient()

--- a/Tests/TMDbTests/Networking/HTTPClient/HTTPRequestMethodTests.swift
+++ b/Tests/TMDbTests/Networking/HTTPClient/HTTPRequestMethodTests.swift
@@ -27,4 +27,9 @@ struct HTTPRequestMethodTests {
         #expect(HTTPRequest.Method.delete.rawValue == "DELETE")
     }
 
+    @Test("put method should be equal to \"PUT\"")
+    func putMethod() {
+        #expect(HTTPRequest.Method.put.rawValue == "PUT")
+    }
+
 }

--- a/Tests/TMDbTests/Networking/RetryHTTPClientIdempotencyTests.swift
+++ b/Tests/TMDbTests/Networking/RetryHTTPClientIdempotencyTests.swift
@@ -44,6 +44,43 @@ struct RetryHTTPClientIdempotencyTests {
         #expect(mockClient.performCount == 2)
     }
 
+    @Test("a state-changing GET is not retried, despite GET being idempotent")
+    func stateChangingGetIsNotRetried() async throws {
+        // `GET /4/list/{id}/clear` empties the list. Replaying it after a lost
+        // response reports `items_deleted: 0` for a clear that did happen.
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 429)))
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.fastConfig
+        )
+        let url = try #require(URL(string: "https://api.themoviedb.org/4/list/1/clear"))
+
+        let response = try await retryClient.perform(request: HTTPRequest(url: url))
+
+        #expect(response.statusCode == 429)
+        #expect(mockClient.performCount == 1)
+    }
+
+    @Test("an ordinary GET is still retried")
+    func ordinaryGetIsRetried() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 429)))
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 200)))
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.fastConfig
+        )
+        let url = try #require(URL(string: "https://api.themoviedb.org/4/list/1"))
+
+        let response = try await retryClient.perform(request: HTTPRequest(url: url))
+
+        #expect(response.statusCode == 200)
+        #expect(mockClient.performCount == 2)
+    }
+
     @Test("POST with a retryable response is not retried — it appends")
     func postWithRetryableResponseIsNotRetried() async throws {
         let mockClient = SequencingHTTPMockClient()

--- a/Tests/TMDbTests/Networking/RetryHTTPClientIdempotencyTests.swift
+++ b/Tests/TMDbTests/Networking/RetryHTTPClientIdempotencyTests.swift
@@ -1,0 +1,65 @@
+//
+//  RetryHTTPClientIdempotencyTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+///
+/// Which methods may be replayed. Split from `RetryHTTPClientTests` so neither
+/// suite breaches swiftlint's `type_body_length`.
+///
+@Suite(.tags(.networking))
+struct RetryHTTPClientIdempotencyTests {
+
+    private static let fastConfig = RetryConfiguration(
+        maxRetries: 3,
+        initialDelay: .milliseconds(1),
+        maxDelay: .milliseconds(10),
+        retryableErrors: [.rateLimit, .serverErrors]
+    )
+
+    @Test("PUT with a retryable response is retried — it is idempotent")
+    func putWithRetryableResponseIsRetried() async throws {
+        // PUT replaces the resource with the request's own representation, so
+        // replaying it converges on the same state.
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 429)))
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 200)))
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.fastConfig
+        )
+        let url = try #require(URL(string: "https://example.com"))
+        let request = HTTPRequest(url: url, method: .put)
+
+        let response = try await retryClient.perform(request: request)
+
+        #expect(response.statusCode == 200)
+        #expect(mockClient.performCount == 2)
+    }
+
+    @Test("POST with a retryable response is not retried — it appends")
+    func postWithRetryableResponseIsNotRetried() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 429)))
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.fastConfig
+        )
+        let url = try #require(URL(string: "https://example.com"))
+        let request = HTTPRequest(url: url, method: .post)
+
+        let response = try await retryClient.perform(request: request)
+
+        #expect(response.statusCode == 429)
+        #expect(mockClient.performCount == 1)
+    }
+
+}

--- a/Tests/TMDbTests/Networking/RetryHTTPClientTests.swift
+++ b/Tests/TMDbTests/Networking/RetryHTTPClientTests.swift
@@ -206,6 +206,25 @@ struct RetryHTTPClientTests {
         #expect(mockClient.performCount == 1)
     }
 
+    @Test("PUT with retryable response is retried — it is idempotent")
+    func putWithRetryableResponseIsRetried() async throws {
+        let mockClient = SequencingHTTPMockClient()
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 429)))
+        mockClient.enqueue(.success(HTTPResponse(statusCode: 200)))
+
+        let retryClient = RetryHTTPClient(
+            httpClient: mockClient,
+            configuration: Self.fastConfig
+        )
+        let url = try #require(URL(string: "https://example.com"))
+        let request = HTTPRequest(url: url, method: .put)
+
+        let response = try await retryClient.perform(request: request)
+
+        #expect(response.statusCode == 200)
+        #expect(mockClient.performCount == 2)
+    }
+
     @Test("502 bad gateway is retried")
     func badGatewayIsRetried() async throws {
         let mockClient = SequencingHTTPMockClient()

--- a/Tests/TMDbTests/Networking/RetryHTTPClientTests.swift
+++ b/Tests/TMDbTests/Networking/RetryHTTPClientTests.swift
@@ -206,25 +206,6 @@ struct RetryHTTPClientTests {
         #expect(mockClient.performCount == 1)
     }
 
-    @Test("PUT with retryable response is retried — it is idempotent")
-    func putWithRetryableResponseIsRetried() async throws {
-        let mockClient = SequencingHTTPMockClient()
-        mockClient.enqueue(.success(HTTPResponse(statusCode: 429)))
-        mockClient.enqueue(.success(HTTPResponse(statusCode: 200)))
-
-        let retryClient = RetryHTTPClient(
-            httpClient: mockClient,
-            configuration: Self.fastConfig
-        )
-        let url = try #require(URL(string: "https://example.com"))
-        let request = HTTPRequest(url: url, method: .put)
-
-        let response = try await retryClient.perform(request: request)
-
-        #expect(response.statusCode == 200)
-        #expect(mockClient.performCount == 2)
-    }
-
     @Test("502 bad gateway is retried")
     func badGatewayIsRetried() async throws {
         let mockClient = SequencingHTTPMockClient()

--- a/Tests/TMDbTests/Networking/TMDbAPIClientCredentialTests.swift
+++ b/Tests/TMDbTests/Networking/TMDbAPIClientCredentialTests.swift
@@ -120,6 +120,54 @@ struct TMDbAPIClientCredentialTests {
         #expect(request.isUserSpecific)
     }
 
+    @Test("isUserSpecific is set for a v3 session request")
+    @MainActor
+    func isUserSpecificSetForSessionRequest() async throws {
+        // A v3 session request is user-scoped too. Its `session_id` is in the
+        // URL, so the on-disk cache keys differ per user and nothing leaks
+        // across users — but the response is still private data being written
+        // to a shared cache that survives relaunch.
+        let client = apiClient(credential: .apiKey("abc123"))
+        let stubRequest = APIStubRequest<String, String>(
+            path: "/account/42/lists",
+            queryItems: ["session_id": "user-session"]
+        )
+        httpClient.result = .success(HTTPResponse())
+
+        _ = try? await client.perform(stubRequest)
+
+        let request = try #require(httpClient.lastRequest)
+        #expect(request.isUserSpecific)
+    }
+
+    @Test("isUserSpecific is set for a guest session request")
+    @MainActor
+    func isUserSpecificSetForGuestSessionRequest() async throws {
+        let client = apiClient(credential: .apiKey("abc123"))
+        let stubRequest = APIStubRequest<String, String>(
+            path: "/guest_session/abc/rated/movies"
+        )
+        httpClient.result = .success(HTTPResponse())
+
+        _ = try? await client.perform(stubRequest)
+
+        let request = try #require(httpClient.lastRequest)
+        #expect(request.isUserSpecific)
+    }
+
+    @Test("isUserSpecific is not set for an ordinary api_key request")
+    @MainActor
+    func isUserSpecificNotSetForAPIKeyRequest() async throws {
+        let client = apiClient(credential: .apiKey("abc123"))
+        let stubRequest = APIStubRequest<String, String>(path: "/movie/550")
+        httpClient.result = .success(HTTPResponse())
+
+        _ = try? await client.perform(stubRequest)
+
+        let request = try #require(httpClient.lastRequest)
+        #expect(request.isUserSpecific == false)
+    }
+
     @Test("isUserSpecific is not set when only the client credential authenticates")
     @MainActor
     func isUserSpecificNotSetForClientCredential() async throws {

--- a/Tests/TMDbTests/Networking/TMDbAPIClientCredentialTests.swift
+++ b/Tests/TMDbTests/Networking/TMDbAPIClientCredentialTests.swift
@@ -63,4 +63,78 @@ struct TMDbAPIClientCredentialTests {
         #expect(hasAPIKey == false)
     }
 
+    // MARK: - Per-call credential precedence
+
+    @Test("a request's own Authorization header wins over the client's bearer token")
+    @MainActor
+    func requestAuthorizationWinsOverBearerCredential() async throws {
+        let client = apiClient(credential: .bearerToken("application-token"))
+        let stubRequest = APIStubRequest<String, String>(
+            path: "/endpoint",
+            headers: ["Authorization": "Bearer user-token"]
+        )
+        httpClient.result = .success(HTTPResponse())
+
+        _ = try? await client.perform(stubRequest)
+
+        let request = try #require(httpClient.lastRequest)
+        #expect(request.headers["Authorization"] == "Bearer user-token")
+    }
+
+    @Test("a request's own Authorization header suppresses the client's api_key query item")
+    @MainActor
+    func requestAuthorizationSuppressesAPIKey() async throws {
+        // Sending both credentials would leave precedence to the server, which
+        // was never probed — so the client credential is withheld entirely.
+        let client = apiClient(credential: .apiKey("abc123"))
+        let stubRequest = APIStubRequest<String, String>(
+            path: "/endpoint",
+            headers: ["Authorization": "Bearer user-token"]
+        )
+        httpClient.result = .success(HTTPResponse())
+
+        _ = try? await client.perform(stubRequest)
+
+        let request = try #require(httpClient.lastRequest)
+        #expect(request.headers["Authorization"] == "Bearer user-token")
+        let components = try #require(URLComponents(url: request.url, resolvingAgainstBaseURL: false))
+        let hasAPIKey = components.queryItems?.contains { $0.name == "api_key" } ?? false
+        #expect(hasAPIKey == false)
+    }
+
+    // MARK: - isUserSpecific
+
+    @Test("isUserSpecific is set when the request carries its own Authorization")
+    @MainActor
+    func isUserSpecificSetForPerCallCredential() async throws {
+        let client = apiClient(credential: .bearerToken("application-token"))
+        let stubRequest = APIStubRequest<String, String>(
+            path: "/endpoint",
+            headers: ["Authorization": "Bearer user-token"]
+        )
+        httpClient.result = .success(HTTPResponse())
+
+        _ = try? await client.perform(stubRequest)
+
+        let request = try #require(httpClient.lastRequest)
+        #expect(request.isUserSpecific)
+    }
+
+    @Test("isUserSpecific is not set when only the client credential authenticates")
+    @MainActor
+    func isUserSpecificNotSetForClientCredential() async throws {
+        // A bearer-token client puts an Authorization header on *every* request,
+        // so the header alone cannot mean "user-specific" — otherwise caching
+        // would be disabled wholesale for those clients.
+        let client = apiClient(credential: .bearerToken("application-token"))
+        let stubRequest = APIStubRequest<String, String>(path: "/endpoint")
+        httpClient.result = .success(HTTPResponse())
+
+        _ = try? await client.perform(stubRequest)
+
+        let request = try #require(httpClient.lastRequest)
+        #expect(request.headers["Authorization"] == "Bearer application-token")
+        #expect(request.isUserSpecific == false)
+    }
+
 }

--- a/Tests/TMDbTests/Resources/json/v4-account-lists.json
+++ b/Tests/TMDbTests/Resources/json/v4-account-lists.json
@@ -1,0 +1,27 @@
+{
+  "page": 1,
+  "results": [
+    {
+      "account_object_id": "1a2b3c4d5e6f7a8b9c0d1e2f",
+      "adult": 0,
+      "average_rating": 0.0,
+      "backdrop_path": null,
+      "created_at": "2026-08-06 23:26:00 UTC",
+      "description": "Films and shows to catch up on",
+      "featured": 0,
+      "id": 8678999,
+      "iso_3166_1": "US",
+      "iso_639_1": "en",
+      "name": "My Watchlist",
+      "number_of_items": 2,
+      "poster_path": null,
+      "public": 1,
+      "revenue": 0,
+      "runtime": "0",
+      "sort_by": 1,
+      "updated_at": "2026-08-06 23:26:04 UTC"
+    }
+  ],
+  "total_pages": 1,
+  "total_results": 1
+}

--- a/Tests/TMDbTests/Resources/json/v4-account-lists.json
+++ b/Tests/TMDbTests/Resources/json/v4-account-lists.json
@@ -17,7 +17,7 @@
       "poster_path": null,
       "public": 1,
       "revenue": 0,
-      "runtime": "0",
+      "runtime": "8433",
       "sort_by": 1,
       "updated_at": "2026-08-06 23:26:04 UTC"
     }

--- a/Tests/TMDbTests/Resources/json/v4-clear-list-result.json
+++ b/Tests/TMDbTests/Resources/json/v4-clear-list-result.json
@@ -1,0 +1,7 @@
+{
+  "success": true,
+  "status_code": 1,
+  "status_message": "Success.",
+  "id": 8678999,
+  "items_deleted": 2
+}

--- a/Tests/TMDbTests/Resources/json/v4-create-list-result.json
+++ b/Tests/TMDbTests/Resources/json/v4-create-list-result.json
@@ -1,0 +1,6 @@
+{
+  "success": true,
+  "status_code": 1,
+  "status_message": "Success.",
+  "id": 8678999
+}

--- a/Tests/TMDbTests/Resources/json/v4-list-item-status.json
+++ b/Tests/TMDbTests/Resources/json/v4-list-item-status.json
@@ -1,0 +1,8 @@
+{
+  "success": true,
+  "status_code": 1,
+  "status_message": "Success.",
+  "id": 8678999,
+  "media_id": 550,
+  "media_type": "movie"
+}

--- a/Tests/TMDbTests/Resources/json/v4-list-items-result-partial-failure.json
+++ b/Tests/TMDbTests/Resources/json/v4-list-items-result-partial-failure.json
@@ -1,0 +1,12 @@
+{
+  "success": true,
+  "status_code": 1,
+  "status_message": "Success.",
+  "results": [
+    {
+      "media_id": 550,
+      "media_type": "movie",
+      "success": false
+    }
+  ]
+}

--- a/Tests/TMDbTests/Resources/json/v4-list-items-result.json
+++ b/Tests/TMDbTests/Resources/json/v4-list-items-result.json
@@ -1,0 +1,17 @@
+{
+  "success": true,
+  "status_code": 1,
+  "status_message": "Success.",
+  "results": [
+    {
+      "media_id": 550,
+      "media_type": "movie",
+      "success": true
+    },
+    {
+      "media_id": 1399,
+      "media_type": "tv",
+      "success": true
+    }
+  ]
+}

--- a/Tests/TMDbTests/Resources/json/v4-list-minimal.json
+++ b/Tests/TMDbTests/Resources/json/v4-list-minimal.json
@@ -1,0 +1,9 @@
+{
+  "id": 8679001,
+  "name": "Minimal List",
+  "created_by": {
+    "id": "1a2b3c4d5e6f7a8b9c0d1e2f",
+    "name": "Test User",
+    "username": "testuser"
+  }
+}

--- a/Tests/TMDbTests/Resources/json/v4-list-with-comments.json
+++ b/Tests/TMDbTests/Resources/json/v4-list-with-comments.json
@@ -1,0 +1,77 @@
+{
+  "average_rating": 0.0,
+  "backdrop_path": null,
+  "results": [
+    {
+      "adult": false,
+      "backdrop_path": "/c6OLXfKAk5BKeR6broC8pYiCquX.jpg",
+      "id": 550,
+      "title": "Fight Club",
+      "original_title": "Fight Club",
+      "overview": "A ticking-time-bomb insomniac and a slippery soap salesman channel primal male aggression into a shocking new form of therapy. Their concept catches on, with underground \"fight clubs\" forming in every town, until an eccentric gets in the way and ignites an out-of-control spiral toward oblivion.",
+      "poster_path": "/jSziioSwPVrOy9Yow3XhWIBDjq1.jpg",
+      "media_type": "movie",
+      "original_language": "en",
+      "genre_ids": [
+        18,
+        53
+      ],
+      "popularity": 54.7069,
+      "release_date": "1999-10-15",
+      "softcore": false,
+      "video": false,
+      "vote_average": 8.437,
+      "vote_count": 32546
+    },
+    {
+      "adult": false,
+      "backdrop_path": "/2OMB0ynKlyIenMJWI2Dy9IWT4c.jpg",
+      "id": 1399,
+      "name": "Game of Thrones",
+      "original_name": "Game of Thrones",
+      "overview": "Seven noble families fight for control of the mythical land of Westeros. Friction between the houses leads to full-scale war. All while a very ancient evil awakens in the farthest north. Amidst the war, a neglected military order of misfits, the Night's Watch, is all that stands between the realms of men and icy horrors beyond.",
+      "poster_path": "/1XS1oqL89opfnbLl8WnZY1O1uJx.jpg",
+      "media_type": "tv",
+      "original_language": "en",
+      "genre_ids": [
+        10765,
+        18,
+        10759
+      ],
+      "popularity": 154.0924,
+      "first_air_date": "2011-04-17",
+      "softcore": false,
+      "vote_average": 8.468,
+      "vote_count": 27430,
+      "origin_country": [
+        "US"
+      ]
+    }
+  ],
+  "comments": {
+    "movie:550": "A movie comment",
+    "tv:1399": "A TV comment"
+  },
+  "created_by": {
+    "avatar_path": "/1AbCdEfGhIjKlMnOpQrStUvWxYz.jpg",
+    "gravatar_hash": "0123456789abcdef0123456789abcdef",
+    "id": "1a2b3c4d5e6f7a8b9c0d1e2f",
+    "name": "Test User",
+    "username": "testuser"
+  },
+  "description": "",
+  "id": 8679004,
+  "iso_3166_1": "US",
+  "iso_639_1": "en",
+  "item_count": 2,
+  "name": "comment-stitch fixture",
+  "object_ids": {},
+  "page": 1,
+  "poster_path": null,
+  "public": true,
+  "revenue": 0,
+  "runtime": 0,
+  "sort_by": "original_order.asc",
+  "total_pages": 1,
+  "total_results": 2
+}

--- a/Tests/TMDbTests/Resources/json/v4-list-with-images.json
+++ b/Tests/TMDbTests/Resources/json/v4-list-with-images.json
@@ -1,0 +1,77 @@
+{
+  "average_rating": 0.0,
+  "backdrop_path": "/c6OLXfKAk5BKeR6broC8pYiCquX.jpg",
+  "results": [
+    {
+      "adult": false,
+      "backdrop_path": "/c6OLXfKAk5BKeR6broC8pYiCquX.jpg",
+      "id": 550,
+      "title": "Fight Club",
+      "original_title": "Fight Club",
+      "overview": "A ticking-time-bomb insomniac and a slippery soap salesman channel primal male aggression into a shocking new form of therapy. Their concept catches on, with underground \"fight clubs\" forming in every town, until an eccentric gets in the way and ignites an out-of-control spiral toward oblivion.",
+      "poster_path": "/jSziioSwPVrOy9Yow3XhWIBDjq1.jpg",
+      "media_type": "movie",
+      "original_language": "en",
+      "genre_ids": [
+        18,
+        53
+      ],
+      "popularity": 54.7069,
+      "release_date": "1999-10-15",
+      "softcore": false,
+      "video": false,
+      "vote_average": 8.437,
+      "vote_count": 32545
+    },
+    {
+      "adult": false,
+      "backdrop_path": "/2OMB0ynKlyIenMJWI2Dy9IWT4c.jpg",
+      "id": 1399,
+      "name": "Game of Thrones",
+      "original_name": "Game of Thrones",
+      "overview": "Seven noble families fight for control of the mythical land of Westeros. Friction between the houses leads to full-scale war. All while a very ancient evil awakens in the farthest north. Amidst the war, a neglected military order of misfits, the Night's Watch, is all that stands between the realms of men and icy horrors beyond.",
+      "poster_path": "/1XS1oqL89opfnbLl8WnZY1O1uJx.jpg",
+      "media_type": "tv",
+      "original_language": "en",
+      "genre_ids": [
+        10765,
+        18,
+        10759
+      ],
+      "popularity": 178.5243,
+      "first_air_date": "2011-04-17",
+      "softcore": false,
+      "vote_average": 8.468,
+      "vote_count": 27430,
+      "origin_country": [
+        "US"
+      ]
+    }
+  ],
+  "comments": {
+    "movie:550": "updated comment",
+    "tv:1399": null
+  },
+  "created_by": {
+    "avatar_path": "/1AbCdEfGhIjKlMnOpQrStUvWxYz.jpg",
+    "gravatar_hash": "0123456789abcdef0123456789abcdef",
+    "id": "1a2b3c4d5e6f7a8b9c0d1e2f",
+    "name": "Test User",
+    "username": "testuser"
+  },
+  "description": "With artwork",
+  "id": 8678999,
+  "iso_3166_1": "US",
+  "iso_639_1": "en",
+  "item_count": 2,
+  "name": "My Watchlist",
+  "object_ids": {},
+  "page": 1,
+  "poster_path": "/jSziioSwPVrOy9Yow3XhWIBDjq1.jpg",
+  "public": true,
+  "revenue": 0,
+  "runtime": 0,
+  "sort_by": "original_order.asc",
+  "total_pages": 1,
+  "total_results": 2
+}

--- a/Tests/TMDbTests/Resources/json/v4-list.json
+++ b/Tests/TMDbTests/Resources/json/v4-list.json
@@ -1,0 +1,77 @@
+{
+  "average_rating": 0.0,
+  "backdrop_path": null,
+  "results": [
+    {
+      "adult": false,
+      "backdrop_path": "/c6OLXfKAk5BKeR6broC8pYiCquX.jpg",
+      "id": 550,
+      "title": "Fight Club",
+      "original_title": "Fight Club",
+      "overview": "A ticking-time-bomb insomniac and a slippery soap salesman channel primal male aggression into a shocking new form of therapy. Their concept catches on, with underground \"fight clubs\" forming in every town, until an eccentric gets in the way and ignites an out-of-control spiral toward oblivion.",
+      "poster_path": "/jSziioSwPVrOy9Yow3XhWIBDjq1.jpg",
+      "media_type": "movie",
+      "original_language": "en",
+      "genre_ids": [
+        18,
+        53
+      ],
+      "popularity": 54.7069,
+      "release_date": "1999-10-15",
+      "softcore": false,
+      "video": false,
+      "vote_average": 8.437,
+      "vote_count": 32545
+    },
+    {
+      "adult": false,
+      "backdrop_path": "/2OMB0ynKlyIenMJWI2Dy9IWT4c.jpg",
+      "id": 1399,
+      "name": "Game of Thrones",
+      "original_name": "Game of Thrones",
+      "overview": "Seven noble families fight for control of the mythical land of Westeros. Friction between the houses leads to full-scale war. All while a very ancient evil awakens in the farthest north. Amidst the war, a neglected military order of misfits, the Night's Watch, is all that stands between the realms of men and icy horrors beyond.",
+      "poster_path": "/1XS1oqL89opfnbLl8WnZY1O1uJx.jpg",
+      "media_type": "tv",
+      "original_language": "en",
+      "genre_ids": [
+        10765,
+        18,
+        10759
+      ],
+      "popularity": 178.5243,
+      "first_air_date": "2011-04-17",
+      "softcore": false,
+      "vote_average": 8.468,
+      "vote_count": 27430,
+      "origin_country": [
+        "US"
+      ]
+    }
+  ],
+  "comments": {
+    "movie:550": "updated comment",
+    "tv:1399": null
+  },
+  "created_by": {
+    "avatar_path": "/1AbCdEfGhIjKlMnOpQrStUvWxYz.jpg",
+    "gravatar_hash": "0123456789abcdef0123456789abcdef",
+    "id": "1a2b3c4d5e6f7a8b9c0d1e2f",
+    "name": "Test User",
+    "username": "testuser"
+  },
+  "description": "Films and shows to catch up on",
+  "id": 8678999,
+  "iso_3166_1": "US",
+  "iso_639_1": "en",
+  "item_count": 2,
+  "name": "My Watchlist",
+  "object_ids": {},
+  "page": 1,
+  "poster_path": null,
+  "public": true,
+  "revenue": 0,
+  "runtime": 0,
+  "sort_by": "original_order.asc",
+  "total_pages": 1,
+  "total_results": 2
+}

--- a/knowledge/decisions/0017-v4-api-client.md
+++ b/knowledge/decisions/0017-v4-api-client.md
@@ -75,9 +75,55 @@ token (the normal case — it is what you put in the keychain) to synthesise a
   `knowledge/gotchas.md` § *Growing a public protocol additively*), so v4 work
   is split by protocol, never by adding methods to a shipped one.
 
-### Still open — decisions deferred to the v4 list work
+### Resolved in the v4 list work (2026-08-07)
 
-These are **not** settled by this ADR and must be recorded when they are:
+The four decisions this ADR deferred are now taken. Each is recorded here rather
+than in a new ADR, because each is an amendment to *this* design rather than a
+separate one.
+
+- **Carrying a per-call bearer token.** Option (a): `TMDbAPIClient` applies the
+  client credential only when the request did not bring its own `Authorization`.
+  It also withholds the `api_key` query item in that case — sending two
+  credentials would leave precedence to the server, which was never probed. The
+  decorator chain is untouched.
+
+- **`.put` on the public `HTTPRequest.Method`.** Added, and taken deliberately
+  as a **source-breaking** change shipping in 20.0.0: a consumer whose custom
+  `HTTPClient` switches exhaustively over the enum stops compiling. There is no
+  other seam through which to express a PUT. `RetryHTTPClient` classifies it as
+  idempotent — PUT replaces the resource with the request's own representation,
+  so replaying it converges, unlike POST.
+
+- **Credential-aware caching — in both layers, keyed on a new
+  `HTTPRequest.isUserSpecific`.** The honest predicate is *"does this require a
+  user's credential"*, not *"does it have an `Authorization` header"*: a
+  `TMDbClient(bearerToken:)` sends that header on every request including wholly
+  public ones, so keying on it would disable caching for every such client while
+  protecting nothing. `TMDbAPIClient` is the only component that can tell a
+  request-level credential from the client's own, so it sets the flag there, for
+  all three user-scoped mechanisms (a v4 access token, a v3 `session_id`, a
+  guest session). `CacheHTTPClient` then bypasses; `URLSessionHTTPClientAdapter`
+  routes through a second session with no `URLCache`, because policy alone would
+  stop a stale read but not the write. `isUserSpecific` is **public** because the
+  README invites custom `HTTPClient`s, and a contract that cannot be seen cannot
+  be honoured.
+
+- **`GET /4/list/{id}/clear`.** A `GET` whose path ends `/clear` routes through
+  `CacheHTTPClient`'s mutation path, so it invalidates rather than populates.
+  v3's clear is a `POST` and never reaches it.
+
+- **`create(isPublic:)`.** It **ships**, contrary to this ADR's original
+  expectation — but only because probing established *how*. `{"public": false}`
+  is silently ignored and the list comes back public; `{"public": 0}` is
+  honoured. So the parameter is real and the request body encodes it as an
+  integer, pinned by a test asserting the raw JSON text. (Update accepts either
+  form.) The earlier "appears to be ignored" reading came from sending a boolean.
+
+### Originally deferred — kept for the reasoning, all now resolved above
+
+These were open when this ADR was written. Each is settled in *Resolved in the
+v4 list work*; the original framing is kept because the reasoning that
+identified them is what made them findable:
 
 - **Carrying a per-call bearer token — the seam this ADR's own design needs.**
   `TMDbAPIClient.buildHTTPRequest` copies `request.headers` and *then* sets

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,7 +14,7 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
-## 2026-08-07 — ✨ TMDb v4 lists, `client.v4Lists` (#TBD) · full
+## 2026-08-07 — ✨ TMDb v4 lists, `client.v4Lists` (#411) · full
 
 - **Phases / skills:** 0–8 pre-PR. `consulted:` ADR-0017 (its four open
   decisions are what this settles), ADR-0005/0008/0011, gotchas *bearer-token

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,6 +14,58 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-08-07 — ✨ TMDb v4 lists, `client.v4Lists` (#TBD) · full
+
+- **Phases / skills:** 0–8 pre-PR. `consulted:` ADR-0017 (its four open
+  decisions are what this settles), ADR-0005/0008/0011, gotchas *bearer-token
+  URLCache*, *False green*, *file_length*; tmdb-api-notes v4 section; wiki
+  *bridge-a-wire-type-to-a-domain-type*, *prove-an-api-honours-a-field-by-
+  reading-it-back*, *only-auto-retry-idempotent-operations*,
+  *ship-your-packages-test-doubles-as-a-public-product*. Plan Fable-reviewed
+  before delivery (3 majors applied).
+- **Worked — Phase 0 probing changed the shipped API twice, and both were
+  unfixable later.** `details`/`items` take `sortedBy:` because the read-side
+  `sort_by` turned out to be honoured; adding a protocol requirement afterwards
+  is source-breaking. And `create(isPublic:)` ships after all — ADR-0017 had
+  concluded TMDb ignores the field, but it ignores the *boolean* and honours the
+  *integer*. The earlier conclusion came from a probe that sent a bool. Reading
+  the resource back is what caught both.
+- **Worked — the count-reconciliation assertion caught a real drop on its first
+  outing.** The `V4List` round-trip failed because `Show.encode` writes no
+  `media_type`, so every encoded item failed to decode and `FailableDecodable`
+  silently dropped the lot — an empty list, no error. Exactly the failure the
+  assertion was added for, found within minutes of adding it.
+- **Friction — I misread a rate limit as an API verdict.** Ten identical
+  "rejected" results across a `sort_by` sweep looked like a definitive answer
+  about `sort_by`. They were TMDb's spam filter (`status_code` 18) reacting to
+  rapid list creation, and only the error *body* disproved it. A uniform failure
+  across a parameter sweep is evidence about the sweep, not the parameter. Now
+  an api-note.
+- **Friction — my own cleanup didn't run.** A probe script's `EXIT` trap never
+  fired and orphaned four lists on Adam's account until I enumerated and deleted
+  them. The integration suite's teardown therefore *enumerates* the account
+  rather than trusting a remembered id, so an interrupted run self-heals.
+- **Deviations:** (1) A **correction mid-delivery**: I told Adam the API key and
+  password were committed in `Integration.xctestplan`. They are not — the file is
+  gitignored and absent from HEAD. They *were* committed in 2023 and remain in
+  public history, so rotation is still the remedy, but the "blank the values"
+  work item was struck as a no-op. I had read the file off disk and never run
+  `git ls-files`. (2) Adam corrected the cache criterion mid-flight — my flag
+  only covered v4 per-call tokens, leaving v3 session and guest-session responses
+  on disk. Widened to "requires a user's credential", which is the right
+  predicate and should have been the first one.
+- **One improvement:** two of this delivery's three bugs were *my probe scripts*
+  lying — the trap that never ran, and the sweep that misattributed a rate
+  limit. Live-API probing has become a core part of how this repo establishes
+  truth, but the scripts doing it get none of the rigour the Swift does: no
+  review, no assertion that cleanup happened, no check that a uniform result
+  isn't an artifact. A probe worth trusting should end by *verifying its own
+  postcondition* — here, enumerating the account and asserting it is empty.
+- **`swept:`** Makefile, .github/workflows/integration.yml,
+  integration-failure.yml → 1 entry rewritten (gotchas *bearer-token clients
+  share one credential-free URLCache key space*, now false in every particular);
+  skill-improvement-log citations of integration-failure.yml still accurate.
+
 ## 2026-08-07 — 🐛 Defaulted-witness convenience sweep, 37 sites (#410) · medium
 
 - **Phases / skills:** 0–8 pre-PR. `consulted:` gotchas *defaulted-argument
@@ -483,31 +535,6 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
   standalone invocations (deliberately out of scope this run; noted in the
   plan).
 
-## 2026-07-05 — ♻️ Restructure /deliver for progressive disclosure (#383) · lite
-
-- **Phases / skills:** phases 0–9 (new numbering); markdown-only so the Swift
-  review gates self-skipped — but the plan's **rule-inventory mapping check**
-  ran as a dedicated adversarial `code-reviewer` pass instead (the diff's real
-  risk was rule loss, not code). Stacked dependent PR: branched off
-  `chore/deliver-retro-before-pr` (#382), base retargets on its merge.
-- **Worked:** the **inventory-first** method — extract every load-bearing rule
-  with a destination *before* rewriting, then have an independent reviewer
-  diff old-vs-new against it. The reviewer confirmed all ten known
-  load-bearing rules survived in the core and caught **8 real text drops**
-  (1 Medium, 7 Low — e.g. the merge/auto-mode routing for scan-applied skill
-  edits), all restored. 915 → 343 core lines + four on-demand reference
-  files.
-- **Friction:** the ≤~350-line AC needed a second compression pass (first
-  rewrite landed at 401) — line budgets are easy to overshoot while
-  preserving every rule.
-- **Deviations:** `/pr`'s rebase-onto-`origin/main` step doesn't apply to a
-  stacked PR (it would fold the dependency's diff into this one) — based on
-  the dependency branch instead, per `/watch-pr`'s stacking guidance.
-- **One improvement:** the mapping-check-in-lieu-of-code-review worked well
-  for a docs-structure diff; if meta-changes to `.claude/skills/**` recur,
-  consider making "no-Swift but skill-structure diff → run a rule-loss
-  review" an explicit branch in the review phase.
-
 ## Archive (distilled)
 
 Older entries condensed per the rolling window (`knowledge/README.md` →
@@ -515,6 +542,7 @@ Older entries condensed per the rolling window (`knowledge/README.md` →
 
 | Date | PR | Weight | Outcome |
 | --- | --- | --- | --- |
+| 2026-07-05 | #383 | lite | Restructured `deliver/SKILL.md` for progressive disclosure — a lean core plus `references/` loaded on demand — after the skill had grown past what fits in working context. Paired with an adversarial mapping review that diffed old against new hunting specifically for dropped or weakened rules, which is the practice that made the compression safe and is now the wiki entry *restructure-a-normative-doc-with-a-rule-inventory-and-an-adversarial-mapping-review*. |
 | 2026-07-05 | #382 | lite | Moved the `/deliver` retro to pre-PR so it rides the delivery's own PR instead of re-opening the ready gate. Both open design decisions were settled with the user via `AskUserQuestion` *before* any edit, and the change was dogfooded immediately — its own entry was written under the sequencing it introduced. Surfaced the `EnterWorktree` gotcha: the tool ignores the requested name for the **branch** (`git branch -m` after entering), now a `gotchas.md` entry and a standing Phase 1 step. |
 | 2026-07-02 | #374 | lite | Reconciled docs/config honesty gaps from two external reviews. The lasting lesson is **verify a review's claims before acting on them**: an 18-agent read-only pass opened and counted every assertion in-repo and caught real overstatements (eight tools not seven, 84 request files not ~95, `.unsupportedLanguage` reachable rather than dead), so only the verified, softened subset shipped — the origin of the wiki heuristic *treat review findings as hypotheses*. Also diagnosed the xcsift false-failure: a benign DocC "unhandled file" warning lands in toon's `errors[]` and flips `status:` to failed on an exit-0 build, so the four build/test skills now say trust the exit status, not the summary. |
 | 2026-06-30 | #368 | lite | Hardened the `/deliver` pipeline from an adversarial audit (P1–P5). Established the pattern this repo keeps returning to: an unenforceable process rule gets silently skipped, so encode the ones that matter as blocking gates (the Phase 3a/4a reference-unit review became a ledger task that blocks a later phase). Skipped code review and `/security-review` on its no-Swift diff (as #365 and #366 had) — the self-gating that #407 later had to override deliberately, when a docs-only change carried real risk. |

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -816,21 +816,37 @@ separator. That residual is path-only — `urlFromPath` force-overrides
 (no SSRF). If you ever need to neutralise `/` too, encode after the round-trip
 (set `percentEncodedPath`) rather than relying on the segment encoder alone.
 
-### Bearer-token clients share one credential-free `URLCache` key space
+### Caching a credentialed response: the predicate is "needs a user", not "has a header"
 
-- `TMDbClient(bearerToken:)` (v4 auth) sends the token as an
-  `Authorization: Bearer` header, so — unlike `api_key` mode — the credential is
-  **not** in the request URL. That's the point (keys stay out of logs/proxies),
-  but it means the process-wide default `URLCache` (and the opt-in
-  `CacheHTTPClient`, which keys on `request.url.absoluteString`) no longer
-  partitions cache entries by credential. Two bearer clients with **different**
-  tokens in one process can therefore serve each other cache hits.
-- This is **benign today**: the affected v3 `GET` endpoints return app-level
-  public data identical across tokens, and user-specific requests carry
-  `session_id` in the URL (distinct cache keys, and `CacheHTTPClient` bypasses
-  session requests entirely). It would only matter if TMDb started returning
-  token-specific data on an otherwise-public GET — worth remembering before
-  relying on per-token cache isolation.
+*Rewritten 2026-08-07, when v4 lists made this real.* Both caches key on the URL
+alone — `CacheHTTPClient` on `request.url.absoluteString`, and the process-wide
+`URLCache` on the URL too. A v4 list read carries its user token in a **header**,
+so two different users requesting one list send byte-identical URLs: a URL-keyed
+cache would serve one user's private list to another.
+
+The fix that looks obvious — bypass any request with an `Authorization` header —
+is wrong, and it took a review to notice. A `TMDbClient(bearerToken:)` sends that
+header on **every** request, including wholly public ones, because it is the
+*application's* API Read Access Token. Keying on the header would disable
+caching for every such client while protecting nothing.
+
+So `HTTPRequest.isUserSpecific` is set by `TMDbAPIClient` — the only component
+that sees a request *before* the client credential is applied, and can therefore
+tell a per-call credential from the client's own. It covers all three user-scoped
+mechanisms: a v4 access token, a v3 `session_id`, and a guest session.
+
+The v3 mechanisms matter for a different reason, which is easy to wave away: they
+put the credential in the URL, so keys already differ per user and nothing
+crosses between them. But the response is still one person's watchlist being
+written to a cache that is process-wide and survives relaunch. *No cross-user
+leak* is not the same as *safe to store*.
+
+Both layers act on the flag, and both are needed: `CacheHTTPClient` bypasses,
+and `URLSessionHTTPClientAdapter` routes through a second session with
+`urlCache = nil`. A cache *policy* alone stops a stale read but not the write.
+That second session copies the injected session's configuration rather than
+building a fresh one — otherwise tests injecting a `MockURLProtocol` session
+would silently reach the live network, and the bypass would be untestable.
 
 ## Swift concurrency
 

--- a/knowledge/tmdb-api-notes.md
+++ b/knowledge/tmdb-api-notes.md
@@ -69,6 +69,60 @@ decoder handles both, so a v4 decoder needs a strategy that tries each in turn.
   field of their own, so a per-item comment must be stitched in from that dict.
 - **Create returns HTTP 201** with `id` — not v3's `list_id`. Delete returns
   `status_code` 13.
+- **Add-items accepts a per-item `comment`, answers `success: true`, and stores
+  nothing.** Only `PUT /4/list/{id}/items` persists one. So an add-items input
+  model must *not* expose a comment field, or it is a parameter that silently
+  does nothing.
+- **A write's `success` describes the request, not the items.** Removing an item
+  that is not in the list returns overall `success: true` with that item's
+  per-item `success: false`. Always read `results[]`.
+
+### `{"public": false}` is ignored on create; `{"public": 0}` is honoured
+
+*2026-08-07.* `POST /4/list` accepts a visibility field, but only as an
+**integer**. Sending the boolean `false` returns a list that reads back
+`public: true`; sending `0` produces a private list. `is_public` and `private`
+are ignored entirely. `PUT /4/list/{id}` accepts *either* form, so the asymmetry
+is specific to create.
+
+This is why the v4 auth work concluded "TMDb ignores the visibility field" and
+nearly shipped without the parameter — the probe had sent a boolean. **Prove a
+field is honoured by reading the resource back, and if it appears ignored, try
+the other wire type before concluding anything.** The same endpoint reports
+`public` as a bool on read while requiring an int on create.
+
+### `sort_by` is honoured on create, update **and read**, with exactly ten values
+
+*2026-08-07.* `GET /4/list/{id}?sort_by=title.desc` genuinely reorders the
+response — it is not decoration, so a client wrapping this endpoint needs a sort
+parameter on its *read* methods, not only on create and update.
+
+Accepted values, each confirmed by setting it and reading the list back:
+`original_order`, `vote_average`, `primary_release_date`, `release_date` and
+`title`, each `.asc` and `.desc`. **Rejected** (`success: false`, value
+unchanged): `popularity`, `runtime`, `revenue`, `first_air_date`, `vote_count` —
+several of which *are* valid on the v3 discover endpoints, so the sets are not
+interchangeable. A new list defaults to `original_order.asc`.
+
+### List creation is spam-filtered — `status_code` 18
+
+*2026-08-07.* Creating several lists in quick succession, with
+machine-looking names (`probe 24985`, `probe 7122`, …), gets them rejected with:
+
+```json
+{"success": false, "status_code": 18, "status_message": "Validation failed.",
+ "errors": ["Content is suspected to be spam"]}
+```
+
+Two consequences. An integration suite that creates a list per test can trip
+this in CI, so create once per run with a plausible name — and do **not** turn
+the rejection into a skip, or a run that created nothing looks exactly like one
+that worked.
+
+And the diagnostic trap: ten identical failures across a parameter sweep read as
+a definitive answer about the *parameter*. Here they were a rate limit, and only
+the error **body** disproved it. A uniform failure across a sweep is evidence
+about the sweep, not about what you were varying.
 
 ## HTTP caching
 


### PR DESCRIPTION
Closes #394.

## Summary

`client.v4Lists` — TMDb v4 lists. Unlike the v3 `client.lists`, a v4 list holds
**movies and TV series together**, can be private, and carries a comment on each
item. That combination is the package's last meaningful API gap and what a real
"my watchlist" feature needs.

All eleven operations ship in one PR, deliberately: growing a public protocol by
adding requirements is source-breaking (ADR-0005), so the protocol had to be
right the first time rather than grown later.

This is the second half of #394 — [#410](https://github.com/adamayoung/TMDb/pull/410)
delivered the v4 client foundation and `V4AuthenticationService`.

## The four decisions ADR-0017 deferred, now settled

The ADR from the first half listed four things it could not decide without the
list endpoints in view. All four are resolved here and recorded in place:

- **`.put` on the public `HTTPRequest.Method`** — v4 list update is a PUT and
  there is no other seam. Taken as a deliberate **source-breaking** change for
  20.0.0, and classified retryable: PUT replaces the resource with the request's
  own representation, so replaying it converges.
- **Per-call credentials.** `buildHTTPRequest` copied `request.headers` then
  overwrote `Authorization` from the client credential — so a user access token
  threaded per call never reached the wire, and a user-scoped read would have
  returned the **application owner's** lists. The client credential is now
  withheld when the request brings its own.
- **Credential-aware caching, both layers** — see below.
- **The state-changing `GET`.** `GET /4/list/{id}/clear` empties a list, so it
  invalidates rather than caches, and is never replayed by retry.

## Caching: the predicate is "needs a user", not "has a header"

v4 list reads are the package's first genuinely private `GET`s whose URL carries
no credential — two users reading one list send byte-identical URLs. The obvious
fix, *bypass anything with an `Authorization` header*, is wrong: a
`TMDbClient(bearerToken:)` sends that header on **every** request including
wholly public ones, so it would disable caching for those clients while
protecting nothing.

So `HTTPRequest` gains `isUserSpecific`, set by `TMDbAPIClient` — the only
component that sees a request before the client credential is applied. It covers
all three user-scoped mechanisms: a v4 access token, a v3 `session_id`, and a
guest session. Both layers act on it, and both are needed — a cache *policy*
stops a stale read, but not the write.

**This fixes a pre-existing leak.** v3 session and guest-session responses — a
user's watchlist, their ratings — were previously written to the process-wide
1 GB on-disk `URLCache`, which survives relaunch. They no longer are.

## Established by probing, not by reading the docs

- **`create(isPublic:)` ships, sending an integer.** ADR-0017 had concluded TMDb
  ignores the field. It ignores the *boolean*: `{"public": false}` comes back
  public, `{"public": 0}` is honoured. The earlier probe had sent a bool.
- **`details`/`items` take `sortedBy:`.** `GET /4/list/{id}?sort_by=title.desc`
  genuinely reorders. Adding that parameter later would have been a
  source-breaking new requirement.
- **`V4ListSortBy` has exactly ten cases**, each confirmed by setting it and
  reading the list back. `popularity`, `runtime`, `revenue`, `first_air_date`
  and `vote_count` are rejected — several *are* valid on v3 discover, so the
  sets are not interchangeable.
- **Add-items discards a comment** while answering `success: true`; only `PUT`
  persists one. Hence two input types — `V4ListMediaItem` has no comment field,
  because one that silently did nothing would be worse than none.
- **A write's `success` describes the request, not the items.** Removing an
  absent item returns overall success with that item failed, so
  `V4ListItemsResult` exposes `failures` and `allItemsSucceeded`.

## Verification

- `make ci` green: swiftlint `--strict` + swiftformat, markdownlint, **3095
  unit tests**, the live integration suite, `swift build -c release`, and
  `make build-docs` (warnings-as-errors).
- **The full lifecycle runs green against the real API**: create a private list,
  add a movie *and* a TV series, read both back as the right `Show` cases,
  comment, check status both ways, remove, clear, rename, re-sort, and read the
  account lists — the only endpoint where the integer/string wire types appear.
- One test reads a public list with **no** user token, pinning that path.

## Review notes

Two review iterations, converged to 0 Critical / 0 High. The substantive
findings, all real:

- Every `V4List` test decoded a fixture carrying *every* key, so not one of its
  fourteen decode fallbacks ever ran. Fixed with a minimal fixture and per-default
  assertions.
- `V4ListSummary` decoded every field non-optionally. Since `PageableListResult`
  wraps results in `FailableDecodable`, one field TMDb stopped sending would have
  made a user's list **silently vanish** from their results rather than error.
- `URLSessionHTTPClientAdapter` mutated the injected session's configuration on
  Linux, where `URLSession.configuration` returns the stored instance rather than
  a copy — unhooking the `URLCache` from the primary session too.
- The caching article told readers to honour `isUserSpecific` and then showed a
  sample `HTTPClient` that ignored it.

`/security-review`: **no findings**. It confirmed no token can reach a URL, an
error context, a cache key or a fixture, and could not construct a private
response that still gets cached.

Two bugs were caught by tests rather than review, both worth noting: the
`V4List` round-trip failed because `Show.encode` writes no `media_type`, so every
item silently vanished on re-decode — exactly what the count-reconciliation
assertion exists for; and lint caught a seven-parameter `create`, which became
`V4ListAttributes`.

## Not in this PR

The remaining 54 defaulted-witness conveniences (`knowledge/next-major.md`), and
the `Network.homepage` → `homepageURL` rename, which is a separate small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01JFyg8ZxHDCWLFMj4oZ6ZZQ>
