### PR TITLE
🔧 Make the review-knowledge widening real, and fix its findings

### DIFF
--- a/.claude/skills/capture-knowledge/SKILL.md
+++ b/.claude/skills/capture-knowledge/SKILL.md
@@ -130,4 +130,9 @@ Report concisely what you captured: each entry → which file (and ADR number fo
 decisions), and note anything you deliberately skipped as not durable. If nothing
 met the bar, say so plainly — capturing nothing is a valid outcome.
 
+**Always end with the `swept:` line from step 5.4** — `swept: <infra files> →
+<entries rewritten/deleted | none cited>`, or `swept: n/a`. It is not optional
+prose: `/deliver` copies it into the retro and treats its **absence as proof the
+retirement sweep never ran**. A report without it reads as a skipped step.
+
 Arguments: $ARGUMENTS

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deliver
-description: Take the current plan all the way to a ready-to-merge pull request — review the plan (scaled to risk), implement it test-first, code-review and fix, run the CI gate, open the PR, and watch it green. Use after you have an approved plan (e.g. from /plan) and want the rest of the feature pipeline run end-to-end. Invoking it is itself plan approval — it then runs autonomously to a single hard stop: ready-to-merge.
+description: Take the current plan all the way to a ready-to-merge pull request — review the plan (scaled to risk), implement it test-first, code-review and fix, run the CI gate, open the PR, and watch it green. Use after you have an approved plan (from plan mode, or the Plan agent) and want the rest of the feature pipeline run end-to-end. Invoking it is itself plan approval — it then runs autonomously to a single hard stop: ready-to-merge.
 ---
 
 # Deliver
@@ -13,7 +13,8 @@ approval) to a single hard stop — **ready-to-merge** — auto-scaling its
 machinery to the change's risk, and writing a short **retrospective** that
 rides the delivery's own PR. Every run happens in its **own git worktree**
 (Phase 1; torn down on merge, Phase 12) so the user's main checkout stays
-free. The plan is created first with `/plan` (or plan mode) — `/deliver`
+free. The plan is created first in **plan mode** (or with the `Plan` agent;
+there is no `/plan` skill) — `/deliver`
 picks up from there.
 
 ```text
@@ -145,7 +146,7 @@ implementation = separate `/deliver` sessions.)
 ## Phase 0 — Preconditions
 
 - **A plan must exist** (named target → plan-mode plan → most recent in
-  conversation). None → stop; point at `/plan`. Never invent one.
+  conversation). None → stop; ask for one in plan mode. Never invent one.
 - **A plan born from a review finding is a hypothesis** — verify against the
   code (quick `Explore`) *before* planning or asking strategy questions.
 - **State the goal** in a sentence; **judge the weight**; open the ledger.
@@ -312,8 +313,13 @@ work is committed; re-confirm the weight from the diff. Three hard checkpoints:
 
 ## Phase 4 — Code review + fix loop
 
-**Skip entirely if the diff has no reviewable code — no Swift and no
-`.claude/workflows/` script** (`/review-changes` self-gates). Review
+**Skip entirely if the diff has no reviewable code — no Swift, no
+`.claude/workflows/` script and nothing under `Scripts/`** (`/review-changes`
+self-gates on the same set). **Exception — a reflexive delivery** (Phase 0 set
+`reflexive: true`): do **not** skip. Run `/review-changes` with
+`force-review` so it reviews the change on its own terms; a diff being
+markdown is not evidence it is low-risk, and this is the case #407 shipped
+three defects through. Review
 **stable** code once the design settles — not per TDD item. Granularity by
 weight:
 

--- a/.claude/skills/fix-pr-checks/SKILL.md
+++ b/.claude/skills/fix-pr-checks/SKILL.md
@@ -247,8 +247,9 @@ note it for the user, and move on.
 ## 4. Push once, then finish
 
 After all failing checks are handled, if you committed any fixes, `git push` once
-(it re-triggers CI — expected). Every commit fires the pre-commit `make lint`
-hook; fix lint before retrying.
+(it re-triggers CI — expected). **There is no pre-commit hook** (`.git/hooks/`
+holds only `*.sample`), so nothing lints on your behalf — run `/lint` before
+committing, or a lint fix can itself land a lint failure.
 
 ## Return: sweep summary
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -13,12 +13,19 @@ and fixed its findings (e.g. `/deliver`'s code-review phase via
 `/review-changes`), so **skip steps 5–7** to avoid reviewing identical code
 twice. Otherwise (standalone `/pr`), run the internal review as normal.
 
-**Also skip steps 5–7 when the branch changes no Swift** — code review is for
-Swift, so a docs-only / config-only PR needs none:
+**Also skip steps 5–7 when the branch changes no reviewable code.** Use
+`/review-changes`' own gate set, not a narrower one — committed scripts under
+`.claude/workflows/` and `Scripts/` are reviewable too, and a PR editing only
+`Scripts/check-defaulted-witnesses.py` changes a CI gate:
 
 ```bash
