### PR TITLE
♻️ Rename Network.homepage to homepageURL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   supply your own `HTTPClient` **and** switch exhaustively over the method — add
   a `.put` branch, or a `default`.
 
+- **Breaking:** `Network.homepage` is renamed to `homepageURL`, matching
+  `Company.homepageURL`. The two models describe the same kind of thing and
+  disagreed only by accident. The JSON key is unchanged, so only Swift call
+  sites need updating: `network.homepage` becomes `network.homepageURL`.
+
 - `HTTPRequest` gains `isUserSpecific`. It is `true` when a request required a
   specific user's credential — a v4 access token, a v3 `session_id`, or a guest
   session. **A custom `HTTPClient` must not cache, store or log such a

--- a/Sources/TMDb/Domain/Models/Network.swift
+++ b/Sources/TMDb/Domain/Models/Network.swift
@@ -42,7 +42,7 @@ public struct Network: Identifiable, Codable, Equatable, Hashable, Sendable {
     ///
     /// Network homepage URL.
     ///
-    public let homepage: URL?
+    public let homepageURL: URL?
 
     ///
     /// Creates a network object.
@@ -53,7 +53,7 @@ public struct Network: Identifiable, Codable, Equatable, Hashable, Sendable {
     ///    - logoPath: Network logo path.
     ///    - originCountry: Network origin country.
     ///    - headquarters: Network headquarters location.
-    ///    - homepage: Network homepage URL.
+    ///    - homepageURL: Network homepage URL.
     ///
     public init(
         id: Int,
@@ -61,14 +61,14 @@ public struct Network: Identifiable, Codable, Equatable, Hashable, Sendable {
         logoPath: URL? = nil,
         originCountry: String? = nil,
         headquarters: String? = nil,
-        homepage: URL? = nil
+        homepageURL: URL? = nil
     ) {
         self.id = id
         self.name = name
         self.logoPath = logoPath
         self.originCountry = originCountry
         self.headquarters = headquarters
-        self.homepage = homepage
+        self.homepageURL = homepageURL
     }
 
 }
@@ -81,7 +81,7 @@ extension Network {
         case logoPath
         case originCountry
         case headquarters
-        case homepage
+        case homepageURL = "homepage"
     }
 
     ///
@@ -105,7 +105,7 @@ extension Network {
         self.logoPath = try container.decodeIfPresent(URL.self, forKey: .logoPath)
         self.originCountry = try container.decodeIfPresent(String.self, forKey: .originCountry)
         self.headquarters = try container.decodeIfPresent(String.self, forKey: .headquarters)
-        self.homepage = try container.decodeNonEmptyURLIfPresent(forKey: .homepage)
+        self.homepageURL = try container.decodeNonEmptyURLIfPresent(forKey: .homepageURL)
     }
 
 }

--- a/Sources/TMDbTesting/Samples/Network+Sample.swift
+++ b/Sources/TMDbTesting/Samples/Network+Sample.swift
@@ -18,7 +18,7 @@ public extension Network {
             logoPath: URL(string: "/tuomPhY2UtuPTqqFnKMVHvSb724.png"),
             originCountry: "US",
             headquarters: "New York City, New York",
-            homepage: URL(string: "https://www.hbo.com")
+            homepageURL: URL(string: "https://www.hbo.com")
         )
     }
 

--- a/Tests/TMDbTestFixtures/Mocks/Models/Network+Mocks.swift
+++ b/Tests/TMDbTestFixtures/Mocks/Models/Network+Mocks.swift
@@ -16,7 +16,7 @@ package extension Network {
         logoPath: URL? = URL(string: "/tuomPhY2UtuPTqqFnKMVHvSb724.png"),
         originCountry: String? = "US",
         headquarters: String? = "New York City, New York",
-        homepage: URL? = URL(string: "https://www.hbo.com")
+        homepageURL: URL? = URL(string: "https://www.hbo.com")
     ) -> Network {
         Network(
             id: id,
@@ -24,7 +24,7 @@ package extension Network {
             logoPath: logoPath,
             originCountry: originCountry,
             headquarters: headquarters,
-            homepage: homepage
+            homepageURL: homepageURL
         )
     }
 
@@ -35,7 +35,7 @@ package extension Network {
             logoPath: URL(string: "/tuomPhY2UtuPTqqFnKMVHvSb724.png"),
             originCountry: "US",
             headquarters: "New York City, New York",
-            homepage: URL(string: "https://www.hbo.com")
+            homepageURL: URL(string: "https://www.hbo.com")
         )
     }
 

--- a/Tests/TMDbTests/Domain/Models/NetworkTests.swift
+++ b/Tests/TMDbTests/Domain/Models/NetworkTests.swift
@@ -21,7 +21,7 @@ struct NetworkTests {
         #expect(result.logoPath == network.logoPath)
         #expect(result.originCountry == network.originCountry)
         #expect(result.headquarters == network.headquarters)
-        #expect(result.homepage == network.homepage)
+        #expect(result.homepageURL == network.homepageURL)
     }
 
     @Test("JSON decoding of Network when homepage is empty string", .tags(.decoding))
