### PR TITLE
🔧 Enforce the agent tool prohibitions, and lint knowledge/

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -3,6 +3,7 @@ name: code-reviewer
 description: Code reviewer subagent to be used to review code changes when asked, or at appropriate points when implementing new features
 model: opus
 permissionMode: auto
+disallowedTools: Edit, Write, NotebookEdit, Skill
 skills:
   - swift-concurrency
   - swift-testing-expert
@@ -50,6 +51,14 @@ guidelines mark as "tool-permitting / local only":
   settled without executing something, say so in the finding and let the
   caller run it — serially, once. Never read or touch `.swiftpm/` or
   `.build/`.
+
+  **Half of this is enforced, half is not — know which.** The frontmatter's
+  `disallowedTools` removes `Edit`/`Write`/`NotebookEdit` (you cannot modify
+  the tree, so "produce findings, don't fix" is structural) and `Skill` (so
+  `/build`, `/test` and `/integration-test` are unreachable). `Bash` you keep,
+  because you need `git diff` and `git log` — so **`make` and `swift build` are
+  still physically reachable and the rule against them rests on you**. That is
+  the one prohibition here with nothing behind it.
 
 ## Output
 

--- a/.claude/agents/tooling-runner.md
+++ b/.claude/agents/tooling-runner.md
@@ -3,6 +3,7 @@ name: tooling-runner
 description: Haiku runner for TMDb build/test commands — executes exactly one make target (or its xcode-tools MCP equivalent), writes the full output to a .build/last-*.log file, and returns only a concise pass/fail + failures-as-file:line summary. Spawned by the /build, /build-for-testing, /test, and /integration-test skills; not for ad-hoc shell work.
 model: haiku
 permissionMode: auto
+disallowedTools: Edit, Write, NotebookEdit, Agent, Skill
 ---
 
 # Claude Subagent: Tooling Runner (build/test)
@@ -11,6 +12,13 @@ You run **exactly one** build or test target for the TMDb Swift package and
 report the result concisely. Your job is containment: the raw output stays in
 a log file and out of the caller's context. Run only the target you were
 asked for — nothing else.
+
+**You cannot modify the tree.** `disallowedTools` removes `Edit`, `Write` and
+`NotebookEdit` — you report failures, you never fix them — plus `Agent` and
+`Skill`, so you cannot fan out or re-enter the build skills that spawned you.
+`Bash` and the `xcode-tools` MCP are yours, because running the target is the
+job. The log file is written by the shell redirect in the `make` command, not
+by a file-writing tool.
 
 ## Working directory — required, and never assumed
 

--- a/.claude/skills/capture-knowledge/SKILL.md
+++ b/.claude/skills/capture-knowledge/SKILL.md
@@ -116,11 +116,12 @@ observation rather than an invariant.
       `swept: <infra files touched> → <entries rewritten/deleted | none cited>`.
       No infra files in the diff → `swept: n/a`, and fall back to scanning
       the neighbouring entries of any knowledge file you edited.
-6. **Keep it tidy by hand** — blank lines around headings/lists/code fences, a
-   language on every fence, one `#` H1 per file. Note `knowledge/` is **not** in
-   the `make lint-markdown` scope (which covers `README.md`, `CLAUDE.md`,
-   `**/*.docc/**`, and `.claude/**`), so there's no CI gate on these files —
-   readability is on you. Aim for ~80-col prose; long `jq`/URL lines are fine.
+6. **Keep it tidy** — blank lines around headings/lists/code fences, a language
+   on every fence, one `#` H1 per file. `knowledge/**` **is** in the
+   `make lint-markdown` scope and the CI `Lint Markdown` job, so a malformed
+   entry fails the gate rather than rendering wrong in silence (a raw `|` inside
+   a table cell once did exactly that). Run `make lint-markdown` after writing.
+   Aim for ~80-col prose; long `jq`/URL lines are fine — `MD013` is disabled.
 7. **Update `knowledge/README.md`** only if you added a new file or category (the
    per-entry index inside each file is enough otherwise).
 

--- a/.claude/skills/diagnose-ci-failure/references/markdown.md
+++ b/.claude/skills/diagnose-ci-failure/references/markdown.md
@@ -7,14 +7,19 @@ The **Lint Markdown** job runs in the
 markdownlint "README.md" "CLAUDE.md" "**/*.docc/**/*.md" ".claude/**/*.md"
 ```
 
-Four path groups: `README.md`, `CLAUDE.md`, DocC catalog markdown
-(`Sources/**/*.docc/**/*.md`), and **every skill and agent file under
-`.claude/`** — which in this repo is the most frequently edited of the four, so
-a failure here is most often a skill edit, not a README one. `knowledge/**` is
-deliberately **not** linted. The job runs only when the `markdown` paths filter
+Five path groups: `README.md`, `CLAUDE.md`, DocC catalog markdown
+(`Sources/**/*.docc/**/*.md`), **every skill and agent file under `.claude/`**,
+and **the knowledge base under `knowledge/`** — the last two are the most
+frequently edited, so a failure here is most often a skill edit or a captured
+entry, not a README one. The job runs only when the `markdown` paths filter
 matched one of those, or on `workflow_dispatch`.
 
-Config is `.markdownlintrc`, shared by all four groups. Note **`MD013`
+`knowledge/skill-improvement-log.md` carries a scoped
+`<!-- markdownlint-disable-file MD001 -->`: its entries are dated `###` headings
+with no `##` sections, which is the documented log shape. That is the only
+per-file exemption — don't add more without saying why in the file.
+
+Config is `.markdownlintrc`, shared by all five groups. Note **`MD013`
 (line-length) and `MD041` (first-line heading) are disabled**, so neither can
 be the cause — don't start there.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
               - 'CLAUDE.md'
               - '**/*.docc/**/*.md'
               - '.claude/**/*.md'