-git diff --name-only origin/main...HEAD | grep -qE '\.swift$' || echo "no-swift → skip review"
+git diff --name-only origin/main...HEAD \
+  | grep -qE '\.swift$|^\.claude/workflows/|^Scripts/' \
+  || echo "no reviewable code → skip review"
 ```
+
+(If the change rewrites the pipeline's own skills, don't skip — pass
+`force-review` to `/review-changes`; see its §0.)
 
 1. Run `/format` to format code
 2. **Commit all outstanding work.** Run `git status`. If the working tree has **any** uncommitted or unstaged changes (the feature work, plus the formatting from step 1), stage and commit them — the PR reflects **committed history only**, so anything left uncommitted will be **missing from the PR**. First **verify no secrets, `.env`, or build artifacts** are included (per CLAUDE.md — `.env` must stay gitignored; check `git status` before `git add`). Use a descriptive gitmoji message (or several logical commits if the work spans concerns); formatting-only changes can use "🎨 apply code formatting". If the tree is already clean (e.g. work was committed during `/deliver`), this is a no-op.
@@ -52,12 +59,12 @@ git diff --name-only origin/main...HEAD | grep -qE '\.swift$' || echo "no-swift 
         ```
 
         Fix anything it flags (oversized files: split, or add a `// swiftlint:disable` directive matching the `AccountService+Pagination.swift` precedent) and re-run. This catches file-size violations locally instead of on a CI round-trip.
-5. *(skip in `reviewed` mode or when no Swift changed)* Run the **`/review-changes`** skill — it scales the review to the diff (a single `code-reviewer` for a small change, the fan-out + adversarial-verify Workflow for a large one), follows `.github/CODE_REVIEW.md`, and returns a severity-graded report
-6. *(skip in `reviewed` mode or when no Swift changed)* Summarize the code review findings:
+5. *(skip in `reviewed` mode or when no reviewable code changed)* Run the **`/review-changes`** skill — it scales the review to the diff (a single `code-reviewer` for a small change, the fan-out + adversarial-verify Workflow for a large one), follows `.github/CODE_REVIEW.md`, and returns a severity-graded report
+6. *(skip in `reviewed` mode or when no reviewable code changed)* Summarize the code review findings:
     - List any critical or high-severity issues that should be addressed
     - List any medium-severity suggestions for improvement
     - Note any low-severity or stylistic recommendations
-7. *(skip in `reviewed` mode or when no Swift changed)* If there are critical/high-severity issues:
+7. *(skip in `reviewed` mode or when no reviewable code changed)* If there are critical/high-severity issues:
     - Recommend specific changes needed
     - Ask user for confirmation before proceeding (fix issues or continue anyway)
     - If user wants to fix issues, stop and let them address the feedback

--- a/.claude/skills/review-changes/SKILL.md
+++ b/.claude/skills/review-changes/SKILL.md
@@ -47,6 +47,17 @@ review skipped." Do not run §1–§3. (JSON fixtures under
 `Tests/**/Resources/` accompany Swift changes; a fixture-only change with no
 `.swift` is rare — note it and let the caller decide.)
 
+**Override — `force-review` in the arguments skips this gate entirely.** The
+caller has decided the change carries risk the file extensions don't show.
+`/deliver` passes it for a **reflexive delivery** — one that rewrites the
+skills, agents or review spec the pipeline itself runs, where the diff is
+markdown but the blast radius is the pipeline (#407 shipped three defects
+exactly there). Take the §2a single-reviewer path with a brief aimed at the
+change's own subject matter: which rule changed, whether anything still
+depends on the old wording, and whether the new rule is enforced or merely
+stated. Without this the gate and the caller contradict each other and the
+skip silently wins.
+
 **If the only reviewable change is a script** (`.claude/workflows/` or
 `Scripts/`), take the §2a single-reviewer path with a **script-focused brief**
 in place of the Swift lens: input guards and executable `throw`s, schema

