### PR TITLE
🔧 Fix eleven P2 findings from the pipeline audit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,18 @@
     }
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); [ -z \"$f\" ] && exit 0; d=$(dirname \"$f\"); while [ ! -d \"$d\" ] && [ \"$d\" != \"/\" ]; do d=$(dirname \"$d\"); done; root=$(git -C \"$d\" rev-parse --show-toplevel 2>/dev/null) || exit 0; case \"$(git -C \"$root\" remote get-url origin 2>/dev/null)\" in *adamayoung/TMDb*) ;; *) exit 0 ;; esac; [ \"$(git -C \"$root\" branch --show-current 2>/dev/null)\" = \"main\" ] || exit 0; echo \"Refusing to edit on main: $f - CLAUDE.md requires all changes on a branch. Run: git checkout -b <prefix>/<slug>\" >&2; exit 2",
+            "statusMessage": "Checking branch..."
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/.claude/skills/capture-knowledge/SKILL.md
+++ b/.claude/skills/capture-knowledge/SKILL.md
@@ -55,6 +55,13 @@ Quality over volume: a few high-signal entries beat a long dump.
 4. **Write each entry** in the right file:
    - Gotchas / API notes: a short dated subsection (`### <title>`), newest at the
      top, under the right heading. Date it with today's date.
+   - **Cite the PR that did the work, not the issue it came from.** A bare
+     `#NNN` is ambiguous — this repo's numbers interleave issues and PRs, so
+     `(#432)` and `(#417)` look identical and only one is the change. Take the
+     number from the branch's own PR; if it doesn't exist yet, leave a
+     placeholder and backfill it. Name the issue only when the issue itself is
+     the subject, and then say "issue #NNN" in words. (See
+     [`knowledge/README.md`](../../../knowledge/README.md) → *How to use it*.)
    - Decisions: copy `decisions/0000-template.md` to
      `decisions/NNNN-<kebab-title>.md` (next free number), fill in Status / Date /
      Context / Decision / Consequences / Alternatives. Cross-link related ADRs.

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -152,9 +152,29 @@ implementation = separate `/deliver` sessions.)
   [`knowledge/gotchas.md`](../../../knowledge/gotchas.md) and
   [`knowledge/tmdb-api-notes.md`](../../../knowledge/tmdb-api-notes.md), read
   the entries (and any `knowledge/decisions/` ADR) relevant to the goal's
