### PR TITLE
🔧 Fix drift and harden review seams across CLAUDE.md, skills and agents

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -43,8 +43,13 @@ guidelines mark as "tool-permitting / local only":
   review and `swift-testing-expert` for test-code review.
 - **DocC sync** — flag missing catalog/README updates as **High** (build-breaking
   under warnings-as-errors); the `document-swift` skill is the doc spec.
-- You normally just read; if you must build/test, the `make` commands are fine.
-  Never read or touch `.swiftpm/` or `.build/`.
+- **Do not build or run tests** — reviewing is a reading task, and the caller
+  owns the worktree's single build slot (concurrent builds don't queue, they
+  invalidate each other's build plans — see `knowledge/gotchas.md` → *Docs
+  builds need their own scratch path*). If a finding genuinely cannot be
+  settled without executing something, say so in the finding and let the
+  caller run it — serially, once. Never read or touch `.swiftpm/` or
+  `.build/`.
 
 ## Output
 

--- a/.claude/agents/documentation-writer.md
+++ b/.claude/agents/documentation-writer.md
@@ -2,18 +2,11 @@
 name: documentation-writer
 description: Swift DocC subagent for BULK documentation work — documenting many public declarations across multiple files (e.g. a whole new service, or every undocumented symbol in a diff) in an isolated context. For documenting a single symbol as you write it, apply the `document-swift` skill inline instead.
 model: sonnet
-permissionMode: restricted
+permissionMode: auto
+tools: Read, Glob, Grep, Edit, Write, Bash, Skill, mcp__sosumi__searchAppleDocumentation, mcp__sosumi__fetchAppleDocumentation
 skills:
+  - document-swift
   - swift-concurrency
-autoApprove:
-  - Read
-  - Glob
-  - Grep
-  - mcp__sosumi__searchAppleDocumentation
-  - mcp__sosumi__fetchAppleDocumentation
-  - "Bash(git diff:*)"
-  - "Bash(git log:*)"
-  - "Bash(ls:*)"
 ---
 
 # Claude Subagent: Swift Documentation Writer (bulk)
@@ -31,11 +24,9 @@ main agent via the `document-swift` skill — not by you.
 ## The conventions live in one place — read it first
 
 **The single source of truth for this project's DocC style is the
-`document-swift` skill.** Before writing anything, read:
-
-```text
-.claude/skills/document-swift/SKILL.md
-```
+`document-swift` skill.** Its full content is preloaded into your context via
+this agent's `skills` frontmatter (on disk at
+`.claude/skills/document-swift/SKILL.md`).
 
 Follow it exactly — scope, `///` style, summary patterns per declaration kind,
 section order (API link → Precondition → Parameters → Throws → Returns), the

--- a/.claude/skills/canon-tdd/SKILL.md
+++ b/.claude/skills/canon-tdd/SKILL.md
@@ -78,8 +78,8 @@ Apply the loop with the project's tooling and conventions:
 - **Bug fixes:** the first item on the list is a test that **reproduces the bug**
   (red), then the fix (green) — never fix first.
 - **New public API:** the test list should include the doc/DocC and README
-  updates as completion items, even though they aren't tests (CLAUDE.md
-  consistency checklist).
+  updates as completion items, even though they aren't tests (per the
+  `document-swift` skill's consistency checklist).
 
 ## When NOT to use it
 

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -71,9 +71,9 @@ Non-negotiable. Do these by default, without being reminded.
 ## Auto mode & async invocation
 
 `/deliver auto` replaces every stop-and-ask decision with an **adversarial
-panel** of three independent Opus jurors (a dead panel is not a proceed;
-ledger audit trail);
-decision points are marked **Auto:** below. Never delegated: a **data-loss or
+panel** of three independent Opus jurors — a dead panel is never a proceed,
+and every panel convened leaves an audit line in the ledger. Decision points
+are marked **Auto:** below. Never delegated: a **data-loss or
 breaking-change plan blocker is a hard stop even in auto**. `/deliver` can
 also be queued headless (the plan + ACs must travel in the trigger prompt).
 Panel procedure and queuing caveats:
@@ -89,7 +89,10 @@ new public API beyond a simple additive method; under a few hundred changed
 lines) ⇒ skip `/review-plan`'s critics; `/review-changes` takes its
 single-reviewer path. **Full** — anything risky or large ⇒ the three-critic
 `/review-plan` and the fan-out + adversarial-verify `/review-changes`.
-**When unsure, prefer full.**
+**When unsure, prefer full.** The vocabulary is **binary** — a hybrid run
+(e.g. a pre-reviewed plan with the full review machinery) records as **full**
+with the skipped machinery noted, in the ledger and the retro; never invent a
+third tier.
 
 ## Multi-deliverable plans — one run, several PRs
 
@@ -205,8 +208,10 @@ enter, proceed.
 
 ## Phase 2 — Harden the plan (no approval stop)
 
