### PR TITLE
🔧 Fix five P1 findings from the pipeline audit

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -211,8 +211,10 @@ Procedures and traps:
    `live` (lock PID alive — never touch) / `report` / `reclaim` (merged **and**
    Phase 12's two proofs) / `resumable` / `settled`. **Report, never remove,
    anything that doesn't prove reclaimable**, and verify a directory is gone
-   before counting it reclaimed. Record `swept:` in the ledger and the
-   `reconciled` block in the run file. Procedure, buckets and traps:
+   before counting it reclaimed. Record `reconciled:` in the ledger, the
+   `reconciled` block in the run file, and the retro (Phase 8) — **never as
+   `swept:`, which is Phase 7's knowledge sweep and will silently take the
+   slot**. Procedure, buckets and traps:
    [`references/worktree-lifecycle.md`](references/worktree-lifecycle.md).
 2. **Enter** with `EnterWorktree(name: "<prefix>/<slug>")` (`feature/`,
    `fix/`, `chore/`, …) — sanctioned auto-use, don't ask. **Verify the branch

--- a/.claude/skills/deliver/references/wrap-up.md
+++ b/.claude/skills/deliver/references/wrap-up.md
@@ -16,12 +16,19 @@ not a ceremony (a handful of bullets):
   phases `0–9`; skills `review-plan, implement-plan, review-changes,
   security-review, capture-knowledge`). Telemetry for the recurring-pattern
   scan: which skills fire, which phases get skipped, where deliveries stop.
-- **`swept:`** — Phase 1's reconcile result, e.g.
-  `swept: 2 in scope / 1 reclaimed / 0 resumable / 1 reported`. **An entry
-  without this line means the sweep did not run** — the same tripwire as
-  Phase 0's `consulted:` and Phase 7's `swept:` report line, but stronger,
-  because the retro is committed and goes through PR review, so a human sees
-  the omission.
+- **`reconciled:`** — Phase 1's worktree sweep, e.g.
+  `reconciled: 2 in scope / 1 reclaimed / 0 resumable / 1 reported`. Named for
+  the run file's own `reconciled` block.
+- **`swept:`** — Phase 7's knowledge-retirement sweep, verbatim from
+  `/capture-knowledge`'s report line, e.g.
+  `swept: Makefile, ci.yml → 1 entry rewritten`, or `swept: n/a`.
+- **Both are tripwires. An entry missing either line means that sweep did not
+  run** — stronger than Phase 0's `consulted:`, because the retro is committed
+  and goes through PR review, so a human sees the omission. **They are
+  separate keys on purpose:** when both were called `swept:`, the Phase 7 form
+  filled the slot for four consecutive deliveries and Phase 1's tripwire went
+  missing without anyone noticing — a filled slot looks identical to the right
+  one.
 - **What worked** — one or two things the pipeline did well.
 - **Friction** — where it was rough, slow, or stopped unnecessarily.
 - **Deviations** — anywhere you had to depart from the skill to do the right
@@ -94,6 +101,15 @@ The loop that turns one-off retros into reviewed skill improvements:
    already **applied**, or **deferred/rejected** (don't re-propose a settled
    *no*; only resurface it if its recorded "reconsider when…" condition now
    holds).
+
+   **Then raise every unrecorded "one improvement", including singletons.** A
+   *pattern* needs two entries to recur; a retro's **one improvement** needs
+   none — it is already the single highest-value change that run identified.
+   Scan the window's "one improvement" bullets and propose any with **no entry
+   at all** in `skill-improvement-log.md` (not applied, not deferred, not
+   rejected). It does not have to be *applied* — but it must reach a **recorded
+   decision**, which is what the log is for. Without this step an improvement
+   that never recurs is proposed by nobody: six went unrecorded this way.
 3. **Stop and ask.** **Do not edit any skill files.** Present the proposals
    and wait for **explicit approval on each one**. If no *new* pattern recurs
    across multiple entries, say so and stop — emit no proposals.

--- a/.claude/skills/diagnose-ci-failure/references/_index.md
+++ b/.claude/skills/diagnose-ci-failure/references/_index.md
@@ -11,7 +11,7 @@ matching file.
 | **Lint** | [lint.md](lint.md) | `swiftlint --strict .` or `swiftformat --lint .` failed |
 | **Lint Markdown** | [markdown.md](markdown.md) | `markdownlint` failed on README or a DocC `.md` |
 | **Build and Test** (build step) | [build.md](build.md) | `swift build … -warnings-as-errors` failed (error or warning) |
-| **Build and Test** (test step) | [unit-tests.md](unit-tests.md) | `swift test --filter TMDbTests` failed |
+| **Build and Test** (test step) | [unit-tests.md](unit-tests.md) | `swift test` failed (filter covers all four unit-test targets) |
 | **Build and Test (Linux)** | [linux.md](linux.md) | Fails in the `swift:6.1-jammy` container but passes on macOS |
 
 ## By symptom

