### PR TITLE
🐛 Decode empty-string credit dates as nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `credits.details(forCredit:)` no longer fails for a credit attached to an
+  unreleased movie or an unaired TV series. TMDb reports an absent date as an
+  empty string, which the day-precision date parser rejected, so the whole call
+  threw `TMDbError.decode`. `CreditMovie.releaseDate` and
+  `CreditTVSeries.firstAirDate` now decode an empty string as `nil`, matching
+  every sibling model.
+
 - 37 convenience methods on the public service protocols no longer share a
   signature with the requirement they forward to. A default argument value is
   not part of a signature for witness matching, so each of these *was* its

--- a/Sources/TMDb/Domain/Models/CreditMovie.swift
+++ b/Sources/TMDb/Domain/Models/CreditMovie.swift
@@ -115,3 +115,52 @@ Hashable, Sendable {
     }
 
 }
+
+extension CreditMovie {
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case originalTitle
+        case overview
+        case posterPath
+        case backdropPath
+        case popularity
+        case releaseDate
+        case voteAverage
+        case voteCount
+        case character
+    }
+
+    ///
+    /// Creates a new instance by decoding from the given decoder.
+    ///
+    /// This initializer throws an error if reading from the decoder fails, or
+    /// if the data read is corrupted or otherwise invalid.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    ///
+    /// - Throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested
+    /// type.
+    /// - Throws: `DecodingError.keyNotFound` if self does not have an entry for the given key.
+    /// - Throws: `DecodingError.valueNotFound` if self has a null entry for the given key.
+    ///
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.id = try container.decode(Int.self, forKey: .id)
+        self.title = try container.decodeIfPresent(String.self, forKey: .title)
+        self.originalTitle = try container.decodeIfPresent(String.self, forKey: .originalTitle)
+        self.overview = try container.decodeIfPresent(String.self, forKey: .overview)
+        self.posterPath = try container.decodeIfPresent(URL.self, forKey: .posterPath)
+        self.backdropPath = try container.decodeIfPresent(URL.self, forKey: .backdropPath)
+        self.popularity = try container.decodeIfPresent(Double.self, forKey: .popularity)
+        // An unreleased movie reports `release_date` as an empty string, which
+        // the day-precision date strategy cannot parse.
+        self.releaseDate = try container.decodeNonEmptyDateIfPresent(forKey: .releaseDate)
+        self.voteAverage = try container.decodeIfPresent(Double.self, forKey: .voteAverage)
+        self.voteCount = try container.decodeIfPresent(Int.self, forKey: .voteCount)
+        self.character = try container.decodeIfPresent(String.self, forKey: .character)
+    }
+
+}

--- a/Sources/TMDb/Domain/Models/CreditTVSeries.swift
+++ b/Sources/TMDb/Domain/Models/CreditTVSeries.swift
@@ -115,3 +115,52 @@ Hashable, Sendable {
     }
 
 }
+
+extension CreditTVSeries {
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case originalName
+        case overview
+        case posterPath
+        case backdropPath
+        case popularity
+        case firstAirDate
+        case voteAverage
+        case voteCount
+        case character
+    }
+
+    ///
+    /// Creates a new instance by decoding from the given decoder.
+    ///
+    /// This initializer throws an error if reading from the decoder fails, or
+    /// if the data read is corrupted or otherwise invalid.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    ///
+    /// - Throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested
+    /// type.
+    /// - Throws: `DecodingError.keyNotFound` if self does not have an entry for the given key.
+    /// - Throws: `DecodingError.valueNotFound` if self has a null entry for the given key.
+    ///
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.id = try container.decode(Int.self, forKey: .id)
+        self.name = try container.decodeIfPresent(String.self, forKey: .name)
+        self.originalName = try container.decodeIfPresent(String.self, forKey: .originalName)
+        self.overview = try container.decodeIfPresent(String.self, forKey: .overview)
+        self.posterPath = try container.decodeIfPresent(URL.self, forKey: .posterPath)
+        self.backdropPath = try container.decodeIfPresent(URL.self, forKey: .backdropPath)
+        self.popularity = try container.decodeIfPresent(Double.self, forKey: .popularity)
+        // An unaired TV series reports `first_air_date` as an empty string,
+        // which the day-precision date strategy cannot parse.
+        self.firstAirDate = try container.decodeNonEmptyDateIfPresent(forKey: .firstAirDate)
+        self.voteAverage = try container.decodeIfPresent(Double.self, forKey: .voteAverage)
+        self.voteCount = try container.decodeIfPresent(Int.self, forKey: .voteCount)
+        self.character = try container.decodeIfPresent(String.self, forKey: .character)
+    }
+
+}

--- a/Tests/TMDbIntegrationTests/CreditIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/CreditIntegrationTests.swift
@@ -37,4 +37,31 @@ struct CreditIntegrationTests {
         #expect(credit.person.name == "Bryan Cranston")
     }
 
+    /// Deliberately a long-released film: this covers the `CreditMedia` movie
+    /// branch, which had no live coverage at all. The empty-`release_date`
+    /// regression is locked by the `credit-movie-blank-release-date` fixture
+    /// instead — a live credit cannot guard it, because TMDb fills the date in
+    /// once the film is dated, and an unreleased title's credit ID is volatile
+    /// enough to 404 a gate that runs on every PR.
+    @Test("details for a movie credit")
+    func detailsForMovieCredit() async throws {
+        let creditID = "52fe4250c3a36847f80149f3"
+
+        let credit = try await creditService.details(
+            forCredit: creditID
+        )
+
+        #expect(credit.id == creditID)
+        #expect(credit.creditType == .cast)
+        #expect(credit.person.name == "Edward Norton")
+
+        guard case .movie(let movie) = credit.media else {
+            Issue.record("Expected movie media type")
+            return
+        }
+
+        #expect(movie.id == 550)
+        #expect(movie.title == "Fight Club")
+    }
+
 }