--- a/.claude/skills/review-knowledge/SKILL.md
+++ b/.claude/skills/review-knowledge/SKILL.md
@@ -103,12 +103,28 @@ const LENSES = [
   {
     key: 'accuracy',
     title: 'Accuracy & Staleness',
-    brief: `Assume the knowledge base is lying to you. For every load-bearing factual claim, check it against the CURRENT tree and flag what no longer holds. Prioritise claims about things that move: Makefile targets and variables, .github/workflows/ci.yml (toolchain pins, job names, lint scopes, test filters), Package.swift (targets, dependencies, exclude lists), test-target layout and file locations, swiftlint/swiftformat pins, and live-API behaviours. Hunt specifically for: entries describing a FIXED problem as still live; entries that contradict EACH OTHER; entries that contradict CLAUDE.md; and entries that have accreted several generations of truth instead of being rewritten to the present. Read git log for the PRs an entry cites — an entry whose fix shipped should have been retired.`,
+    brief: `Assume the text is lying to you. For every load-bearing factual claim, check it against the CURRENT tree and flag what no longer holds. Prioritise claims about things that move: Makefile targets and variables, .github/workflows/ci.yml (toolchain pins, job names, lint scopes, test filters), Package.swift (targets, dependencies, exclude lists), test-target layout and file locations, swiftlint/swiftformat pins, skill and tool names, and live-API behaviours. Hunt specifically for: text describing a FIXED problem as still live; passages that contradict EACH OTHER; passages that contradict CLAUDE.md; and text that has accreted several generations of truth instead of being rewritten to the present. Read git log for the PRs a passage cites — one whose fix shipped should have been retired. A cited file:line that no longer points at what it claims is itself a defect, and so is a claimed mechanism (a git hook, a make target, a tool, a skill) that does not exist — verify a mechanism by looking for it, never by trusting the sentence.`,
   },
   {
     key: 'structure',
     title: 'Structure, Policy Compliance & Gaps',
-    brief: `Audit the base against its OWN stated rules in knowledge/README.md (rolling windows, retire-what-is-untrue, ADR immutability and superseding, do-not-pre-split, dated grep-friendly headings) and against knowledge/decisions/README.md (numbering, status upkeep). Hunt for: duplicate or out-of-order headings, numbering collisions, index drift, broken or missing cross-references, orphaned files, statuses that lag reality, entries filed under the wrong file, and windows that have drifted. Then ask what is MISSING: a decision made but never recorded as an ADR, a recurring trap with no entry, a deferred item with no trigger that would ever surface it. Check the base applies its own hygiene rules TO ITSELF.`,
+    brief: `Audit the tree against its OWN stated rules, and against what its siblings say about it. Hunt for: duplicate or out-of-order headings, numbering collisions, index drift, broken or missing cross-references, orphaned files, statuses that lag reality, content filed in the wrong place, and windows that have drifted. Then ask what is MISSING: a decision made but never recorded, a recurring trap with no entry, a deferred item with no trigger that would ever surface it, a rule stated where nothing enforces it. Check the tree applies its own hygiene rules TO ITSELF.`,
+  },
+]
+
+// Both lenses run against BOTH trees — four audits. Widening the scope prose
+// without widening these briefs is how this skill silently audited only half
+// the repo while its own scope table claimed otherwise (#443).
+const TREES = [
+  {
+    key: 'knowledge',
+    title: 'the engineering knowledge base at knowledge/',
+    scope: `Everything under knowledge/: gotchas.md, tmdb-api-notes.md, decisions/ (the ADRs, their README index, and 0000-template.md), delivery-retros.md, skill-improvement-log.md, next-major.md, README.md. Its own rules live in knowledge/README.md — rolling windows, retire-what-is-no-longer-true, ADR immutability and superseding, do-not-pre-split, dated grep-friendly headings, and CITE THE PR THAT DID THE WORK, NOT THE ISSUE (this repo's numbers interleave issues and PRs, so check each cited number with \`gh api\`) — and in knowledge/decisions/README.md: numbering, the 0000-template shape, and status upkeep, where an unreleased CHANGELOG section is NOT a release, only a tag is.`,
+  },
+  {
+    key: 'claude',
+    title: 'the operating instructions in CLAUDE.md, .claude/ and .github/CODE_REVIEW.md',
+    scope: `CLAUDE.md, every SKILL.md and reference file under .claude/skills/, .claude/agents/*.md, .claude/workflows/*.js, .claude/settings.json, and .github/CODE_REVIEW.md. This tree is LARGER and MORE NORMATIVE than knowledge/ and decays the same way. Its decay modes, in the order they have actually bitten this repo: a rule stated in two or three places where the copies drift apart; a rule stated as advice where a gate, hook or frontmatter tools-allowlist could enforce it; a precedence clause ("if your memory and the file disagree, the file wins") pointing at a file that no longer says what the caller assumes, leaving the rule inert; two rules sharing one key, so the loser vanishes while the slot still looks filled; a skill delegating to another without passing the argument that skill needs, so it silently falls back to a default the caller just forbade; a phase mandated to write state that no phase actually writes; and a claimed mechanism that does not exist.`,
   },
 ]
 
@@ -128,11 +144,11 @@ const FINDING_SCHEMA = {
           severity: { type: 'string', enum: ['critical', 'major', 'minor'] },
           confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
           claim: { type: 'string', description: 'one-line statement of the defect' },
-          knowledgeLocation: { type: 'string', description: 'the knowledge/ file:line at fault' },
+          location: { type: 'string', description: 'the file:line at fault (in either audited tree)' },
           evidence: { type: 'string', description: 'how you VERIFIED it against the tree — the file:line or command whose output proves the entry wrong' },
           fix: { type: 'string', description: 'the concrete change: rewrite / retire / renumber / relocate, and to what' },
         },