@@ -30,7 +30,7 @@ struct NetworkTests {
             Network.self, fromResource: "network-blank-homepage"
         )
 
-        #expect(result.homepage == nil)
+        #expect(result.homepageURL == nil)
         #expect(result.id == network.id)
     }
 
@@ -40,7 +40,7 @@ struct NetworkTests {
         logoPath: URL(string: "/tuomPhY2UtuPTqqFnKMVHvSb724.png"),
         originCountry: "US",
         headquarters: "New York City, New York",
-        homepage: URL(string: "https://www.hbo.com")
+        homepageURL: URL(string: "https://www.hbo.com")
     )
 
 }

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,7 +14,7 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
-## 2026-08-07 — ♻️ Rename `Network.homepage` to `homepageURL` (#TBD) · lite
+## 2026-08-07 — ♻️ Rename `Network.homepage` to `homepageURL` (#412) · lite
 
 - **Phases / skills:** 0–8 pre-PR; lite, so no `/review-plan` critics and the
   single-reviewer path. `consulted:` next-major.md (the source), gotchas

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,6 +14,36 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-08-07 — ♻️ Rename `Network.homepage` to `homepageURL` (#TBD) · lite
+
+- **Phases / skills:** 0–8 pre-PR; lite, so no `/review-plan` critics and the
+  single-reviewer path. `consulted:` next-major.md (the source), gotchas
+  *Renaming a method's internal parameter name is source- and ABI-compatible*
+  (this is the opposite case — a public *property* rename **is** breaking).
+- **Worked — the queue fired for the second time.** `next-major.md` existed
+  precisely so a deferred breaking change would resurface at the next major
+  rather than be forgotten. This entry was written on 2026-07-27, deferred out
+  of 19.0.0 as cosmetic scope creep on a bug fix, and shipped here because the
+  file was read when the 20.0.0 window opened. That is the whole design working
+  end to end.
+- **Worked — the entry that did *not* ship was recorded, not skipped.** The
+  `TMDbError.invalidRating` item stays deferred because its own condition is
+  unmet: it is only worth doing inside a wider `TMDbError` review, and 20.0.0
+  did not open one. Recorded explicitly, so the next reader can tell
+  "considered and declined" from "missed".
+- **Friction:** none material. The rename is three files plus fixtures; the JSON
+  key is unchanged so only Swift call sites move. `Translation.homepage` was
+  deliberately left alone — it is a `String`, a different type, and outside the
+  entry's scope.
+- **Deviations:** stacked on `feature/v4-lists` rather than branched from
+  `main`, because both edit `CHANGELOG.md`'s `[20.0.0]` section and would
+  otherwise conflict. Rebase onto `main` once #411 merges.
+- **One improvement:** the file now carries a status line saying the 20.0.0
+  window is open, so a future entry is not filed against a version that has
+  already shipped. Worth `/capture-knowledge` asserting that whenever it adds an
+  entry.
+- **`swept:`** n/a — no infra files touched.
+
 ## 2026-08-07 — ✨ TMDb v4 lists, `client.v4Lists` (#411) · full
 
 - **Phases / skills:** 0–8 pre-PR. `consulted:` ADR-0017 (its four open

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -614,7 +614,7 @@ target compiles, so `/integration-test` catches it; a unit-only check may not.
 ### Model-decode equality tests: build the expected value directly, not from an over-populated mock
 
 *2026-06-19.* `Network` is `Equatable` over **all six** stored properties
-(`id`, `name`, `logoPath`, `originCountry`, `headquarters`, `homepage`), and both
+(`id`, `name`, `logoPath`, `originCountry`, `headquarters`, `homepageURL`), and both
 the `Network.mock()` helper and `Network.hbo` default `headquarters` **and**
 `homepage` to **non-nil** values. When a decode test compares a decoded value
 against an expected one built from a **minimal** JSON fixture entry (only

--- a/knowledge/next-major.md
+++ b/knowledge/next-major.md
@@ -13,6 +13,11 @@ deferred *because* it is breaking. **Remove an entry when it ships** (the
 CHANGELOG records it) or is rejected outright (record that in
 `skill-improvement-log.md`).
 
+> **Status: the 20.0.0 window is OPEN.** The `Network.homepage` rename shipped
+> into it (2026-08-07) and the `TMDbError` item below was consciously
+> re-deferred. Anything added here now is queued for **21.0.0** unless 20.0.0 is
+> still untagged when you read this.
+>
 > **This file has earned its keep once.** It was written on 2026-07-27 and read
 > on 2026-07-28, while 19.0.0 was assembled but still untagged — which is the
 > only reason the `Company.logoPath` decode bug (#404) made that release instead
@@ -44,24 +49,15 @@ CHANGELOG records it) or is rejected outright (record that in
   and its two invocations.
 - **Source:** 20.0.0 sweep (2026-08-07), which fixed the 37 cheap sites.
 
-### Align the `Company`/`Network` model shapes deliberately — *partially shipped*
-
-- **Shipped in 19.0.0 (2026-07-28):** the *nullability* half. `Company.logoPath`
-  → `URL?`, `Company.originCountry` → `String?`, `Company.Parent.logoPath` →
-  `URL?`, bringing `Company` into line with `Network`'s optionality. This also
-  closed the separate "Make `Company.logoPath` optional" entry, which is
-  removed. Plan review caught that `originCountry` throws on exactly the same
-  records, so shipping `logoPath` alone would not have fixed the bug.
-- **Consciously re-deferred:** the *naming* half — renaming `Network.homepage`
-  to `homepageURL` for parity with `Company.homepageURL`. Deliberately left out
-  of 19.0.0: it is a pure rename with no correctness benefit, and bundling it
-  would have widened a bug-fix PR into a cosmetic breaking change. It buys
-  nothing that waiting does not.
-- **Why it still waits:** public property rename — breaking.
-- **Source:** `skill-improvement-log.md` → *Align `Network` to `Company`*
-  (rejected 2026-06-30; "Reconsider when: a major-version bump…").
-
 ### Revisit `TMDbError.invalidRating` inside a broader `TMDbError` review
+
+- **Re-deferred at 20.0.0 (2026-08-07), deliberately.** The window was open and
+  this entry was read. It stays because its own condition is not met: it is only
+  worth doing *inside* a wider `TMDbError` review, and 20.0.0 did not open one.
+  Shipping the merge on its own would trade a precise typed case for a
+  stringly-typed one with no compensating cleanup — the reason it was rejected
+  in the first place. Recorded rather than skipped, so the next reader knows it
+  was considered and not merely missed.
 
 - **What:** the audit floated merging `.invalidRating` into `.badRequest` and
   rejected it as a net-worse API (a precise typed case traded for a

--- a/knowledge/next-major.md
+++ b/knowledge/next-major.md
@@ -21,8 +21,7 @@ CHANGELOG records it) or is rejected outright (record that in
 > **This file has earned its keep once.** It was written on 2026-07-27 and read
 > on 2026-07-28, while 19.0.0 was assembled but still untagged — which is the
 > only reason the `Company.logoPath` decode bug (#404) made that release instead
-> of waiting for 20.0.0. The next window is **20.0.0**; everything below is
-> queued for it.
+> of waiting for 20.0.0.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

Renames the public property `Network.homepage` to `homepageURL`, matching
`Company.homepageURL`. The two models describe the same kind of thing and
disagreed only by accident.

This was queued in `knowledge/next-major.md`, deliberately deferred out of
19.0.0 because bundling a cosmetic rename into a bug-fix PR would have widened
it into a breaking change for no correctness benefit. The 20.0.0 window is open,
the file was read at release time, and it ships. That is the second time that
queue has caught something that would otherwise have been forgotten.

## The wire format is unchanged

`CodingKeys` maps `homepageURL` back to `"homepage"`, exactly as `Company`
already does, so only Swift call sites move:

```swift
network.homepage      // before
network.homepageURL   // after
```

## The other backlog entry, recorded rather than skipped

`TMDbError.invalidRating` **stays deferred**, and `next-major.md` now says why:
its own condition is unmet. It is only worth doing inside a wider `TMDbError`
review, and 20.0.0 did not open one — merging it alone would trade a precise
typed case for a stringly-typed one with no compensating cleanup, which is why
it was rejected originally. Written down so the next reader can tell "considered
and declined" from "missed".

The file also gains a status line stating the 20.0.0 window is open, so a future
entry is not filed against a version that has already shipped.

## Scope

`Translation.homepage` is deliberately untouched: it is a `String` rather than a
`URL`, so renaming it to `homepageURL` would be actively misleading. Whether
those should be `URL?` at all is a separate question, noted in review.

## Verification

Rebased onto `main` after #411 merged, and re-verified on the rebased tree:

- `make ci` green: swiftlint `--strict` + swiftformat, markdownlint, unit tests,
  integration, `swift build -c release`, `make build-docs`.
- `make test-linux` green (3030 tests) — worth running here because `make ci`
  does not cover Linux, which is how #411's only CI failure got through.
- Review confirmed the rename is complete tree-wide and the wire key is
  genuinely unchanged in both directions, checked against the live API.

Review also caught two stale citations in files this PR already touches:
`gotchas.md` still named `Network.homepage`, and `next-major.md` asserted both
"the next window is 20.0.0" and "anything added now targets 21.0.0". Both fixed
— a release-time checklist giving two opposite instructions is worse than none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01JFyg8ZxHDCWLFMj4oZ6ZZQ>
