### PR TITLE
🔧 Add .worktreeinclude and fix the P3 audit findings

### DIFF
--- a/.claude/skills/capture-knowledge/SKILL.md
+++ b/.claude/skills/capture-knowledge/SKILL.md
@@ -27,7 +27,11 @@ a future me waste time without this?":
 - **Deferred breaking changes** → `knowledge/next-major.md` — any fix
   rejected or deferred *because* it is breaking. The skill-improvement log
   remembers the "no"; this file is what makes the deferred "yes" resurface
-  at the next major.
+  at the next major. **Reconcile its status line whenever you add an entry:**
+  it states which major window is open, and an entry filed against a window
+  that already shipped is invisible at exactly the moment it should fire. A
+  window is open until the version is **tagged** — an unreleased `CHANGELOG`
+  section is not a release (`git tag --list | sort -V | tail -1`).
 
 ## What NOT to capture
 
@@ -39,6 +43,21 @@ Mirror the discipline of a good memory — don't record:
   *non-obvious* part (what surprised you) or skip it.
 
 Quality over volume: a few high-signal entries beat a long dump.
+
+## When an entry records a count, ask what enforces it
+
+If a candidate entry states a **known-remaining defect count** — "54 sites still
+do X", "3 models still decode Y unsafely" — stop and ask the follow-up:
+**"what fails if that number changes?"** A number in a markdown file is a
+promise with nothing behind it; it silently goes stale as sites are fixed *or*
+regressed, and the two cancel out.
+
+Prefer a committed check with an **explicit set**, not a count (an exact
+allowlist so a fix and a regression can't cancel, and an empty scan can't pass),
+wired into **both** `make lint` and CI — no workflow runs `make`, so one alone
+is invisible. `Scripts/check-defaulted-witnesses.py` is the worked example. If a
+guard isn't worth building, say so in the entry, so the number reads as an
+observation rather than an invariant.
 
 ## Steps
 

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -53,9 +53,12 @@ Non-negotiable. Do these by default, without being reminded.
    the live view (one task per phase, statuses current, branch, PR number,
    weight); the **run file** is the durable one, because the ledger does not
    survive `EnterWorktree`, an MCP reconnect, or a plan-mode exit. Phase 0
-   writes it, Phase 1 records the sweep into it, **Phase 6 reads the rubric
-   from it** — so a skipped step fails loudly at a later phase instead of
-   silently. Location and schema:
+   writes it, Phase 1 records the reconcile into it, **Phases 4/5/6 each stamp
+   it on convergence** (`stamps.reviewedClean` / `securityClean` — that is what
+   makes a resume able to skip a pass already done), and **Phase 6 reads the
+   rubric from it** — so a skipped step fails loudly at a later phase instead of
+   silently. This list is exhaustive: if a phase isn't named here, nothing
+   writes on its behalf. Location and schema:
    [`references/worktree-lifecycle.md`](references/worktree-lifecycle.md). A
    template→replicate delivery adds the **`Phase 4a — reference-unit
    review`** gate task, which **blocks Phase 9**. A multi-deliverable plan
@@ -240,8 +243,16 @@ Procedures and traps:
    `fix/`, `chore/`, …) — sanctioned auto-use, don't ask. **Verify the branch
    name afterwards** (`git branch --show-current`; `git branch -m` if the
    tool renamed it). Already in a worktree? Don't nest — branch there.
-3. **Copy `.claude/settings.local.json` in** from the main checkout (the
-   permission allowlist; credentials come from the process env).
+3. **Check `.claude/settings.local.json` arrived** — `.worktreeinclude` at the
+   repo root copies it into every worktree Claude Code creates, so this is a
+   verification (`test -f .claude/settings.local.json`), not a copy. Missing →
+   copy it from the main checkout and say so.
+   **It carries the credentials**, not just permissions: `TMDB_API_KEY`,
+   `TMDB_USERNAME`, `TMDB_PASSWORD` and the two v4 tokens live in its `env`
+   block, and a fresh checkout has none of them, so without it the integration
+   suites cannot authenticate. (Permission *approvals* no longer need copying —
+   since Claude Code v2.1.211 they save to the **main checkout's** copy and
+   apply in every worktree of the repo.) Never paste its contents anywhere.
 4. **Record worktree + branch in the run file and the ledger, and (re-)create
    the ledger here** — the ledger is CWD-scoped and cleared by `EnterWorktree`,
    an MCP reconnect, or a plan-mode exit; found empty later → re-create from