-  area, and record one `consulted: <entries | none relevant>` line in the
-  ledger. Captured knowledge only compounds if it is read at entry — the
-  ledger line is what makes this step checkable.
+  area, and record one `consulted: <entries | none relevant>` line **in the run
+  file** (and the ledger for convenience). Captured knowledge only compounds if
+  it is read at entry — that line is what makes this step checkable, so it must
+  live where it survives: **the ledger alone is not enough, because Phase 1's
+  `EnterWorktree` clears it.** Phase 8 copies it into the retro, which is the
+  committed, human-reviewed copy.
+- **Flag a reflexive delivery.** If the plan touches `.claude/skills/**`,
+  `.claude/agents/**` or `.github/CODE_REVIEW.md`, this run is **rewriting the
+  machinery that runs it**. Record `reflexive: true` in the run file and hold
+  two consequences for the rest of the pipeline:
+  1. **It cannot be dogfooded before merge.** The skill registry loaded at
+     session start comes from the **main checkout**, so your edits are not what
+     executes this run. Verify by reading, and say so in the PR — never claim a
+     changed skill was exercised end-to-end.
+  2. **Pin verification to the original text.** A rewritten rule must not be
+     the thing that grades its own rewrite: Phase 6's rubric and any review of
+     this diff judge against the ACs and the text as they stood at Phase 0.
+     (#407 shipped three defects from exactly this: a rewritten `/deliver`
+     grading itself, ACs that outlived the mechanisms they graded, and a
+     fan-out shipped as prose in the PR arguing prose isn't a gate.)
+  Phase 4 and Phase 5 both self-skip on a no-Swift diff — **override that here**
+  and review the change on its own terms; the diff being markdown is not
+  evidence it is low-risk.
 - **Decompose a multi-deliverable plan** (rules above); single-deliverable
   plans skip this.
 - **Entry gate — a gradeable rubric required.** Plans are expected as

--- a/.claude/skills/deliver/references/worktree-lifecycle.md
+++ b/.claude/skills/deliver/references/worktree-lifecycle.md
@@ -121,6 +121,16 @@ loudly instead of silently. **A missing run file at Phase 6 is a hard stop**,
 exactly as a dead grader is not a pass. `rubric: none` (present, empty) is the
 sanctioned rubric-less path and is *not* the same as a missing file.
 
+**Writing it from inside a worktree.** Phase 0 writes the file *before*
+`EnterWorktree`, so no guard applies there. Later updates do: a worktree-isolated
+session refuses `Bash` commands it cannot statically prove stay inside the
+worktree, and `.git/deliver/` is outside it **by design** (it lives in the common
+git dir). `Edit`/`Write` on that path are refused too. Use a single-purpose
+command with a **fully literal** path — `sed -i '' 's/…/…/' /abs/literal/path`
+works where the `jq`-to-temp-then-`mv` idiom is refused. Full workaround list:
+`knowledge/gotchas.md` → *In a worktree session, Bash refuses commands it can't
+prove stay inside it*.
+
 `rubricProvenance` records where the ACs came from — `supplied` when the plan
 carried them, or `derived — <source>` when Phase 0 derived them from a linked
 issue or an explicit test list (its second entry-gate case). It exists so a

--- a/.claude/skills/deliver/references/wrap-up.md
+++ b/.claude/skills/deliver/references/wrap-up.md
@@ -16,19 +16,22 @@ not a ceremony (a handful of bullets):
   phases `0–9`; skills `review-plan, implement-plan, review-changes,
   security-review, capture-knowledge`). Telemetry for the recurring-pattern
   scan: which skills fire, which phases get skipped, where deliveries stop.
+- **`consulted:`** — Phase 0's knowledge-consult proof, copied from the run
+  file: the `knowledge/` entries and ADRs read at entry, or `none relevant`.
 - **`reconciled:`** — Phase 1's worktree sweep, e.g.
   `reconciled: 2 in scope / 1 reclaimed / 0 resumable / 1 reported`. Named for
   the run file's own `reconciled` block.
 - **`swept:`** — Phase 7's knowledge-retirement sweep, verbatim from
   `/capture-knowledge`'s report line, e.g.
   `swept: Makefile, ci.yml → 1 entry rewritten`, or `swept: n/a`.
-- **Both are tripwires. An entry missing either line means that sweep did not
-  run** — stronger than Phase 0's `consulted:`, because the retro is committed
-  and goes through PR review, so a human sees the omission. **They are
-  separate keys on purpose:** when both were called `swept:`, the Phase 7 form
-  filled the slot for four consecutive deliveries and Phase 1's tripwire went
-  missing without anyone noticing — a filled slot looks identical to the right
-  one.
+- **All three are tripwires. A missing line means that step did not run** —
+  and the retro is where they bite, because it is committed and goes through
+  PR review, so a human sees the omission. (`consulted:` and `reconciled:` also
+  live in the run file, which is durable but never reviewed; `.git/` is not a
+  diff.) **They are three separate keys on purpose:** when Phase 1 and Phase 7
+  both wrote `swept:`, the Phase 7 form filled the slot for four consecutive
+  deliveries and Phase 1's tripwire went missing without anyone noticing — a
+  filled slot looks identical to the right one.
 - **What worked** — one or two things the pipeline did well.
 - **Friction** — where it was rough, slow, or stopped unnecessarily.
 - **Deviations** — anywhere you had to depart from the skill to do the right

--- a/.claude/skills/diagnose-ci-failure/references/lint.md
+++ b/.claude/skills/diagnose-ci-failure/references/lint.md
@@ -26,7 +26,7 @@ release binaries). Local versions must match (the local pin lives at
      nothing more.
    - For SwiftLint rules that can't autocorrect (e.g. line length, cyclomatic
      complexity, force-unwrap), fix the flagged `file:line` by hand per the