--- a/Tests/TMDbTests/Domain/Models/CreditMovieTests.swift
+++ b/Tests/TMDbTests/Domain/Models/CreditMovieTests.swift
@@ -1,0 +1,103 @@
+//
+//  CreditMovieTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.models, .credit))
+struct CreditMovieTests {
+
+    @Test("JSON decoding of CreditMovie", .tags(.decoding))
+    func decodeCreditMovie() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            Credit.self,
+            fromResource: "credit-movie"
+        )
+
+        guard case .movie(let movie) = result.media else {
+            Issue.record("Expected movie media type")
+            return
+        }
+
+        #expect(movie == fightClub)
+    }
+
+    @Test(
+        "JSON decoding of CreditMovie with an empty release date returns nil release date",
+        .tags(.decoding)
+    )
+    func decodeCreditMovieWithEmptyReleaseDateReturnsNilReleaseDate() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            Credit.self,
+            fromResource: "credit-movie-blank-release-date"
+        )
+
+        guard case .movie(let movie) = result.media else {
+            Issue.record("Expected movie media type")
+            return
+        }
+
+        #expect(movie.id == 1_047_807)
+        #expect(movie.title == "Heat 2")
+        #expect(movie.releaseDate == nil)
+        #expect(movie.character == nil)
+        #expect(movie.backdropPath == nil)
+    }
+
+    @Test(
+        "JSON decoding of CreditMovie without optional properties returns nil properties",
+        .tags(.decoding)
+    )
+    func decodeCreditMovieWithoutOptionalPropertiesReturnsNilProperties() throws {
+        let data = Data(#"{"media_type": "movie", "id": 550}"#.utf8)
+
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            CreditMedia.self,
+            from: data
+        )
+
+        guard case .movie(let movie) = result else {
+            Issue.record("Expected movie media type")
+            return
+        }
+
+        #expect(movie.id == 550)
+        #expect(movie.title == nil)
+        #expect(movie.originalTitle == nil)
+        #expect(movie.overview == nil)
+        #expect(movie.posterPath == nil)
+        #expect(movie.backdropPath == nil)
+        #expect(movie.popularity == nil)
+        #expect(movie.releaseDate == nil)
+        #expect(movie.voteAverage == nil)
+        #expect(movie.voteCount == nil)
+        #expect(movie.character == nil)
+    }
+
+}
+
+extension CreditMovieTests {
+
+    private var fightClub: CreditMovie {
+        .init(
+            id: 550,
+            title: "Fight Club",
+            originalTitle: "Fight Club",
+            // swiftlint:disable:next line_length
+            overview: "A ticking-time-bomb insomniac and a slippery soap salesman channel primal male aggression into a shocking new form of therapy.",
+            posterPath: URL(string: "/jSziioSwPVrOy9Yow3XhWIBDjq1.jpg"),
+            backdropPath: URL(string: "/c6OLXfKAk5BKeR6broC8pYiCquX.jpg"),
+            popularity: 44.4391,
+            releaseDate: DateFormatter.theMovieDatabase.date(from: "1999-10-15"),
+            voteAverage: 8.437,
+            voteCount: 32596,
+            character: "Narrator"
+        )
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Models/CreditTVSeriesTests.swift
+++ b/Tests/TMDbTests/Domain/Models/CreditTVSeriesTests.swift
@@ -1,0 +1,101 @@
+//
+//  CreditTVSeriesTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.models, .credit))
+struct CreditTVSeriesTests {
+
+    @Test("JSON decoding of CreditTVSeries", .tags(.decoding))
+    func decodeCreditTVSeries() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            Credit.self,
+            fromResource: "credit"
+        )
+
+        guard case .tvSeries(let tvSeries) = result.media else {
+            Issue.record("Expected TV series media type")
+            return
+        }
+
+        #expect(tvSeries == breakingBad)
+    }
+
+    @Test(
+        "JSON decoding of CreditTVSeries with an empty first air date returns nil first air date",
+        .tags(.decoding)
+    )
+    func decodeCreditTVSeriesWithEmptyFirstAirDateReturnsNilFirstAirDate() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            Credit.self,
+            fromResource: "credit-tv-blank-first-air-date"
+        )
+
+        guard case .tvSeries(let tvSeries) = result.media else {
+            Issue.record("Expected TV series media type")
+            return
+        }
+
+        #expect(tvSeries.id == 302_069)
+        #expect(tvSeries.name == "Untitled Peaky Blinders Sequel")
+        #expect(tvSeries.firstAirDate == nil)
+        #expect(tvSeries.character == nil)
+    }
+
+    @Test(
+        "JSON decoding of CreditTVSeries without optional properties returns nil properties",
+        .tags(.decoding)
+    )
+    func decodeCreditTVSeriesWithoutOptionalPropertiesReturnsNilProperties() throws {
+        let data = Data(#"{"media_type": "tv", "id": 1396}"#.utf8)
+
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            CreditMedia.self,
+            from: data
+        )
+
+        guard case .tvSeries(let tvSeries) = result else {
+            Issue.record("Expected TV series media type")
+            return
+        }
+
+        #expect(tvSeries.id == 1396)
+        #expect(tvSeries.name == nil)
+        #expect(tvSeries.originalName == nil)
+        #expect(tvSeries.overview == nil)
+        #expect(tvSeries.posterPath == nil)
+        #expect(tvSeries.backdropPath == nil)
+        #expect(tvSeries.popularity == nil)
+        #expect(tvSeries.firstAirDate == nil)
+        #expect(tvSeries.voteAverage == nil)
+        #expect(tvSeries.voteCount == nil)
+        #expect(tvSeries.character == nil)
+    }
+
+}
+
+extension CreditTVSeriesTests {
+
+    private var breakingBad: CreditTVSeries {
+        .init(
+            id: 1396,
+            name: "Breaking Bad",
+            originalName: "Breaking Bad",
+            overview: "Walter White, a New Mexico chemistry teacher, is diagnosed with Stage III cancer.",
+            posterPath: URL(string: "/ztkUQFLlC19CCMYHW9o1zWhJRNq.jpg"),
+            backdropPath: URL(string: "/tsRy63Mu5cu8etL1X7ZLyf7UP1M.jpg"),
+            popularity: 108.6266,
+            firstAirDate: DateFormatter.theMovieDatabase.date(from: "2008-01-20"),
+            voteAverage: 8.937,
+            voteCount: 17020,
+            character: "Walter White"
+        )
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Models/CreditTests.swift
+++ b/Tests/TMDbTests/Domain/Models/CreditTests.swift
@@ -35,4 +35,72 @@ struct CreditTests {
         }
     }
 
+    @Test(
+        "JSON decoding of Credit with an unknown media type throws a data corrupted error",
+        .tags(.decoding)
+    )
+    func decodeCreditWithUnknownMediaTypeThrowsDataCorruptedError() throws {
+        let data = Data(#"{"media_type": "podcast", "id": 1}"#.utf8)
+
+        let error = #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder.theMovieDatabase.decode(
+                CreditMedia.self,
+                from: data
+            )
+        }
+
+        guard case .dataCorrupted(let context) = try #require(error) else {
+            Issue.record("Expected a data corrupted error")
+            return
+        }
+
+        #expect(context.debugDescription.contains("Unknown media type"))
+    }
+
+    @Test("JSON encoding of movie CreditMedia", .tags(.encoding))
+    func encodeMovieCreditMedia() throws {
+        let releaseDate = DateFormatter.theMovieDatabase.date(from: "1999-10-15")
+        let media = CreditMedia.movie(
+            .mock(id: 550, releaseDate: releaseDate, character: "Narrator")
+        )
+
+        let data = try JSONEncoder.theMovieDatabase.encode(media)
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            CreditMedia.self,
+            from: data
+        )
+
+        guard case .movie(let movie) = result else {
+            Issue.record("Expected movie media type")
+            return
+        }
+
+        #expect(movie.id == 550)
+        #expect(movie.releaseDate == releaseDate)
+        #expect(movie.character == "Narrator")
+    }
+
+    @Test("JSON encoding of TV series CreditMedia", .tags(.encoding))
+    func encodeTVSeriesCreditMedia() throws {
+        let firstAirDate = DateFormatter.theMovieDatabase.date(from: "2008-01-20")
+        let media = CreditMedia.tvSeries(
+            .mock(id: 1396, firstAirDate: firstAirDate, character: "Walter White")
+        )
+
+        let data = try JSONEncoder.theMovieDatabase.encode(media)
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            CreditMedia.self,
+            from: data
+        )
+
+        guard case .tvSeries(let tvSeries) = result else {
+            Issue.record("Expected TV series media type")
+            return
+        }
+
+        #expect(tvSeries.id == 1396)
+        #expect(tvSeries.firstAirDate == firstAirDate)
+        #expect(tvSeries.character == "Walter White")
+    }
+
 }