--- a/.claude/skills/implement-plan/SKILL.md
+++ b/.claude/skills/implement-plan/SKILL.md
@@ -31,6 +31,11 @@ These are non-negotiable. Do them by default, without being reminded.
    the list has a written, passing test and the full suite is green — nothing
    less. Pair this with the `/goal` command for autonomous cross-turn iteration
    (see *Set the finishing goal*).
+   **Exactly three kinds of item are exempt**, because `canon-tdd` puts them on
+   the list and no test can assert them: the `///` doc comment, the DocC catalog
+   entry, and the `README.md` update. They are done when `make build-docs`
+   passes and the README is in sync — not when a test covers them. Nothing else
+   is exempt; don't reclassify a behavioural item into this set.
 4. **Reach for the right specialist skill.** Use `swift-testing-expert` when
    writing/structuring tests and `swift-concurrency` for anything touching
    tasks, actors, `@MainActor`, `Sendable`, or data races — don't hand-roll what
@@ -69,6 +74,21 @@ test list is anchored to it:
 If there is no plan, stop and say so — offer to draft one first (e.g. via the
 `Plan` agent or plan mode), and to `/review-plan` it before implementing. Never
 fabricate a plan in order to implement it.
+
+## Step 0 — Consult the knowledge base
+
+**Before deriving the list**, skim the entry headings of
+[`knowledge/gotchas.md`](../../../knowledge/gotchas.md) and
+[`knowledge/tmdb-api-notes.md`](../../../knowledge/tmdb-api-notes.md), read the
+entries (and any `knowledge/decisions/` ADR) relevant to what you are about to
+build, and say in one line what you consulted — `consulted: <entries | none
+relevant>`. Captured knowledge only compounds if it is read *before* the code,
+and half these entries exist precisely to stop a test list being written with a
+known trap missing from it.
+
+`/deliver` does this at its Phase 0, so a run reaching here through the pipeline
+has it already; this step is what makes a **standalone** `/implement-plan`
+equivalent rather than a knowledge-blind shortcut.
 
 ## Step 1 — Derive and show the test list
 

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,27 @@
+# Gitignored files copied into every worktree Claude Code creates
+# (--worktree, subagent worktrees, desktop parallel sessions).
+#
+# Syntax is .gitignore's, but the rule is narrower: a pattern only takes effect
+# if the file it matches is ALSO gitignored. Tracked files are never duplicated.
+#
+# Carries the TMDb credentials into worktrees. `.claude/settings.local.json`
+# holds TMDB_API_KEY / TMDB_USERNAME / TMDB_PASSWORD and the two v4 tokens in
+# its `env` block, and a fresh checkout has none of them — without this the
+# integration suites cannot authenticate (`make integration-test` fails at
+# `.check-env-vars`, and the v4 suites skip). Ignored at .gitignore:16.
+.claude/settings.local.json
+
+# Xcode test plans (ignored at .gitignore:9, so absent from every fresh
+# checkout). `make`/CI drive SwiftPM directly and never read these, but without
+# them a worktree opened in Xcode has no TMDb (unit) or Integration test plan,
+# so the simulator route documented in CLAUDE.md is unavailable there. Both are
+# under 1 KB and hold no absolute paths — their `container:` refs are relative,
+# so a copy works in any checkout.
+#
+# NOTE: `Integration.xctestplan` stores TMDB_API_KEY / TMDB_USERNAME /
+# TMDB_PASSWORD as literal values in `environmentVariableEntries` — Xcode cannot
+# read the `env` block above, so the Xcode route needs them here. Same three
+# secrets already copied above, no new class of exposure, and worktrees are
+# gitignored (.gitignore:18) — but treat this file as credential-bearing:
+# never paste it, and never commit it.
+*.xctestplan

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,16 +112,22 @@ cache decorators are opt-in (see `TMDbFactory.httpClient(wrapping:...)`).
 
 ```text
 Service (e.g. TMDbMovieService)
-└── APIClient
-    └── TMDbAPIClient            (adds api_key, validates status, decodes)
-        └── HTTPClient (protocol)
-            └── CacheHTTPClient          (opt-in; cache hits short-circuit)
-                └── RetryHTTPClient      (opt-in; exponential backoff)
-                    └── URLSessionHTTPClientAdapter  (or user-supplied client)
+└── APIClient (protocol)
+    └── ErrorMappingAPIClient           (TMDbAPIError -> public TMDbError)
+        └── UnmappedAPIClient (protocol)
+            └── TMDbAPIClient           (adds api_key, validates status, decodes)
+                └── HTTPClient (protocol)
+                    └── CacheHTTPClient         (opt-in; hits short-circuit)
+                        └── RetryHTTPClient     (opt-in; exponential backoff)
+                            └── URLSessionHTTPClientAdapter  (or user-supplied)
 ```
 