-        required: ['id', 'severity', 'confidence', 'claim', 'knowledgeLocation', 'evidence', 'fix'],
+        required: ['id', 'severity', 'confidence', 'claim', 'location', 'evidence', 'fix'],
       },
     },
     verifiedAccurate: { type: 'string', description: 'load-bearing claims you checked that ARE still true — say what you checked and how' },
@@ -166,39 +182,49 @@ const REBUTTAL_SCHEMA = {
 const READONLY = `You are READ-ONLY. Read the repo freely (Read/Grep/Bash for git log, grep, ls) but do NOT edit any file, do not fix anything, and do not run builds or tests (slow and unnecessary). `
 
 phase('Audit')
-const audits = await parallel(LENSES.map((lens) => () =>
+const JOBS = TREES.flatMap((tree) => LENSES.map((lens) => ({ tree, lens })))
+const audits = await parallel(JOBS.map(({ tree, lens }) => () =>
   agent(
-    `You are an ADVERSARIAL auditor of the engineering knowledge base at knowledge/ in this repo, working the "${lens.title}" lens.\n\n` +
-    `${lens.brief}\n\n` +
+    `You are an ADVERSARIAL auditor of ${tree.title} in this repo, working the "${lens.title}" lens.\n\n` +
+    `SCOPE — audit ONLY this tree, and cite every finding inside it:\n${tree.scope}\n\n` +
+    `LENS:\n${lens.brief}\n\n` +
     `${READONLY}\n\n` +
-    `EVERY finding must be VERIFIED against the current tree and cite the evidence that proves it — the file:line or command output that contradicts the entry. A finding derived only from reading the knowledge base is inadmissible; that credulity is the exact failure mode you are auditing. Equally: do NOT manufacture findings to look thorough. If a file is accurate, say so in "verifiedAccurate" and name what you checked.\n\n` +
+    `EVERY finding must be VERIFIED against the current tree and cite the evidence that proves it — the file:line or command output that contradicts the text. A finding derived only from reading the documentation is inadmissible; that credulity is the exact failure mode you are auditing. Equally: do NOT manufacture findings to look thorough. If a file is accurate, say so in "verifiedAccurate" and name what you checked.\n\n` +
     `SEVERITY RUBRIC:\n${SEVERITY}`,
-    { label: `audit:${lens.key}`, phase: 'Audit', model: 'fable', effort: 'high', schema: FINDING_SCHEMA }
-  ).then((v) => v && { ...v, lens: lens.title, key: lens.key })
+    { label: `audit:${tree.key}:${lens.key}`, phase: 'Audit', model: 'fable', effort: 'high', schema: FINDING_SCHEMA }
+  ).then((v) => v && { ...v, lens: lens.title, key: lens.key, tree: tree.key, treeTitle: tree.title })
 ))
 
 const live = audits.filter(Boolean)
-if (live.length < 2) {
-  log(`WARNING: only ${live.length} of 2 auditors returned — cross-examination skipped, treat the result as unreconciled`)
-  return { audits: live, rebuttals: [], degraded: true }
-}
+
+// Cross-examine WITHIN each tree, so the two lenses challenge each other on the
+// same material. A tree with fewer than two survivors is reported UNRECONCILED
+// rather than passed off as consensus — a dead auditor is not a clean bill.
+const groups = TREES.map((tree) => ({ tree, members: live.filter((a) => a.tree === tree.key) }))
+const unreconciled = groups.filter((g) => g.members.length < 2).map((g) => g.tree.key)
+unreconciled.forEach((k) => log(`WARNING: ${k} had fewer than 2 auditors return — its findings are UNRECONCILED, not consensus`))
+if (live.length === 0) return { audits: [], rebuttals: [], unreconciled, degraded: true }
 
 phase('Cross-examine')
-const rebuttals = await parallel(live.map((mine, i) => () => {
-  const theirs = live[1 - i]
-  return agent(
-    `An audit of this knowledge base was run through the "${mine.lens}" lens — those findings are YOURS, reproduced below. Another independent auditor worked the "${theirs.lens}" lens. Your job now is to CROSS-EXAMINE their findings — try to refute each one.\n\n` +
-    `YOUR findings (the "${mine.lens}" lens):\n${JSON.stringify(mine.findings, null, 2)}\n\n` +
-    `THEIR findings (the "${theirs.lens}" lens), which you must assess:\n${JSON.stringify(theirs.findings, null, 2)}\n\n` +
-    `For each, independently verify it against the tree and take a position: "confirm" (you checked, it holds), "refute" (you checked, it is wrong or the entry is actually fine — say what they misread), or "amend" (real, but the severity or the proposed fix is wrong — give the corrected one).\n\n` +
-    `Default to REFUTE when the evidence is thin. A finding that cannot be independently reproduced from the tree should not survive into the consensus. Do not confirm out of collegiality.\n\n` +
-    `${READONLY}\n\n` +
-    `Finally, in "missedByBoth", note anything their report made you realise you BOTH missed.`,
-    { label: `cross:${mine.key}`, phase: 'Cross-examine', model: 'fable', effort: 'high', schema: REBUTTAL_SCHEMA }
-  ).then((r) => r && { by: mine.lens, ...r })
-}))
+const rebuttals = await parallel(
+  groups.filter((g) => g.members.length === 2).flatMap((g) =>
+    g.members.map((mine, i) => () => {
+      const theirs = g.members[1 - i]
+      return agent(
+        `An audit of ${g.tree.title} was run through the "${mine.lens}" lens — those findings are YOURS, reproduced below. Another independent auditor worked the "${theirs.lens}" lens over the same tree. Your job now is to CROSS-EXAMINE their findings — try to refute each one.\n\n` +
+        `YOUR findings (the "${mine.lens}" lens):\n${JSON.stringify(mine.findings, null, 2)}\n\n` +
+        `THEIR findings (the "${theirs.lens}" lens), which you must assess:\n${JSON.stringify(theirs.findings, null, 2)}\n\n` +
+        `For each, independently verify it against the tree and take a position: "confirm" (you checked, it holds), "refute" (you checked, it is wrong or the text is actually fine — say what they misread), or "amend" (real, but the severity or the proposed fix is wrong — give the corrected one).\n\n` +
+        `Default to REFUTE when the evidence is thin. A finding that cannot be independently reproduced from the tree should not survive into the consensus. Do not confirm out of collegiality.\n\n` +
+        `${READONLY}\n\n` +
+        `Finally, in "missedByBoth", note anything their report made you realise you BOTH missed.`,
+        { label: `cross:${g.tree.key}:${mine.key}`, phase: 'Cross-examine', model: 'fable', effort: 'high', schema: REBUTTAL_SCHEMA }
+      ).then((r) => r && { by: mine.lens, tree: g.tree.key, ...r })
+    })
+  )
+)
 
-return { audits: live, rebuttals: rebuttals.filter(Boolean) }
+return { audits: live, rebuttals: rebuttals.filter(Boolean), unreconciled, degraded: unreconciled.length > 0 }
 ```
 
 To iterate on the script, edit the file path the `Workflow` tool returns and

--- a/.claude/skills/review-pr-threads/SKILL.md
+++ b/.claude/skills/review-pr-threads/SKILL.md
@@ -109,7 +109,8 @@ After every thread is handled, if you committed any fixes, `git push` once (it
 re-triggers CI and the `claude-review` bot — expected). Then post the deferred
 replies + resolves for the fixed threads.
 
-Every commit fires the pre-commit `make lint` hook; fix lint before retrying.
+**There is no pre-commit hook** (`.git/hooks/` holds only `*.sample`), so nothing
+lints on your behalf — run `/lint` before committing.
 
 ## Guardrails
 

--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -210,6 +210,8 @@ coupling unrelated work.
 - If a requested change is ambiguous or risky, reply on the thread with your
   assessment and leave it for the user (note it in the final summary) rather than
   guessing.
-- Every commit fires the pre-commit `make lint` hook; fix lint before retrying.
+- **There is no pre-commit hook** (`.git/hooks/` holds only `*.sample`). Nothing
+  lints on your behalf — run `/lint` before committing, or the PR's `Lint` job is
+  the first thing that tells you.
 
 Arguments: $ARGUMENTS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,8 +266,10 @@ verifies with the targeted suite (not full `make ci`) and opens the PR via
 **Code review** — both the local `/review-changes` and the GitHub Actions reviewer
 follow one shared spec, [`.github/CODE_REVIEW.md`](.github/CODE_REVIEW.md), and
 **run only when the change touches reviewable code** — Swift for both
-reviewers, plus committed `.claude/workflows/` scripts for the local one
-(docs/prose-only changes are not reviewed). Three subagents back the pipeline:
+reviewers, plus committed `.claude/workflows/` and `Scripts/` for the local one
+(docs/prose-only changes are not reviewed, unless the caller passes
+`force-review` — `/deliver` does for a delivery that rewrites the pipeline's own
+skills). Three subagents back the pipeline:
 `code-reviewer` (deep Swift/TMDb review, pinned to Opus),
 `documentation-writer` (bulk DocC generation, pinned to Sonnet), and
 `tooling-runner` (build/test execution, pinned to Haiku).
@@ -486,7 +488,9 @@ before it**: the live integration suite is deliberately serialised, and
 re-running it is the largest avoidable cost in a delivery (#401). `/pr`
 documents the one sanctioned narrowing — a diff touching no `*.swift`,
 `Makefile`, `Package.swift`, `Package.resolved`, `*.xctestplan` or
-`.github/workflows/**` runs `make lint && make lint-markdown` instead.
+`.github/workflows/**` runs `make lint && make lint-markdown && make build-docs`
+instead (drop `build-docs` only if no `*.docc/**` changed). `/pr` owns that rule;
+if this paraphrase and `/pr` ever disagree, `/pr` is right.
 
 **The one thing `make ci` cannot check is `README.md`** — `build-docs` compiles
 DocC but cannot see a stale README. If the public API changed, keep it in sync
@@ -539,4 +543,7 @@ headless Actions). The MCP registration command, the `/x/all`
 path rationale, the owner/repo derivation, and the full `gh`-only exceptions are in
 [ADR-0009](knowledge/decisions/0009-github-mcp-over-gh-cli.md).
 
-**`make ci` must pass before pushing or opening a PR — no exceptions.**
+**The pre-PR gate must pass before pushing or opening a PR — no exceptions.**
+That is full `make ci`, or `/pr`'s docs/config-only narrowing above when the
+diff qualifies. "Narrowed" is not "skipped": one of the two must run and be
+green.

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -69,9 +69,15 @@ age differently:
   that lingers past a major bump is a bug in the process, not a backlog item.
 - **Don't pre-split a file.** Split a section into its own file only when it
   genuinely dominates (e.g. `gotchas.md` → `gotchas/tooling.md`), mirroring the
-  project's "promote a boundary only when the pain shows up" rule. The dated `###`
-  headings (newest at top) are the index — keep them grep-friendly so a reader can
-  pull one entry without reading the whole file.
+  project's "promote a boundary only when the pain shows up" rule. **The entry
+  headings are the index** — keep them grep-friendly so a reader can pull one
+  entry without reading the whole file. The shape differs by file, deliberately:
+  `gotchas.md` and `tmdb-api-notes.md` group `###` *topic* headings under `##`
+  sections and carry the date in the entry's first line (`*2026-08-12 (#440).*`),
+  because you grep them by symptom; `skill-improvement-log.md` uses dated `###`
+  headings newest-first and `delivery-retros.md` dated `##` ones, because you
+  read those chronologically. Match the file you are writing into rather than
+  imposing one scheme.
 
 ## Relationship to other stores
 

--- a/knowledge/decisions/0015-durable-deliver-run-state.md
+++ b/knowledge/decisions/0015-durable-deliver-run-state.md
@@ -1,7 +1,8 @@
 # ADR-0015: Durable `/deliver` run state in `.git/deliver/`
 
-**Date:** 2026-07-29
-**Status:** Accepted (unreleased — tooling only, no library impact)
+- **Status:** Accepted (unreleased — tooling only, no library impact)
+- **Date:** 2026-07-29
+- **Deciders:** Adam Young
 
 ## Context
 

--- a/knowledge/decisions/0016-panel-jurors-and-workflows-directory.md
+++ b/knowledge/decisions/0016-panel-jurors-and-workflows-directory.md
@@ -1,7 +1,8 @@
 # ADR-0016: Auto-mode panel as three independent jurors, in `.claude/workflows/`
 
-**Date:** 2026-07-29
-**Status:** Accepted (unreleased — tooling only, no library impact)
+- **Status:** Accepted (unreleased — tooling only, no library impact)
+- **Date:** 2026-07-29
+- **Deciders:** Adam Young
 
 ## Context
 

--- a/knowledge/decisions/0017-v4-api-client.md
+++ b/knowledge/decisions/0017-v4-api-client.md
@@ -1,10 +1,8 @@
-# 17. A third `TMDbAPIClient` instance for the v4 API
+# ADR-0017: A third `TMDbAPIClient` instance for the v4 API
 
-Date: 2026-08-07
-
-## Status
-
-Accepted
+- **Status:** Accepted (in 20.0.0, unreleased)
+- **Date:** 2026-08-07
+- **Deciders:** Adam Young
 
 ## Context
 

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -575,7 +575,7 @@ the 2026-07-28 audit.*
 
 ### Extraneous `CodingKeys` cases break synthesized `Encodable`
 
-*2026-08-12 (#418).* Adding a `CodingKeys` case with **no matching stored
+*2026-08-12 (#440).* Adding a `CodingKeys` case with **no matching stored
 property** — the normal way to decode a second key spelling, e.g. `name` alongside
 `title` — stops `Encodable` synthesising, because nothing can produce a value for
 that key. The compiler error names the conformance, not the extra case, so it
@@ -591,7 +591,7 @@ from `CodingKeys` is simply not encoded.
 
 ### A `package` symbol cannot be referenced by a DocC link
 
-*2026-08-12 (#418).* ` ``droppedItemCount`` ` in a doc comment fails
+*2026-08-12 (#440).* ` ``droppedItemCount`` ` in a doc comment fails
 `make build-docs` with `error: 'droppedItemCount' doesn't exist at '/TMDb/…'`
 when the symbol is `package` or `internal` — DocC resolves public API only, and
 the build is warnings-as-errors. Describe it in prose or use a code span. Same
@@ -599,7 +599,7 @@ family as the cross-module link trap.
 
 ### Check how a page is *built* before reasoning about its decode tolerance
 
-*2026-08-12 (#418).* Three `PageableListResult` specialisations are never decoded
+*2026-08-12 (#440).* Three `PageableListResult` specialisations are never decoded
 at all — `<MediaListItem>`, `<V4ListItem>` and `<ChangedID>` are assembled in
 Swift from an already-decoded model (`TMDbListService`, `TMDbV4ListService`,
 `ChangesService+Pagination`). The page type's decode behaviour, tolerant or
@@ -613,7 +613,7 @@ the *request* type (`DecodableAPIRequest<…>`) answers it in one step.
 
 ### Carry a decode marker inside a `DecodingError`, not as a bare custom error
 
-*2026-08-12 (#418).* To let a container skip one specific decode failure and stay
+*2026-08-12 (#440).* To let a container skip one specific decode failure and stay
 loud for the rest, you need to mark that failure. Throwing a custom `Error` from
 `init(from:)` works, but leaks: every model's `init(from:)` is **public**, so a
 consumer decoding their own cached JSON gets a type they cannot name, and
@@ -629,7 +629,7 @@ because Linux uses swift-corelibs-foundation's separate implementation.
 
 ### A fixture the author invented tests the author's belief, not the API
 
-*2026-08-12 (#418).* Two bugs in one delivery were hidden by hand-written
+*2026-08-12 (#440).* Two bugs in one delivery were hidden by hand-written
 fixtures that could not fail:
 
 - `tv-series-details-append-response.json` gave the appended `lists` section

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -735,9 +735,11 @@ two fields the dedup step keys on.
   `Network.logoPath` is correctly `URL?` because the API omits it; forcing
   non-optional would make decoding throw. The valuable, non-breaking piece (give
   `Network.homepage` the empty-string→nil guard `Company` already has) is split
-  into its own delivery. The opposite latent issue — `Company.logoPath` is a
-  *required* decode that throws if `logo_path` is absent — is captured in
-  `knowledge/tmdb-api-notes.md` and deferred (fixing it is breaking).
+  into its own delivery. The opposite latent issue — `Company.logoPath` was a
+  *required* decode that threw if `logo_path` was absent — was deferred here as
+  breaking, then **fixed in #404 and released in 19.0.0**: it is now `URL?`
+  decoded with `decodeNonEmptyURLIfPresent` (`Company.swift:48,131`), and so is
+  the nested `Company.Parent.logoPath` (`:163,213`).
 - **Rationale:** "make them consistent" would break public API and degrade decode
   resilience; only the non-breaking robustness improvement is worth doing now.
 - **Reconsider when:** **n/a for the `homepage` rename — it shipped.** The
@@ -745,9 +747,9 @@ two fields the dedup step keys on.
   `homepageURL` was merged in **#412** (2026-08-07) via `next-major.md`, which is
   exactly the route this entry anticipated. (Merged, not released: 20.0.0 is
   still untagged.) The rejection stands only for the *aligning* direction it was
-  written about — forcing `Network.logoPath` non-optional remains wrong, and the
-  open item is a major-version bump letting `Company.logoPath` become optional so
-  the two models can be aligned deliberately.
+  written about — forcing `Network.logoPath` non-optional remains wrong. **The
+  entry is now fully settled**: the `Company.logoPath` half it left open shipped
+  in #404, so there is nothing here for the dedup scan to resurface.
 
 ### 2026-06-24 — "Fix every instance of X" deliveries: enumerate all sites up front · applied
 
@@ -879,12 +881,14 @@ two fields the dedup step keys on.
   now, in opposite directions. #347: local SwiftLint cached a **false green** on
   new files that CI's clean checkout failed. #349: local `make lint-markdown`
   lints `.claude/**` and went **red** on `.claude/skills/deliver/SKILL.md:347`
-  (MD028), but CI's markdown job (`ci.yml:120`) lints only `README.md` + docc, so
+  (MD028), but CI's markdown job then lints only `README.md` + docc, so
   CI is green on it. Both stem from the two gates having different scopes/caches.
 - **Decision:** originally **deferred** (the fix was a repo-config change, outside
   the Phase-6 scan's remit) and **closed as applied on 2026-07-28** — the two
-  scopes are now identical: `Makefile:47–49` and `.github/workflows/ci.yml:122`
-  both lint `README.md`, `CLAUDE.md`, `**/*.docc/**/*.md`, `.claude/**/*.md`.
+  scopes are now identical: the `lint-markdown` target in `Makefile` and the
+  `Lint Markdown` job's run step in `.github/workflows/ci.yml` both lint
+  `README.md`, `CLAUDE.md`, `**/*.docc/**/*.md`, `.claude/**/*.md`. (Named by
+  target and job rather than line number — the numbers rot.)
   The #347 half was already mitigated in `/pr` (the `--no-cache` re-lint step).
 - **Rationale:** a green CI sitting behind a red local `make ci` repeatedly cost
   a triage detour and risked a real local failure being dismissed as "just the


### PR DESCRIPTION
## Summary

`/review-knowledge` was run against the repo after #441/#442/#443. Its first finding was about #442 itself.

## The headline: #442 widened the prose, not the machinery

The Scope table gained `.claude/`, `CLAUDE.md` and `CODE_REVIEW.md`. The **Workflow** — the part that actually runs — kept aiming both critics at `knowledge/` alone:

- the auditor preamble said *"the engineering knowledge base at `knowledge/`"*
- both lens briefs named only `knowledge/` files
- the finding schema's field was `knowledgeLocation: 'the knowledge/ file:line at fault'`

Run verbatim it returned **zero** findings outside `knowledge/` — a skill reporting a clean bill on a tree it never opened. That is this repo's own false-green family, and it is the decay mode the skill's own table lists at line 69 ("a skill delegating without passing the argument the other needs").

**Now two lenses × two trees = four audits**, with cross-examination paired *within* each tree so the lens-vs-lens challenge is preserved. A tree whose pair doesn't return is reported `unreconciled` rather than passed off as consensus — a dead auditor is not a clean bill.

Verified by extracting the script and running it against stubs:

| scenario | audits | cross-exams | result |
|---|---|---|---|
| healthy | 4 | 4 | `unreconciled: []`, `degraded: false` |
| one auditor killed | 4 | 2 | `unreconciled: ['claude']`, `degraded: true` |
| whole tree killed | 4 | 2 | `unreconciled: ['claude']`, `degraded: true` |

## Changes

**A fix that landed inert, and one that landed instance-scoped:**

- 🔧 **The reflexivity gate did nothing.** `/deliver` Phase 0 mandated overriding Phase 4's self-skip for a delivery that rewrites the pipeline — but `/review-changes` stops unconditionally on a "skills-prose change" and exposed no override, and Phase 4 still said *"Skip entirely"*, contradicting Phase 0 inside one file. Added `force-review` to `/review-changes` §0 and wired Phase 4 to pass it.
- 📝 **Five `#418` citations should be `#440`** — the same issue-vs-PR class #442 fixed for `#417`→`#432`, and all five were already in `gotchas.md` **when that sweep ran over that very file**. The rule landed in `/capture-knowledge`; the sweep was scoped to the instances in front of it.

**A phantom mechanism:**

- 🔧 Three skills asserted *"Every commit fires the pre-commit `make lint` hook"*. There is no such hook — `.git/hooks/` holds only `*.sample`. An agent trusting it skips linting and lets the PR's `Lint` job be the first thing that notices.

**Reviewable-set drift:**

- 🔧 `Scripts/` went into `/review-changes`' gate in #442 but not into the two places that restate the set (`CLAUDE.md`, `/deliver` Phase 4), nor `/pr`, which gated steps 5–7 on `.swift` alone. So a PR editing only `Scripts/check-defaulted-witnesses.py` — a CI gate — got no review from either route. All four now use one set.

**Knowledge-base corrections:**

- 📝 `skill-improvement-log.md` still described `Company.logoPath` as a required decode that throws, and framed the open item as a future major. It shipped in #404 and released in **19.0.0** — it is `URL?` with `decodeNonEmptyURLIfPresent` (`Company.swift:48,131`), as is `Company.Parent` (`:163,213`). This is the file the dedup scan reads as memory, so a stale entry there misinforms every future scan.
- 📝 Replaced dead `ci.yml:120` / `Makefile:47–49` pointers with target and job names — the facts were right, the line numbers had rotted.
- 📝 `README.md` claimed "the dated `###` headings are the index", which describes only `skill-improvement-log.md`. `gotchas.md`/`tmdb-api-notes.md` use undated `###` topic headings with the date in the body; `delivery-retros.md` uses dated `##`. Documented the three shapes and why they differ.
- 📝 **ADR headers:** 0017 used a foreign template (`# 17.`, bare `Date:`, `## Status` as a section) and 0015/0016 used unbulleted fields with no `Deciders`, so all three were invisible to the index's title and status sweeps. All 20 ADRs now match `0000-template.md`, verified by a shape check across the directory. Formatting only — `knowledge/README.md` sanctions correcting shape without supersession.

**Contract tightening:**

- 🔧 `/capture-knowledge`'s Return section never required the `swept:` line, though `/deliver` treats its absence as proof the sweep never ran.
- 📝 CLAUDE.md's paraphrase of `/pr`'s fast gate dropped the `make build-docs` leg, and *"`make ci` … no exceptions"* contradicted the narrowing the same file sanctions. Both fixed, with `/pr` named as the owner.
- 📝 `/deliver` referenced `/plan` in three places; CLAUDE.md already says it doesn't exist.

## Refuted by the audit, and not changed

Two findings were raised and **refuted** on evidence, recorded so they aren't re-raised cold: the retro window being "over budget" at 13 (the policy is doubly hedged — "roughly … ~12" — and three landed the same day), and `next-major.md` citing `#419` (the text writes the word "issue" first, which is exactly the carve-out kept for `#417`).

## Verification

`make lint` and `make lint-markdown` green. `knowledge/**` isn't in the lint scope; its one remaining `MD001` is the documented `###` entry convention and is left alone deliberately — changing it means restructuring three files or adding an exception, which is a judgement call, not a drive-by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