-     project's style (line length 100, no force-unwrap/try, guard for early
+     project's style (line length 120, no force-unwrap/try, guard for early
      exits).
 
 2. **Version drift — `superfluous_disable_command` on *unchanged* code.** A

--- a/.claude/skills/diagnose-ci-failure/references/markdown.md
+++ b/.claude/skills/diagnose-ci-failure/references/markdown.md
@@ -1,16 +1,22 @@
 # Lint Markdown job failure (markdownlint)
 
 The **Lint Markdown** job runs in the
-`ghcr.io/igorshubovych/markdownlint-cli:v0.41.0` container and lints:
+`ghcr.io/igorshubovych/markdownlint-cli:v0.48.0` container and lints:
 
 ```bash
-markdownlint "README.md" "**/*.docc/**/*.md"
+markdownlint "README.md" "CLAUDE.md" "**/*.docc/**/*.md" ".claude/**/*.md"
 ```
 
-So only `README.md` and DocC catalog markdown (`Sources/TMDb/TMDb.docc/**/*.md`)
-are checked — not arbitrary repo markdown. It only runs when the `markdown`
-paths filter matched (README or a DocC `.md` changed), or on
-`workflow_dispatch`.
+Four path groups: `README.md`, `CLAUDE.md`, DocC catalog markdown
+(`Sources/**/*.docc/**/*.md`), and **every skill and agent file under
+`.claude/`** — which in this repo is the most frequently edited of the four, so
+a failure here is most often a skill edit, not a README one. `knowledge/**` is
+deliberately **not** linted. The job runs only when the `markdown` paths filter
+matched one of those, or on `workflow_dispatch`.
+
+Config is `.markdownlintrc`, shared by all four groups. Note **`MD013`
+(line-length) and `MD041` (first-line heading) are disabled**, so neither can
+be the cause — don't start there.
 
 ## Reading the failure
 
@@ -21,17 +27,20 @@ code maps to a rule; common ones in this repo:
 - **MD024** duplicate heading — two headings with the same text in one file.
 - **MD031 / MD032** — fenced code blocks / lists need surrounding blank lines.
 - **MD040** — fenced code block missing a language (` ``` ` → ` ```swift `/` ```text `).
-- **MD041** — first line in the file should be a top-level heading.
-
-Configuration, if present, lives in a `.markdownlint*` file at the repo root —
-check it before assuming the default limits.
+Configuration is `.markdownlintrc` at the repo root. It **disables** `MD013`
+(line length), `MD033` (inline HTML), `MD041` (first-line heading) and `MD060`,
+and scopes `MD024` (duplicate heading) to siblings only — so none of those can
+be the failure. Read it before assuming a default limit applies.
 
 ## Common causes & fixes
 
+- **A skill or agent file under `.claude/`** — the most common cause, since this
+  repo edits those constantly. Usually MD040 (fence with no language) or
+  MD031/MD032 (missing blank line around a fence or list).
 - **A DocC `.md` you edited** (service extension file, `TMDb.md`, `TMDbClient.md`)
-  introduced a long line, a missing code-fence language, or a duplicate heading.
+  introduced a missing code-fence language or a duplicate sibling heading.
   Fix the flagged `file:line` to satisfy the rule.
-- **README edits** — same rules; watch MD013 line length and MD040 fence
+- **`README.md` or `CLAUDE.md` edits** — same rules; watch MD040 fence
   languages in examples.
 
 ## Reproduce locally
@@ -40,11 +49,12 @@ check it before assuming the default limits.
 make lint-markdown
 ```
 
-(runs the same `markdownlint` invocations as CI — `markdownlint "README.md"` and
-`markdownlint "**/*.docc/**/*.md"`). Fix, re-run until clean.
+(runs the same four `markdownlint` invocations as CI — verified identical to
+`.github/workflows/ci.yml`'s `Lint Markdown` step). Fix, re-run until clean.
 
 ## Output
 
 **Summary:** Lint Markdown — `MD0xx` at `file:line`.
-**Cause:** the rule violation in the changed README/DocC file.
+**Cause:** the rule violation in the changed README / `CLAUDE.md` / DocC /
+`.claude/` file.
 **Fix:** correct the flagged line; re-run `make lint-markdown`.

--- a/.claude/skills/review-changes/SKILL.md
+++ b/.claude/skills/review-changes/SKILL.md
@@ -28,12 +28,16 @@ code-review phase, or you) applies the fixes.
 ## 0. Gate — skip if there is no reviewable code
 
 Code review exists to review **code** — Swift source, plus the committed
-Workflow scripts under `.claude/workflows/` (they are decision infrastructure,
-not prose). If the diff touches neither, there is nothing to review — return
+scripts under `.claude/workflows/` (decision infrastructure) and `Scripts/`
+(enforcement infrastructure: `check-defaulted-witnesses.py` runs from `make
+lint` **and** as its own CI `Lint` step, so a bug there silently weakens a
+gate — it shipped as a false green once already, passing on an empty scan).
+If the diff touches none of them, there is nothing to review — return
 immediately, don't spawn any reviewer.
 
 ```bash
-git diff --name-only origin/main...HEAD | grep -qE '\.swift$|^\.claude/workflows/' \
+git diff --name-only origin/main...HEAD \
+  | grep -qE '\.swift$|^\.claude/workflows/|^Scripts/' \
   || echo "no-reviewable-code"
 ```
 
@@ -43,12 +47,15 @@ review skipped." Do not run §1–§3. (JSON fixtures under
 `Tests/**/Resources/` accompany Swift changes; a fixture-only change with no
 `.swift` is rare — note it and let the caller decide.)
 