--- a/.claude/skills/diagnose-ci-failure/references/linux.md
+++ b/.claude/skills/diagnose-ci-failure/references/linux.md
@@ -4,7 +4,7 @@ The **Build and Test (Linux)** job runs in the `swift:6.1-jammy` container:
 
 ```bash
 swift build --build-tests -Xswiftc -warnings-as-errors
-swift test  --skip-build  --filter TMDbTests
+swift test  --skip-build  --filter "TMDbTests|TMDbTestingTests|TMDbIntelligenceTests|TMDbIntelligenceTestingTests"
 swift build -c release    -Xswiftc -warnings-as-errors
 ```
 

--- a/.claude/skills/diagnose-ci-failure/references/unit-tests.md
+++ b/.claude/skills/diagnose-ci-failure/references/unit-tests.md
@@ -3,7 +3,8 @@
 The **Build and Test** job runs the unit suite:
 
 ```bash
-swift test --filter TMDbTests --enable-code-coverage --xunit-output junit.xml
+swift test --filter "TMDbTests|TMDbTestingTests|TMDbIntelligenceTests|TMDbIntelligenceTestingTests" \
+  --enable-code-coverage --xunit-output junit.xml
 ```
 
 Tests use the **Swift Testing** framework (`@Suite`, `@Test`, `#expect`,

--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -45,6 +45,14 @@ uppercase `mergeStateStatus`). Read the check runs separately with method
 - **Thread data is a separate call** — `pull_request_read` method `get` does not
   return review threads. Fetch them with method `get_review_comments` (delegated to
   `/review-pr-threads`); never expect thread data on the PR `get`.
+- **Pin the tree to the PR, and re-check it every pass.** The number alone is
+  not enough: both sweeps in §1 **edit and push the current working tree**, so
+  a drifted CWD doesn't just read the wrong PR, it commits to the wrong branch.
+  Before each pass assert `git branch --show-current` equals the PR's
+  `head.ref` (already fetched above, so this is free). Mismatch → **stop and
+  report; never sweep.** This is the case §0 exists for — a background watch
+  outlives the session's CWD, and `/deliver` Phase 10 moves to the next
+  deliverable's worktree while this loop is still running.
 
 Keep a **run ledger** in your working notes: resolved thread IDs, a topic
 signature per handled thread (`path:line` + short gist), and a fix-attempt
@@ -56,7 +64,9 @@ Repeat the pass below until the PR is **ready** (§3) or **stuck** (§2).
 
 ### 1a. Review threads
 