-In 18.0.0 an `ErrorMappingAPIClient` decorator wraps the `APIClient` to
-centralise mapping of `TMDbAPIError` into the public `TMDbError`.
+`ErrorMappingAPIClient` is the **outermost** `APIClient`, so no service does its
+own error translation. The two-protocol split is what enforces it: services
+depend on `APIClient`, `TMDbAPIClient` conforms only to `UnmappedAPIClient`, so a
+service *cannot* be wired to the unmapped client by accident. All three factory
+methods (`apiClient`, `authAPIClient`, `v4APIClient`) wrap the same way — see
+[ADR-0001](knowledge/decisions/0001-error-mapping-api-client.md).
 
 ### Language Model Tools (Apple-only)
 
@@ -193,13 +199,32 @@ for:
 1. Check the OpenAPI spec for endpoint structure and parameters
 2. Use MCP to fetch real data (e.g., `mcp__tmdb__movie_details`)
 3. Examine the actual JSON response structure
-4. Create models based on real data, not assumptions
-5. Save response as JSON fixture in `Tests/TMDbTests/Resources/json/`
-6. Implement the feature
+4. **Sample the population before deciding optionality — don't spot-check.**
+   One record tells you what *that* record has. Pull tens of records and build a
+   field/nullability matrix: #404 nearly shipped a one-field fix because a
+   single `curl` looked conclusive, and 54 companies showed a second field had
+   the same bug; #432's 300-record sweep both cleared five decodes *and* found a
+   bug the issue never mentioned. A sweep earns its keep by **excluding** as
+   much as by finding — a measured "we checked, it isn't in the class" survives
+   review; "the API probably never sends that" doesn't.
+5. Create models based on real data, not assumptions
+6. Save response as JSON fixture in `Tests/TMDbTests/Resources/json/`
+7. Implement the feature
+
+**A probe script must verify its own postcondition.** Live-API probing is how
+this repo establishes truth, but the scripts doing it get none of the rigour the
+Swift does, and two of #411's three bugs *were the probe lying*: a cleanup
+`EXIT` trap that never fired and orphaned four lists on a real account, and a
+uniform "rejected" result across a parameter sweep that was the spam filter
+(`status_code` 18), not an answer. So: end a probe by asserting the state it
+claims to have left — enumerate and confirm the cleanup happened — and treat a
+**uniform** result across a sweep as evidence about the *sweep* until the error
+body says otherwise.
 
 ## Development Workflow
 
-Feature work is **skill-driven**. Draft and approve a plan with `/plan`, then run
+Feature work is **skill-driven**. Draft and approve a plan in **plan mode**
+(there is no `/plan` skill — use plan mode, or the `Plan` agent), then run
 `/deliver` to carry it through to a ready-to-merge PR. **Invoking `/deliver` is
 itself the plan-approval gate** — it then runs autonomously to a single hard stop,
 **ready-to-merge**, pausing only for a plan-review blocker or a red gate it can't
@@ -313,6 +338,16 @@ build-docs); a single test runs via `swift test --filter "Suite/test"`.
 There is no `make test-ios` target. Run simulator tests
 (iOS/watchOS/tvOS/visionOS) from Xcode using the **TMDb** (unit) or
 **Integration** test plans.
+
+**The `.xctestplan` files are gitignored (`.gitignore:9`) and untracked**, so a
+fresh clone has neither and this Xcode route is unavailable until you create
+them locally. Nothing in CI depends on them — CI and `make` both drive SwiftPM
+directly — so a contributor without them loses only the simulator route, not
+coverage. Don't plan work that edits them: they are not in the repo (a plan once
+scheduled a sweep over files that don't exist, #398). **Worktrees do get them**,
+via `.worktreeinclude`. `Integration.xctestplan` stores the TMDb credentials as
+literal values, since Xcode can't read `settings.local.json` — treat it as
+credential-bearing.
 
 ## Code Style
 

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,13 @@ lint: lint-witnesses
 # Cross-symbol check that swiftlint cannot express: a public-extension
 # convenience must not share a requirement's signature (see the script, and
 # knowledge/gotchas.md).