--- a/Tests/TMDbTests/Domain/Models/CreditTypeTests.swift
+++ b/Tests/TMDbTests/Domain/Models/CreditTypeTests.swift
@@ -34,6 +34,22 @@ struct CreditTypeTests {
         #expect(result == .crew)
     }
 
+    /// TMDb also returns `credit_type` values outside this enum — a live
+    /// example is credit 5257855d19c29531db28adea, which reports "creator".
+    /// Decoding one throws today, failing the whole `details(forCredit:)` call.
+    /// This test locks that behaviour so making it tolerant is a deliberate,
+    /// source-breaking change rather than an accident; tracked in issue #418.
+    @Test("JSON decoding of an unknown CreditType throws", .tags(.decoding))
+    func decodeUnknownCreditTypeThrows() {
+        let data = Data(#""creator""#.utf8)
+
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(
+                CreditType.self, from: data
+            )
+        }
+    }
+
     @Test("JSON encoding of cast CreditType", .tags(.encoding))
     func encodeCast() throws {
         let data = try JSONEncoder().encode(CreditType.cast)

--- a/Tests/TMDbTests/Resources/json/credit-movie-blank-release-date.json
+++ b/Tests/TMDbTests/Resources/json/credit-movie-blank-release-date.json
@@ -1,0 +1,40 @@
+{
+    "credit_type": "crew",
+    "department": "Directing",
+    "job": "Director",
+    "media": {
+        "adult": false,
+        "backdrop_path": null,
+        "id": 1047807,
+        "title": "Heat 2",
+        "original_title": "Heat 2",
+        "overview": "Spanning the years 1988–2000, this sequel/prequel will explore the lives of homicide detective Vincent Hanna and criminals Neil McCauley and Chris Shiherlis years before their paths cross in 1995, and will follow Shiherlis and Hanna's lives in the aftermath of McCauley's death.",
+        "poster_path": "/8nVqwnRrTQZatWqaVtobjmFUdbJ.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+            80,
+            18,
+            28
+        ],
+        "popularity": 2.6161,
+        "release_date": "",
+        "softcore": false,
+        "video": false,
+        "vote_average": 0,
+        "vote_count": 0
+    },
+    "media_type": "movie",
+    "id": "63704523e894a6008292323c",
+    "person": {
+        "adult": false,
+        "id": 638,
+        "name": "Michael Mann",
+        "original_name": "Michael Mann",
+        "media_type": "person",
+        "popularity": 2.163,
+        "gender": 2,
+        "known_for_department": "Directing",
+        "profile_path": "/kEYrCk6y6siUOxUlMD2KyFuRBQK.jpg"
+    }
+}

--- a/Tests/TMDbTests/Resources/json/credit-movie.json
+++ b/Tests/TMDbTests/Resources/json/credit-movie.json
@@ -1,0 +1,40 @@
+{
+    "credit_type": "cast",
+    "department": "Acting",
+    "job": "Actor",
+    "media": {
+        "adult": false,
+        "backdrop_path": "/c6OLXfKAk5BKeR6broC8pYiCquX.jpg",
+        "id": 550,
+        "title": "Fight Club",
+        "original_title": "Fight Club",
+        "overview": "A ticking-time-bomb insomniac and a slippery soap salesman channel primal male aggression into a shocking new form of therapy.",
+        "poster_path": "/jSziioSwPVrOy9Yow3XhWIBDjq1.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+            18,
+            53
+        ],
+        "popularity": 44.4391,
+        "release_date": "1999-10-15",
+        "softcore": false,
+        "video": false,
+        "vote_average": 8.437,
+        "vote_count": 32596,
+        "character": "Narrator"
+    },
+    "media_type": "movie",
+    "id": "52fe4250c3a36847f80149f3",
+    "person": {
+        "adult": false,
+        "id": 819,
+        "name": "Edward Norton",
+        "original_name": "Edward Norton",
+        "media_type": "person",
+        "popularity": 6.5852,
+        "gender": 2,
+        "known_for_department": "Acting",
+        "profile_path": "/8nytsqL59SFJTVYVrN72k6qkGgJ.jpg"
+    }
+}