-Delegate the thread sweep to **`/review-pr-threads`** — it resolves the
+Delegate the thread sweep to **`/review-pr-threads <number>`** — **always pass
+the PR number.** Without it the skill falls back to "the current branch's PR"
+(`review-pr-threads` §1), re-introducing exactly the dependency §0 forbids. It resolves the
 currently-unresolved threads in one pass (assess → fix+verify / reply-only →
 reply → resolve), reusing **this run's ledger** so a topic you already fixed isn't
 re-edited, and returns a summary (fixed w/ SHAs, replied-only, left-for-user,
@@ -69,7 +79,8 @@ not duplicate its per-thread logic here.
 
 ### 1b. Status checks
 
-Delegate failing-check fixing to **`/fix-pr-checks`** — it routes each failing
+Delegate failing-check fixing to **`/fix-pr-checks <number>`** — **always pass
+the PR number**, for the same reason as §1a. It routes each failing
 check to the right diagnosis skill (`/diagnose-ci-failure` or
 `/diagnose-integration-failure`) via a Haiku subagent, applies and verifies the
 fix, commits, pushes once, and returns a summary (fixed w/ SHAs, exhausted,

--- a/.github/CODE_REVIEW.md
+++ b/.github/CODE_REVIEW.md
@@ -24,10 +24,16 @@ Only raise a finding you can **substantiate in your environment**. This is what
 keeps the two reviews aligned instead of one inventing issues the other can verify
 away:
 
-- **Local reviewer** — has the repo, build/test (via the `/build`, `/test`,
-  `/integration-test` skills), and MCP (`mcp__tmdb__*`, the OpenAPI spec via
-  `WebFetch`, sosumi). Do the deep verification the sections below describe:
-  model↔API alignment, fixture accuracy, and Apple-API checks.
+- **Local reviewer** — has the repo and MCP (`mcp__tmdb__*`, the OpenAPI spec
+  via `WebFetch`, sosumi). Do the deep verification the sections below
+  describe: model↔API alignment, fixture accuracy, and Apple-API checks.
+  **But do not build or run tests** — no `make`, no `swift build`, no
+  `swift test`, and don't invoke `/build`, `/test` or `/integration-test`.
+  Reviewing is a reading task: the caller has already run every gate and owns
+  the worktree's single build slot, and parallel reviewers building into one
+  scratch path *invalidate* each other's build plans rather than queueing. If
+  a finding genuinely cannot be settled without executing something, say so in
+  the finding and let the caller run it — serially, once.
 - **GitHub Actions reviewer** — has only the **diff and the checked-out repo**: no
   MCP, no build, no test run. Review what the code itself shows. Do **not**
   speculate about model/API accuracy, fixture correctness, or whether tests pass —

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -245,10 +245,23 @@ CWD>` in the task, and `tooling-runner` refuses to run without it, verifies
 echoes the directory it used. So the failure mode is now an explicit error
 rather than a plausible-looking wrong answer. **If you see a runner report
 without a `Directory:` line, it predates the fix — treat its result as
-untrusted** and re-run. The manual fallback (`swift build --build-tests`, then
-`swift test --skip-build --scratch-path .build --filter
-"TMDbTests|TMDbTestingTests"` directly via `Bash`, which does run in the
-worktree CWD) still works if you need it.
+untrusted** and re-run. **Prefer `make -C "<dir>" test`** as the fallback: it
+runs in the worktree CWD *and* takes the filter from `Makefile`'s `TEST_TARGET`,
+so it cannot drift.
+
+Going direct via `Bash` means hand-writing the filter, and **all four**
+unit-test targets must be named:
+
+```bash
+swift build --build-tests --scratch-path .build
+swift test --skip-build --scratch-path .build \
+  --filter "TMDbTests|TMDbTestingTests|TMDbIntelligenceTests|TMDbIntelligenceTestingTests"
+```
+
+A hand-copied two-target filter runs half the suite and reports green — at the
+exact moment this entry says to distrust the runner, i.e. when a narrower green
+is least likely to be questioned (**False green**, top of this file). Check it
+against `Makefile:2` before trusting it.
 
 **Extended 2026-07-29** — the `Directory:` / `Status:` lines are now a
 **contract**, and refusals report in the same shape (`Status: refused —


### PR DESCRIPTION
## Summary

An audit of `knowledge/`, `CLAUDE.md` and all 21 skills found the knowledge base and CLAUDE.md broadly sound — 28 services, 8 tools, all four test-target hardcodes, the ADR index and the lint scope all verify clean. What leaks is the path *between* them: lessons get recorded faithfully and then never reach the skill that would enforce them.

These are the five highest-blast-radius instances. Three of them are cases where a rule that already exists is silently inert.

## Changes

**Two false greens in the process itself:**

- 🔧 **`swept:` collided.** Phase 1's worktree reconcile and Phase 7's knowledge sweep both mandated a retro line by that name, and the retro format has one slot. The last four deliveries (#433, #412, #411, #410) filled it with the Phase 7 form, so the Phase 1 tripwire — the one `wrap-up.md` calls *"stronger, because a human sees the omission"* — went missing without anyone noticing, because a filled slot looks identical to the right one. Phase 1's line is now `reconciled:`, matching the run file's own field.
- 🔧 **The documented manual fallback ran half the suite.** `gotchas.md` prescribed `--filter "TMDbTests|TMDbTestingTests"` — two of the four unit-test targets — *inside the entry whose whole purpose is to stop silent wrong answers*, and at the exact moment it tells you to distrust the runner. Now prefers `make -C "<dir>" test` (which takes the filter from `TEST_TARGET` and cannot drift); the direct form spells out all four. Three `diagnose-ci-failure` reference files carried the same stale filter.

**A rule undone by a precedence clause:**

- 🔧 **`CODE_REVIEW.md` granted the local reviewer build/test capability that `code-reviewer.md` forbids** — and `code-reviewer.md:28` says that where the two disagree, *the file wins*. The no-build default added on 2026-08-07 was therefore inert. Fixed in the file that wins. This is the rule whose violation produced #401's cyclical build storm, where reviewers sharing one scratch path invalidated each other's build plans.

**A safety rule defeated one section later:**

- 🔧 **`/watch-pr` §0 requires the PR number** precisely so a background watch never depends on the current branch — then §1a/§1b delegated to `/review-pr-threads` and `/fix-pr-checks` without it, and both fall back to *"the current branch's PR"*. Both already accept an overriding number; now they get one. Added the load-bearing half too: a per-pass assertion that the working tree still matches the PR's `head.ref`, since both sweeps **edit and push** that tree — so a drifted CWD doesn't just read the wrong PR, it commits to the wrong branch.

**The transmission leak itself:**

- 🔧 **The recurring-pattern scan only proposes what appears in ≥2 retros**, but every retro ends with a *"one improvement"* — so a high-value singleton is proposed by nobody. Six are currently stranded with no entry in `skill-improvement-log.md` at all (not applied, not deferred, not rejected). The scan now also raises any unrecorded "one improvement"; it need not be *applied*, but it must reach a **recorded decision**.

## Benefits

- **Restores two tripwires that were silently off** — the Phase 1 reconcile check and the full-suite fallback both looked like they were working.
- **Makes an applied decision actually apply** — the reviewer no-build rule has been overridden by the spec since it was introduced.
- **Closes the loop the pipeline exists to run** — a retro's single highest-value lesson can no longer fall through for want of a second occurrence.

## Verification

Docs/config-only diff (no Swift, `Makefile`, `Package.swift` or workflows), so `/pr`'s fast gate applies — `make lint` and `make lint-markdown` both green. Every four-target filter written here was diffed against `Makefile`'s `TEST_TARGET` programmatically rather than by eye, which is the same discipline the `gotchas.md` fix is about.

Remaining audit findings (P2/P3) are not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