+#
+# NO WORKFLOW RUNS `make`. The CI Lint job invokes swiftlint/swiftformat as
+# inline steps, so a check wired only here never reaches CI and green means
+# "nobody looked". This one is mirrored as the `Defaulted-witness check` step in
+# .github/workflows/ci.yml. Adding a check? Wire it in BOTH places, and add its
+# inputs to the `changes` paths filter, or a PR touching only that input skips
+# the whole job that runs it.
 .PHONY: lint-witnesses
 lint-witnesses:
 	@python3 Scripts/check-defaulted-witnesses.py

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -8,9 +8,20 @@ nothing. The point is **continuous improvement**: when the same friction or
 deviation recurs across entries, fold the fix into the relevant skill. Keep each
 entry to a handful of bullets — a log, not a ceremony.
 
-Format: **Feature / PR** · date · weight · *phases completed / skills invoked* ·
-*what worked* · *friction* · *deviations* · *one improvement* · *watch:*
-(optional, amended post-gate).
+Format: **Feature / PR** · date · **weight** · *phases completed / skills
+invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *friction*
+· *deviations* · *one improvement* · *watch:* (optional, amended post-gate).
+
+- **Weight is `lite` or `full` — there is no third tier.** A hybrid run (say, a
+  pre-reviewed plan that still gets the full review machinery) records as
+  **full** with the skipped machinery noted.
+- The three lowercase keys are **tripwires**, one per phase that can be silently
+  skipped: `consulted:` (Phase 0's knowledge consult), `reconciled:` (Phase 1's
+  worktree sweep), `swept:` (Phase 7's knowledge-retirement sweep). **A missing
+  line means that step did not run.** They are deliberately three distinct keys:
+  when Phase 1 and Phase 7 both wrote `swept:`, one silently occupied the
+  other's slot for four deliveries. See
+  [`wrap-up.md`](../.claude/skills/deliver/references/wrap-up.md).
 
 ---
 
@@ -289,7 +300,7 @@ Format: **Feature / PR** · date · weight · *phases completed / skills invoked
   share one credential-free URLCache key space*, now false in every particular);
   skill-improvement-log citations of integration-failure.yml still accurate.
 
-## 2026-08-07 — 🐛 Defaulted-witness convenience sweep, 37 sites (#410) · medium
+## 2026-08-07 — 🐛 Defaulted-witness convenience sweep, 37 sites (#410) · full
 
 - **Phases / skills:** 0–8 pre-PR. `consulted:` gotchas *defaulted-argument
   witness* (the source), *Growing a public protocol additively*, *sweep the

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -740,8 +740,14 @@ two fields the dedup step keys on.
   `knowledge/tmdb-api-notes.md` and deferred (fixing it is breaking).
 - **Rationale:** "make them consistent" would break public API and degrade decode
   resilience; only the non-breaking robustness improvement is worth doing now.
-- **Reconsider when:** a major-version bump lets `Company.logoPath` become optional
-  and the two models can be aligned deliberately.
+- **Reconsider when:** **n/a for the `homepage` rename — it shipped.** The
+  condition was met when the 20.0.0 window opened, and `Network.homepage` →
+  `homepageURL` was merged in **#412** (2026-08-07) via `next-major.md`, which is
+  exactly the route this entry anticipated. (Merged, not released: 20.0.0 is
+  still untagged.) The rejection stands only for the *aligning* direction it was
+  written about — forcing `Network.logoPath` non-optional remains wrong, and the
+  open item is a major-version bump letting `Company.logoPath` become optional so
+  the two models can be aligned deliberately.
 
 ### 2026-06-24 — "Fix every instance of X" deliveries: enumerate all sites up front · applied
 

--- a/knowledge/tmdb-api-notes.md
+++ b/knowledge/tmdb-api-notes.md
@@ -139,10 +139,13 @@ gives real on-disk caching for free on Apple platforms — see
 [ADR-0007](decisions/0007-document-existing-response-caching.md).
 
 **The v4 surface does the same** — `GET /4/list/{id}` serves
