### PR TITLE
🔧 Drop knowledge-shaped ACs at the /deliver entry gate

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -166,6 +166,16 @@ implementation = separate `/deliver` sessions.)
   worktree. **Auto:** panel — proceed rubric-less (Phase 6 no-ops) vs stop;
   record that as `rubric: none`, which is **present-and-empty**, not a missing
   file.
+  - **Reject a knowledge-shaped AC — it cannot pass.** An AC whose evidence is a
+    `knowledge/` artifact ("an ADR records X", "the `next-major.md` entry is
+    removed", "a gotcha is captured") is **guaranteed** to fail its first
+    grading, because Phase 7 writes that artifact *after* Phase 6 grades. That
+    ordering is deliberate — capture must observe the delivery's final state, not
+    an intermediate one — so the fix is at this gate, not in the sequence.
+    Drop such an AC from the rubric when extracting it; the work still happens
+    and is still enforced, by Phase 7's own contract (its `swept:` line and
+    capture report). Say which ACs you dropped and why, rather than silently
+    reshaping the user's criteria.
 - **Read the plan's content into context now** — `EnterWorktree` switches CWD
   (clearing the plans cache), and a fresh worktree lacks uncommitted local
   files; the plan must travel in the conversation.
@@ -338,6 +348,10 @@ deduped against `knowledge/`, written to the right file (gotchas / API notes
 a valid outcome. Exception: one or two small entries already authored during
 implementation may be committed inline instead — note the inline capture in
 the retro.
+
+That ordering is why Phase 0 **drops a knowledge-shaped AC** from the rubric:
+grading it would always precede the work. This phase's own contract — the
+`swept:` line and the capture report below — is what enforces it instead.
 
 Its report must include the `swept:` line — Phase 7 is the knowledge base's
 retirement trigger (the skill's step 5); a report without it means the sweep

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -30,6 +30,38 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-08-12 — Phase 0 entry gate: drop knowledge-shaped ACs from the rubric (#433) · applied
+
+- **Pattern:** a rubric item whose evidence is a `knowledge/` artifact is
+  **guaranteed** to fail its first grading, because Phase 6 grades before Phase 7
+  writes. In #433 the delivery-agreed AC6 ("ADR-0018 records the decision,
+  ADR-0013's superseded consequence is amended, the `next-major.md` entry is
+  removed") came back `NOT MET` from the independent grader with `git diff … --
+  knowledge/` **empty** — correctly, and for no reason but the ordering. The
+  other seven ACs passed. Second entry touching the capture-vs-grading seam,
+  after the 2026-07-28 swap below.
+- **Decision:** **applied.** `.claude/skills/deliver/SKILL.md` Phase 0's entry
+  gate gains a sub-bullet: extract the ACs as now, but **drop** any whose
+  evidence is a `knowledge/` artifact, and say which were dropped and why rather
+  than silently reshaping the user's criteria. Phase 7 gains a reciprocal
+  sentence so the rule is visible from either end. No new **Auto:** marker — the
+  drop is deterministic, not a panel decision, so the reference's count of six
+  panel decision points still holds.
+- **Rationale:** the tempting fix — grade knowledge ACs after capture — would
+  revert the 2026-07-28 decision below, which exists because capture must observe
+  the delivery's **final** state; #404 shipped a knowledge entry that the next
+  phase's grader then invalidated. Both constraints are real and they point in
+  opposite directions, so neither phase can move. The gate is the only place left
+  to fix it, and nothing is lost: the work is still enforced, by Phase 7's own
+  contract (its `swept:` line and capture report) rather than by a rubric row.
+- **Reconsider when:** n/a (applied). Adjacent but distinct: the deferred #432
+  entry below proposes a *third* entry-gate branch for ACs that are absent but
+  **derivable**. The two compose — one governs where a missing AC may come from,
+  this one governs which extracted ACs are gradeable — and neither supersedes the
+  other.
+
+---
+
 ### 2026-08-12 — Merge `TMDbError.invalidRating` into `.badRequest` · rejected
 
 - **Pattern:** `knowledge/next-major.md` carried a deferred entry — *"Revisit


### PR DESCRIPTION
## Summary

A `/deliver` rubric item whose evidence is a `knowledge/` artifact **cannot pass its first grading**, because Phase 6 grades before Phase 7 writes.

Surfaced concretely in #433. The agreed AC6 —

> ADR-0018 records the cancellation decision, ADR-0013's superseded consequence is amended, and the `next-major.md` `invalidRating` entry is removed

— came back `NOT MET` from the independent grader, with `git diff origin/main...HEAD -- knowledge/` **empty**. The grader was right, and for no reason but the ordering. The other seven ACs passed. The work was then done in Phase 7 and re-graded green.

## Why not just grade knowledge ACs after capture

That was my first instinct, and it's wrong. Consulting `knowledge/skill-improvement-log.md` first is what caught it: the 2026-07-28 entry (#404) **deliberately swapped** these two phases, because capture must observe the delivery's *final* state — #404 had shipped a `tmdb-api-notes.md` entry whose whole argument was invalidated by the grader that ran next, and it had to be rewritten inside the same delivery.

So both constraints are real and they point in opposite directions:

- capture must run **after** the last gate that can change the decision;
- a knowledge AC must be graded **after** capture.

Neither phase can move. The entry gate is the only place left to fix it.

## Changes

**`.claude/skills/deliver/SKILL.md`:**
- 🔧 Phase 0's entry gate gains a sub-bullet: extract the ACs as before, but **drop** any whose evidence is a `knowledge/` artifact — and say which were dropped and why, rather than silently reshaping the user's criteria.
- 📝 Phase 7 gains a reciprocal sentence, so the rule is visible from either end rather than only where it is enforced.

**`knowledge/skill-improvement-log.md`:**
- 📚 The decision recorded in the file's five-field format, cross-referencing the 2026-07-28 entry it deliberately does *not* revert.

## Notes

- **Nothing is lost by dropping the AC.** The knowledge work is still enforced — by Phase 7's own contract (its mandatory `swept:` line and capture report), which is a stronger check than a rubric row, since it also covers the retirement sweep.
- **No new `Auto:` marker.** The drop is deterministic, not a judgement call, so `references/auto-and-async.md`'s "six panel decision points" still holds — verified against the file.
- **Composes with, does not supersede, the deferred #432 proposal** for a third entry-gate branch covering ACs that are *absent but derivable*. That one governs where a missing AC may come from; this one governs which extracted ACs are gradeable.
- Docs/config only — no Swift and no `.claude/workflows/`, so code review and security review self-skip per their own gating. `make lint` and `make lint-markdown` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7BGkPGuBDQPdm9Xq1Zukr