### PR TITLE
🐛 Decode a creator credit type instead of throwing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** `CreditType` gains `.creator` and `.unknown` cases, and an
+  unrecognised `credit_type` now decodes to `.unknown` instead of throwing.
+  TMDb returns `"creator"` for a TV series creator — so
+  `credits.details(forCredit:)` failed outright with `TMDbError.decode` for
+  every such credit, including Steven Spielberg's on *Invasion America*. This
+  only affects you if you switch exhaustively over `CreditType` — add
+  `.creator` and `.unknown` branches, or a `default`. `CreditType` now matches
+  the tolerance every other decoded enum in the library already has
+  (`Status`, `VideoType`, `ReleaseType`, `VideoSize`, `Gender`,
+  `TMDbStatusCode`).
+
 - **Breaking:** `HTTPRequest.Method` gains a `.put` case. v4 list update is a
   PUT and there is no other way to express it. This only affects you if you
   supply your own `HTTPClient` **and** switch exhaustively over the method — add

--- a/Sources/TMDb/Domain/Models/CreditType.swift
+++ b/Sources/TMDb/Domain/Models/CreditType.swift
@@ -22,4 +22,37 @@ public enum CreditType: String, Codable, Equatable, Hashable, Sendable {
     ///
     case crew
 
+    ///
+    /// Creator credit type.
+    ///
+    /// TMDb uses this for the creator of a TV series, alongside a `department`
+    /// and `job` of `Creator`.
+    ///
+    case creator
+
+    ///
+    /// Unknown.
+    ///
+    /// Used when TMDb returns a credit type this library does not yet model,
+    /// so decoding a ``Credit`` does not fail on an unrecognised value.
+    ///
+    case unknown
+
+    ///
+    /// Creates a new instance by decoding from the given decoder.
+    ///
+    /// An unrecognised raw value decodes to ``unknown`` rather than throwing.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    ///
+    /// - Throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to
+    /// the requested type.
+    /// - Throws: `DecodingError.valueNotFound` if self has a null entry.
+    ///
+    public init(from decoder: Decoder) throws {
+        self =
+            try CreditType(rawValue: decoder.singleValueContainer().decode(RawValue.self))
+            ?? .unknown
+    }
+
 }

--- a/Tests/TMDbIntegrationTests/CreditIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/CreditIntegrationTests.swift
@@ -64,4 +64,26 @@ struct CreditIntegrationTests {
         #expect(movie.title == "Fight Club")
     }
 
+    /// A TV series creator credit: `credit_type` is neither `cast` nor `crew`,
+    /// which used to fail the whole call. A 1998 series, so the credit is stable.
+    @Test("details for a creator credit")
+    func detailsForCreatorCredit() async throws {
+        let creditID = "5257855d19c29531db28adea"
+
+        let credit = try await creditService.details(
+            forCredit: creditID
+        )
+
+        #expect(credit.id == creditID)
+        #expect(credit.creditType == .creator)
+        #expect(credit.person.name == "Steven Spielberg")
+
+        guard case .tvSeries(let tvSeries) = credit.media else {
+            Issue.record("Expected TV series media type")
+            return
+        }
+
+        #expect(tvSeries.id == 6227)
+    }
+
 }

--- a/Tests/TMDbTests/Domain/Models/CreditTests.swift
+++ b/Tests/TMDbTests/Domain/Models/CreditTests.swift
@@ -35,6 +35,31 @@ struct CreditTests {
         }
     }
 