-`Cache-Control: public, max-age=300` (verified 2026-08-07). That is a hazard
-rather than a gift: v4 list responses are *user-private* yet carry no credential
-in the URL, so both cache layers would key them identically across users. See
-[ADR-0017](decisions/0017-v4-api-client.md) → *Still open*.
+`Cache-Control: public, max-age=300` (verified 2026-08-07). Left alone that is a
+hazard rather than a gift: v4 list responses are *user-private* yet carry no
+credential in the URL, so both cache layers would key them identically across
+users. **Resolved in the v4 list work (2026-08-07)** — credential-bearing
+responses now bypass both layers. For the predicate and how it is applied, see
+[ADR-0017](decisions/0017-v4-api-client.md) → *Resolved in the v4 list work*;
+don't restate the mechanism here, it lives with the code.
 
 ## Errors
 
@@ -368,7 +371,7 @@ them:
 | Model | Required decodes | Sample | Result |
 | --- | --- | --- | --- |
 | `ProductionCompany` | `id`, `name`, `originCountry` | `/search/company` ×5, N=100 | never `null`/absent |
-| `MediaListSummary` | `id`, `name`, `itemCount`, `favoriteCount` | `/movie|tv/{id}/lists`, N=539 | never `null`/absent |
+| `MediaListSummary` | `id`, `name`, `itemCount`, `favoriteCount` | `/movie\|tv/{id}/lists`, N=539 | never `null`/absent |
 | `TaggedImage` | 8 fields + nested `media` | `/person/{id}/tagged_images`, N=229 | never `null`/absent |
 | `TVSeriesListItem` | incl. `originCountries` | search/discover/trending/similar, N=1,046 | never `null`/absent (7 rows `[]`) |
 | `MovieListItem` | `title`, `originalTitle`, … | search/discover/trending, N=758 | never `null`/absent |

--- a/plans/tmdb-intelligence-product-extraction.md
+++ b/plans/tmdb-intelligence-product-extraction.md
@@ -1,5 +1,15 @@
 # Plan: Extract `TMDbIntelligence` target + product
 
+> **SUPERSEDED — this plan shipped in #398 (2026-07-24) and is kept only for
+> its reasoning.** Do not pick it up as "the current plan": `/deliver` Phase 0
+> resolves a plan from a named target, plan mode, or the conversation, never
+> from this directory. `TMDbIntelligence` exists; see
+> [ADR-0010](../knowledge/decisions/0010-tmdb-intelligence-product.md) for the
+> decision as shipped and the retro for #398 in
+> [`knowledge/delivery-retros.md`](../knowledge/delivery-retros.md) for how it
+> went. A spent plan is archive material — git history keeps it if this file is
+> ever deleted.
+
 Implements [ADR-0010](../knowledge/decisions/0010-tmdb-intelligence-product.md).
 Read the ADR first — it holds the rationale and the alternatives already
 rejected; this plan is the mechanics. Drafted 2026-07-06 against `main` at


### PR DESCRIPTION
## Summary

Completes the pipeline audit after #441 (P1s) and #442 (P2s), plus the `.worktreeinclude` change.

## Changes

**`.worktreeinclude` — carry local config into worktrees:**

- 🔧 A worktree is a fresh checkout, so gitignored files don't exist there. The mechanism only copies files that match a pattern **and** are already gitignored; both sets here qualify (verified).
  - **`.claude/settings.local.json`** — replaces the manual "copy it in" step in `/deliver` Phase 1, which is exactly the kind of process rule this repo keeps finding gets silently skipped. It also now covers subagent worktrees and desktop sessions, which the skill step never reached.
  - **`*.xctestplan`** — without them a worktree opened in Xcode has no test plan, so the simulator route CLAUDE.md documents is unavailable there. Both are under 1 KB and hold no absolute paths (`container:` refs are relative), so the copy is portable.
- 📝 **And corrected what the skill said about that file.** Phase 1 read *"(the permission allowlist; credentials come from the process env)"* — the reassuring half is false. The credentials come from that file's own `env` block (`CLAUDE.md:296`), and it holds five. The step is now a *verification* that `.worktreeinclude` delivered it, and says what it actually carries. The old rationale was obsolete in the other direction too: since Claude Code v2.1.211, permission approvals save to the **main checkout's** copy and apply in every worktree — permissions are the half that no longer needs copying. `Integration.xctestplan` is flagged credential-bearing for the same reason: Xcode can't read the `env` block, so the values live in the plan.

**Tripwires, weight, and the retro format:**

