### PR TITLE
🔧 Fix the worktree-lifecycle drift and give refutations a memory

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -176,6 +176,26 @@ implementation = separate `/deliver` sessions.)
      (#407 shipped three defects from exactly this: a rewritten `/deliver`
      grading itself, ACs that outlived the mechanisms they graded, and a
      fan-out shipped as prose in the PR arguing prose isn't a gate.)
+  3. **Sweep the rule's whole footprint, not the file you opened.** Changing a
+     rule in a `SKILL.md` is not done until you have grepped its own
+     `references/`, the skills that delegate to it, and `CLAUDE.md` for the old
+     wording — a reference is not a copy of the skill, it is where the skill
+     sends you for the procedure, so a stale one is followed rather than
+     ignored. Grep for the *old* term, not the new one:
+
+     ```bash
+     git diff --name-only origin/main...HEAD | grep '^\.claude/skills/' \
+       | sed 's|/[^/]*$||' | sort -u        # every skill dir you touched
+     grep -rn '<the old wording>' .claude/ CLAUDE.md .github/CODE_REVIEW.md
+     ```
+
+     This has now recurred twice. #441–#443 each fixed `deliver/SKILL.md` and
+     left `deliver/references/worktree-lifecycle.md` — the file `SKILL.md`
+     points at — still teaching the forbidden `swept:` key, the superseded
+     "copy the settings file in" procedure, and a run-file schema missing the
+     field Phase 0 had just been told to write. Same shape as #444's
+     "the rule landed in `/capture-knowledge`; the sweep was scoped to the
+     instances in front of it".
   Phase 4 and Phase 5 both self-skip on a no-Swift diff — **override that here**
   and review the change on its own terms; the diff being markdown is not
   evidence it is low-risk.

--- a/.claude/skills/deliver/references/worktree-lifecycle.md
+++ b/.claude/skills/deliver/references/worktree-lifecycle.md
@@ -50,8 +50,13 @@ git worktree list --porcelain | awk -v r="$main_root/.claude/worktrees/" \
    Rows 2 and 6 make this total: **nothing can fail to classify**, so the sweep
    can never brick the pipeline on an unrecognised state.
 
-3. Record one ledger line: `swept: <n> in scope / <k> reclaimed / <r> resumable
-   / <o> reported`.
+3. Record one ledger line: `reconciled: <n> in scope / <k> reclaimed / <r>
+   resumable / <o> reported`, and carry it into the retro (Phase 8).
+   **The key is `reconciled:`, never `swept:`** — `swept:` belongs to Phase 7's
+   knowledge-retirement sweep, and when both wrote the same key the Phase 7 form
+   occupied the slot for four consecutive deliveries while this tripwire went
+   missing unnoticed. A filled slot looked identical to the right one. See
+   `SKILL.md` Phase 1 and `references/wrap-up.md`'s retro format.
 
 ### Liveness is a fact, not a timeout
 
@@ -142,6 +147,8 @@ PR body is required to say so.
 {
   "id": "harden-delivery-skills-2026-07-29T19:28:23Z",
   "goal": "…", "weight": "full",
+  "reflexive": false,
+  "consulted": "gotchas §False green, §Docs scratch path; ADR-0014",
   "reconciled": { "inScope": 1, "reclaimed": 0, "resumable": 0, "reported": 0 },
   "deliverables": [{
     "title": "…", "dependsOn": [],
@@ -161,6 +168,15 @@ PR body is required to say so.
 A **batch is the N=1 case generalised** — more entries in `deliverables[]`. No
 separate mechanism, and it is the only state that survives Phase 10's
 background-watch handoff, where the conductor moves to the next worktree.
+
+Two run-scoped fields sit outside `deliverables[]` because they describe the
+run, not a deliverable. **`consulted`** is Phase 0's knowledge-consult proof —
+the ledger that would otherwise hold it does not survive `EnterWorktree`, so
+this is its durable home, and Phase 8 copies it into the retro.
+**`reflexive`** is true when the diff touches `.claude/skills/**`,
+`.claude/agents/**` or `.github/CODE_REVIEW.md`, which changes what Phases 4
+and 5 do (see `SKILL.md` Phase 0). A field mandated by a phase but absent from
+this schema is a field nothing ends up writing.
 
 ### Stamps: hash content, never a commit
 
@@ -220,27 +236,29 @@ must never destroy unpushed commits.
   create the branch in it (`git checkout -b feature/<slug>`). `EnterWorktree`
   refuses to nest anyway.
 
-## Restore the permission allowlist
+## Confirm `.claude/settings.local.json` arrived
 
-Credentials are **not** the concern — `TMDB_API_KEY` / `USERNAME` / `PASSWORD`
-are injected into the session's **process environment** at startup
-(CWD-independent), and `make ci` / `make integration-test` read them straight
-from the environment. What a fresh worktree lacks is the **gitignored
-`.claude/settings.local.json`**, which holds the **permission allowlist** —
-without it an autonomous run could stall on permission prompts. Copy it in as
-cheap insurance:
+**`.worktreeinclude` copies it in.** The repo-root `.worktreeinclude` lists this
+file (and `*.xctestplan`), and Claude Code copies every gitignored file it names
+into each worktree it creates. So this is a **verification, not a copy**:
 
 ```bash
-# CWD is the worktree; the main checkout is the first entry of `git worktree list`.
-main_root=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
-mkdir -p .claude
-cp "$main_root/.claude/settings.local.json" .claude/settings.local.json 2>/dev/null || true
+test -f .claude/settings.local.json || echo "MISSING — copy from the main checkout"
 ```
 
-It stays gitignored in the worktree, so it won't be committed. If `make ci`'s
-integration leg fails on **credentials**, the cause is the *env* not being
-inherited by whatever spawned the subshell — **not** this file; check the
-environment first.
+Missing → copy it from the main checkout and say so in the ledger, because a
+worktree without it is a worktree that cannot authenticate.
+
+**It carries the credentials, not just permissions.** `TMDB_API_KEY`,
+`TMDB_USERNAME`, `TMDB_PASSWORD` and the two v4 tokens live in its `env` block
+(`CLAUDE.md` → *Shell Environment*), and a fresh checkout has none of them — so
+without this file `make integration-test` fails at `.check-env-vars` and the v4
+suites skip. Treat it as credential-bearing: never paste its contents, never
+commit it. It stays gitignored inside the worktree.
+
+Permission *approvals* no longer need copying at all: since Claude Code
+v2.1.211 an approval granted in a worktree saves to the **main checkout's** copy
+and applies across every worktree of the repo.
 
 ## The main-checkout path trap
 

--- a/.claude/skills/review-knowledge/SKILL.md
+++ b/.claude/skills/review-knowledge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-knowledge
-description: Audit the knowledge/ base and the .claude/ skills, agents and workflows for staleness, self-contradiction, and drift from their own stated rules — two independent adversarial critics verify every load-bearing claim against the current tree, cross-examine each other, and reach a consensus on if/what needs changing. Use periodically, after a run of deliveries that changed build config, target layout or the skills themselves, or whenever you suspect the docs have aged out of true.
+description: Audit the knowledge/ base and the .claude/ skills, agents and workflows for staleness, self-contradiction, and drift from their own stated rules — four independent adversarial auditors (two lenses over two trees) verify every load-bearing claim against the current tree, cross-examine each other within their tree, and reach a consensus on if/what needs changing. Use periodically, after a run of deliveries that changed build config, target layout or the skills themselves, or whenever you suspect the docs have aged out of true.
 ---
 
 # Review Knowledge
@@ -12,8 +12,10 @@ phase) but retirements are not, so truth decays exactly where the code moves
 fastest — `Makefile`, `.github/workflows/ci.yml`, `Package.swift`, target layout,
 toolchain pins.
 
-Two independent adversarial critics audit it, cross-examine each other's findings,
-and converge on a consensus. You adjudicate only what survives disputed.
+Four independent adversarial auditors — an accuracy lens and a structure lens over
+each of the two trees — audit them, cross-examine each other's findings within
+their tree, and converge on a consensus. You adjudicate only what survives
+disputed.
 
 > The base's own entries are the thing under suspicion. An entry that reads
 > confidently and cites a file is exactly the kind that goes stale unnoticed —
@@ -23,24 +25,33 @@ and converge on a consensus. You adjudicate only what survives disputed.
 
 The point of this skill: do these by default, without being reminded.
 
-1. **Two critics, two lenses, one Workflow.** Run the embedded `Workflow` below.
-   It fans out exactly two auditors in parallel, each pinned to the **`fable`**
-   model, then runs a **cross-examination** round where each sees the other's
-   findings. Invoking this skill is itself the opt-in to call `Workflow`.
-2. **Verify, never trust the prose.** Every finding must be checked against the
+1. **Two lenses × two trees, one Workflow.** Run the embedded `Workflow` below.
+   It fans out **four** auditors in parallel — each lens against each tree —
+   every one pinned to the **`fable`** model, then runs a **cross-examination**
+   round **paired within each tree**, so the two lenses challenge each other on
+   the same material. Invoking this skill is itself the opt-in to call
+   `Workflow`. A tree whose pair doesn't both return is reported
+   `unreconciled`, never as consensus.
+2. **Consult the refutation memory first.** Before reporting, grep
+   [`knowledge/skill-improvement-log.md`](../../../knowledge/skill-improvement-log.md)
+   for `· refuted` entries and drop any finding already settled there whose
+   *Reconsider when* condition is unmet. Say in the report how many you dropped
+   this way. Re-deriving a settled refutation costs a full audit cycle and buys
+   nothing.
+3. **Verify, never trust the prose.** Every finding must be checked against the
    actual tree (`Read`/`Grep`/`Bash`) and cite `file:line`. A finding sourced only
    from reading the knowledge base itself is inadmissible — that is the failure
    mode being audited.
-3. **Critics are read-only.** They audit and report. They do not edit `knowledge/`,
+4. **Critics are read-only.** They audit and report. They do not edit `knowledge/`,
    do not fix anything, and do not open PRs. Applying is the conductor's job, after
    the user approves.
-4. **"Nothing needs changing" is a real, respectable outcome.** A critic that
+5. **"Nothing needs changing" is a real, respectable outcome.** A critic that
    finds a file accurate must say so and name what it checked. Do not manufacture
    findings to look thorough — a padded audit trains the next one to be ignored.
-5. **Adjudicate only genuine deadlock.** After cross-examination, findings both
+6. **Adjudicate only genuine deadlock.** After cross-examination, findings both
    critics confirm are consensus and need no debate from you. Resolve only what
    remains disputed, with a stated rationale grounded in the tree.
-6. **Report before you fix.** Present the consensus, get the user's go-ahead, then
+7. **Report before you fix.** Present the consensus, get the user's go-ahead, then
    apply. Never silently rewrite the knowledge base on the strength of an audit.
 
 ## Scope
@@ -78,17 +89,17 @@ propagated it upstream.
 
 ## Run the audit (Workflow)
 
-Two auditors run as a single `Workflow` so the **`fable`** model is guaranteed per
-agent and each verdict is schema-validated rather than free-text. No `args` are
-needed — the scope is the repository itself.
+Four auditors run as a single `Workflow` so the **`fable`** model is guaranteed
+per agent and each verdict is schema-validated rather than free-text. No `args`
+are needed — the scope is the repository itself.
 
 ```javascript
 export const meta = {
   name: 'review-knowledge-critics',
-  description: 'Two adversarial Fable critics audit the knowledge base, then cross-examine',
+  description: 'Four adversarial Fable auditors (2 lenses x 2 trees), then cross-examine',
   phases: [
-    { title: 'Audit', detail: 'two fable critics, one per lens' },
-    { title: 'Cross-examine', detail: 'each critic tries to refute the other' },
+    { title: 'Audit', detail: 'four fable auditors: each lens over each tree' },
+    { title: 'Cross-examine', detail: 'lenses refute each other, paired within a tree' },
   ],
   model: 'fable',
 }
@@ -237,9 +248,17 @@ The critics have already done the reconciling work — read it, don't redo it:
 1. **Consensus findings** — raised by one critic and **confirmed** by the other.
    These are settled. Do not re-litigate them; carry them at the confirmed
    severity (or the amended one, if the cross-examiner amended and justified it).
-2. **Refuted findings** — dropped. Record them in the report as *raised and
-   refuted*, with the refutation's reasoning, so the next audit doesn't re-raise
-   them cold.
+2. **Refuted findings** — dropped. Report them as *raised and refuted* with the
+   refutation's reasoning **and write them into
+   [`knowledge/skill-improvement-log.md`](../../../knowledge/skill-improvement-log.md)
+   as `· refuted` entries** (its five-field shape; the *Rationale* carries the
+   tree evidence, the *Reconsider when* the condition that would revive the
+   claim). **A refutation recorded only in a PR body does not exist**: the next
+   audit greps `knowledge/`, finds nothing, and re-raises it cold — observed on
+   2026-08-13, when a finding refuted in #444 came back on the very next run.
+   Like every other edit, these entries are written in **Apply**, after the
+   user's go-ahead — and they are worth writing even when the user declines
+   every fix, because the memory is what stops the next run re-deriving them.
 3. **Disputed** — a finding whose rebuttal is itself unconvincing (asserts rather
    than evidences). **This is the only place you adjudicate.** Verify it yourself
    against the tree and make the call, stating what you checked.

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -6,33 +6,72 @@
 
 # Skill-Improvement Log
 
-A durable record of every skill-improvement proposal raised by `/deliver`'s
-**wrap-up recurring-pattern scan**, and the decision on it. Newest at the top.
+A durable record of every proposal raised against this repo's own tooling, and
+the decision on it. Newest at the top. Two producers write here:
 
-**Why this exists:** the scan surfaces proposals and waits for approval.
-Without a memory of past decisions, it would re-propose ideas already **applied**
-or deliberately **deferred/rejected** — wasting attention and re-litigating
-settled calls. The scan **consults this log before proposing** and skips any
-pattern already decided here. Record both the *yes* and the *no* (with rationale)
-— the *no*s are what stop the loop repeating itself.
+- **`/deliver`'s wrap-up recurring-pattern scan** — proposals to change a skill.
+- **`/review-knowledge`** — audit findings that were **refuted**, and any
+  finding accepted as a standing exception rather than fixed.
 
-Status values: **applied** · **deferred** · **rejected**.
+**Why this exists:** both producers surface candidates and wait for approval.
+Without a memory of past decisions they re-raise what is already **applied** or
+deliberately **deferred/rejected/refuted** — wasting attention and re-litigating
+settled calls. Both **consult this log before raising** and skip anything
+already decided here. Record the *no*s with their evidence: the *no*s are what
+stop the loop repeating itself.
+
+**Refutations must live here, not in a PR body.** A refutation recorded only in
+a PR description is invisible to the next audit, which then re-raises it cold —
+observed on 2026-08-13, when a finding refuted in #444 came back on the very
+next run because `grep -rn "refut" knowledge/` found nothing.
+
+Status values: **applied** · **deferred** · **rejected** · **refuted**.
 
 Format per entry:
 
 ```text
-### <date> — <short title> · <applied|deferred|rejected>
-- **Pattern:** what kept recurring (and the retro entries it appeared in).
+### <date> — <short title> · <applied|deferred|rejected|refuted>
+- **Pattern:** what kept recurring (and the retro entries it appeared in), or —
+  for a refutation — what was claimed and where.
 - **Decision:** what was agreed, and where it landed (skill + commit/PR) if applied.
-- **Rationale:** one or two sentences — why this call.
-- **Reconsider when:** (deferred/rejected only) the condition under which the scan
-  should resurface this — or `n/a` for applied entries. The scan reads this
-  field to decide whether a settled *no* may be re-proposed.
+- **Rationale:** one or two sentences — why this call. For a refutation, the
+  evidence from the tree that disproves the claim, not an opinion.
+- **Reconsider when:** (deferred/rejected/refuted only) the condition under which
+  the producer may resurface this — or `n/a` for applied entries. Both the
+  wrap-up scan and `/review-knowledge` read this field to decide whether a
+  settled *no* may be raised again.
 ```
 
 Keep this five-field shape on every entry so the scan can parse the log
 consistently — in particular **Decision** (status) and **Reconsider when** are the
 two fields the dedup step keys on.
+
+---
+
+### 2026-08-13 — `/review-knowledge` findings refuted on evidence · refuted
+
+- **Pattern:** two findings raised by the audit behind #444 were refuted after
+  verification, and the refutations were recorded **only in the PR body**. The
+  next run of the skill re-raised one of them cold, because nothing under
+  `knowledge/` carried the decision. The skill's own contract says to record a
+  refuted finding "so the next audit doesn't re-raise them cold" — it had no
+  place to record it.
+- **Decision:** **refuted**, both, and recorded here so they are dedup memory
+  rather than PR archaeology:
+  1. *"`delivery-retros.md` is over its ~12-entry rolling window (13 entries)."*
+     The policy at `knowledge/README.md` is doubly hedged — "roughly … ~12" —
+     and three of the 13 landed on one day. In spec.
+  2. *"`next-major.md` cites issue #419 where the rule requires the PR (#433)."*
+     The text writes the word **issue** before `#419`, which is exactly the
+     carve-out the cite-the-PR rule allows and which #442 deliberately kept for
+     "issue #417". Adding `#433` would be cosmetic.
+- **Rationale:** both refutations rest on the audited file's own stated policy,
+  not on taste, and the 2026-08-13 run independently reached the same verdict on
+  (1) — a re-derivation that cost a full audit cycle to buy nothing.
+- **Reconsider when:** (1) if `delivery-retros.md` reaches ~15 full prose entries,
+  or the README's hedge is tightened to a hard number — then it is a real
+  overflow, not a rounding argument. (2) if the entry is ever reworded to drop
+  the literal word "issue" before the number.
 
 ---
 


### PR DESCRIPTION
## Summary

From the **first real run** of the widened `/review-knowledge` — 8/8 auditors returned, `unreconciled: []`, `degraded: false`, so #444's 2×2 rewrite is validated on its first outing. This takes the high-value subset of that audit.

## One file absorbed three fixes that never reached it

#441, #442 and #443 each edited `deliver/SKILL.md` and left **`deliver/references/worktree-lifecycle.md`** — the file `SKILL.md` points at for the procedure — still teaching the superseded version.

- 🐛 **critical** — `:53` said `Record one ledger line: swept: <n> in scope …`, the exact key `SKILL.md:239` now forbids (*"**never as `swept:`**"*). #441 split those keys **because** a `swept:` collision swallowed the Phase 1 tripwire for four consecutive deliveries — so following `SKILL.md`'s own pointer landed you straight back on the collision it fixed. Now `reconciled:`, with the incident recorded so it reads as a reason rather than a preference.
- 🔧 **major** — the settings-file section led with *"Credentials are **not** the concern"* plus a copy recipe. Both halves are false as of #443: the file's `env` block **is** where the credentials come from, and `.worktreeinclude` now copies it, making Phase 1 a *verification*. Rewritten, and noting permission approvals no longer need copying at all (Claude Code v2.1.211 saves them to the main checkout).
- 🔧 **major** — the run-file schema had no `consulted` field, though #442 moved Phase 0's knowledge-consult proof into the run file and `wrap-up.md` copies it *"from the run file"*. **A field mandated by a phase but absent from the schema is a field nothing writes.** Added, with `reflexive` alongside it, and a note on why both sit outside `deliverables[]`.

## Refutations now have a durable home

The audit's sharpest finding was about the skill itself: #444 refuted two findings and recorded them **only in the PR body**, so `grep -rn "refut" knowledge/` found nothing and the next run re-raised one **cold**. The skill's own contract says to record refutations *"so the next audit doesn't re-raise them cold"* — it had nowhere to put them.

`skill-improvement-log.md` already **is** a dedup memory keyed on Decision and Reconsider-when, so a refutation fits its shape exactly:

- 🔧 Widened to take a second producer; `refuted` added to the status vocabulary; both lost refutations recorded with their tree evidence.
- 🔧 `/review-knowledge` now **consults** it before reporting (contract item 2) and **writes** refutations in Apply — worth doing even when the user declines every fix, because the memory is the point.

## The class, not just the instances

Six findings shared one shape: **a fix scoped to the file in front of it.** The reflexivity gate — which already fires on `.claude/skills/**` — gains a third consequence: sweep the rule's whole footprint (its own `references/`, the skills that delegate to it, `CLAUDE.md`) by grepping the **old** wording, not the new one. A reference is not a copy of a skill; it is *where the skill sends you*, so a stale one is followed rather than ignored.

## Applying that sweep to this change caught five more

Grepping the old wording found `/review-knowledge` still advertising **"two independent adversarial critics"** in:

- its frontmatter `description`
- its intro paragraph
- its prose (*"Two auditors run as a single Workflow"*)
- its `Workflow` `meta.description` **and both phase details** — which are what you actually see in progress output
- contract item 1 (*"exactly two auditors"*)

All corrected to four. The rule earned its keep on the very commit that introduced it.

## Verification

The workflow script still parses — extracted and `node --check`ed, since it can't run standalone (harness globals + a top-level `return`). `make lint` and `make lint-markdown` green. Docs-only diff: no Makefile, workflow or Swift change, so `/pr`'s fast gate applies.

Not included from the audit: ~19 minor findings (log ordering, ADR index annotations, a stale `/lint` description in a diagnosis reference, retro tripwire back-dating). Real but hygiene — happy to take them as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