+              - 'knowledge/**/*.md'
               - '.github/workflows/ci.yml'
 
   lint:
@@ -132,7 +133,7 @@ jobs:
 
       - name: Lint Markdown
         if: needs.changes.outputs.markdown == 'true' || github.event_name == 'workflow_dispatch'
-        run: markdownlint "README.md" "CLAUDE.md" "**/*.docc/**/*.md" ".claude/**/*.md"
+        run: markdownlint "README.md" "CLAUDE.md" "**/*.docc/**/*.md" ".claude/**/*.md" "knowledge/**/*.md"
 
   build-test:
     name: Build and Test

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ lint-markdown:
 	markdownlint "README.md" "CLAUDE.md"
 	markdownlint "**/*.docc/**/*.md"
 	markdownlint ".claude/**/*.md"
+	markdownlint "knowledge/**/*.md"
 
 .PHONY: build
 build:

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -1,3 +1,9 @@
+<!-- markdownlint-disable-file MD001 -->
+<!-- Entries are dated `###` headings under the H1 with no `##` sections —
+     the flat newest-first log shape documented in README.md and in the
+     format block below. MD001 (heading-increment) would require inventing
+     `##` sections this file does not have. Scoped here, not disabled repo-wide. -->
+
 # Skill-Improvement Log
 
 A durable record of every skill-improvement proposal raised by `/deliver`'s


### PR DESCRIPTION
## Summary

The two audit findings that were parked on an unanswered question. Both questions resolved — and one resolved into a *better* answer than the original plan.

## Agent prohibitions: a denylist, not an allowlist

`code-reviewer` and `tooling-runner` stated "do not edit" / "do not build" in prose, while `documentation-writer` had the enforceable version. The fix was parked because an **allowlist** means enumerating every tool the agent needs — `mcp__tmdb__*` for model↔API checks, `mcp__xcode-tools__*` inside Xcode — and silently crippling it if one is missed.

The docs settle it two ways: both fields accept `mcp__<server>__*` patterns, **and** `disallowedTools` *"inherits the subagent's tool pool except"* what it names, keeping Bash, MCP tools and the rest. A denylist removes exactly what the prose forbids and **cannot omit something needed**, so that's what this uses:

| agent | `disallowedTools` |
|---|---|
| `code-reviewer` | `Edit, Write, NotebookEdit, Skill` |
| `tooling-runner` | `Edit, Write, NotebookEdit, Agent, Skill` |

- 🔧 Denying `Skill` is what makes "do not build" real for the reviewer — `/build`, `/test` and `/integration-test` become unreachable.
- 🔧 **`Bash` must stay** (it needs `git diff` / `git log`), so `make` and `swift build` remain physically reachable and *that* half is still prose. Both agent files now say **which half is enforced and which is not**, rather than letting the frontmatter imply a guarantee it doesn't give.
- 🔧 `tooling-runner` also loses `Agent` — it runs one target, it doesn't fan out.

## knowledge/ joins the markdown gate

~2,700 lines, rewritten every delivery, with no gate at all. A raw `|` inside a table cell shipped and rendered a 5-column row in a 4-column table until #443 caught it by eye — exactly what `MD056` exists for.

- 🔧 Wired in **all three** places, per the rule the Makefile comment records: the `lint-markdown` target, the CI `Lint Markdown` run step, and the `markdown` **paths filter**. Miss the filter and a knowledge-only PR skips the very job that would have checked it.
- 🔧 The one blocker was `MD001` on `skill-improvement-log.md`: its entries are dated `###` headings under the H1 with no `##` sections. That shape is documented in `knowledge/README.md` *and* in the file's own format block, so it gets a scoped `<!-- markdownlint-disable-file MD001 -->` with the reason inline — rather than restructuring 44 headings or disabling `MD001` repo-wide. It's the only per-file exemption, and the diagnosis reference now says so.
- 📝 Corrected the two places that claimed knowledge/ is unlinted: `/capture-knowledge` (*"no CI gate on these files — readability is on you"*) and `diagnose-ci-failure/references/markdown.md` (*"deliberately not linted"*).

## Verification

**The gate was negative-tested, not merely observed green.** A deliberate malformed table planted in `knowledge/next-major.md` failed `make lint-markdown` with **exit 2** and a named `MD056`; reverting restored exit 0 and a clean diff. A gate that has never failed is indistinguishable from one that doesn't work — and that's the bug class this change exists to catch.

The diff touches `Makefile` and `ci.yml`, so `/pr`'s docs/config fast gate does **not** apply. Rather than skip, I proved the blast radius: `make -n` output is **byte-identical to `origin/main`** for `lint`, `lint-witnesses`, `test`, `build-release`, `build-docs` and `integration-test` — the sole behavioural change is one added `markdownlint` invocation in `lint-markdown`.

Ran every `make ci` leg except `integration-test`:

| leg | result |
|---|---|
| `lint` | PASS |
| `lint-markdown` | PASS |
| `test` | PASS |
| `build-release` | PASS |
| `build-docs` | PASS |

The live suite cannot be affected by a markdownlint path list, and the PR's CI runs the full matrix regardless since `ci.yml` is in the `swift` paths filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