+    /// The bug this guards is not the enum in isolation but the whole call:
+    /// before `CreditType` tolerated `"creator"`, `details(forCredit:)` threw
+    /// `TMDbError.decode` for every TV creator credit.
+    @Test("JSON decoding of Credit with a creator credit type", .tags(.decoding))
+    func decodeCreditWithCreatorCreditType() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            Credit.self,
+            fromResource: "credit-creator"
+        )
+
+        #expect(result.id == "5257855d19c29531db28adea")
+        #expect(result.creditType == .creator)
+        #expect(result.department == "Creator")
+        #expect(result.job == "Creator")
+        #expect(result.person.name == "Steven Spielberg")
+
+        guard case .tvSeries(let tvSeries) = result.media else {
+            Issue.record("Expected TV series media type")
+            return
+        }
+
+        #expect(tvSeries.id == 6227)
+        #expect(tvSeries.name == "Invasion America")
+    }
+
     @Test(
         "JSON decoding of Credit with an unknown media type throws a data corrupted error",
         .tags(.decoding)

--- a/Tests/TMDbTests/Domain/Models/CreditTypeTests.swift
+++ b/Tests/TMDbTests/Domain/Models/CreditTypeTests.swift
@@ -34,20 +34,31 @@ struct CreditTypeTests {
         #expect(result == .crew)
     }
 
-    /// TMDb also returns `credit_type` values outside this enum — a live
-    /// example is credit 5257855d19c29531db28adea, which reports "creator".
-    /// Decoding one throws today, failing the whole `details(forCredit:)` call.
-    /// This test locks that behaviour so making it tolerant is a deliberate,
-    /// source-breaking change rather than an accident; tracked in issue #418.
-    @Test("JSON decoding of an unknown CreditType throws", .tags(.decoding))
-    func decodeUnknownCreditTypeThrows() {
+    /// A TV series creator credit — live example: credit
+    /// 5257855d19c29531db28adea, Steven Spielberg on *Invasion America*.
+    @Test("JSON decoding of creator CreditType", .tags(.decoding))
+    func decodeCreator() throws {
         let data = Data(#""creator""#.utf8)
 
-        #expect(throws: DecodingError.self) {
-            _ = try JSONDecoder().decode(
-                CreditType.self, from: data
-            )
-        }
+        let result = try JSONDecoder().decode(
+            CreditType.self, from: data
+        )
+
+        #expect(result == .creator)
+    }
+
+    @Test(
+        "JSON decoding of an unrecognised CreditType returns unknown",
+        .tags(.decoding)
+    )
+    func decodeWhenUnrecognisedValueReturnsUnknown() throws {
+        let data = Data(#""some-new-credit-type""#.utf8)
+
+        let result = try JSONDecoder().decode(
+            CreditType.self, from: data
+        )
+
+        #expect(result == .unknown)
     }
 
     @Test("JSON encoding of cast CreditType", .tags(.encoding))
@@ -64,6 +75,25 @@ struct CreditTypeTests {
         let result = String(data: data, encoding: .utf8)
 
         #expect(result == #""crew""#)
+    }
+
+    @Test("JSON encoding of creator CreditType", .tags(.encoding))
+    func encodeCreator() throws {
+        let data = try JSONEncoder().encode(CreditType.creator)
+        let result = String(data: data, encoding: .utf8)
+
+        #expect(result == #""creator""#)
+    }
+
+    /// `unknown` carries no TMDb vocabulary, so it round-trips as the literal
+    /// `"unknown"` rather than the value that produced it. Asserted so the wire
+    /// form is a deliberate choice rather than an accident of case ordering.
+    @Test("JSON encoding of unknown CreditType", .tags(.encoding))
+    func encodeUnknown() throws {
+        let data = try JSONEncoder().encode(CreditType.unknown)
+        let result = String(data: data, encoding: .utf8)
+
+        #expect(result == #""unknown""#)
     }
 
 }

--- a/Tests/TMDbTests/Resources/json/credit-creator.json
+++ b/Tests/TMDbTests/Resources/json/credit-creator.json
@@ -1,0 +1,43 @@
+{
+    "credit_type": "creator",
+    "department": "Creator",
+    "job": "Creator",
+    "media": {
+        "adult": false,
+        "backdrop_path": null,
+        "id": 6227,
+        "name": "Invasion America",
+        "original_name": "Invasion America",
+        "overview": "Invasion America is an animated science fiction miniseries that aired in the prime time lineup on The WB Television Network.",
+        "poster_path": "/jzWTpVGzJ9X6vW4Hj2iUdmp79Xh.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+            10765,
+            16
+        ],
+        "popularity": 3.3331,
+        "first_air_date": "1998-06-08",
+        "softcore": false,
+        "vote_average": 7,
+        "vote_count": 9,
+        "origin_country": [
+            "US"
+        ],
+        "episodes": [],
+        "seasons": []
+    },
+    "media_type": "tv",
+    "id": "5257855d19c29531db28adea",
+    "person": {
+        "adult": false,
+        "id": 488,
+        "name": "Steven Spielberg",
+        "original_name": "Steven Spielberg",
+        "media_type": "person",
+        "popularity": 7.7254,
+        "gender": 2,
+        "known_for_department": "Directing",
+        "profile_path": "/tZxcg19YQ3e8fJ0pOs7hjlnmmr6.jpg"
+    }
+}

--- a/knowledge/tmdb-api-notes.md
+++ b/knowledge/tmdb-api-notes.md
@@ -282,17 +282,21 @@ public method that silently does nothing.
 
 ### `credit_type` is not just `cast`/`crew` — `"creator"` exists
 
-*2026-08-12 (#417), found in a 300-credit sample.* `GET /credit/{id}` can return
+*2026-08-12, found in a 300-credit sample.* `GET /credit/{id}` can return
 `"credit_type": "creator"` (with `department` and `job` both `"Creator"`) — live
 example `5257855d19c29531db28adea`, Steven Spielberg on *Invasion America*. Rare
 (1 in 300) but a normal category: it is how TMDb models a TV series creator.
 
-`CreditType` has only `cast`/`crew` with synthesized `Decodable`, so
-`credits.details(forCredit:)` throws `TMDbError.decode` for these credits. #417
-deliberately left it that way — adding a case to a public two-case enum breaks
-exhaustive switches, and mapping `creator` → `crew` would be data corruption —
-so the throw is pinned by `CreditTypeTests.decodeUnknownCreditTypeThrows` and the
-policy decision belongs to #418. Invert that test when the enum grows.
+`CreditType` models it as `.creator`, and any other unrecognised value decodes
+to `.unknown` rather than throwing — the same tolerance `Status`, `VideoType`,
+`ReleaseType`, `VideoSize`, `Gender` and `TMDbStatusCode` have. Before 20.0.0 it
+was a two-case `cast`/`crew` enum with synthesized `Decodable`, so
+`credits.details(forCredit:)` failed outright for every creator credit.
+
+The lesson generalises past this field: a two-case enum over server vocabulary is
+a latent whole-response failure, and "the API only documents two values" is not
+evidence that it only sends two. `credit_type` was not in the reviewed inventory
+of brittle enums precisely because nobody had sampled it.
 
 ### Unknown enum-like string values should decode resiliently
 


### PR DESCRIPTION
## Summary

`credits.details(forCredit:)` throws `TMDbError.decode` for every TV series **creator** credit. TMDb reports those as `"credit_type": "creator"` (with `department` and `job` both `"Creator"`), and `CreditType` was a two-case `cast`/`crew` `String` enum with synthesized `Decodable` — so an unmodelled value failed the entire response.

Live reproducer, verified today: `GET /credit/5257855d19c29531db28adea` — Steven Spielberg on *Invasion America*.

This is the residual [#432](https://github.com/adamayoung/TMDb/pull/432) deliberately left behind. That PR fixed the empty-string-date half of the same failure family and pinned this throw with a behaviour test, because fixing it is source-breaking and needed a decision. Taking it now because the **20.0.0 window is open and untagged** — `git tag` tops out at `19.0.0` and the `## [20.0.0]` CHANGELOG section already carries Breaking entries, so this is the cheapest window the change will ever get.

Refs #418

## The fix

Adds `.creator` — the value TMDb actually documents — **and** `.unknown` with the `init(from:)` fallback, following `Status.swift:47-77`.

Both, not one or the other, because that is the house pattern: `Status` enumerates all six known values *plus* `unknown`, and `VideoType`, `ReleaseType`, `VideoSize`, `Gender` and `TMDbStatusCode` all do the same. `CreditType` was the odd one out. Modelling the known value keeps the information a consumer wants (a creator is not a crew member), and the fallback means the *next* new value degrades instead of failing the call.

The fallback is deliberately narrow — only an **unrecognised string** becomes `.unknown`. A `null` still throws `valueNotFound` and a non-string still throws `typeMismatch`, exactly as before.

## Breaking

- **`CreditType` gains two cases.** This breaks consumer code that switches exhaustively over it — add `.creator` and `.unknown` branches, or a `default`. Nothing inside the package switches over `CreditType` (only `Credit.swift:24` stores it and `TMDbTesting` constructs `.cast`), so the break is purely outward-facing.
- Recorded as a `**Breaking:**` bullet under `### Changed` in the open `## [20.0.0]`.

`.unknown` has no explicit raw value, so it round-trips as the literal `"unknown"` — a value TMDb never sends. That matches `Status.unknown` and is asserted by a test, so the wire form is a deliberate choice rather than an accident of case ordering.

## Tests

- `CreditTypeTests`: `"creator"` → `.creator`; an unrecognised string → `.unknown`; encode round-trips for both, including the `"unknown"` wire form. The behaviour-locking `decodeUnknownCreditTypeThrows` test from #432 is **removed** and replaced — it existed precisely to make this change deliberate.
- `CreditTests.decodeCreditWithCreatorCreditType`: the end-to-end case, decoding a whole `Credit` from a new fixture. This is the test that matters, because the bug was never the enum in isolation — it was the entire `details(forCredit:)` call failing.
- `credit-creator.json`: a verbatim live capture of `5257855d19c29531db28adea`, overview truncated at a sentence boundary per the existing `credit.json` convention.
- `CreditIntegrationTests.detailsForCreatorCredit`: live proof against the real credit. A 1998 series, so the credit is stable — unlike an unreleased title's.

## Also

Rewrites the `knowledge/tmdb-api-notes.md` entry that #432 added, which recorded this throw as deferred and pinned. Rewritten rather than annotated, per the knowledge base's retention rule that entries are a cache of current truths, not a changelog.

## Still open in #418

This closes one item. #418 remains open for `ShowType`'s unknown case, tolerant `PersonCombinedCredits` arrays, `PageableListResult`'s unbounded silent drops, and the ADR recording the overall policy — the last of which is better written once the "too lenient" half is decided, since that is a different call from this one.

## Verification

`make ci` green on this tip: 0 lint violations, **3109** unit tests, **311** integration tests, release build and docs clean. The new integration test was confirmed to run by name, not inferred from the aggregate count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXqnyxKF2CcNPNtyJgfnq2