-**If the only reviewable change is under `.claude/workflows/`**, take the §2a
-single-reviewer path with a **script-focused brief** in place of the Swift
-lens: input guards and executable `throw`s, schema shapes, tally / dead-agent
-handling, and prompt-injection surface (what untrusted text reaches an agent
-prompt). `.github/CODE_REVIEW.md`'s severity rubric and adversarial
-re-evaluation still apply; its Swift-specific checks don't.
+**If the only reviewable change is a script** (`.claude/workflows/` or
+`Scripts/`), take the §2a single-reviewer path with a **script-focused brief**
+in place of the Swift lens: input guards and executable `throw`s, schema
+shapes, tally / dead-agent handling, and prompt-injection surface (what
+untrusted text reaches an agent prompt). For a `Scripts/` checker add the
+question that matters most: **can it pass while measuring nothing?** — an empty
+scan, a typo'd path, a count compared instead of an explicit set.
+`.github/CODE_REVIEW.md`'s severity rubric and adversarial re-evaluation still
+apply; its Swift-specific checks don't.
 
 ## 1. Scope the change
 

--- a/.claude/skills/review-knowledge/SKILL.md
+++ b/.claude/skills/review-knowledge/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: review-knowledge
-description: Audit the knowledge/ base for staleness, self-contradiction, and drift from its own retention policy — two independent adversarial critics verify every load-bearing claim against the current tree, cross-examine each other, and reach a consensus on if/what needs changing. Use periodically, after a run of deliveries that changed build config or target layout, or whenever you suspect the knowledge base has aged out of true.
+description: Audit the knowledge/ base and the .claude/ skills, agents and workflows for staleness, self-contradiction, and drift from their own stated rules — two independent adversarial critics verify every load-bearing claim against the current tree, cross-examine each other, and reach a consensus on if/what needs changing. Use periodically, after a run of deliveries that changed build config, target layout or the skills themselves, or whenever you suspect the docs have aged out of true.
 ---
 
 # Review Knowledge
 
-Audit `knowledge/` against reality. A knowledge base is a **cache of currently-true
+Audit `knowledge/` **and `.claude/`** against reality. Both are a **cache of currently-true
 facts** (`knowledge/README.md` → *Maintenance & retention*), and caches go stale
 silently: writes are engineered here (`/capture-knowledge`, `/deliver`'s capture
 phase) but retirements are not, so truth decays exactly where the code moves
@@ -45,7 +45,7 @@ The point of this skill: do these by default, without being reminded.
 
 ## Scope
 