- 📝 `delivery-retros.md`'s Format line listed **none** of the three tripwires and didn't state the weight vocabulary. It now names `consulted:` / `reconciled:` / `swept:`, says a missing line means that step did not run, and records *why* they are three distinct keys.
- 📝 Retro #410 was recorded as weight `medium` — a third tier the skill forbids. Its own text says the plan was pre-reviewed so Phase 2's critics were skipped: the textbook hybrid, which records as `full` with the skip noted.
- 🔧 Run-file rule 6 enumerated Phase 0/1/6 as if exhaustively, which is why no phase thought stamping was its job while `worktree-lifecycle.md` defined a `stamps` object nothing ever wrote. Phases 4/5/6 are now named, and the list says it is exhaustive.

**Stranded improvements, wired:**

- 🔧 `/implement-plan` gains a **Step 0 knowledge consult** (#384's improvement, which the archive still marked "still stands"). `/deliver` covers this at Phase 0; this makes a standalone invocation equivalent rather than knowledge-blind.
- 🔧 Its finishing condition — "every item has a written, passing test" — was **unsatisfiable** for the doc items `canon-tdd` puts on the list. Exactly three are now exempt (`///`, DocC catalog, README), as a closed set so a behavioural item can't be reclassified into it.
- 🔧 `/capture-knowledge` now reconciles `next-major.md`'s open-window status line (#412), and asks **"what fails if that number changes?"** when an entry records a defect count (#410) — pointing at an explicit-set check wired into *both* `make lint` and CI, since neither alone is a gate.
- 📝 CLAUDE.md's endpoint workflow gains **sample the population, don't spot-check** (#404, #432) and **a probe must verify its own postcondition** (#411, where two of three bugs were the probe lying — a cleanup trap that never fired, and a rate limit misread as an API verdict).

**Factual corrections:**

- 📝 The networking diagram omitted `ErrorMappingAPIClient` and carried an "In 18.0.0" stamp two majors old. Verified against `TMDbFactory`: it is the outermost `APIClient` in all three factory methods, and the `APIClient` / `UnmappedAPIClient` split is what makes it un-bypassable — which the diagram now shows.
- 📝 **`/plan` does not exist** as a skill at project or user level, yet CLAUDE.md opened the workflow section with it. Points at plan mode instead.
- 📝 The `.xctestplan` files are gitignored and untracked, so the Xcode route CLAUDE.md prescribes doesn't exist on a fresh clone. Said so.
- 📝 `tmdb-api-notes.md` pointed at ADR-0017 → *Still open*, a section that no longer exists — and the hazard it described was resolved in the v4 list work. Repointed, without restating the mechanism (it already lives in three places that track the code).
- 📝 The `Network.homepage` log entry still read as a live rejection; the rename **shipped in #412** once its own "reconsider when" condition was met. Rewrote that field — the one the dedup step keys on. Merged, not released: 20.0.0 is untagged.
- 🐛 A raw `|` inside a table cell in `tmdb-api-notes.md` produced a 5-column row in a 4-column table, so the row rendered wrong (MD056).
- 📝 The Makefile comment above `lint-witnesses` now records that **no workflow runs `make`**, so a check wired only there never reaches CI.
- 📝 Marked the shipped `plans/` plan superseded so it can't be mistaken for the current one.

## Deliberately not done

A `tools:` allowlist for `code-reviewer` and `tooling-runner`. The finding is real — their "don't build / don't edit" prohibitions are prose-only, while `documentation-writer` has the enforceable version — but both need broad MCP access (`mcp__tmdb__*` for model↔API checks, `mcp__xcode-tools__*` inside Xcode) and I could not verify that the frontmatter `tools` field supports wildcards. A guessed allowlist that silently omits a needed tool would neuter the deep reviewer, which is worse than the prose. Needs the schema confirmed first.

Also left alone: adding `knowledge/**` to the markdown lint scope. It currently fails one rule — `MD001` on `skill-improvement-log.md:33`, because the file uses `#` then `###` entries, and `###` headings are the documented index convention across the whole knowledge base. Fixing it means either restructuring three files or adding an `MD001` exception; that's your call, not a drive-by.

## Verification

`make lint` and `make lint-markdown` green. The `Makefile` change is **comment-only**, proved mechanically rather than by eye: every added line starts with `#`, and `make -n` output is byte-identical to `origin/main` for `lint`, `lint-witnesses`, `lint-markdown`, `test`, `build-release`, `build-docs` and `ci`. So the local gate was the fast one — but the PR's CI runs the full matrix regardless, and now genuinely runs it rather than skipping, since `Makefile` is in the `swift` paths filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