-**Lite, or already reviewed this session** (a converged `/review-plan`, or
-`ExitPlanMode` approval) → skip the critics. **Full with an unreviewed plan**
+**Lite, or already adversarially reviewed this session** (a converged
+`/review-plan`, or an equivalent in-conversation critique whose findings were
+applied) → skip the critics. `ExitPlanMode` approval alone is consent, not
+review — it does **not** skip. **Full with an unreviewed plan**
 → invoke `/review-plan`, present the revised plan + a one-line change log
 (applied / rejected) as an **FYI**, keep going —
 except a **blocker** (wrong approach, breaking, data-loss), which stops the
@@ -227,9 +232,9 @@ work is committed; re-confirm the weight from the diff. Three hard checkpoints:
   `-enable-testing`; the release build does not, so **access-level and
   `@testable` mistakes fail there and nowhere else** — precisely what target
   extractions, new non-test targets, and visibility changes are made of. It is
-  a ~30s check that guards `make build-release`, `make ci`, and both CI *Build
-  for Release* jobs. (Incident: PR #398 shipped a `@testable import` inside a
-  new non-test fixtures target; debug, `--build-tests`, 2869 unit and 291
+  a ~30s check that guards `make build-release`, `make ci`, and the *Build for
+  Release* steps of both CI Build and Test jobs. (Incident: PR #398 shipped a
+  `@testable import` inside a new non-test fixtures target; debug, `--build-tests`, 2869 unit and 291
   integration tests all passed while release was red — caught only in code
   review. See `knowledge/gotchas.md`.)
 
@@ -247,9 +252,10 @@ work is committed; re-confirm the weight from the diff. Three hard checkpoints:
 
 ## Phase 4 — Code review + fix loop
 
-**Skip entirely if the diff has no Swift source** (`/review-changes`
-self-gates). Review **stable** code once the design settles — not per TDD
-item. Granularity by weight:
+**Skip entirely if the diff has no reviewable code — no Swift and no
+`.claude/workflows/` script** (`/review-changes` self-gates). Review
+**stable** code once the design settles — not per TDD item. Granularity by
+weight:
 
 - **Lite / single-unit** → one review of the full diff (single-reviewer
   path).

--- a/.claude/skills/deliver/references/auto-and-async.md
+++ b/.claude/skills/deliver/references/auto-and-async.md
@@ -48,7 +48,7 @@ tallied.
 **live** jurors **and** at least two live jurors; everything else is `stop`. So
 3 live → 2 of 3; 2 live → both must agree (a 1-1 is a `stop`); ≤1 live → `stop`,
 `degraded: true`. **A dead panel is not a proceed** — Phase 6's *"a dead grader
-is not a pass"* (Phase 6) applied here. The asymmetry is justified, not
+is not a pass"* applied here. The asymmetry is justified, not
 squeamish: `stop` hands back to a human and is recoverable; `proceed` may not be.
 
 **The conductor may not state a preference.** `args` carries facts only —

--- a/.claude/skills/diagnose-ci-failure/references/linux.md
+++ b/.claude/skills/diagnose-ci-failure/references/linux.md
@@ -10,7 +10,7 @@ swift build -c release    -Xswiftc -warnings-as-errors
 
 The telltale signature: **it fails on Linux but the macOS `Build and Test` job
 passes.** That is almost always a **platform-portability** problem, not a logic
-bug — the package targets Linux and Windows alongside the Apple platforms.
+bug — the package targets Linux alongside the Apple platforms.
 
 ## Reading the failure
 

--- a/.claude/skills/diagnose-integration-failure/SKILL.md
+++ b/.claude/skills/diagnose-integration-failure/SKILL.md
@@ -7,7 +7,7 @@ description: Diagnose a failing TMDb integration-test run — summarise the fail
 
 The TMDb integration tests hit the **live** TMDb API. The suite runs on three
 triggers — **`pull_request` / `push`** (where it *gates* the change) and
-**`schedule`** (the nightly live-API canary). **Which run failed flips the most
+**`schedule`** (the weekly live-API canary). **Which run failed flips the most
 likely cause, so determine the trigger first** (step 0):
 
 - **PR / push-triggered** → this run is the gate for a code change, so a

--- a/.claude/skills/document-swift/SKILL.md
+++ b/.claude/skills/document-swift/SKILL.md
@@ -200,8 +200,8 @@ grows — update it in the same change, then run `make lint-markdown`:
 - **Available Services table** (`## Available Services`) — one row per service,
   `| **serviceName** | capability, capability, … |`.
   - *New service* → add a row, and bump the service count in the
-    `**Comprehensive API Coverage**` feature bullet (currently "26 specialized
-    services") so the number stays accurate.
+    `**Comprehensive API Coverage**` feature bullet so the number stays
+    accurate.
   - *New method/capability on an existing service* → extend that service's row
     description if it adds a notable capability (e.g. add "watch providers" to the
     **movies** row). A new endpoint that's just a variant of an existing one does

--- a/.claude/skills/implement-plan/SKILL.md
+++ b/.claude/skills/implement-plan/SKILL.md
@@ -78,7 +78,7 @@ path the plan implies — as a plain checklist, not code. For this package that
 means thinking about: each new/changed public method, Codable decode paths
 (every optional/appended branch — one fixture item per branch), empty/degenerate
 inputs at public boundaries, `Sendable`/concurrency expectations, and
-Linux/Windows portability.
+Linux portability.
 
 **Print the list before writing any code**, e.g.:
 
@@ -203,8 +203,9 @@ Quality, not just presence:
 - Keep the **DocC catalog in sync** when public API changes: the service
   extension file (`TMDb.docc/Extensions/<Service>Service.md`), the catalog
   (`TMDb.docc/TMDb.md`) for new return types, `TMDbClient.md` for new
-  properties, and the `README.md` service table — per the Documentation
-  Consistency Checklist in `CLAUDE.md`.
+  properties, and the `README.md` service table — per the consistency
+  checklist in the `document-swift` skill (its *Verify before finishing*
+  section).
 
 Apply the **`document-swift`** skill — the project's single source of DocC
 conventions — inline as you write each public symbol. For a bulk pass (a whole

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -8,10 +8,10 @@ description: Create a pull request
 I'll create a pull request for the current branch by following these steps. If any steps fail, stop.
 
 **Mode** — check the arguments passed to this skill (shown at the end). If they
-include `reviewed` (or `skip-review`), an upstream step already ran the
-`code-reviewer` and fixed its findings (e.g. `/deliver`'s code-review phase), so
-**skip steps 5–7** to avoid reviewing identical code twice. Otherwise (standalone
-`/pr`), run the internal review as normal.
+include `reviewed` (or `skip-review`), an upstream step already ran the review
+and fixed its findings (e.g. `/deliver`'s code-review phase via
+`/review-changes`), so **skip steps 5–7** to avoid reviewing identical code
+twice. Otherwise (standalone `/pr`), run the internal review as normal.
 
 **Also skip steps 5–7 when the branch changes no Swift** — code review is for
 Swift, so a docs-only / config-only PR needs none:
@@ -52,7 +52,7 @@ git diff --name-only origin/main...HEAD | grep -qE '\.swift$' || echo "no-swift 
         ```
 
         Fix anything it flags (oversized files: split, or add a `// swiftlint:disable` directive matching the `AccountService+Pagination.swift` precedent) and re-run. This catches file-size violations locally instead of on a CI round-trip.
-5. *(skip in `reviewed` mode or when no Swift changed)* Spawn the `code-reviewer` agent to perform a code review of all changes (pass the git diff output as context)
+5. *(skip in `reviewed` mode or when no Swift changed)* Run the **`/review-changes`** skill — it scales the review to the diff (a single `code-reviewer` for a small change, the fan-out + adversarial-verify Workflow for a large one), follows `.github/CODE_REVIEW.md`, and returns a severity-graded report
 6. *(skip in `reviewed` mode or when no Swift changed)* Summarize the code review findings:
     - List any critical or high-severity issues that should be addressed
     - List any medium-severity suggestions for improvement
@@ -108,5 +108,8 @@ git diff --name-only origin/main...HEAD | grep -qE '\.swift$' || echo "no-swift 
 
     🤖 Generated with [Claude Code](https://claude.com/claude-code)
     ```
+
+    The harness appends a `claude.ai/code` session link after the attribution
+    line — that is expected; leave it in place.
 
 $ARGUMENTS

--- a/.claude/skills/review-changes/SKILL.md
+++ b/.claude/skills/review-changes/SKILL.md
@@ -25,20 +25,30 @@ code-review phase, or you) applies the fixes.
    finding is independently refuted before it's reported — the strongest lever
    against false positives.
 
-## 0. Gate — skip if there are no Swift changes
+## 0. Gate — skip if there is no reviewable code
 
-Code review exists to review **Swift**. If the diff touches no Swift source,
-there is nothing to review — return immediately, don't spawn any reviewer.
+Code review exists to review **code** — Swift source, plus the committed
+Workflow scripts under `.claude/workflows/` (they are decision infrastructure,
+not prose). If the diff touches neither, there is nothing to review — return
+immediately, don't spawn any reviewer.
 
 ```bash
-git diff --name-only origin/main...HEAD | grep -qE '\.swift$' || echo "no-swift"
+git diff --name-only origin/main...HEAD | grep -qE '\.swift$|^\.claude/workflows/' \
+  || echo "no-reviewable-code"
 ```
 
-If that prints `no-swift` (no `*.swift` files changed — e.g. a docs-only,
-config-only, or `.claude/` change), **stop here** and report "No Swift changes —
-code review skipped." Do not run §1–§3. (JSON fixtures under
+If that prints `no-reviewable-code` (e.g. a docs-only, config-only, or
+skills-prose change), **stop here** and report "No reviewable code — code
+review skipped." Do not run §1–§3. (JSON fixtures under
 `Tests/**/Resources/` accompany Swift changes; a fixture-only change with no
 `.swift` is rare — note it and let the caller decide.)
+
+**If the only reviewable change is under `.claude/workflows/`**, take the §2a
+single-reviewer path with a **script-focused brief** in place of the Swift
+lens: input guards and executable `throw`s, schema shapes, tally / dead-agent
+handling, and prompt-injection surface (what untrusted text reaches an agent
+prompt). `.github/CODE_REVIEW.md`'s severity rubric and adversarial
+re-evaluation still apply; its Swift-specific checks don't.
 
 ## 1. Scope the change
 
@@ -105,7 +115,7 @@ const SPEC = '.github/CODE_REVIEW.md'
 const DIMENSIONS = [
   { key: 'correctness', focus: 'correctness & safety — logic bugs, behavioural regressions, force unwraps / try!, and input validation at system boundaries' },
   { key: 'concurrency', focus: 'Swift 6 concurrency — async/await, actor isolation, Sendable conformance, no blanket @MainActor, and justified @preconcurrency / @unchecked Sendable' },
-  { key: 'architecture', focus: 'architecture — protocol + TMDb-prefixed implementation, service-layer boundaries, new API exposed on TMDbClient and wired in TMDbFactory, required model conformances, AND sibling-convention conformance: a newly-added member of an existing family (service method, model, guarded method) must match its siblings — same input validation, same error case, same conformance set / decode strategy — or the divergence is flagged' },
+  { key: 'architecture', focus: 'architecture — protocol + TMDb-prefixed implementation, service-layer boundaries, new API exposed on TMDbClient with the service constructed in its private init (TMDbFactory vends shared plumbing only — services are not registered there), required model conformances, AND sibling-convention conformance: a newly-added member of an existing family (service method, model, guarded method) must match its siblings — same input validation, same error case, same conformance set / decode strategy — or the divergence is flagged' },
   { key: 'testing', focus: 'tests — both unit and integration present, fixtures exercise EVERY decoder branch, edge cases (boundaries / empty / nil), request-pattern correctness, #require over force-unwrap, AND test-suite convention conformance: a new @Suite matches its siblings (same tags / construction pattern) or the divergence is flagged' },
   { key: 'api-docs', focus: 'model<->API alignment (verify properties/optionality/types/CodingKeys via mcp__tmdb__* and the OpenAPI spec) and public-API docs + DocC catalog + README sync' },
 ]

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -93,7 +93,7 @@ const LENSES = [
   {
     key: 'correctness',
     title: 'Correctness & Completeness',
-    brief: `Does the plan actually achieve the goal? Hunt for: missing steps, wrong assumptions about how the code works, unhandled edge cases and error paths, ordering/dependency mistakes, missing tests, and "done" criteria that do not actually prove the feature works. This is a Swift package (see CLAUDE.md) — scrutinise Sendable/concurrency gaps, Codable/JSON-fixture coverage of every decoder branch, Linux/Windows portability, and public-API + DocC obligations.`,
+    brief: `Does the plan actually achieve the goal? Hunt for: missing steps, wrong assumptions about how the code works, unhandled edge cases and error paths, ordering/dependency mistakes, missing tests, and "done" criteria that do not actually prove the feature works. This is a Swift package (see CLAUDE.md) — scrutinise Sendable/concurrency gaps, Codable/JSON-fixture coverage of every decoder branch, Linux portability, and public-API + DocC obligations.`,
   },
   {
     key: 'risk',

--- a/.claude/skills/review-pr-threads/SKILL.md
+++ b/.claude/skills/review-pr-threads/SKILL.md
@@ -12,11 +12,13 @@ threads that are unresolved *right now* — it does not wait for new reviews to
 arrive. The caller (you, or `/watch-pr`) decides whether to run it again after a
 push triggers a fresh review.
 
-Repo is `adamayoung/TMDb`. GitHub reads (find the PR, fetch threads) and the
-**resolve** use the **GitHub MCP** (`mcp__github__*`); the thread **reply** stays on
-`gh api graphql` — the MCP reply tool needs a numeric REST comment id that the thread
-read doesn't expose, whereas the GraphQL reply takes the thread node id we already
-have. `gh` is authenticated.
+Repo is `adamayoung/TMDb`. GitHub reads (find the PR, fetch threads), the
+**reply**, and the **resolve** all use the **GitHub MCP** (`mcp__github__*`):
+`get_review_comments` exposes each comment's numeric REST id in its `html_url`
+(the `#discussion_r<id>` anchor — verified 2026-08-07), which is exactly the id
+`add_reply_to_pull_request_comment` takes. `gh` is authenticated and kept as
+the reply **fallback** (`gh api graphql` with the thread node id) on a 401/403
+or if the anchor is ever absent.
 
 ## Principles
 
@@ -55,7 +57,9 @@ read a specific one with `mcp__github__pull_request_read` method `get`
 Use `mcp__github__pull_request_read` method `get_review_comments` (owner/repo from
 `origin`, `pullNumber: <n>`). It returns review **threads**, each with metadata
 (`isResolved`, `isOutdated`, `isCollapsed`), the thread **node id** (`PRRT_…`, used to
-resolve in §2), `path`/`line`, and the grouped comments. Paginate with
+resolve in §2), `path`/`line`, and the grouped comments — each comment carrying an
+`html_url` whose `#discussion_r<id>` anchor is the numeric comment id §2's reply
+needs. Paginate with
 `perPage`/`after` (the `endCursor` from the previous page's `pageInfo`) if needed.
 
 Process each thread where `isResolved` is `false` and whose thread id is not already
@@ -76,10 +80,13 @@ For each unresolved thread:
 3. **No fix warranted** (disagree / out of scope / a question / already done) →
    make no code change; you'll say why in the reply.
 4. **Reply** on the thread — what you assessed and whether you fixed it (include
-   the commit SHA when you did). This step stays on `gh api graphql`: the GraphQL
-   reply takes the thread **node id** (`PRRT_…`) we already have from §1, whereas the
-   MCP `add_reply_to_pull_request_comment` needs a numeric REST comment id that
-   `get_review_comments` doesn't return.
+   the commit SHA when you did). Use
+   `mcp__github__add_reply_to_pull_request_comment` (owner/repo from `origin`,
+   `pullNumber: <n>`, `body`, and `commentId` — the number from the thread's
+   first comment's `html_url` anchor, `…#discussion_r<ID>`; the number only,
+   never the `PRRT_…` node id). On a **401/403**, or if no comment in the
+   thread carries the anchor, fall back to the GraphQL reply with the thread
+   node id we already have from §1:
 
    ```bash
    gh api graphql -f query='mutation($id:ID!,$body:String!){

--- a/.github/CODE_REVIEW.md
+++ b/.github/CODE_REVIEW.md
@@ -57,8 +57,12 @@ inflate nitpicks to Critical.
 - A **library** (not an app) — no UI frameworks. Swift 6.0+ strict concurrency.
   No external dependencies (stdlib + Foundation only).
 - Platforms: iOS 16+, macOS 13+, watchOS 9+, tvOS 16+, visionOS 1+, Linux.
-- **28 services** behind `TMDbClient`, each a public `protocol` + an internal
-  `TMDb`-prefixed implementation; the `naturalLanguageSearch` service is Apple-only.
+- The per-domain services behind `TMDbClient`, each a public `protocol` + an
+  internal `TMDb`-prefixed implementation. On-device intelligence lives in the
+  separate **`TMDbIntelligence`** product (Apple-only): `naturalLanguageSearch`
+  and the FoundationModels language-model tools are `TMDbClient` *extensions*
+  there, gated by `#if canImport(...)` — on those diffs, also review platform
+  gating and `@available` annotations.
 - **Networking decorator chain:**
 
   ```text
@@ -71,8 +75,10 @@ inflate nitpicks to Critical.
                       └── URLSessionHTTPClientAdapter  (or user-supplied client)
   ```
 
-- DI via `TMDbFactory`; new public API must be exposed on `TMDbClient` and wired
-  in `TMDbFactory`. Models conform to `Codable, Equatable, Hashable, Sendable`.
+- New services are constructed and exposed in `TMDbClient`'s private init;
+  `TMDbFactory` vends only shared plumbing (`makeServiceDependencies`, the API
+  clients, `httpClient(wrapping:)`) — services are **not** registered there.
+  Models conform to `Codable, Equatable, Hashable, Sendable`.
 
 ## What to check (in scope)
 
@@ -84,7 +90,8 @@ inflate nitpicks to Critical.
   Sendable`. (For deep analysis the local reviewer uses the `swift-concurrency`
   skill.)
 - **Architecture** — protocol + `TMDb`-prefixed impl pattern; service-layer
-  boundaries; new API exposed on `TMDbClient` and registered in `TMDbFactory`;
+  boundaries; new API exposed on `TMDbClient` (the service constructed in its
+  private init, dependencies via `TMDbFactory.makeServiceDependencies`);
   required model conformances.
 - **Testing** — Swift Testing (`@Suite`/`@Test`/`#expect`/`#require`, never force
   unwrap in tests). New behaviour needs **both** unit (mock + JSON fixture) and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,9 @@ repository.
 ## Project Overview
 
 TMDb is a Swift Package for The Movie Database API, supporting iOS 16+,
-macOS 13+, watchOS 9+, tvOS 16+, visionOS 1+, Linux, and Windows. Built
-with Swift 6.0+ and strict concurrency.
+macOS 13+, watchOS 9+, tvOS 16+, visionOS 1+, and Linux. Built with
+Swift 6.0+ and strict concurrency. (Windows is deliberately **not**
+claimed — no CI job builds it; see PR #374, which dropped the claim.)
 
 ## Knowledge Base
 
@@ -21,6 +22,11 @@ knowledge; `CLAUDE.md` stays imperative.)
   that needed a lookup.
 - [`knowledge/tmdb-api-notes.md`](knowledge/tmdb-api-notes.md) — live-API
   behaviours.
+- [`knowledge/next-major.md`](knowledge/next-major.md) — deferred **breaking
+  changes**, queued so they resurface when the next major version opens.
+- [`knowledge/skill-improvement-log.md`](knowledge/skill-improvement-log.md) —
+  every skill-improvement proposal and its decision; the recurring-pattern
+  scan's dedup memory.
 
 **Before solving a non-trivial problem**, skim the relevant file. **After learning
 something durable** (a gotcha, an API quirk, a design decision), record it there —
@@ -68,8 +74,8 @@ TMDbClient (main facade)
 
 The on-device intelligence features live in a **separate `TMDbIntelligence`
 library product** (see [ADR-0010](knowledge/decisions/0010-tmdb-intelligence-product.md)),
-so the core `TMDb` product carries no API that cannot function on Linux and
-Windows. `TMDbIntelligence` depends on `TMDb` and adds two `TMDbClient`
+so the core `TMDb` product carries no API that cannot function on Linux.
+`TMDbIntelligence` depends on `TMDb` and adds two `TMDbClient`
 extensions, both **Apple-platforms only**:
 
 - `naturalLanguageSearch` — gated by `#if canImport(NaturalLanguage)`. It
@@ -88,7 +94,7 @@ alongside `import TMDb`. Its test doubles ship in `TMDbIntelligenceTesting`.
 - `Sources/TMDb/TMDbClient.swift` — main public API entry point
 - `Sources/TMDb/TMDbFactory.swift` — dependency injection factory
 - `Sources/TMDb/Domain/Services/` — service protocols and implementations
-- `Sources/TMDb/Domain/Models/` — Codable data models (~170 files)
+- `Sources/TMDb/Domain/Models/` — Codable data models
 - `Sources/TMDbIntelligence/NaturalLanguageSearch/` — on-device
   natural-language search (Apple-only)
 - `Sources/TMDbIntelligence/LanguageModelTools/` — FoundationModels `Tool`s
@@ -204,8 +210,8 @@ than stalling, and records each delivery's short retrospective into
 opens**, so it rides the delivery's own PR:
 
 branch → (`/review-plan` for risky/large changes) → `/implement-plan` →
-`/review-changes` (+ fix) → `/security-review` (+ fix) → `/capture-knowledge` →
-retro → `/pr reviewed` → `/watch-pr`.
+`/review-changes` (+ fix) → `/security-review` (+ fix) → rubric check →
+`/capture-knowledge` → retro → `/pr reviewed` → `/watch-pr`.
 
 Key skills (the README's *Claude Code Skills* tables list them all):
 
@@ -234,10 +240,12 @@ verifies with the targeted suite (not full `make ci`) and opens the PR via
 
 **Code review** — both the local `/review-changes` and the GitHub Actions reviewer
 follow one shared spec, [`.github/CODE_REVIEW.md`](.github/CODE_REVIEW.md), and
-**run only when the change touches Swift** (docs/config-only changes are not
-reviewed). Three subagents back the pipeline: `code-reviewer` (deep Swift/TMDb
-review, pinned to Opus), `documentation-writer` (bulk DocC generation, pinned
-to Sonnet), and `tooling-runner` (build/test execution, pinned to Haiku).
+**run only when the change touches reviewable code** — Swift for both
+reviewers, plus committed `.claude/workflows/` scripts for the local one
+(docs/prose-only changes are not reviewed). Three subagents back the pipeline:
+`code-reviewer` (deep Swift/TMDb review, pinned to Opus),
+`documentation-writer` (bulk DocC generation, pinned to Sonnet), and
+`tooling-runner` (build/test execution, pinned to Haiku).
 
 ## Build and Test Tooling
 
@@ -288,7 +296,7 @@ Run shell commands directly — do not prefix them with
 `TMDB_USERNAME`, `TMDB_PASSWORD`) plus the two v4 credentials
 (`TMDB_API_READ_ONLY_TOKEN`, `TMDB_API_USER_TOKEN` — without them the v4 suites
 skip) are injected via the `env` block in `.claude/settings.local.json`, and Homebrew tools (`gh`, `swiftlint`,
-`swiftformat`, `xcsift`, `markdownlint-cli2`) are already on `PATH`.
+`swiftformat`, `xcsift`, `markdownlint`) are already on `PATH`.
 
 ```bash
 make integration-test
@@ -479,8 +487,8 @@ the final pipeline step. The gitmoji title convention and the PR body template l
 in that skill.
 
 GitHub access goes through the **GitHub MCP** (`mcp__github__*`), with `gh` as the
-fallback and for the few things the MCP can't do (the blocking CI wait, the
-review-thread reply, headless Actions). The MCP registration command, the `/x/all`
+fallback and for the few things the MCP can't do (the blocking CI wait,
+headless Actions). The MCP registration command, the `/x/all`
 path rationale, the owner/repo derivation, and the full `gh`-only exceptions are in
 [ADR-0009](knowledge/decisions/0009-github-mcp-over-gh-cli.md).
 

--- a/knowledge/decisions/0009-github-mcp-over-gh-cli.md
+++ b/knowledge/decisions/0009-github-mcp-over-gh-cli.md
@@ -86,3 +86,11 @@ read -r OWNER REPO < <(git remote get-url origin \
   `CLAUDE.md` are the onboarding breadcrumb.
 - All team skills now hinge on **one user's PAT** — a single point of failure the
   `gh`-per-developer model didn't have.
+- *Addendum (2026-08-07):* holdout **2 (review-thread reply)** has closed —
+  `get_review_comments` now exposes each comment's numeric REST id in its
+  `html_url` (the `#discussion_r<id>` anchor), which is exactly the id
+  `add_reply_to_pull_request_comment` documents taking. `/review-pr-threads`
+  now replies via the MCP, keeping `gh api graphql` as the 401/403 fallback.
+  Holdouts 1 and 3 were re-checked the same day and still stand: the mounted
+  toolset has no blocking-wait tool, and CI runners still mount no
+  user-scoped MCP.

--- a/knowledge/decisions/0014-subagent-model-tiers.md
+++ b/knowledge/decisions/0014-subagent-model-tiers.md
@@ -61,6 +61,12 @@ re-diagnoses only where judgment demonstrably matters.
   model family shift (e.g. pinning the top judgment calls to a Fable-class
   model) revisits this ADR — the *shape → tier* mapping is the durable part,
   not the model names.
+- *Addendum (2026-08-07):* `/review-knowledge` (added after this ADR) pins its
+  two audit critics to a **Fable-class** model — the first judgment role above
+  the Opus floor, chosen for verification depth on the knowledge audit. The
+  shape → tier mapping is unchanged, and the trigger for revisiting the
+  remaining Opus pins (the `/review-plan` critics, the `/deliver` panel) stays
+  "critics start missing blockers".
 
 ## Alternatives considered
 

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -384,7 +384,7 @@ in isolation.
 ### `make ci` skips the Linux build — CI has a separate `build-test-linux` job
 
 *2026-06-23.* `make ci` does **not** run `make build-linux` (it's lint,
-lint-markdown, test, integration-test, build-release, build-docs). Linux/Windows
+lint-markdown, test, integration-test, build-release, build-docs). Linux
 portability is instead gated by `.github/workflows/ci.yml`'s **`build-test-linux`**
 job (container `swift:6.1-jammy`, runs `swift build --build-tests`). So when Docker
 isn't available locally to run `make build-linux`, the PR's CI is the authoritative
@@ -668,7 +668,7 @@ only", which is easy to over-apply. In fact the **protocol** and all its types
 the `TMDbClient.naturalLanguageSearch` *accessor* (and the on-device planner
 implementation, e.g. `PersonNameExtracting`, `FoundationModelsSearchPlanGenerator`).
 So code that merely conforms to or references the protocol/types (e.g. a mock)
-compiles on Linux/Windows and must **not** be wrapped in `#if canImport(...)` —
+compiles on Linux and must **not** be wrapped in `#if canImport(...)` —
 over-gating would needlessly remove it off-Apple. Gate only the specific symbol
 that actually imports `NaturalLanguage`/`FoundationModels`.
 
@@ -786,7 +786,7 @@ emoji, invalid percent-escapes (`%zz`), `<>`, `\`, `^`, `|`.
 
 - So on macOS/iOS that error path is effectively only reachable with an empty
   path — you cannot construct a "token-bearing invalid path" test case there.
-- **swift-corelibs-foundation (Linux/Windows) parses more strictly**, so the
+- **swift-corelibs-foundation (Linux) parses more strictly**, so the
   branch is not dead code across the package's supported platforms — which is
   why the thrown path is still redacted.
 - **Probe empirically** (a throwaway `swift script.swift` with the candidate

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,47 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-08-07 — Full CLAUDE.md/skills/agents review: drift fixes + review-integrity seams · applied
+
+- **Pattern:** an external full review (not the wrap-up scan) of `CLAUDE.md`,
+  all 21 skills, the 3 agents and the panel script found drift concentrated
+  where prose describes things that move: the weekly canary called "nightly"
+  (`diagnose-integration-failure`); `document-swift` quoting a README service
+  count that had already moved; two skills pointing at a consistency checklist
+  that had moved out of `CLAUDE.md`; `CODE_REVIEW.md`'s context block still
+  describing `naturalLanguageSearch` as a core service and services as "wired
+  in `TMDbFactory`"; and `CLAUDE.md` still claiming Windows after #374 dropped
+  that claim from the README/`CODE_REVIEW.md` (no CI builds it). Plus four
+  seams: `code-reviewer.md` permitting builds while every caller forbids them;
+  `/pr`'s standalone review spawning a non-scaling single reviewer;
+  `.claude/workflows/` scripts having no correctness-review path; and
+  `documentation-writer.md` declaring an invalid `permissionMode: restricted`
+  plus a nonexistent `autoApprove` field — both silently ignored per the
+  official subagent frontmatter schema, so its permission scheme never applied.
+- **Decision:** **applied** (user-approved, this PR). All drift corrected
+  (Windows aligned to #374's call); `code-reviewer.md` now defaults to
+  no-build; `/pr` step 5 delegates to `/review-changes`; the `/review-changes`
+  gate widens to `.claude/workflows/` (script-focused §2a brief);
+  `/review-pr-threads` replies via the MCP (`add_reply_to_pull_request_comment`
+  with the `#discussion_r<id>` anchor id — verified 2026-08-07; `gh api
+  graphql` demoted to fallback) with ADR-0009 annotated; `documentation-writer`
+  gets `permissionMode: auto` + a real `tools` allowlist (including
+  `Edit`/`Write`) and preloads `document-swift`; ADR-0014 gains an addendum
+  recording `/review-knowledge`'s Fable pin. Two deliberate narrowings, both
+  user-chosen: `/deliver` Phase 2's skip now requires an actual adversarial
+  review (`ExitPlanMode` approval alone is consent, not review), and the
+  delivery-weight vocabulary stays **binary** (hybrids record as full with
+  skips noted — no "medium" tier).
+- **Rationale:** the drift sat exactly where `review-knowledge`'s scope table
+  predicts (prose describing moving parts); the seams all reduce to one
+  principle — a guard that lives only in per-call prompts, or in a frontmatter
+  field the schema ignores, is not a guard.
+- **Reconsider when:** for the weight binary — a third genuinely distinct
+  scaling shape recurs across retros (not a full run with one skipped step).
+  For the narrowed Phase 2 skip — if the three-critic pass starts firing
+  redundantly on plans that plainly had equivalent in-conversation review,
+  tighten the *wording* of what qualifies, not the gate.
+
 ### 2026-07-29 — Tooling-runner report becomes a shape-based contract · applied
 
 - **Pattern:** the four tooling skills had no handling for the *subagent* dying,


### PR DESCRIPTION
## Summary

A full external review of `CLAUDE.md`, all 21 skills, the 3 agents and the panel script found factual drift concentrated where prose describes moving parts, plus four review-integrity seams. This PR applies every finding in one sweep — drift corrected, seams closed, decisions recorded.

## Changes

**Drift fixes:**

- 📝 `diagnose-integration-failure` — the scheduled canary is **weekly**, not "nightly"
- 📝 `CODE_REVIEW.md` context block — `naturalLanguageSearch` is a `TMDbIntelligence` extension (not a core service); services are constructed in `TMDbClient`'s private init, **not** "wired in `TMDbFactory`" (same fix in `review-changes`' architecture dimension, which was steering reviewers at the wrong pattern)
- 📝 Windows claim aligned to PR #374's recorded decision (dropped from README/CODE_REVIEW there, but `CLAUDE.md`, two skill briefs, `linux.md` and three `gotchas.md` entries were missed)
- 📝 `implement-plan` / `canon-tdd` — repointed at the consistency checklist's real home (`document-swift`); `document-swift` no longer quotes a rotting README service count
- 📝 `CLAUDE.md` — knowledge list gains `next-major.md` + `skill-improvement-log.md`; pipeline summary gains the rubric check; `markdownlint` (not `-cli2`); model-count precision dropped; two editing artifacts in `deliver` cleaned up

**Review-integrity seams:**

- 🔧 `code-reviewer.md` now defaults to **no-build** (was "the `make` commands are fine", contradicting every caller's one-build-slot rule)
- 🔧 `/pr` step 5 delegates to `/review-changes` instead of spawning a non-scaling single reviewer
- 🔧 `/review-changes`' gate widens to `.claude/workflows/**` — committed Workflow scripts get a correctness review (script-focused single-reviewer brief), not just the security pass
- 🔧 `/review-pr-threads` replies via the GitHub MCP — `get_review_comments` exposes the numeric comment id in each comment's `html_url` `#discussion_r<id>` anchor (verified 2026-08-07 against PR #361), so the `gh api graphql` holdout is demoted to 401/403 fallback; ADR-0009 annotated
- 🔧 `documentation-writer.md` — `permissionMode: restricted` and `autoApprove` are not in the subagent frontmatter schema (both silently ignored); replaced with `permissionMode: auto` + a real `tools` allowlist (including `Edit`/`Write`, which its bulk-editing job needs), and `document-swift` is now preloaded via `skills`
- 🔧 `/deliver` Phase 2 skip narrowed: `ExitPlanMode` approval alone is consent, not review — an adversarial review (or equivalent in-conversation critique) is what skips the critics
- 🔧 Delivery weight vocabulary pinned as **binary** (hybrids record as full with skips noted — retro #410's "medium" won't recur)

**Documentation:**

- 📚 New `skill-improvement-log.md` entry recording every decision (including the two deliberate narrowings) so the recurring-pattern scan won't re-litigate
- 📚 ADR-0009 addendum (reply holdout closed; holdouts 1 and 3 re-checked, still stand) and ADR-0014 addendum (records `/review-knowledge`'s Fable-class critic pin)

## Benefits

- **Reviewer accuracy**: the shared spec no longer instructs reviewers to check for a `TMDbFactory` registration pattern the codebase abandoned
- **Guards that actually guard**: the no-build rule lives in the agent definition (not just per-call prompts), and `documentation-writer`'s permissions now use fields the schema honours
- **One review implementation**: standalone `/pr` inherits `/review-changes`' scaling and coverage reporting
- **Honest platform claims**: #374's Windows decision now applied consistently everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mg9GBEDEPnvZxcJMxXoWzZ