-Everything under `knowledge/`:
+Two trees. First, everything under `knowledge/`:
 
 | File | What decay looks like here |
 | --- | --- |
@@ -57,9 +57,24 @@ Everything under `knowledge/`:
 | `next-major.md` | An item that shipped, or one whose "breaking" premise no longer holds. It is a **queue**: anything still listed after its major version tagged is a process failure, not a backlog item. |
 | `README.md` | The stated policy no longer matching what the files actually do. |
 
-Also in scope: **contradictions with `CLAUDE.md`**. When the base and `CLAUDE.md`
-disagree, determine which is right from the tree — the base is often the one that
-already diagnosed the truth, and nobody propagated it upstream.
+Also in scope: **`CLAUDE.md` and everything under `.claude/`** — skills, agents,
+`workflows/`, and `.github/CODE_REVIEW.md`. This tree is *larger and more
+normative* than `knowledge/`, decays the same way, and until 2026-08-12 had no
+periodic audit at all — an audit that month found most of its defects here, not
+in `knowledge/`.
+
+| Where | What decay looks like here |
+| --- | --- |
+| A skill's prose | A `make` target, CI job name, path, test filter or tool version that moved; a count quoted from another file. |
+| A rule stated in two places | The copies drift; one silently becomes wrong. Prefer one owner and a pointer. |
+| A rule with no enforcement | Stated as advice where a gate, hook or `tools` allowlist could carry it — this repo's recurring failure (`#368`). |
+| Precedence clauses | "If X and this file disagree, the file wins" — check the file actually says what X assumes, or X's rule is inert. |
+| Two rules sharing one key | Two mandated report lines with the same name, one retro slot: the loser vanishes while the slot still looks filled. |
+| A skill's handoff | Skill A delegates to B without passing the argument B needs, so B falls back to a default A just forbade. |
+
+When the base and `CLAUDE.md` disagree, determine which is right from the tree —
+the base is often the one that already diagnosed the truth, and nobody
+propagated it upstream.
 
 ## Run the audit (Workflow)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,7 +318,9 @@ There is no `make test-ios` target. Run simulator tests
 
 Enforced via `swiftlint` and `swiftformat`:
 
-- **Line length:** 100 characters
+- **Line length:** 120 characters (`.swiftformat --maxwidth 120`; SwiftLint's
+  `line_length` default, with URLs, comments and interpolated strings exempt
+  per `.swiftlint.yml`)
 - **All public declarations must have documentation** (`///` style)
 - **No force unwrapping** (`!`) or force try (`try!`)
 - **Use guard for early exits**
@@ -340,8 +342,10 @@ Two `PostToolUse` hooks (in `.claude/settings.json`) run automatically after eve
 `Edit`/`Write`, so files are reshaped on disk **after** you write them:
 
 - **`.swift`** → `swiftlint --fix` then `swiftformat`.
-- **`.md` / `.markdown`** → `markdownlint --fix` (auto-fixable rules only — it
-  **cannot** fix `MD013` line-length, so still wrap long lines by hand).
+- **`.md` / `.markdown`** → `markdownlint --fix` (auto-fixable rules only).
+  `MD013` line-length is **disabled** repo-wide in `.markdownlintrc`, so long
+  lines are not a lint failure — wrap prose near 80 columns for readability,
+  not to satisfy a gate.
 
 Consequences: the on-disk content can differ from what you wrote (imports
 reordered, blank lines collapsed, list markers normalised). **Re-`Read` a file
@@ -439,12 +443,20 @@ comments in sync with every public-API change.
 
 ## Completion Checklist
 
