### PR TITLE
🔧 Apply two skill improvements raised by #432

### DIFF
--- a/.claude/agents/tooling-runner.md
+++ b/.claude/agents/tooling-runner.md
@@ -116,6 +116,34 @@ integration-test` checks these first: a missing var is an
 failure: a genuine assertion failure vs a **transient live-API issue**
 (HTTP 429 / timeout / network) — transients are not code bugs.
 
+## Never claim a *named* test ran — the log only carries counts
+
+The test log is an **aggregate**: xcsift's toon summary reports
+`passed_tests` / `failed_tests` and names only the **failures**. It contains no
+list of the tests that passed. So `passed_tests: 3105` reads identically whether
+a specific test ran, or was never compiled in at all.
+
+Therefore: **report the counts, and never volunteer that a particular test ran.**
+Not even when the caller's task mentions it by name, and not even when the total
+went up — a total is not evidence about any individual test. Concretely:
+
+- Never write *"including the new `detailsForMovieCredit` test"*, *"the new
+  suite passed"*, or any per-test claim about a **passing** test, unless the log
+  literally contains that test's name. Naming **failures** is required, and safe
+  — those the log does name.
+- Add a `Names observed: yes|no` line to your report, so the caller knows
+  whether per-test detail was available at all. It is `no` for an ordinary
+  `make test` / `make integration-test` run.
+- A caller who needs to prove a specific test executed must ask for a **scoped**
+  run (the `--filter` recipe above), whose output *does* name each test. If your
+  task asks you to confirm a named test ran and you were told to run the full
+  suite, say plainly that the full-suite log cannot show it and recommend the
+  scoped run — do not infer it from the count.
+
+This is the **False green** family (`knowledge/gotchas.md`): a report that looks
+the same whether or not the thing was observed certifies a gap instead of
+closing it.
+
 ## Refusing safely
 
 A refusal is a **caller bug** — a wrong or missing directory — and it must be
@@ -141,6 +169,8 @@ Never soften a refusal into a failure, and never run the target anyway.
 - **Status** — `passed`/`succeeded`, `failed`, or `refused — <reason>`.
   **Contractual, not formatting**, for the same reason.
 - **Counts** — errors + warnings (builds) or total / passed / failed (tests)
+- **Names observed** — `yes`/`no`: whether the log named individual tests (`no`
+  for a full-suite run, `yes` for a scoped `--filter` run). Tests only
 - Each failure on one line: build errors as `file:line — message`, test
   failures as `SuiteName/testName` with `file:line` and the assertion
   message (omit the list when there are none)

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -157,25 +157,42 @@ implementation = separate `/deliver` sessions.)
   ledger line is what makes this step checkable.
 - **Decompose a multi-deliverable plan** (rules above); single-deliverable
   plans skip this.
-- **Entry gate — acceptance criteria required.** Plans are expected as
+- **Entry gate — a gradeable rubric required.** Plans are expected as
   *"As a \<user-type\> I want \<feature\> so that \<reason\>"* + acceptance
   criteria. Extract the ACs verbatim as
   the **delivery rubric** (consumed in Phase 6) into **the run file** (and the
-  ledger for convenience). Absent →
-  stop and ask for them ("Given X, when Y, then Z") — don't enter the
-  worktree. **Auto:** panel — proceed rubric-less (Phase 6 no-ops) vs stop;
-  record that as `rubric: none`, which is **present-and-empty**, not a missing
-  file.
-  - **Reject a knowledge-shaped AC — it cannot pass.** An AC whose evidence is a
-    `knowledge/` artifact ("an ADR records X", "the `next-major.md` entry is
-    removed", "a gotcha is captured") is **guaranteed** to fail its first
-    grading, because Phase 7 writes that artifact *after* Phase 6 grades. That
-    ordering is deliberate — capture must observe the delivery's final state, not
-    an intermediate one — so the fix is at this gate, not in the sequence.
-    Drop such an AC from the rubric when extracting it; the work still happens
-    and is still enforced, by Phase 7's own contract (its `swept:` line and
-    capture report). Say which ACs you dropped and why, rather than silently
-    reshaping the user's criteria.
+  ledger for convenience), and record
+  `rubricProvenance: supplied`. Three cases, and only the last one stops:
+  - **ACs supplied** → the above.
+  - **ACs absent but derivable** — the plan has a definition of done in the
+    wrong *shape* rather than none at all: a linked issue stating observable
+    before/after behaviour, or an explicit `canon-tdd` test list. **Derive** the
+    ACs into "Given X, when Y, then Z" form, record
+    `rubricProvenance: derived — <the source>`, and say in the PR body that the
+    rubric was derived rather than supplied. Bug fixes land here routinely;
+    stopping to ask a question the plan already answers is ceremony, not rigour.
+  - **Neither** → stop and ask for them ("Given X, when Y, then Z") — don't
+    enter the worktree. **Auto:** panel — proceed rubric-less (Phase 6 no-ops)
+    vs stop; record that as `rubric: none`, which is **present-and-empty**, not
+    a missing file.
+
+  **Reject a knowledge-shaped AC — it cannot pass.** This applies to whichever
+  case produced the rubric: an AC whose evidence is a `knowledge/` artifact ("an
+  ADR records X", "the `next-major.md` entry is removed", "a gotcha is
+  captured") is **guaranteed** to fail its first grading, because Phase 7 writes
+  that artifact *after* Phase 6 grades. That ordering is deliberate — capture
+  must observe the delivery's final state, not an intermediate one — so the fix
+  is at this gate, not in the sequence. Drop such an AC from the rubric when
+  extracting it; the work still happens and is still enforced, by Phase 7's own
+  contract (its `swept:` line and capture report). Say which ACs you dropped and
+  why, rather than silently reshaping the user's criteria. When *deriving*, don't
+  write one in the first place.
+
+  Derive to *grade yourself honestly*, not to pass: write the ACs from the
+  source's own words before implementing, never after, and never soften one
+  because the implementation went another way. The provenance field is what
+  makes a derived rubric auditable, and Phase 6's independent grader — which
+  sees only the ACs and the committed diff — is what stops a self-serving one.
 - **Read the plan's content into context now** — `EnterWorktree` switches CWD
   (clearing the plans cache), and a fresh worktree lacks uncommitted local
   files; the plan must travel in the conversation.
@@ -305,7 +322,9 @@ Take the rubric (Phase 0 ACs) **from the run file** — the ledger copy is a
 convenience, not a source, and the plan text in context is not one either.
 Three distinct cases, and they must not be conflated:
 
-- **File present, rubric populated** → grade it (below).
+- **File present, rubric populated** → grade it (below). Grade a `derived`
+  rubric exactly as strictly as a `supplied` one — the provenance is there to be
+  disclosed, never to lower the bar.
 - **File present, `rubric: none`** → the sanctioned rubric-less path; skip.
 - **File missing, or missing its `reconciled` block** → **hard stop.** A
   missing run file is not a pass, exactly as a dead grader is not a pass; and a

--- a/.claude/skills/deliver/references/auto-and-async.md
+++ b/.claude/skills/deliver/references/auto-and-async.md
@@ -65,8 +65,12 @@ unattended run must still be reviewable.
 
 **Panel decision points** — **six** (marked **Auto:** in `SKILL.md`):
 
-- Phase 0 — missing acceptance criteria: proceed without a rubric (Phase 6
-  becomes a no-op) vs stop.
+- Phase 0 — acceptance criteria neither supplied **nor derivable**: proceed
+  without a rubric (Phase 6 becomes a no-op) vs stop. ACs that are *derivable*
+  from a linked issue or an explicit test list are **not** a panel decision — the
+  entry gate's second case derives them and records `rubricProvenance`, so the
+  delivery keeps its exit gate. Only a plan with no definition of done at all
+  reaches this panel.
 - Phase 2 — a plan-review blocker that is *not* data-loss/breaking: proceed
   vs stop. (Data-loss/breaking = hard stop, never delegated.)
 - Phases 4/5 — Critical/High (or High security) findings persisting after the

--- a/.claude/skills/deliver/references/worktree-lifecycle.md
+++ b/.claude/skills/deliver/references/worktree-lifecycle.md
@@ -121,6 +121,13 @@ loudly instead of silently. **A missing run file at Phase 6 is a hard stop**,
 exactly as a dead grader is not a pass. `rubric: none` (present, empty) is the
 sanctioned rubric-less path and is *not* the same as a missing file.
 
+`rubricProvenance` records where the ACs came from — `supplied` when the plan
+carried them, or `derived — <source>` when Phase 0 derived them from a linked
+issue or an explicit test list (its second entry-gate case). It exists so a
+derived rubric is auditable rather than indistinguishable from a supplied one:
+Phase 6 grades both identically, but a reader can tell which was which, and the
+PR body is required to say so.
+
 ```json
 {
   "id": "harden-delivery-skills-2026-07-29T19:28:23Z",
@@ -132,6 +139,7 @@ sanctioned rubric-less path and is *not* the same as a missing file.
     "branch": "chore/harden-delivery-skills",
     "entry": "created",
     "rubric": ["Given …, when …, then …"],
+    "rubricProvenance": "supplied",
     "stamps": { "reviewedClean": "<content hash>", "securityClean": null,
                 "rubricGraded": null },
     "openFindings": [], "knowledgeCandidates": [], "pr": null,

--- a/.claude/skills/integration-test/SKILL.md
+++ b/.claude/skills/integration-test/SKILL.md
@@ -29,6 +29,25 @@ the issues, re-invoke this skill to re-check. To attribute a failure
 (live-API/backend drift vs a regression in your change), use
 `/diagnose-integration-failure`.
 
+## A count is not evidence that *your* new test ran
+
+The log is an **aggregate** — it names failures only, never the tests that
+passed, so `passed_tests: 310` looks the same whether a test you just added ran
+or never compiled into the bundle. The runner reports `Names observed: no` for a
+full run and is instructed not to claim any passing test by name; treat such a
+claim as unfounded, and a rising total as no evidence about an individual test.
+
+This bites hardest here, because a new integration test is usually the *only*
+live proof that a fix works. When it matters, follow up with a scoped run and
+read the names:
+
+```bash
+swift test --skip-build --scratch-path .build --filter 'SuiteName'
+```
+
+Seconds against an already-built bundle, and it distinguishes "the live suite is
+green" from "my new test reached the API and passed".
+
 ## If the report is missing or malformed
 
 Judge the runner's report by **shape**, not by tone — the three outcomes are

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -31,6 +31,21 @@ tests faster, ask the runner for a scoped run instead:
 > Run the `test` target scoped to `SuiteName/testName`.
 > Package directory: `<your current working directory, absolute>`
 
+## A count is not evidence that *your* new test ran
+
+The full-suite log is an **aggregate** — it names failures only, never the tests
+that passed. So `passed_tests: 3105` looks the same whether a test you just
+wrote ran, or never compiled into the bundle. The runner is instructed not to
+claim otherwise and to report `Names observed: no` for a full run; treat any
+per-test claim about a *passing* test in a full-suite report as unfounded, and a
+rising total as no evidence about any individual test.
+
+When it matters that a **specific** new test executed — a reproducer for the bug
+you are fixing, or a test guarding a branch that had none — ask for the scoped
+run above and read the test names in its output. That output *does* name each
+test. It costs seconds against an already-built bundle, and it is the difference
+between "the suite is green" and "the thing I wrote is doing its job".
+
 ## If the report is missing or malformed
 
 Judge the runner's report by **shape**, not by tone — the three outcomes are

--- a/.claude/workflows/deliver-panel.js
+++ b/.claude/workflows/deliver-panel.js
@@ -12,7 +12,7 @@ export const meta = {
 // least of all this script.
 const POINTS = {
   'phase0-no-acs':
-    'The plan arrived with no acceptance criteria. Proceeding makes Phase 6 (rubric verification) a no-op for the whole delivery — it ships with no exit gate.',
+    'The plan arrived with no acceptance criteria AND none derivable from a linked issue or an explicit test list (derivable ACs are handled by the entry gate, not panelled). Proceeding makes Phase 6 (rubric verification) a no-op for the whole delivery — it ships with no exit gate.',
   'phase2-blocker':
     'A /review-plan blocker that is NOT data loss and NOT a breaking change. (Those two never reach this panel.)',
   'phase4-findings':

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -54,11 +54,12 @@ two fields the dedup step keys on.
   opposite directions, so neither phase can move. The gate is the only place left
   to fix it, and nothing is lost: the work is still enforced, by Phase 7's own
   contract (its `swept:` line and capture report) rather than by a rubric row.
-- **Reconsider when:** n/a (applied). Adjacent but distinct: the deferred #432
-  entry below proposes a *third* entry-gate branch for ACs that are absent but
-  **derivable**. The two compose — one governs where a missing AC may come from,
-  this one governs which extracted ACs are gradeable — and neither supersedes the
-  other.
+- **Reconsider when:** n/a (applied). Adjacent but distinct: the #432 entry below
+  adds a *third* entry-gate branch for ACs that are absent but **derivable**, and
+  was applied in #438. The two compose — one governs where a missing AC may come
+  from, this one governs which extracted ACs are gradeable — and neither
+  supersedes the other. #438 promoted this rule from a sub-bullet of the old flat
+  gate to a peer rule alongside the three cases, since it applies to all of them.
 
 ---
 
@@ -90,7 +91,7 @@ two fields the dedup step keys on.
 
 ---
 
-### 2026-08-12 — Phase 0 entry gate: sanction *deriving* ACs, with provenance (#432) · deferred
+### 2026-08-12 — Phase 0 entry gate: sanction *deriving* ACs, with provenance (#432) · applied
 
 - **Pattern:** the entry gate treats acceptance criteria as binary — present, or
   stop and ask. A bug fix whose issue already states observable before/after
@@ -104,26 +105,27 @@ two fields the dedup step keys on.
   `rubricProvenance: derived-…` in the run file, and the Phase 6 grader returned
   ALL MET against them — so the workaround demonstrably works; it is just
   unsanctioned.
-- **Decision:** **deferred — raised in an unattended background run, needs
-  review; nothing applied.** Proposal: add a third entry-gate branch — ACs
-  absent **but derivable from a linked issue or an explicit test list** may be
-  derived by the conductor, provided the run file records a
-  `rubricProvenance` field naming the source, and the PR body states the rubric
-  was derived rather than supplied. The hard stop stays for a plan with neither
-  ACs nor a derivable definition of done. Would touch
-  `.claude/skills/deliver/SKILL.md` Phase 0 and the run-file schema in
-  `references/worktree-lifecycle.md`.
+- **Decision:** **applied** (#438), after the user reviewed it. The entry gate is
+  now three cases rather than two: ACs **supplied** → extract verbatim; ACs
+  absent **but derivable** from a linked issue or an explicit test list → derive
+  into Given/When/Then, record `rubricProvenance: derived — <source>`, and state
+  in the PR body that the rubric was derived; **neither** → the hard stop, kept
+  intact. `rubricProvenance` added to the run-file schema in
+  `references/worktree-lifecycle.md`, and Phase 6 now says explicitly that a
+  `derived` rubric is graded exactly as strictly as a `supplied` one.
 - **Rationale:** the gate exists so Phase 6 has something real to grade, and a
   derived-with-provenance rubric satisfies that while a hard stop in an
-  autonomous run does not. The risk is the conductor grading against ACs it
-  invented to be easy to meet — which is why the provenance field and the
-  independent grader both matter, and why this needs a human's yes rather than a
-  self-approval.
-- **Reconsider when:** the user reviews this entry. If rejected, the fallback is
-  to make `rubric: none` the explicit expectation for bug fixes and let Phase 6
-  no-op — but note that trades a graded delivery for an ungraded one.
+  autonomous run does not. The risk is the conductor deriving ACs that are easy
+  to meet, so three things carry the weight: the ACs must be written from the
+  source's own words *before* implementing, the provenance field makes a derived
+  rubric auditable rather than invisible, and Phase 6's independent grader sees
+  only the ACs and the committed diff.
+- **Reconsider when:** n/a — but if a delivery is ever found to have derived a
+  rubric that flattered its own implementation, tighten by requiring the derived
+  ACs to be quoted in the PR body for inspection, not merely disclosed as
+  derived.
 
-### 2026-08-12 — A well-formed tooling-runner report can still assert an unobserved green (#432) · deferred
+### 2026-08-12 — A well-formed tooling-runner report can still assert an unobserved green (#432) · applied
 
 - **Pattern:** third occurrence in the same family — the runner's report reads
   green while the thing you actually cared about was never observed. #374
@@ -137,22 +139,25 @@ two fields the dedup step keys on.
   new test silently never ran. The existing shape-based contract (2026-07-29)
   covers *refused / passed / void* but says nothing about narrative claims inside
   a valid report.
-- **Decision:** **deferred — raised in an unattended background run, needs
-  review; nothing applied.** Proposal: (a) `tooling-runner.md` forbids asserting
-  that any *named* test ran unless the log evidences it, and reports counts plus
-  a `namesObserved: yes|no` marker; (b) the `/test` and `/integration-test`
-  skills state that confirming a specific new test executed requires a scoped
-  `--filter` run, since the default log is aggregate-only.
+- **Decision:** **applied** (#438), after the user reviewed it.
+  `.claude/agents/tooling-runner.md` gains a *Never claim a named test ran*
+  section — the runner reports counts and must not volunteer that any **passing**
+  test ran (naming **failures** stays required, since the log does name those),
+  not even when asked by name or when the total rose; asked to confirm a named
+  test, it says the full-suite log cannot show it and recommends the scoped run.
+  A `Names observed: yes|no` line joins its report contract. `/test` and
+  `/integration-test` each gain *A count is not evidence that your new test ran*,
+  pointing at the scoped `--filter` run.
 - **Rationale:** this is the repo's most-hit defect family (`gotchas.md` → *False
   green*), and the wiki heuristic *a detector whose green looks the same when it
   didn't run is not a detector* applies directly: "310 passed" looks identical
-  whether the new test ran or was never compiled in. Deferred rather than applied
-  because it edits a shared agent contract three skills depend on, and because the
-  cheap half — the caller doing a scoped verification run — is already the
-  conductor's habit and needs no skill change to keep doing.
-- **Reconsider when:** the user reviews this entry, or a delivery is found where a
-  new test genuinely did not run and the aggregate report concealed it — which
-  would upgrade this from a near-miss to a real incident.
+  whether the new test ran or was never compiled in. Applied on both sides
+  deliberately — telling the caller to verify is the durable half, but leaving the
+  runner free to volunteer an unfounded claim would keep manufacturing the very
+  assurance the caller is meant to distrust.
+- **Reconsider when:** n/a. If xcsift ever grows a passing-test name list, the
+  `Names observed` marker becomes the place to surface it rather than a reason to
+  drop the rule.
 
 ### 2026-08-07 — Full CLAUDE.md/skills/agents review: drift fixes + review-integrity seams · applied
 


### PR DESCRIPTION
## Summary

Applies the two proposals #432's wrap-up scan raised. Both were logged `deferred` rather than applied, because that delivery ran unattended and neither could be self-approved — they edit the pipeline's own instructions. Now approved, so both are applied and the log entries flipped to `applied`.

## 1. Phase 0's entry gate becomes three cases, not two

It treated acceptance criteria as binary: supplied, or **stop and ask**. But a bug fix whose issue already states observable before/after behaviour is a third case — the definition of done exists, in the wrong *shape*. Stopping to ask a question the plan already answers is ceremony, and in an autonomous run it blocks the whole delivery.

- **ACs supplied** → extract verbatim, record `rubricProvenance: supplied`.
- **ACs absent but derivable** from a linked issue or an explicit `canon-tdd` test list → derive into Given/When/Then, record `rubricProvenance: derived — <source>`, and state in the PR body that the rubric was derived.
- **Neither** → the hard stop, unchanged.

**Second occurrence.** #365 hit it first — "the plan had no formal ACs (circular dependency, noted)" — and its own "one improvement" was recorded as *still standing* and never applied. #432 hit it again and worked around it ad hoc, deriving seven ACs whose independent grader returned ALL MET; this makes the workaround the sanctioned path.

The obvious risk is a conductor deriving ACs that flatter its own implementation, so three things carry that weight and are stated explicitly: the ACs are written from the source's own words **before** implementing, `rubricProvenance` makes a derived rubric auditable instead of invisible, and Phase 6 now says a `derived` rubric is graded **exactly as strictly** as a `supplied` one. Phase 6's grader already sees only the ACs and the committed diff.

Touches `deliver/SKILL.md` (Phase 0 and Phase 6) and the run-file schema in `references/worktree-lifecycle.md`.

### Composed with #439, which landed mid-branch

#439 changed the same entry gate — dropping knowledge-shaped ACs, since Phase 6 grades before Phase 7 writes. Its author flagged the overlap and called it correctly: *"Adjacent but distinct… that governs where a missing AC may come from, this governs which extracted ACs are gradeable. They compose."*

So this rebases onto it and composes rather than competing. One structural change to #439's text: its rule was a **sub-bullet of the old flat gate**, and with three cases now it applies to all of them — a *supplied* AC can be knowledge-shaped just as easily — so it is promoted to a **peer rule** alongside the three cases, wording otherwise intact. Its reciprocal Phase 7 sentence is untouched, and the derivable case now says not to write a knowledge-shaped AC in the first place.

## 2. The tooling-runner may no longer claim a named test ran

Its log is an **aggregate**: xcsift's toon summary reports counts and names only *failures*. So `passed_tests: 3105` reads identically whether a given test ran or was never compiled into the bundle.

In #432 a well-formed report (`Status: passed`, 310 tests) volunteered *"including the newly added `detailsForMovieCredit` test"*. That happened to be true — a scoped `--filter` re-run confirmed it — but the log could not support it, and an identical report would have been produced had the test silently never run.

**Third occurrence in the False-green family**, after #374 (misread `errors[]`) and #390/#397 (ran in the main checkout, returned baseline counts as a pass). Those fixes covered exit-status and wrong-directory fidelity; none covered narrative claims *inside* a valid report, which the 2026-07-29 shape-based contract explicitly does not reach.

- `tooling-runner.md` gains *Never claim a named test ran* — no volunteering any **passing** test by name, not even when asked by name or when the total rose. Naming **failures** stays required, since the log does name those. Asked to confirm a named test after a full-suite run, it must say the log cannot show it and recommend the scoped run.
- `Names observed: yes|no` joins its report contract (`no` for a full run, `yes` for a scoped one).
- `/test` and `/integration-test` each gain *A count is not evidence that your new test ran*, pointing at the scoped `--filter` run. Called out hardest in the integration skill, where a new test is often the only live proof a fix works.

Applied on **both** sides deliberately: telling the caller to verify is the durable half, but leaving the runner free to volunteer an unfounded claim would keep manufacturing the very assurance the caller is being told to distrust.

## Knock-on fixes

- `deliver-panel.js`'s `phase0-no-acs` point and `auto-and-async.md`'s panel list both described the Phase 0 panel as firing on "missing acceptance criteria". Change 1 narrows that to *neither supplied nor derivable* — left stale, an auto run would convene a panel for a decision the entry gate can now make itself. Both updated; the panel-script edit is its description string only, no logic, and #439's count of six panel points still holds.
- #439's log entry cross-referenced "the **deferred** #432 entry below", which this PR makes false. Updated to say it was applied in #438, and to note the sub-bullet → peer-rule promotion.

## Verification

Docs-only **fast gate**, disclosed rather than silent: `make lint` (0 violations across 1343 files), `make lint-markdown` (clean — `.claude/**` is in its scope), and `node --check` on the panel script, re-run after each of the two rebases. I did **not** run the full `make ci` locally: the diff contains no Swift, `Package.swift`, `Makefile` or workflow change, so the unit and live-API suites cannot be affected — and re-running the live suite for a prose change adds API load that already tripped TMDb's v4 list-creation spam filter twice today. `/pr` sanctions this fast gate, widened in #363 to "no semantic Swift change".

CI agrees with that scoping: the workflows do fire on `.claude/**`, and `Detect Changes` then short-circuits the heavy jobs — so `Build and Test` reports a pass in ~5s without running the suite. Worth being precise that this is a **skip-shaped pass**, not a full test run; the lint jobs are the ones doing real work here.

I self-reviewed rather than spawning a `code-reviewer` agent. The one reviewable-code file, `deliver-panel.js`, changed by a single description string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXqnyxKF2CcNPNtyJgfnq2