--- a/Tests/TMDbTests/Resources/json/credit-tv-blank-first-air-date.json
+++ b/Tests/TMDbTests/Resources/json/credit-tv-blank-first-air-date.json
@@ -1,0 +1,55 @@
+{
+    "credit_type": "crew",
+    "department": "Production",
+    "job": "Executive Producer",
+    "media": {
+        "adult": false,
+        "backdrop_path": "/qQyzfPaMcFR41mJCXVGhygxHa6b.jpg",
+        "id": 302069,
+        "name": "Untitled Peaky Blinders Sequel",
+        "original_name": "Untitled Peaky Blinders Sequel",
+        "overview": "In this new era of Peaky Blinders, a decade after World War Two, the race to rebuild Birmingham becomes a brutal contest of mythical dimensions. This is a city of unprecedented opportunity and jeopardy. At its blood-soaked heart is Duke Shelby: older, wiser, more ambitious, and most certainly more dangerous.",
+        "poster_path": "/nsyIOzlruBQ8wHXUOJ0238ZDqym.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+            18
+        ],
+        "popularity": 1.8405,
+        "first_air_date": "",
+        "softcore": false,
+        "vote_average": 0,
+        "vote_count": 0,
+        "origin_country": [
+            "GB"
+        ],
+        "episodes": [],
+        "seasons": [
+            {
+                "id": 478065,
+                "name": "Season 1",
+                "overview": "Britain, 1953. After being heavily bombed in WWII, Birmingham is building a better future out of concrete and steel.",
+                "poster_path": null,
+                "media_type": "tv_season",
+                "vote_average": 0,
+                "air_date": null,
+                "season_number": 1,
+                "show_id": 302069,
+                "episode_count": 1
+            }
+        ]
+    },
+    "media_type": "tv",
+    "id": "68df0276225889fef91299a5",
+    "person": {
+        "adult": false,
+        "id": 2037,
+        "name": "Cillian Murphy",
+        "original_name": "Cillian Murphy",
+        "media_type": "person",
+        "popularity": 7.5411,
+        "gender": 2,
+        "known_for_department": "Acting",
+        "profile_path": "/2lKs67r7FI4bPu0AXxMUJZxmUXn.jpg"
+    }
+}

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,7 +14,7 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
-## 2026-08-12 — 🐛 Decode empty-string credit dates as nil (`fix/credit-empty-date-decoding`) · full
+## 2026-08-12 — 🐛 Decode empty-string credit dates as nil (#432) · full
 
 - **Phases / skills:** 0–11; **full** (a `Decodable`/`CodingKeys` change is a
   named risky surface), so the 3-critic `/review-plan` ran and Phase 6 used an

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -14,6 +14,72 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
 
 ---
 
+## 2026-08-12 — 🐛 Decode empty-string credit dates as nil (`fix/credit-empty-date-decoding`) · full
+
+- **Phases / skills:** 0–11; **full** (a `Decodable`/`CodingKeys` change is a
+  named risky surface), so the 3-critic `/review-plan` ran and Phase 6 used an
+  independent grader. `/review-changes` took the single-reviewer path (555 lines,
+  one cohesive unit). `consulted:` gotchas *Guard consistently within a type*,
+  *Sweep the failure class, not the property name*, *Model-decode equality tests*,
+  *`Date(iso8601:)` is not visible to `TMDbIntegrationTests`*; api-notes
+  *Verify optionality against real responses*, *`/company/{id}` nullability*;
+  issues #418, #426, #430 for scope boundaries.
+- **Worked — the #404 failure-class sweep, in both directions.** The plan reached
+  Phase 0 having excluded the URL decodes from a *single* spot-check of one
+  record. Sweeping the whole `/credit/{id}` tree over 300 live records instead
+  both **cleared** those five URL decodes with a measurement (`null`-bearing,
+  never `""`) and **found a bug the issue never mentioned**: `credit_type:
+  "creator"` throws today. Without the sweep the first would have been an
+  assertion a reviewer could reasonably reject, and the second would have
+  shipped undiscovered.
+- **Worked — the critics found the false green I had built in.** All three
+  returned `sound-with-fixes` and every load-bearing claim I checked held up.
+  The best catch was mine to be embarrassed by: **no fixture in my test list
+  omitted `character`**, so a `decode`-instead-of-`decodeIfPresent` slip in
+  either hand-written init would have compiled, passed everything, and broken
+  36% of live credits. Re-sourcing both blank-date fixtures to **crew** credits
+  fixed it for free — TMDb omits `character` entirely on crew credits, so one
+  fixture now covers an empty date *and* an absent optional.
+- **Worked — reconciling a 2-vs-1 critic split on evidence rather than vote.**
+  One critic read *Guard consistently within a type* as requiring
+  `decodeNonEmptyURLIfPresent` on the image paths. The rule is about one **value
+  class** diverging (`Company.logoPath` vs `Company.Parent.logoPath`), not a date
+  differing from a URL — and guarding would have made `CreditMovie` the lone
+  divergence across ~20 models. The gotcha now records that scope explicitly, so
+  the next reader doesn't re-derive it.
+- **Friction — the worktree Bash guard.** A worktree-isolated session refuses any
+  command it cannot statically prove stays inside the worktree, which blocked
+  writing the durable run file under `.git/deliver/` (outside the worktree *by
+  design* — it lives in the common git dir) via `jq`+`mv` **and** via `Edit`,
+  plus several `curl -o` and multi-pipe sampling commands that were never leaving.
+  `sed` with fully literal paths worked. Now a `gotchas.md` entry; the deeper
+  issue is that `/deliver`'s own run-file location is at odds with its own
+  worktree isolation.
+- **Friction — two API 529s killed the code reviewer** before it started. Retried
+  after doing unrelated work; the second retry succeeded. Void ≠ failed was the
+  right read.
+- **Friction — a subagent asserted a green it could not see.** The
+  `tooling-runner` reported the integration suite passed "including the newly
+  added `detailsForMovieCredit` test", but the xcsift log carries only aggregate
+  counts — no test names. A scoped `--filter` run proved it genuinely ran. The
+  runner's report shape cannot distinguish *ran and passed* from *never ran*.
+- **Deviations:** (1) The plan had **no formal ACs** — a bug-fix plan written as
+  a test list. Rather than stop the run for a rubric the author could not supply
+  mid-flight, I derived seven Given/When/Then ACs from the issue and the test
+  list and recorded `rubricProvenance: derived-…` in the run file; the grader
+  then judged against them and returned ALL MET. Flagged as derived, not
+  supplied. (2) Reported the `creator` finding to #418 **before** the PR rather
+  than in Phase 11, because all three critics independently observed that
+  "defer to #418" deferred it *nowhere* — #418's body never mentioned
+  `CreditType`.
+- **One improvement:** `/deliver`'s Phase 0 entry gate assumes a plan either has
+  ACs or doesn't. A bug fix whose issue already states observable
+  before/after behaviour is a third case: the ACs are *derivable* rather than
+  absent, and stopping to ask for them is pure ceremony. The gate should sanction
+  deriving them with recorded provenance — which is what `rubricProvenance` did
+  here ad hoc — instead of forcing a choice between a hard stop and
+  `rubric: none`.
+
 ## 2026-08-07 — ♻️ Rename `Network.homepage` to `homepageURL` (#412) · lite
 
 - **Phases / skills:** 0–8 pre-PR; lite, so no `/review-plan` critics and the