-Before a task is complete: `/format`, `/lint`, then run **both** unit and
-integration tests (`/test`, `/integration-test`) — both must pass. If the public
-API changed, build docs (`make build-docs`) and keep `README.md` in sync (see
-`/document-swift`). Lint markdown (`make lint-markdown`) if any `.md` changed.
-Record durable learnings with `/capture-knowledge`. **`make ci` is the mandatory
-gate before pushing or opening a PR — no exceptions.**
+Iterate with `/format`, `/lint`, `/test` and `/integration-test` **while you
+work** — then run **`make ci` once** before pushing or opening a PR. That is the
+mandatory gate, and it already runs lint, markdown lint, both test suites, the
+release build and the docs build, so **don't run those individually again just
+before it**: the live integration suite is deliberately serialised, and
+re-running it is the largest avoidable cost in a delivery (#401). `/pr`
+documents the one sanctioned narrowing — a diff touching no `*.swift`,
+`Makefile`, `Package.swift`, `Package.resolved`, `*.xctestplan` or
+`.github/workflows/**` runs `make lint && make lint-markdown` instead.
+
+**The one thing `make ci` cannot check is `README.md`** — `build-docs` compiles
+DocC but cannot see a stale README. If the public API changed, keep it in sync
+by hand (see `/document-swift`). Record durable learnings with
+`/capture-knowledge`.
 
 `/deliver` runs this checklist, the self-review (`/review-changes`), and the PR
 end-to-end; the individual skills are the manual fallback. Self-review still

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -312,7 +312,7 @@ by hand, or the call silently no-ops while you report a reclaim
 
 ### In a worktree session, Bash refuses commands it can't prove stay inside it
 
-*2026-08-12 (#417).* A worktree-isolated session guards `Bash`, rejecting
+*2026-08-12 (#432).* A worktree-isolated session guards `Bash`, rejecting
 anything it cannot statically verify targets the worktree:
 *"this command is too complex to verify that it stays inside the worktree; break
 it into plain, separate commands."* It fires on shape, not on actual destination,
@@ -422,9 +422,22 @@ in isolation.
 *2026-06-23.* `make ci` does **not** run `make build-linux` (it's lint,
 lint-markdown, test, integration-test, build-release, build-docs). Linux
 portability is instead gated by `.github/workflows/ci.yml`'s **`build-test-linux`**
-job (container `swift:6.1-jammy`, runs `swift build --build-tests`). So when Docker
-isn't available locally to run `make build-linux`, the PR's CI is the authoritative
-off-Apple check — don't treat a missing local Linux build as a blocker.
+job (container `swift:6.1-jammy`), which runs the full trio — `swift build
+--build-tests`, `swift test` over all four unit-test targets, and
+`swift build -c release`. So when Docker isn't available locally to run
+`make build-linux`, the PR's CI is the authoritative off-Apple check — don't
+treat a missing local Linux build as a blocker.
+
+**One carve-out, added 2026-08-12 (#433).** For a **hand-rolled concurrency
+primitive** — a continuation wrapper, a lock, an `@unchecked Sendable` box —
+run `make test-linux` *before* opening the PR if Docker is up. That class is
+invisible to every Apple-side gate and to a diff-reading reviewer: an
+uninitialised read in `ResumeOnce` was `nil` garbage on Darwin and passed 3144
+tests, `make ci`, two review passes, a security review and an independent
+grader, then segfaulted on Linux and wedged the runner so hard it ignored both
+GitHub's concurrency cancel and `gh run cancel`. Everything else (`#if os(…)`,
+ordinary portability) fails loudly at compile time and can safely wait for CI.
+Docker down → say so and flag the PR Linux-unverified, don't skip silently.
 
 ### Edits can land in the main checkout instead of the active worktree
 
@@ -637,7 +650,7 @@ all**; `git grep` for a fixture's name before trusting that it covers anything.
 
 ### An empty-string-guard fixture must come from a real record — `null` passes either way
 
-*2026-08-12 (#417).* `decodeNonEmptyDateIfPresent` and plain
+*2026-08-12 (#432).* `decodeNonEmptyDateIfPresent` and plain
 `decodeIfPresent(Date.self)` behave **identically** on JSON `null` and on an
 absent key. Only `""` tells them apart. So a hand-written "blank date" fixture
 that uses `null` instead of `""` passes with *and* without the guard — the
@@ -662,7 +675,7 @@ regression test is void while looking green, and the same applies to
 
 ### A `#expect(throws: DecodingError.self)` test is a false green twice over
 
-*2026-08-12 (#417).* Two independent traps when pinning "this input must throw":
+*2026-08-12 (#432).* Two independent traps when pinning "this input must throw":
 
 1. **Copying `ImageSizeTests` uses a bare `JSONDecoder()`.**
    `ImageSizeTests.swift:49-55` decodes a single-value enum, so it needs no key
@@ -706,7 +719,7 @@ grader caught it; three plan critics had split 2–1 on it beforehand.
   `init(from:)` to use the helper — roughly 15 lines. That was the real cost
   being weighed, and it was worth paying.
 
-**Scope of the rule: same value class, not same file.** *2026-08-12 (#417),
+**Scope of the rule: same value class, not same file.** *2026-08-12 (#432),
 where one of three plan critics read this entry as requiring
 `decodeNonEmptyURLIfPresent` on `CreditMovie.posterPath` because the neighbouring
 `releaseDate` had just been guarded.* That over-applies it. The #404 asymmetry was
@@ -744,7 +757,7 @@ shipped with its own integration test still failing.
   `tmdb-api-notes.md`) — which is what proved `origin_country` was in scope and
   `description`/`headquarters` were not.
 - **The sweep earns its keep by *excluding*, not only by finding.** *2026-08-12
-  (#417).* Sweeping the whole `/credit/{id}` response tree did both: it turned up
+  (#432).* Sweeping the whole `/credit/{id}` response tree did both: it turned up
   an unrelated live decode failure the issue never mentioned (`credit_type:
   "creator"`), **and** it cleared five URL decodes the plan had excluded on a
   single spot-check. The second half is what makes a narrow scope defensible in

--- a/knowledge/tmdb-api-notes.md
+++ b/knowledge/tmdb-api-notes.md
@@ -309,7 +309,7 @@ of brittle enums precisely because nobody had sampled it.
 
 ### `/credit/{id}`: dates are `""`, image paths are `null` — never the other way round
 
-*2026-08-12 (#417), 300-credit sample* biased toward sparse records (upcoming
+*2026-08-12 (#432), 300-credit sample* biased toward sparse records (upcoming
 movies, in-development TV, and the combined credits of prolific people).
 Measured, not guessed:
 


### PR DESCRIPTION
## Summary

Follows #441 (the P1s). Same audit, same theme: **rules that exist but are inert**, and reference prose that has drifted from the tree it describes.

All eleven P2 findings.

## Changes

**CLAUDE.md factual corrections:**

- 📝 **Line length was documented as 100; the enforced limit is 120.** `.swiftformat` sets `--maxwidth 120` and `.swiftlint.yml` leaves SwiftLint's 120 default in place — four lines in `TMDbClient.swift` already sit between 101 and 120 and pass `--strict`. An agent following the old rule wrapped twenty characters early and could "fix" compliant code. Corrected here **and** in `diagnose-ci-failure/references/lint.md`, which handed out the same wrong number as a hand-fix target.
- 📝 **The Completion Checklist prescribed running every gate, then `make ci`, which runs them all again.** Every listed item is a strict subset of `make ci`, and the live integration suite is deliberately serialised — this is the redundancy #401 measured at 69 minutes against a true cost of a few. Now: iterate with the skills while working, `make ci` once before pushing, plus a pointer to `/pr`'s sanctioned docs/config-only narrowing. Keeps the README-sync clause explicitly, since `build-docs` compiles DocC but cannot see a stale README — the one thing the gate genuinely can't cover.
- 📝 **`MD013` was cited as unfixable-so-wrap-by-hand.** It's disabled repo-wide in `.markdownlintrc`; long lines aren't a lint failure at all.

**Reference prose that had drifted:**

- 🔧 **`diagnose-ci-failure/references/markdown.md` had the wrong lint scope** — it claimed only `README.md` and DocC are linted, when CI also covers `CLAUDE.md` and all of `.claude/**/*.md`. That's the most frequently edited group in this repo, so a Lint Markdown failure caused by a skill edit was being diagnosed against a file set that excluded it. Also pinned the wrong container (v0.41.0 → **v0.48.0**) and led with `MD013`/`MD041`, both disabled. Scope and version now match `ci.yml` byte-for-byte; the disabled/scoped rule lists were diffed against `.markdownlintrc` programmatically.

**Rules that existed but did not bind:**

- 🔧 **"Never make changes directly on `main`" was enforced by nothing.** CLAUDE.md's most emphatic rule was prose only, in a repo whose own recorded lesson (#368) is that unenforceable rules get silently skipped — and which already wires PostToolUse hooks. Now a `PreToolUse` guard on `Edit|Write|NotebookEdit`. It resolves the repo root from the **target path**, not the CWD, so it is correct for not-yet-existing files and for worktrees; it scopes itself to this repo by `origin` URL so it cannot misfire on another project sitting on `main`; and it allows anything outside a git repo. Verified in both directions against the command *as stored in the JSON*, with the `main` cases exercised on a real throwaway worktree rather than asserted.
- 🔧 **`consulted:` was written only to the ledger `EnterWorktree` destroys.** Phase 0's knowledge-consult proof now goes to the run file and into the retro — the committed, human-reviewed copy. Reworded the tripwire paragraph, which called `consulted:` the *weaker* one precisely *because* it wasn't in the retro: true before this change, self-contradictory after it.
- 🔧 **No reflexivity gate.** A delivery rewriting `.claude/skills/**`, `.claude/agents/**` or `CODE_REVIEW.md` is verified by the machinery it's rewriting. Phase 0 now records `reflexive: true` and holds two consequences: the registry loads from the **main checkout** so the edits can't be dogfooded before merge, and verification pins to the Phase 0 text so a rewritten rule never grades its own rewrite. Phases 4/5 self-skip on a no-Swift diff — now explicitly overridden here. (#407 shipped three defects from exactly this.)
- 🔧 **`/review-changes` skipped `Scripts/`.** `check-defaulted-witnesses.py` runs from `make lint` *and* as its own CI Lint step, and shipped as a false green once — passing on an empty scan — yet a PR editing only it got no review. Added to the gate and routed to the script brief with the question that matters for a checker: **can it pass while measuring nothing?**
- 🔧 **`/review-knowledge` audited the healthier tree.** Its scope was `knowledge/`; most of this audit's defects were in `.claude/`, which had no periodic audit at all. Widened, with a decay table for the failure modes actually observed — drifted paths, duplicated rules, unenforced rules, inert precedence clauses, colliding keys, dropped handoff arguments.
- 🔧 **The run file lives where the worktree guard refuses to write.** Documented the mechanics: Phase 0 writes *before* `EnterWorktree` so no guard applies, but later updates need a single-purpose `sed` with a literal path. Links the gotcha rather than restating it.

**Knowledge-base hygiene:**

- 📝 **Six entries cited issue #417 where the rule requires PR #432.** Fixed in `gotchas.md` (×5) and `tmdb-api-notes.md` (×1). The one remaining `#417` is in `skill-improvement-log.md`, where the issue genuinely *is* the subject and is labelled "issue #417" in words. **Root cause fixed too:** `/capture-knowledge` now states the cite-the-PR rule, which it never did — so fixing the citations doesn't just reset the clock.
- 📝 **Scoped the Linux carve-out.** The 2026-06-23 gotcha says not to treat a missing local Linux build as a blocker; #433 proved that wrong for one class. Added a carve-out for **hand-rolled concurrency primitives only** — the class invisible to every Apple-side gate and to a diff-reading reviewer — and corrected the job description, which claimed the Linux job only builds when it also runs all four test targets and a release build.

## Benefits

- **Two wrong numbers removed from the hot path** — the line length and the markdown lint scope were both actively misdirecting an agent mid-task.
- **The repo's most emphatic rule is now actually enforced**, not merely stated.
- **The reflexive-delivery blind spot is named** — including for this very PR, which edits the skills that would review it.
- **Citations stop drifting at the source**, because the skill that writes them now carries the rule.

## Verification

Docs/config-only diff, so `/pr`'s fast gate applies — `make lint` and `make lint-markdown` both green. The markdown scope, container version, disabled-rule list, review-gate regex and the hook command were each checked programmatically against their source of truth rather than by eye.

Remaining audit findings are P3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