@@ -544,27 +610,6 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
   post-merge `/build` is the real verification; if it surprises, that's a
   `gotchas.md` entry.
 
-## 2026-07-05 — 🔧 Knowledge consult at entry + independent rubric grader (#384) · lite
-
-- **Phases / skills:** phases 0–10; markdown-only, so `review-plan` skipped
-  (lite + `ExitPlanMode` approval), `review-changes` and `security-review`
-  self-skipped; capture was inline (the `skill-improvement-log.md` entry *is*
-  part of the delivery, per the 2026-07-05 inline-capture decision).
-- **Worked:** the plan arrived with the user story + ACs already in
-  Given/When/Then form, so the Phase 0 entry gate extracted the rubric with
-  zero friction; the diff-by-eye rule-loss check was proportionate for a
-  two-section edit (the full inventory method stayed shelved, correctly).
-- **Friction:** none material — smallest delivery to date (2 files at
-  implement, +49/−8).
-- **Deviations:** the change originated from an external article review
-  rather than a repo-native trigger; the knowledge-consult it adds was done
-  implicitly this run (the design phase had already read the relevant
-  gotchas/wiki material) — the new `consulted:` ledger line is what makes it
-  explicit from the next run on.
-- **One improvement:** extend the consult step to `/implement-plan`
-  standalone invocations (deliberately out of scope this run; noted in the
-  plan).
-
 ## Archive (distilled)
 
 Older entries condensed per the rolling window (`knowledge/README.md` →
@@ -572,6 +617,7 @@ Older entries condensed per the rolling window (`knowledge/README.md` →
 
 | Date | PR | Weight | Outcome |
 | --- | --- | --- | --- |
+| 2026-07-05 | #384 | lite | Added the Phase 0 knowledge-consult step and the independent Phase 6 rubric grader — the two gates that make captured knowledge compound and stop the maker grading its own homework. Smallest delivery to date (+49/−8), and the plan arrived with ACs already in Given/When/Then form, so the entry gate extracted the rubric with zero friction. Its own knowledge-consult was done implicitly (the design phase had already read the relevant material); the `consulted:` ledger line is what made it explicit from the next run on. Its "one improvement" — extend the consult step to standalone `/implement-plan` invocations — still stands. |
 | 2026-07-05 | #383 | lite | Restructured `deliver/SKILL.md` for progressive disclosure — a lean core plus `references/` loaded on demand — after the skill had grown past what fits in working context. Paired with an adversarial mapping review that diffed old against new hunting specifically for dropped or weakened rules, which is the practice that made the compression safe and is now the wiki entry *restructure-a-normative-doc-with-a-rule-inventory-and-an-adversarial-mapping-review*. |
 | 2026-07-05 | #382 | lite | Moved the `/deliver` retro to pre-PR so it rides the delivery's own PR instead of re-opening the ready gate. Both open design decisions were settled with the user via `AskUserQuestion` *before* any edit, and the change was dogfooded immediately — its own entry was written under the sequencing it introduced. Surfaced the `EnterWorktree` gotcha: the tool ignores the requested name for the **branch** (`git branch -m` after entering), now a `gotchas.md` entry and a standing Phase 1 step. |
 | 2026-07-02 | #374 | lite | Reconciled docs/config honesty gaps from two external reviews. The lasting lesson is **verify a review's claims before acting on them**: an 18-agent read-only pass opened and counted every assertion in-repo and caught real overstatements (eight tools not seven, 84 request files not ~95, `.unsupportedLanguage` reachable rather than dead), so only the verified, softened subset shipped — the origin of the wiki heuristic *treat review findings as hypotheses*. Also diagnosed the xcsift false-failure: a benign DocC "unhandled file" warning lands in toon's `errors[]` and flips `status:` to failed on an exit-0 build, so the four build/test skills now say trust the exit status, not the summary. |

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -297,6 +297,29 @@ entered via `EnterWorktree(path:)` must be removed with `git worktree remove`
 by hand, or the call silently no-ops while you report a reclaim
 ([ADR-0015](decisions/0015-durable-deliver-run-state.md)).
 
+### In a worktree session, Bash refuses commands it can't prove stay inside it
+
+*2026-08-12 (#417).* A worktree-isolated session guards `Bash`, rejecting
+anything it cannot statically verify targets the worktree:
+*"this command is too complex to verify that it stays inside the worktree; break
+it into plain, separate commands."* It fires on shape, not on actual destination,
+so it also blocks commands that were never leaving. Seen refusing:
+
+- `jq … > "$tmp" && mv "$tmp" "$file"` and `curl -o <path>` where the path was
+  built from a variable — including writes to `.git/deliver/` (the durable
+  `/deliver` run file), which lives in the **common** git dir and is therefore
+  outside the worktree path by design.
+- Multi-stage pipelines with `$(…)` substitution, `for`/`while` loops over
+  `curl`, and `cd "$SOMEWHERE"` followed by a redirect.
+
+Workarounds, in order of preference: keep each command **single-purpose with
+fully literal paths** (`sed -i '' 's/…/…/' /abs/literal/path` succeeded where the
+`jq`+`mv` equivalent was refused); write scratch output **inside** the worktree
+under `.build/` (gitignored); or delegate the work to a subagent, which is not
+subject to the caller's guard. `Edit`/`Write` on a path outside the worktree are
+refused too, with a pointer to the worktree copy — which is wrong for
+`.git/`-relative state, so reach for `sed` there.
+
 ### The `Workflow` tool resolves a repo-relative `scriptPath`
 
 *2026-07-29.* The three embedded-script skills describe `scriptPath` only as
@@ -526,6 +549,51 @@ the 2026-07-28 audit.*
 
 ## Testing
 
+### An empty-string-guard fixture must come from a real record — `null` passes either way
+
+*2026-08-12 (#417).* `decodeNonEmptyDateIfPresent` and plain
+`decodeIfPresent(Date.self)` behave **identically** on JSON `null` and on an
+absent key. Only `""` tells them apart. So a hand-written "blank date" fixture
+that uses `null` instead of `""` passes with *and* without the guard — the
+regression test is void while looking green, and the same applies to
+`decodeNonEmptyURLIfPresent`.
+
+- **Capture the fixture from a record that genuinely returns `""`**, and record
+  the source ID. Confirm the red step fails as a **thrown** `DecodingError`, not
+  as a failed `== nil` assertion — a nil-mismatch failure means the fixture is
+  wrong, not the code.
+- **A fixture where every key is present cannot catch the sibling mistake.**
+  Replacing synthesized `Decodable` with a hand-written `init(from:)` loses the
+  compiler's guarantee that optionals use `decodeIfPresent`:
+  `try container.decode(String.self, forKey: .character)` assigned to a `String?`
+  compiles fine and then throws on every record that omits the key. Pair each
+  model with a minimal-JSON test asserting **all** its optionals are `nil` — the
+  "without appended data" pairing `CLAUDE.md` mandates is the only thing that
+  catches this.
+- Prefer a real record that is sparse in *two* ways at once. Here the blank-date
+  fixtures are crew credits, which omit `character` entirely, so one fixture
+  covers the empty-date branch and an absent-optional branch.
+
+### A `#expect(throws: DecodingError.self)` test is a false green twice over
+
+*2026-08-12 (#417).* Two independent traps when pinning "this input must throw":
+
+1. **Copying `ImageSizeTests` uses a bare `JSONDecoder()`.**
+   `ImageSizeTests.swift:49-55` decodes a single-value enum, so it needs no key
+   strategy. Reuse that shape for a *keyed* model and there is no
+   `.convertFromSnakeCase`, so an inline `{"media_type": …}` literal throws
+   `keyNotFound(mediaType)` — never reaching the branch under test. Both are
+   `DecodingError`, so the test passes for the wrong reason. Decode via
+   `JSONDecoder.theMovieDatabase` and assert the **specific** case
+   (`guard case .dataCorrupted(let context)`, then check
+   `context.debugDescription`).
+2. **`decode(_:fromResource:)` records the failure before rethrowing.**
+   `Tests/TMDbTests/TestUtils/JSONDecoder+DecodeFromFile.swift:24` calls
+   `Issue.record(error)` and *then* throws, so a fixture-based
+   `#expect(throws:)` fails the test even when the throw is exactly what was
+   wanted. Throws-tests must build their JSON inline via
+   `Data(#"…"#.utf8)` and call `decode(_:from:)`.
+
 ### Guard consistently within a type, even for a value the API never sends
 
 *2026-07-28 (#404).* Making `Company.logoPath` optional, the question was whether
@@ -552,6 +620,20 @@ grader caught it; three plan critics had split 2–1 on it beforehand.
   `init(from:)` to use the helper — roughly 15 lines. That was the real cost
   being weighed, and it was worth paying.
 
+**Scope of the rule: same value class, not same file.** *2026-08-12 (#417),
+where one of three plan critics read this entry as requiring
+`decodeNonEmptyURLIfPresent` on `CreditMovie.posterPath` because the neighbouring
+`releaseDate` had just been guarded.* That over-applies it. The #404 asymmetry was
+two properties of **one value class** — `Company.logoPath` and
+`Company.Parent.logoPath`, both logo paths, same wire shape, no explicable reason
+to differ. A date behaving differently from a URL is not that: they are different
+types with **measured** different API behaviour (see `tmdb-api-notes.md` →
+*`/credit/{id}`*: dates are `""`, image paths only ever `null`), and every sibling
+model leaves image paths unguarded. The test is *"could a reader explain the
+difference in one sentence?"* — not *"are these two lines identical?"*. Guarding
+here would have made `CreditMovie` the lone divergence across ~20 models and set
+the precedent in all of them.
+
 ### Sweeping for a decode bug: sweep the *failure class*, not the property name
 
 *2026-07-28 (#404).* Fixing `Company.logoPath`'s required decode, a
@@ -575,6 +657,13 @@ shipped with its own integration test still failing.
   companies took a minute and produced the whole field/nullability matrix (see
   `tmdb-api-notes.md`) — which is what proved `origin_country` was in scope and
   `description`/`headquarters` were not.
+- **The sweep earns its keep by *excluding*, not only by finding.** *2026-08-12
+  (#417).* Sweeping the whole `/credit/{id}` response tree did both: it turned up
+  an unrelated live decode failure the issue never mentioned (`credit_type:
+  "creator"`), **and** it cleared five URL decodes the plan had excluded on a
+  single spot-check. The second half is what makes a narrow scope defensible in
+  review instead of merely asserted — a measured "we checked, it isn't in the
+  class" survives a reviewer; "the API probably never sends that" does not.
 
 ### An `async let` binding cannot be captured by `#expect(throws:)`
 

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,70 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-08-12 — Phase 0 entry gate: sanction *deriving* ACs, with provenance (#432) · deferred
+
+- **Pattern:** the entry gate treats acceptance criteria as binary — present, or
+  stop and ask. A bug fix whose issue already states observable before/after
+  behaviour is a **third case**: the ACs are *derivable*, and stopping to ask for
+  them is ceremony. Second occurrence. #365 (2026-06-24) hit it first — "the plan
+  had no formal ACs (circular dependency, noted)", and its own "one improvement",
+  *put an inline `Given X, when Y, then Z` example in the gate prompt*, was
+  recorded as **still standing** and never applied. #432 hit it again: the plan
+  was a `canon-tdd` test list, so it had a crisp definition of done in the wrong
+  shape. The run derived seven ACs from issue #417 plus the test list, recorded
+  `rubricProvenance: derived-…` in the run file, and the Phase 6 grader returned
+  ALL MET against them — so the workaround demonstrably works; it is just
+  unsanctioned.
+- **Decision:** **deferred — raised in an unattended background run, needs
+  review; nothing applied.** Proposal: add a third entry-gate branch — ACs
+  absent **but derivable from a linked issue or an explicit test list** may be
+  derived by the conductor, provided the run file records a
+  `rubricProvenance` field naming the source, and the PR body states the rubric
+  was derived rather than supplied. The hard stop stays for a plan with neither
+  ACs nor a derivable definition of done. Would touch
+  `.claude/skills/deliver/SKILL.md` Phase 0 and the run-file schema in
+  `references/worktree-lifecycle.md`.
+- **Rationale:** the gate exists so Phase 6 has something real to grade, and a
+  derived-with-provenance rubric satisfies that while a hard stop in an
+  autonomous run does not. The risk is the conductor grading against ACs it
+  invented to be easy to meet — which is why the provenance field and the
+  independent grader both matter, and why this needs a human's yes rather than a
+  self-approval.
+- **Reconsider when:** the user reviews this entry. If rejected, the fallback is
+  to make `rubric: none` the explicit expectation for bug fixes and let Phase 6
+  no-op — but note that trades a graded delivery for an ungraded one.
+
+### 2026-08-12 — A well-formed tooling-runner report can still assert an unobserved green (#432) · deferred
+
+- **Pattern:** third occurrence in the same family — the runner's report reads
+  green while the thing you actually cared about was never observed. #374
+  (2026-07-02) misread xcsift's `errors[]` as failure; #390/#397 ran in the main
+  checkout and returned **baseline** counts as a pass; #432 saw a report whose
+  aggregate was true (`Status: passed`, 310 tests) but which volunteered
+  "including the newly added `detailsForMovieCredit` test" — a claim the xcsift
+  toon log cannot support, because it carries only aggregate counts and **no test
+  names**. A scoped `--filter` re-run confirmed the test genuinely ran, so no
+  harm here; the point is the report could not be distinguished from one where a
+  new test silently never ran. The existing shape-based contract (2026-07-29)
+  covers *refused / passed / void* but says nothing about narrative claims inside
+  a valid report.
+- **Decision:** **deferred — raised in an unattended background run, needs
+  review; nothing applied.** Proposal: (a) `tooling-runner.md` forbids asserting
+  that any *named* test ran unless the log evidences it, and reports counts plus
+  a `namesObserved: yes|no` marker; (b) the `/test` and `/integration-test`
+  skills state that confirming a specific new test executed requires a scoped
+  `--filter` run, since the default log is aggregate-only.
+- **Rationale:** this is the repo's most-hit defect family (`gotchas.md` → *False
+  green*), and the wiki heuristic *a detector whose green looks the same when it
+  didn't run is not a detector* applies directly: "310 passed" looks identical
+  whether the new test ran or was never compiled in. Deferred rather than applied
+  because it edits a shared agent contract three skills depend on, and because the
+  cheap half — the caller doing a scoped verification run — is already the
+  conductor's habit and needs no skill change to keep doing.
+- **Reconsider when:** the user reviews this entry, or a delivery is found where a
+  new test genuinely did not run and the aggregate report concealed it — which
+  would upgrade this from a near-miss to a real incident.
+
 ### 2026-08-07 — Full CLAUDE.md/skills/agents review: drift fixes + review-integrity seams · applied
 
 - **Pattern:** an external full review (not the wrap-up scan) of `CLAUDE.md`,

--- a/knowledge/tmdb-api-notes.md
+++ b/knowledge/tmdb-api-notes.md
@@ -280,6 +280,20 @@ public method that silently does nothing.
 
 ## Decoding resilience
 
+### `credit_type` is not just `cast`/`crew` — `"creator"` exists
+
+*2026-08-12 (#417), found in a 300-credit sample.* `GET /credit/{id}` can return
+`"credit_type": "creator"` (with `department` and `job` both `"Creator"`) — live
+example `5257855d19c29531db28adea`, Steven Spielberg on *Invasion America*. Rare
+(1 in 300) but a normal category: it is how TMDb models a TV series creator.
+
+`CreditType` has only `cast`/`crew` with synthesized `Decodable`, so
+`credits.details(forCredit:)` throws `TMDbError.decode` for these credits. #417
+deliberately left it that way — adding a case to a public two-case enum breaks
+exhaustive switches, and mapping `creator` → `crew` would be data corruption —
+so the throw is pinned by `CreditTypeTests.decodeUnknownCreditTypeThrows` and the
+policy decision belongs to #418. Invert that test when the enum grows.
+
 ### Unknown enum-like string values should decode resiliently
 
 - Fields like `status` and `media_type` can return values not in our enums; decode
@@ -288,6 +302,37 @@ public method that silently does nothing.
   history.)
 
 ## Field nullability
+
+### `/credit/{id}`: dates are `""`, image paths are `null` — never the other way round
+
+*2026-08-12 (#417), 300-credit sample* biased toward sparse records (upcoming
+movies, in-development TV, and the combined credits of prolific people).
+Measured, not guessed:
+
+| field | `null` | `""` | absent | notes |
+| --- | --- | --- | --- | --- |
+| `media.release_date` | 0 | **6** of 215 movie | 0 | 2.8% of movie credits |
+| `media.first_air_date` | 0 | **1** of 85 tv | 0 | 1.2% of tv credits |
+| `media.poster_path` | 32 | 0 | 0 | never an empty string |
+| `media.backdrop_path` | 85 | 0 | 0 | never an empty string |
+| `person.profile_path` | 13 | 0 | 0 | never an empty string |
+| `media.character` | 0 | 15 | **109** | absent on every crew credit |
+
+The `""`/`null` split is the whole point: **the two date fields needed
+`decodeNonEmptyDateIfPresent` and the three image paths did not.** `null` and an
+absent key both decode to `nil` through plain `decodeIfPresent`, so a
+null-bearing field is already safe; only `""` throws. This measurement is what
+justified guarding the dates and leaving `posterPath`/`backdropPath` alone —
+matching every sibling model, where image paths are unguarded package-wide.
+
+- **`character` is absent, not empty, on crew credits** — so a crew credit is
+  the cheapest fixture for an absent-optional branch. Cast credits carry
+  `character` (sometimes `""`, on unreleased titles).
+- Every required decode held: top-level `department`, `job`, `id`; `media.id`;
+  `person.id`, `person.name`. None was ever `null` or absent in 300 records.
+- Unmodelled keys on `media`, ignored by the decoder: `genre_ids`, `adult`,
+  `video`, `softcore`, `original_language`, `origin_country`, `episodes`,
+  `seasons`.
 
 ### `/company/{id}`: `logo_path` and `origin_country` are frequently `null`
 


### PR DESCRIPTION
## Summary

`credits.details(forCredit:)` throws `TMDbError.decode` today for any credit attached to an unreleased movie or an unaired TV series.

`CreditMovie.releaseDate` and `CreditTVSeries.firstAirDate` decoded through fully **synthesized** `Decodable`, so they reached the strict day-precision parse strategy in `JSONDecoder+TMDb.swift:15-19` — which cannot parse `""`, the value TMDb sends for an absent date. Every sibling model already guards this with `decodeNonEmptyDateIfPresent`; these two were missed.

Live reproducer, verified today: `GET /credit/63704523e894a6008292323c` (Michael Mann on *Heat 2*) returns `"release_date": ""`.

Both models now get `CodingKeys` + `init(from:)` following `MovieListItem.swift:150-207`. `encode(to:)` stays synthesized — the `CodingKeys` carry no raw values and every property name already equals its post-`.convertFromSnakeCase` key, so the wire format is unchanged. `Media`/`Movie` is the same pattern already shipping on `main`.

Closes #417

## Why the movie branch had no coverage

`CreditMedia`'s movie branch was decoded by **no fixture at all** — `CreditTests` had one TV-only test, and the service-level tests hand `MockAPIClient` a pre-built `Credit`, so they never decode JSON. That is why a 2.8%-of-records failure shipped unnoticed.

## The sweep, and what it changed

Rather than fix only the two properties the issue named, I swept every decode in the `/credit/{id}` response tree against a **300-record live sample** biased toward sparse records (`knowledge/tmdb-api-notes.md` now records the matrix). It cut both ways:

| field | `null` | `""` | in scope? |
| --- | --- | --- | --- |
| `media.release_date` | 0 | **6** of 215 movie | **yes** — 2.8% |
| `media.first_air_date` | 0 | **1** of 85 tv | **yes** — 1.2% |
| `media.poster_path` | 32 | 0 | no |
| `media.backdrop_path` | 85 | 0 | no |
| `person.profile_path` | 13 | 0 | no |

**Image paths are deliberately left unguarded.** They are `null`-bearing but never empty, and `null` already decodes to `nil` through plain `decodeIfPresent`. `decodeNonEmptyURLIfPresent` is used at only six sites package-wide (all `homepageURL`, plus the two `Company.logoPath` from #404); image paths are guarded in none of ~20 sibling models, so guarding here would make `CreditMovie` the lone divergence. One of three plan critics read gotcha *Guard consistently within a type* as requiring it — that rule is about one **value class** diverging within a type, not a date differing from a URL. The gotcha now states that scope explicitly.

Every required decode held across all 300 records, so none needed changing.

## Known residual — `credit_type: "creator"`

The same sweep found a **second, unrelated live failure**: `credit_type` is not limited to `cast`/`crew`. `GET /credit/5257855d19c29531db28adea` (Spielberg on *Invasion America*) returns `"creator"`, which the two-case `CreditType` enum rejects — so `details(forCredit:)` still throws for creator credits after this PR.

It is **not fixed here** because no non-breaking fix exists: adding a case to a public two-case enum breaks exhaustive switches, and mapping `creator` → `crew` would be data corruption. That is a policy call, so it belongs to #418, where it is now [recorded with full context](https://github.com/adamayoung/TMDb/issues/418#issuecomment-5264773454) — it was absent from that issue's inventory. This PR pins the current throw with `CreditTypeTests.decodeUnknownCreditTypeThrows` so making it tolerant is deliberate rather than accidental.

**So: this PR fixes the empty-date class only. It does not make `details(forCredit:)` failure-free.**

## Tests

Three new fixtures, all verbatim live captures. The two blank-date ones are **crew** credits, which is what makes them pull double duty — TMDb omits `character` entirely on crew credits, so each covers an empty date *and* an absent optional. That matters because a hand-written `init(from:)` loses the compiler's guarantee that optionals use `decodeIfPresent`: `try container.decode(String.self, forKey: .character)` assigned to a `String?` compiles and then throws on the 36% of live credits with no `character` key. A fixture carrying every key cannot catch it.

- `CreditMovieTests` / `CreditTVSeriesTests` (new files, keeping `CreditTests` under `type_body_length`): whole-value `#expect(result == expected)` covering **all 11** stored properties per model, the empty-date case, and a minimal-JSON case asserting all 10 optionals are `nil`.
- `CreditTests`: unknown-`media_type` now asserts the **specific** `.dataCorrupted` message rather than any `DecodingError`, plus round-trip encode tests for both `CreditMedia` cases.
- `CreditIntegrationTests`: a movie-branch test on the stable Fight Club credit. Deliberately *not* an unreleased title — `make ci` runs `integration-test` on every PR plus a weekly cron with headless self-heal, so a volatile credit ID that 404s becomes a repo-wide red gate. A live test also cannot guard the empty-date path, because TMDb fills the date in; the frozen fixture owns that regression.

Both reproducers were confirmed to fail as a **thrown** `DecodingError.dataCorrupted` before the fix, not as a nil mismatch.

## Verification

`make ci` green on this tip: 0 lint violations, **3105** unit tests, **310** integration tests, release build and docs clean.

One caveat worth flagging: `V4ListIntegrationTests/removingAbsentItemReportsFailure` failed intermittently on two earlier `make ci` runs with a 404, and passed on re-run and in the final green gate. It is unrelated to this diff (it creates its own v4 list and touches no `Credit` model) and consistent with the documented v4 list-creation spam filter, which my repeated suite runs were aggravating. Flagging rather than hiding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXqnyxKF2CcNPNtyJgfnq2