### PR TITLE
🐛 Fix the tvOS and watchOS build break in TMDbIntelligence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,73 @@ jobs:
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
         run: set -o pipefail && swift build -c release -Xswiftc -warnings-as-errors 2>&1 | xcsift -f github-actions --Werror
 
+  # Compile-only sweep of the non-macOS Apple platforms. `swift build` can only
+  # target the host, so without this job nothing in CI ever compiles for
+  # tvOS/watchOS/iOS/visionOS — which is how #416 shipped green: Xcode 27's tvOS
+  # SDK made `canImport(FoundationModels)` true with every symbol unavailable,
+  # and both macOS and Linux stayed happy. Build-only is deliberate: this bug
+  # class is a compile-time availability failure, and the unit tests already run
+  # on macOS and Linux, so booting four simulators would only buy a slower rerun
+  # of the same assertions.
+  build-platforms:
+    name: Build (${{ matrix.name }})
+    needs: changes
+    if: always()
+    runs-on: >-
+      ${{
+        (needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch')
+        && 'xcode-27' || 'ubuntu-latest'
+      }}
+    strategy:
+      # Report every broken platform in one run — availability breakage is
+      # usually per-platform, and failing fast would hide the others.
+      fail-fast: false
+      matrix:
+        include:
+          - name: iOS
+            destination: generic/platform=iOS Simulator
+          - name: tvOS
+            destination: generic/platform=tvOS Simulator
+          - name: watchOS
+            destination: generic/platform=watchOS Simulator
+          - name: visionOS
+            destination: generic/platform=visionOS Simulator
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_27.0.app/Contents/Developer
+    steps:
+      - name: No changes detected
+        if: needs.changes.outputs.swift != 'true' && github.event_name != 'workflow_dispatch'
+        run: echo "No Swift changes detected, skipping ${{ matrix.name }} build"
+
+      - name: Checkout
+        if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v7
+
+      - name: Cache Xcode DerivedData
+        if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
+        uses: actions/cache@v6
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-xcode-${{ matrix.name }}-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-${{ matrix.name }}-
+
+      - name: Install xcsift
+        if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
+        run: |
+          # Drop runner-preinstalled taps Homebrew's trust policy warns about.
+          brew untap aws/tap azure/bicep 2>/dev/null || true
+          brew install xcsift
+
+      # `TMDb-Package`, never `TMDb`: the `TMDb` scheme builds only the core
+      # target, so it would have compiled cleanly straight through #416 — the
+      # break was in TMDbIntelligence. The generic destination needs the SDK
+      # only (no simulator runtime, no boot), so it does not rot when the runner
+      # image changes its installed device names or OS versions.
+      - name: Build
+        if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
+        run: set -o pipefail && xcodebuild build -scheme TMDb-Package -destination '${{ matrix.destination }}' 2>&1 | xcsift -f github-actions --Werror
+
   build-test-linux:
     name: Build and Test (Linux)
     needs: changes
@@ -265,7 +332,7 @@ jobs:
   ci:
     name: CI
     if: always()
-    needs: [lint, lint-markdown, build-test, build-test-linux]
+    needs: [lint, lint-markdown, build-test, build-platforms, build-test-linux]
     runs-on: ubuntu-latest
     steps:
       - name: Check job results
@@ -274,6 +341,7 @@ jobs:
             "${{ needs.lint.result }}" \
             "${{ needs.lint-markdown.result }}" \
             "${{ needs.build-test.result }}" \
+            "${{ needs.build-platforms.result }}" \
             "${{ needs.build-test-linux.result }}" \
           )
           for result in "${results[@]}"; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,6 @@ jobs:
       }}
     env:
       DEVELOPER_DIR: /Applications/Xcode_27.0.app/Contents/Developer
-      # Pin lint tool versions so CI matches local `make lint` exactly and does
-      # not drift when Homebrew publishes a new release.
       SWIFTLINT_VERSION: 0.63.2
       SWIFTFORMAT_VERSION: 0.61.1
     steps:
@@ -106,11 +104,6 @@ jobs:
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
         run: swiftformat --lint .
 
-      # Cross-symbol check that swiftlint cannot express: a public-extension
-      # convenience must not share a requirement's signature, or it silently
-      # becomes that requirement's witness and self-recurses. `make lint` runs
-      # this too, but the Lint job invokes the tools directly rather than via
-      # make — so without this step the guard would never run in CI.
       - name: Defaulted-witness check
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
         run: python3 Scripts/check-defaulted-witnesses.py
@@ -169,7 +162,6 @@ jobs:
       - name: Install xcsift
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
         run: |
-          # Drop runner-preinstalled taps Homebrew's trust policy warns about.
           brew untap aws/tap azure/bicep 2>/dev/null || true
           brew install xcsift
 
@@ -185,10 +177,6 @@ jobs:
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           set -euo pipefail
-          # Ask SwiftPM where things are rather than hardcoding paths: Swift 6.4
-          # moved the build products to .build/out/Products/Debug and emits one
-          # .xctest bundle per test target instead of a single merged
-          # <Package>PackageTests.xctest.
           BIN_PATH=$(swift build --show-bin-path)
           PROFDATA="$(dirname "$(swift test --show-codecov-path)")/default.profdata"
 
@@ -205,7 +193,6 @@ jobs:
           xcrun llvm-cov export -format="lcov" "${OBJECTS[@]}" \
             -instr-profile "${PROFDATA}" > info.lcov
 
-          # Fail loudly rather than uploading an empty report as 0% coverage.
           if [ ! -s info.lcov ]; then
             echo "::error::Coverage export produced an empty report"
             exit 1
@@ -235,17 +222,6 @@ jobs:
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
         run: set -o pipefail && swift build -c release -Xswiftc -warnings-as-errors 2>&1 | xcsift -f github-actions --Werror
 
-  # Compile-only sweep of the non-macOS Apple platforms' LIBRARY targets.
-  # `swift build` can only target the host, so without this job nothing in CI
-  # ever compiles for tvOS/watchOS/iOS/visionOS — which is how #416 shipped
-  # green: Xcode 27's tvOS SDK made `canImport(FoundationModels)` true with
-  # every symbol unavailable, and both macOS and Linux stayed happy.
-  #
-  # Build-only is deliberate: this bug class is a compile-time availability
-  # failure, and the unit tests already run on macOS and Linux, so booting four
-  # simulators would only buy a slower rerun of the same assertions. Note the
-  # consequence — `xcodebuild build` (unlike `build-for-testing`) does not
-  # compile the test targets, so this net watches shipped code only.
   build-platforms:
     name: Build (${{ matrix.name }})
     needs: changes
@@ -256,8 +232,6 @@ jobs:
         && 'xcode-27' || 'ubuntu-latest'
       }}
     strategy:
-      # Report every broken platform in one run — availability breakage is
-      # usually per-platform, and failing fast would hide the others.
       fail-fast: false
       matrix:
         include:
@@ -285,16 +259,6 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/Library/Developer/Xcode/DerivedData
-          # Deliberately NOT hashFiles('**/Package.resolved'): this package has
-          # no external dependencies, so no Package.resolved is ever written and
-          # that key hashes to the empty string — a constant that `actions/cache`
-          # then never re-saves, freezing DerivedData built by an older toolchain.
-          # Hashing ci.yml covers the DEVELOPER_DIR pin, so an Xcode bump
-          # invalidates the cache by itself.
-          # The ci.yml hash is in the restore PREFIX, not just the key: a bare
-          # prefix would re-import the pre-bump DerivedData on the very miss the
-          # key exists to cause. Package.swift stays in the tail so ordinary
-          # manifest churn still restores a warm cache.
           key: ${{ runner.os }}-xcode-${{ matrix.name }}-${{ hashFiles('.github/workflows/ci.yml') }}-${{ hashFiles('Package.swift') }}
           restore-keys: |
             ${{ runner.os }}-xcode-${{ matrix.name }}-${{ hashFiles('.github/workflows/ci.yml') }}-
@@ -302,15 +266,9 @@ jobs:
       - name: Install xcsift
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
         run: |
-          # Drop runner-preinstalled taps Homebrew's trust policy warns about.
           brew untap aws/tap azure/bicep 2>/dev/null || true
           brew install xcsift
 
-      # `TMDb-Package`, never `TMDb`: the `TMDb` scheme builds only the core
-      # target, so it would have compiled cleanly straight through #416 — the
-      # break was in TMDbIntelligence. The generic destination needs the SDK
-      # only (no simulator runtime, no boot), so it does not rot when the runner
-      # image changes its installed device names or OS versions.
       - name: Build
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
         run: set -o pipefail && xcodebuild build -scheme TMDb-Package -destination '${{ matrix.destination }}' 2>&1 | xcsift -f github-actions --Werror
@@ -345,13 +303,6 @@ jobs:
   ci:
     name: CI
     if: always()
-    # `changes` is in this list on purpose. Every other job is `if: always()`,
-    # so when `changes` fails they all still run — but with its outputs empty,
-    # every *work* step's `if:` is false (only the "No changes detected" echo
-    # fires) and each job exits `success`. Without the `changes` result here,
-    # `CI` would then go green having linted, tested and compiled nothing at
-    # all. The window is `pull_request`/`push`; `workflow_dispatch` runs the
-    # work steps via the second disjunct regardless.
     needs: [changes, lint, lint-markdown, build-test, build-platforms, build-test-linux]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,14 +235,17 @@ jobs:
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
         run: set -o pipefail && swift build -c release -Xswiftc -warnings-as-errors 2>&1 | xcsift -f github-actions --Werror
 
-  # Compile-only sweep of the non-macOS Apple platforms. `swift build` can only
-  # target the host, so without this job nothing in CI ever compiles for
-  # tvOS/watchOS/iOS/visionOS — which is how #416 shipped green: Xcode 27's tvOS
-  # SDK made `canImport(FoundationModels)` true with every symbol unavailable,
-  # and both macOS and Linux stayed happy. Build-only is deliberate: this bug
-  # class is a compile-time availability failure, and the unit tests already run
-  # on macOS and Linux, so booting four simulators would only buy a slower rerun
-  # of the same assertions.
+  # Compile-only sweep of the non-macOS Apple platforms' LIBRARY targets.
+  # `swift build` can only target the host, so without this job nothing in CI
+  # ever compiles for tvOS/watchOS/iOS/visionOS — which is how #416 shipped
+  # green: Xcode 27's tvOS SDK made `canImport(FoundationModels)` true with
+  # every symbol unavailable, and both macOS and Linux stayed happy.
+  #
+  # Build-only is deliberate: this bug class is a compile-time availability
+  # failure, and the unit tests already run on macOS and Linux, so booting four
+  # simulators would only buy a slower rerun of the same assertions. Note the
+  # consequence — `xcodebuild build` (unlike `build-for-testing`) does not
+  # compile the test targets, so this net watches shipped code only.
   build-platforms:
     name: Build (${{ matrix.name }})
     needs: changes
@@ -282,7 +285,13 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/Library/Developer/Xcode/DerivedData
-          key: ${{ runner.os }}-xcode-${{ matrix.name }}-${{ hashFiles('**/Package.resolved') }}
+          # Deliberately NOT hashFiles('**/Package.resolved'): this package has
+          # no external dependencies, so no Package.resolved is ever written and
+          # that key hashes to the empty string — a constant that `actions/cache`
+          # then never re-saves, freezing DerivedData built by an older toolchain.
+          # Hashing ci.yml covers the DEVELOPER_DIR pin, so an Xcode bump
+          # invalidates the cache by itself.
+          key: ${{ runner.os }}-xcode-${{ matrix.name }}-${{ hashFiles('Package.swift', '.github/workflows/ci.yml') }}
           restore-keys: |
             ${{ runner.os }}-xcode-${{ matrix.name }}-
 
@@ -332,12 +341,18 @@ jobs:
   ci:
     name: CI
     if: always()
-    needs: [lint, lint-markdown, build-test, build-platforms, build-test-linux]
+    # `changes` is in this list on purpose. Every other job is `if: always()`,
+    # so when `changes` fails they all still run — but with its outputs empty,
+    # every step's `if:` is false and each job exits `success`. Without the
+    # `changes` result here, `CI` would then go green having linted, tested and
+    # compiled nothing at all.
+    needs: [changes, lint, lint-markdown, build-test, build-platforms, build-test-linux]
     runs-on: ubuntu-latest
     steps:
       - name: Check job results
         run: |
           results=( \
+            "${{ needs.changes.result }}" \
             "${{ needs.lint.result }}" \
             "${{ needs.lint-markdown.result }}" \
             "${{ needs.build-test.result }}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,9 +291,13 @@ jobs:
           # then never re-saves, freezing DerivedData built by an older toolchain.
           # Hashing ci.yml covers the DEVELOPER_DIR pin, so an Xcode bump
           # invalidates the cache by itself.
-          key: ${{ runner.os }}-xcode-${{ matrix.name }}-${{ hashFiles('Package.swift', '.github/workflows/ci.yml') }}
+          # The ci.yml hash is in the restore PREFIX, not just the key: a bare
+          # prefix would re-import the pre-bump DerivedData on the very miss the
+          # key exists to cause. Package.swift stays in the tail so ordinary
+          # manifest churn still restores a warm cache.
+          key: ${{ runner.os }}-xcode-${{ matrix.name }}-${{ hashFiles('.github/workflows/ci.yml') }}-${{ hashFiles('Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-xcode-${{ matrix.name }}-
+            ${{ runner.os }}-xcode-${{ matrix.name }}-${{ hashFiles('.github/workflows/ci.yml') }}-
 
       - name: Install xcsift
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
@@ -343,9 +347,11 @@ jobs:
     if: always()
     # `changes` is in this list on purpose. Every other job is `if: always()`,
     # so when `changes` fails they all still run — but with its outputs empty,
-    # every step's `if:` is false and each job exits `success`. Without the
-    # `changes` result here, `CI` would then go green having linted, tested and
-    # compiled nothing at all.
+    # every *work* step's `if:` is false (only the "No changes detected" echo
+    # fires) and each job exits `success`. Without the `changes` result here,
+    # `CI` would then go green having linted, tested and compiled nothing at
+    # all. The window is `pull_request`/`push`; `workflow_dispatch` runs the
+    # work steps via the second disjunct regardless.
     needs: [changes, lint, lint-markdown, build-test, build-platforms, build-test-linux]
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,9 @@ extensions, both **Apple-platforms only**:
   rule-based intent classifier plus `NLTagger` person-name extraction) and, on
   capable devices, an optional `FoundationModelsSearchPlanGenerator` fallback
   for fuzzier prompts — degrading to a plain multi-search where neither is
-  available.
+  available. That fallback is additionally gated
+  `&& !os(tvOS) && !os(watchOS)`: Apple ships no on-device system language
+  model on those two platforms, so they are always deterministic.
 - `languageModelTools` / `TMDbToolbox` — see *Language Model Tools* below.
 
 Consumers add the `TMDbIntelligence` product and `import TMDbIntelligence`

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
 | **tvEpisodeGroups** | TV episode group details and episode organization |
 | **guestSessions** | Guest session rated movies, TV series, and episodes |
 | **images** | Fully qualified image URLs from model image paths, with the image configuration fetched once and cached |
-| **naturalLanguageSearch** | On-device natural-language search (all Apple platforms; enhanced by Foundation Models with Apple Intelligence on iOS/macOS/visionOS) — requires `import TMDbIntelligence` |
+| **naturalLanguageSearch** | On-device natural-language search (all Apple platforms; enhanced by Foundation Models with Apple Intelligence on iOS/macOS/visionOS 26) — requires `import TMDbIntelligence` |
 | **languageModelTools** | Foundation Models tools for a `LanguageModelSession` movie assistant (iOS/macOS/visionOS 26, watchOS 27) — requires `import TMDbIntelligence` |
 
 See the [full API documentation](https://adamayoung.github.io/TMDb/documentation/tmdb/)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
   search" — type a prompt, get movies, TV series, and people.
   Deterministic interpretation via Apple's Natural Language framework on
   every Apple platform, with Foundation Models handling fuzzier prompts on
-  devices with Apple Intelligence
+  devices with Apple Intelligence (iOS/macOS/visionOS only — tvOS and
+  watchOS stay deterministic)
 * **Language Model Tools** (`TMDbIntelligence`): Drop-in Foundation Models
   `Tool`s for a conversational movie assistant — add them to a
   `LanguageModelSession` and the model searches, fetches details, and finds
@@ -84,7 +85,7 @@ A Swift Package for The Movie Database (TMDb) <https://www.themoviedb.org>
 | **tvEpisodeGroups** | TV episode group details and episode organization |
 | **guestSessions** | Guest session rated movies, TV series, and episodes |
 | **images** | Fully qualified image URLs from model image paths, with the image configuration fetched once and cached |
-| **naturalLanguageSearch** | On-device natural-language search (all Apple platforms; enhanced by Foundation Models with Apple Intelligence) — requires `import TMDbIntelligence` |
+| **naturalLanguageSearch** | On-device natural-language search (all Apple platforms; enhanced by Foundation Models with Apple Intelligence on iOS/macOS/visionOS) — requires `import TMDbIntelligence` |
 | **languageModelTools** | Foundation Models tools for a `LanguageModelSession` movie assistant (iOS/macOS/visionOS 26, watchOS 27) — requires `import TMDbIntelligence` |
 
 See the [full API documentation](https://adamayoung.github.io/TMDb/documentation/tmdb/)

--- a/Sources/TMDbIntelligence/NaturalLanguageSearch/FoundationModelsSearchPlanGenerator.swift
+++ b/Sources/TMDbIntelligence/NaturalLanguageSearch/FoundationModelsSearchPlanGenerator.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2026 Adam Young.
 //
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && !os(tvOS) && !os(watchOS)
     import Foundation
     import FoundationModels
     import TMDb

--- a/Sources/TMDbIntelligence/NaturalLanguageSearch/GeneratedSearchPlan.swift
+++ b/Sources/TMDbIntelligence/NaturalLanguageSearch/GeneratedSearchPlan.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2026 Adam Young.
 //
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && !os(tvOS) && !os(watchOS)
     import Foundation
     import FoundationModels
     import TMDb

--- a/Sources/TMDbIntelligence/NaturalLanguageSearch/SearchPlanMapper.swift
+++ b/Sources/TMDbIntelligence/NaturalLanguageSearch/SearchPlanMapper.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2026 Adam Young.
 //
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && !os(tvOS) && !os(watchOS)
     import Foundation
     import TMDb
 

--- a/Sources/TMDbIntelligence/NaturalLanguageSearch/TMDbClient+NaturalLanguageSearch.swift
+++ b/Sources/TMDbIntelligence/NaturalLanguageSearch/TMDbClient+NaturalLanguageSearch.swift
@@ -23,7 +23,7 @@ import TMDb
         /// compositional prompts. On platforms without either, the prompt runs as a
         /// plain multi-search.
         ///
-        /// - Note: The Foundation Models tier is unavailable on tvOS and watchOS —
+        /// - Important: The Foundation Models tier is unavailable on tvOS and watchOS —
         ///   Apple ships no on-device system language model there — so
         ///   interpretation on those platforms is always deterministic, regardless
         ///   of the device's Apple Intelligence support.

--- a/Sources/TMDbIntelligence/NaturalLanguageSearch/TMDbClient+NaturalLanguageSearch.swift
+++ b/Sources/TMDbIntelligence/NaturalLanguageSearch/TMDbClient+NaturalLanguageSearch.swift
@@ -23,6 +23,11 @@ import TMDb
         /// compositional prompts. On platforms without either, the prompt runs as a
         /// plain multi-search.
         ///
+        /// - Note: The Foundation Models tier is unavailable on tvOS and watchOS —
+        ///   Apple ships no on-device system language model there — so
+        ///   interpretation on those platforms is always deterministic, regardless
+        ///   of the device's Apple Intelligence support.
+        ///
         /// - Note: Each access constructs a new service instance. When checking
         ///   ``NaturalLanguageSearchService/availability`` and then searching, store
         ///   it in a local first — `let search = client.naturalLanguageSearch` — rather

--- a/Sources/TMDbIntelligence/NaturalLanguageSearch/TMDbClient+NaturalLanguageSearch.swift
+++ b/Sources/TMDbIntelligence/NaturalLanguageSearch/TMDbClient+NaturalLanguageSearch.swift
@@ -48,7 +48,7 @@ import TMDb
             // Foundation Models is an optional fallback for the fuzzy tail, only on
             // capable OS versions. The NaturalLanguage planner is always the default.
             var fallback: (any SearchPlanGenerating)?
-            #if canImport(FoundationModels)
+            #if canImport(FoundationModels) && !os(tvOS) && !os(watchOS)
                 if #available(iOS 26, macOS 26, visionOS 26, watchOS 27, *) {
                     fallback = FoundationModelsSearchPlanGenerator()
                 }

--- a/Sources/TMDbIntelligence/TMDbIntelligence.docc/TMDbIntelligence.md
+++ b/Sources/TMDbIntelligence/TMDbIntelligence.docc/TMDbIntelligence.md
@@ -42,6 +42,10 @@ Intelligence, Foundation Models additionally handles fuzzier, compositional
 prompts; where neither is available the prompt degrades to a plain
 multi-search.
 
+The Foundation Models tier is available on iOS, macOS and visionOS only. Apple
+ships no on-device system language model for tvOS or watchOS, so interpretation
+there is always deterministic — the search itself works on all five platforms.
+
 Check ``NaturalLanguageSearchService/availability`` before searching to find
 out which level of interpretation the current device offers.
 

--- a/Tests/TMDbIntegrationTests/NaturalLanguageSearchPlannerEvalTests.swift
+++ b/Tests/TMDbIntegrationTests/NaturalLanguageSearchPlannerEvalTests.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2026 Adam Young.
 //
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && !os(tvOS) && !os(watchOS)
     import Foundation
     import Testing
     @testable import TMDb

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -25,6 +25,74 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
 
 ---
 
+## 2026-08-13 — 🐛 Exclude tvOS/watchOS from the FoundationModels planner (`fix/foundationmodels-platform-guards`) · full
+
+- **Phases / skills:** 0–8 pre-PR. Full weight, but with two pieces of machinery
+  deliberately not used (below): `/review-plan`'s critics and
+  `/review-changes`'s fan-out. Skills: `implement-plan`, `review-changes`,
+  `security-review`, `capture-knowledge`.
+  `consulted:` gotchas *No workflow runs make*, *tooling-runner runs in the main
+  checkout*, *Bash refuses commands it can't prove stay inside the worktree*,
+  *Edits can land in the main checkout*, *EnterWorktree branch name*,
+  *FoundationModels/CoreImage watchOS* (retired by this delivery),
+  *NaturalLanguageSearchService is not platform-gated*, *git ls-tree empty
+  hash*; wiki *before-bumping-a-pinned-ci-toolchain-version-verify-the-runner-
+  image-ships-it*, *a-detector-whose-green-looks-the-same-when-it-didnt-run*,
+  *fix-orphaned-platform-gated-api* (ADR-0010 background).
+  `reconciled:` 0 in scope / 0 reclaimed / 0 resumable / 0 reported.
+  `swept:` `.github/workflows/ci.yml` → 1 entry retired, 2 rewritten; 5 citing
+  entries re-read and left unchanged.
+- **Worked — probing the platforms before accepting the reported fix found a
+  second break.** The issue proposed `&& !os(tvOS)` at four sites and had
+  verified it on 18.2.0. Building the *unfixed* tree for all five Apple
+  platforms first showed watchOS was also red, and `!os(tvOS)` does not fix it:
+  the SDK's availability is asymmetric per symbol, so only the file touching
+  `SystemLanguageModel` breaks there. Shipping the reported patch verbatim
+  would have left watchOS broken and looked like a complete fix.
+- **Worked — the reviewer found a pre-existing false green two lines from the
+  diff.** The aggregate `ci` job never checked the `changes` job's result, and
+  every job is `if: always()` — so a failed paths-filter left all five jobs
+  exiting `success` having done nothing, on a ruleset that requires `CI`. Fixed
+  here because it is the same failure family the delivery exists to close.
+- **Worked — settling a finding by executing it rather than arguing it.** The
+  reviewer flagged that `xcsift --Werror` on a four-SDK `xcodebuild` might fail
+  on Apple's own header warnings — a false *red*, and explicitly "cannot be
+  settled by reading". One cold piped build per new platform answered it (exit
+  0), which is cheaper than the paragraph of speculation it replaced.
+- **Friction — the weight vocabulary did not fit the diff.** Full weight
+  prescribes the fan-out `/review-changes`, but its five dimensions are all
+  Swift lenses (correctness, concurrency, architecture, testing, api-docs) and
+  the risk in this diff was 74 lines of GitHub Actions YAML. A fan-out would
+  have spent four lenses on a five-line Swift change and still had nobody
+  reviewing the workflow. Took the single-reviewer path with a targeted brief.
+- **Friction — the `markdownlint --fix` hook silently corrupted a knowledge
+  entry** by rewriting a line-leading `#416` into an H1, destroying the
+  sentence and then failing the gate on a heading I never wrote. Captured as a
+  gotcha; it will recur, because this repo cites `#NNN` constantly and wraps
+  prose at 80 columns.
+- **Friction (self-inflicted) — ran `make lint` three times** for a diff of five
+  one-line `#if` changes and a doc comment. The `PostToolUse` hook already
+  formats each file on write; `--strict` is the gate and `make ci` runs it. The
+  user pointed this out mid-run.
+- **Deviations:** (1) skipped `/review-plan`'s critics — the plan had been
+  adversarially verified empirically before `/deliver` was invoked, by testing
+  the reporter's proposed fix and finding it insufficient; (2) single-reviewer
+  `/review-changes` at full weight, per the friction above; (3) skipped the
+  standalone `/integration-test` at Phase 3 — the diff is compile-time-only and
+  a provable macOS no-op, the integration target's *compilation* is proven by
+  `--build-tests`, and `make ci` runs the live suite at Phase 9 anyway (the
+  #401 economy); (4) ran `/security-review` inline rather than via sub-tasks,
+  the surface being one workflow file; (5) let the Phase 6 grader run its own
+  platform builds, against the skill's execution cap — the rubric was
+  build-shaped, so having it trust my logs would have made it non-independent
+  on exactly the criteria that mattered.
+- **One improvement:** `/review-changes`'s fan-out has no dimension for CI /
+  workflow changes, so any diff whose risk is in `.github/workflows/` is either
+  reviewed by five Swift lenses or, as here, routed to the single-reviewer path
+  by hand. A sixth `ci-workflow` dimension (gate integrity, false-green paths,
+  secret exposure, cache keys) would make the fan-out usable for
+  infrastructure diffs instead of only Swift ones.
+
 ## 2026-08-12 — 🐛 Surface task cancellation as `TMDbError.cancelled` (#433) · full
 
 - **Phases / skills:** 0–8 pre-PR. Full weight: three-critic `/review-plan`, the
@@ -615,87 +683,6 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
   `@testable` mistakes — exactly what a target-extraction PR is made of. Cheap
   check, would have caught the only Critical in this delivery.
 
-## 2026-07-24 — ✨ Enrich `TMDbError` with structured context (#397) · full
-
-- **Phases / skills:** phases 0–8 pre-PR; full weight (reshapes the package's
-  most load-bearing public enum + networking + new public API). `review-plan`
-  (3 critics) → **1 blocker**, 3 majors, 4 minors; all applied, none rejected.
-  `implement-plan`/`canon-tdd` in 4 committed increments (additive types →
-  atomic reshape + 15-file test migration → fixtures/integration → docs/ADR).
-  `review-changes` fan-out (5 dims + adversarial verify) → 0 Critical/High, 2
-  Medium, 3 Low; fixed 4, rejected 1 (`Codable` on the new value types —
-  speculative, `TMDbError` itself isn't `Codable`). `security-review` → 0
-  vulnerabilities, 1 consistency hardening applied. `capture-knowledge` → 2
-  API notes + 3 gotchas + ADR-0012. Independent grader: **5/5 ACs met**.
-- **Worked:** the plan review paid for the whole delivery — a critic caught that
-  `endpointPath` would carry `guest_session_id` (a bearer-like credential) and
-  `account_id` (PII) into a **public, loggable** field, before a line was
-  written; the redactor and its tests came from that finding, and the security
-  review later confirmed the control covers all 137 request-path templates.
-  Capturing **real** error bodies from the live API during planning (`curl -D-`)
-  beat the plan's guesses: the fixtures became 400/code 22 and 422/code 20 as
-  the API actually returns them, not the invented 422/code 5. Keeping the six
-  cases semantic and putting transport detail in context (wiki: *semantic
-  errors, not transport codes*) un-collapsed the fidelity without exporting 13
-  HTTP-shaped public cases.
-- **Friction (environmental):** the Xcode 27 / Swift 6.4 `.docc` trap that #390
-  logged as annoying became **blocking** — `make ci` cannot run at all. My first
-  attribution (xcsift `--Werror`) was **wrong**; `pipestatus` showed `swift
-  build` exiting 1 and xcsift 0, and the failure reproduced on a pristine
-  `origin/main` worktree, proving toolchain drift rather than a branch defect.
-  The tooling-runner CWD trap recurred with a new symptom: a delegated
-  `swift test` ran in the **main** checkout and reported "no matching test cases
-  found" for suites that plainly exist. Web tools hit a session rate limit
-  mid-task; the GitHub API (`runner-images` README + announcement issue) served
-  as the substitute source.
-- **Deviations:** ran every build/test **directly via `Bash`** in the worktree
-  again; verified the delivery against CI's own commands rather than `make ci`.
-  Mid-delivery the user asked for Xcode 27 adoption, so that work went to its
-  own worktree/branch (**#396**) to keep this PR scoped — its CI then caught a
-  real regression (Swift 6.4 moved build products and split the test bundle per
-  target, so the hardcoded coverage export silently uploaded 0%).
-- **One improvement:** the tooling-runner CWD fix was **already** this file's
-  "one improvement" for #390 and it recurred verbatim one delivery later — two
-  consecutive full deliveries lost time to it. It should stop being a retro line
-  and become a skill change: either pin the tooling-runner's CWD to the active
-  worktree, or have `/build`/`/test` refuse to run when their CWD isn't the
-  conductor's. Second candidate: `Package.swift` should declare the `.docc`
-  catalogs so `-warnings-as-errors` can't fatally trip on them (shipped in #396).
-
-## 2026-07-24 — ♻️ Represent model runtimes as `Duration` instead of `Int` (#390) · full
-
-- **Phases / skills:** phases 0–8 pre-PR; full weight (breaking public API,
-  `Codable`/`CodingKeys`). `review-plan` skipped (`ExitPlanMode` approval this
-  session). `implement-plan`/`canon-tdd`: TDD'd the `RuntimeMinutes` converter,
-  then did the type migration as one **atomic** increment (a breaking type
-  change doesn't compile in partial states). `review-changes` fan-out (5 dims +
-  adversarial verify) → 0 Critical/High/Medium, 2 Low (both fixed).
-  `security-review` → 0 findings. `capture-knowledge` → 3 tooling gotchas +
-  ADR-0011 (inline). Independent grader: 6/6 ACs MET.
-- **Worked:** the stored-minutes / computed-`Duration` design keeps `encode`
-  synthesized, so the integer-minute wire format can't silently drift — no
-  hand-written 30-property encode to maintain — and per-model encode
-  round-trip tests lock it. Two plan-time Explore agents pre-mapped the whole
-  consume/format + test surface, making the migration mechanical. The
-  `.convertFromSnakeCase` → camelCase-`CodingKeys` check (wiki/gotcha) caught
-  the `episodeRunTime` rawValue trap before it silently broke decode.
-- **Friction (environmental, not the change):** the beta Swift 6.4 / macOS 27
-  toolchain makes `-Werror` promote the `.docc` "unhandled file" false alarm to
-  a **fatal** error, so `make test` / `make build-tests` / `make ci` fail
-  locally — and the tooling-runner (Haiku, running in the **main** checkout)
-  misreported the very first build as a failure. Homebrew had also drifted
-  swiftformat to 0.62.1 vs the 0.61.1 pin, flagging unchanged files and
-  reshaping edits. Both cost real diagnosis time.
-- **Deviations:** ran every build/test **directly via `Bash`** in the worktree
-  (the tooling-runner runs in `main` and never saw the worktree diff); built
-  tests without `-Werror` to run them, with `-Werror` + a grep-filter to catch
-  real warnings; reinstalled pinned swiftformat 0.61.1 to `~/.local/bin`.
-- **One improvement:** the tooling-runner / `/deliver` skills should run the
-  tooling-runner **in the active worktree** (or explicitly require builds to go
-  direct-via-`Bash` there) — the CWD mismatch silently builds/reviews the wrong
-  tree. Captured as a gotcha this delivery; a skill fix would stop the next
-  worktree run hitting it cold.
-
 ## Archive (distilled)
 
 Older entries condensed per the rolling window (`knowledge/README.md` →
@@ -703,6 +690,8 @@ Older entries condensed per the rolling window (`knowledge/README.md` →
 
 | Date | PR | Weight | Outcome |
 | --- | --- | --- | --- |
+| 2026-07-24 | #397 | full | Enriched `TMDbError` with structured context (ADR-0012). The plan review paid for the delivery on its own: a critic caught, before a line was written, that the new public `endpointPath` would carry `guest_session_id` (a bearer-like credential) and `account_id` (PII) into a loggable field — the redactor and its tests came from that finding, and `security-review` later confirmed the control covers all 137 request-path templates. Now the wiki pattern *a-diagnostic-field-added-for-logging-is-a-publishing-surface*. Capturing **real** error bodies from the live API while planning (`curl -D-`) beat the plan's guesses: 400/code 22 and 422/code 20, not the invented 422/code 5. Environmental friction was severe — the Xcode 27 / Swift 6.4 `.docc` trap made `make ci` unrunnable, and the first attribution (xcsift `--Werror`) was **wrong**: `pipestatus` showed `swift build` exiting 1 and xcsift 0, which is why the build/test skills now say the exit status is the verdict, not the summary. |
+| 2026-07-24 | #390 | full | Migrated model runtimes from `Int` minutes to `Duration` (ADR-0011). The lasting pattern is store-the-raw / expose-the-computed: keep the integer-minute wire value in a private stored property and expose `Duration` as a computed one, so `Codable` stays synthesized and the wire format cannot silently drift — no hand-written 30-property `encode` to maintain. Now the wiki entry *bridge-a-wire-type-to-a-domain-type-inside-the-model*. The `.convertFromSnakeCase` → camelCase-`CodingKeys` check caught the `episodeRunTime` rawValue trap before it broke decode. Its "one improvement" — run the tooling-runner in the *active worktree* rather than the main checkout — recurred verbatim in #397 one delivery later and shipped in #399. |
 | 2026-07-08 | #387 | lite | Bumped the CI workflows to Xcode 26.6. The lasting practice: a plan-time `WebFetch` of the `macos-26` runner-image README confirmed `/Applications/Xcode_26.6.app` exists (build 17F113) **before** pinning it — retiring the one real risk of a toolchain-version bump, pinning a version the runner does not ship, at plan time rather than in CI. Now the wiki heuristic *before-bumping-a-pinned-ci-toolchain-version-verify-the-runner-image-ships-it*. `security-review` ran (workflows are security-relevant) and returned 0 findings. |
 | 2026-07-06 | #385 | lite | Consolidated the build/test runners into a single `tooling-runner` agent (ADR-0014, model tiers). The plan-time Explore cross-reference sweep pre-scoped the prose blast radius and cut the edit list to 11 files — noticing that "delegates to a Haiku subagent" stays *true* after the refactor, since the runner agent **is** Haiku. Lasting caveat: a freshly added `.claude/agents/*.md` may not register as a spawnable `subagent_type` until a new session, so a consolidation like this cannot be smoke-tested end-to-end inside the delivering session; the first post-merge `/build` is the real verification. |
 | 2026-07-05 | #384 | lite | Added the Phase 0 knowledge-consult step and the independent Phase 6 rubric grader — the two gates that make captured knowledge compound and stop the maker grading its own homework. Smallest delivery to date (+49/−8), and the plan arrived with ACs already in Given/When/Then form, so the entry gate extracted the rubric with zero friction. Its own knowledge-consult was done implicitly (the design phase had already read the relevant material); the `consulted:` ledger line is what made it explicit from the next run on. Its "one improvement" — extend the consult step to standalone `/implement-plan` invocations — **shipped in #443**, which added `/implement-plan`'s *Step 0 — Consult the knowledge base*. |

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -25,7 +25,7 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
 
 ---
 
-## 2026-08-13 — 🐛 Exclude tvOS/watchOS from the FoundationModels planner (`fix/foundationmodels-platform-guards`) · full
+## 2026-08-13 — 🐛 Exclude tvOS/watchOS from the FoundationModels planner (#449) · full
 
 - **Phases / skills:** 0–8 pre-PR. Full weight, but with two pieces of machinery
   deliberately not used (below): `/review-plan`'s critics and

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -199,7 +199,7 @@ jobs. **Debug-green proves nothing here; run the release build.**
 
 ### `hashFiles` over a pattern matching nothing returns the empty string
 
-*2026-08-13 (#PLACEHOLDER-PR).* GitHub Actions' `hashFiles(...)` does not error
+*2026-08-13 (#449).* GitHub Actions' `hashFiles(...)` does not error
 when its glob matches no file — it returns `''`. A cache key built from one then
 collapses to a **constant**:
 
@@ -419,7 +419,7 @@ rather than assuming the tool honoured the name.
 
 ### The `markdownlint --fix` hook turns a line-leading `#416` into an H1
 
-*2026-08-13 (#PLACEHOLDER-PR).* This repo cites issues and PRs as `#NNN`
+*2026-08-13 (#449).* This repo cites issues and PRs as `#NNN`
 everywhere, and prose is wrapped near 80 columns — so sooner or later a
 reference lands at the **start** of a line. The `PostToolUse` hook then runs
 `markdownlint --fix`, reads `#416 ship.` as a malformed ATX heading, and
@@ -615,7 +615,7 @@ members). Every time, `swift build` / `make build-tests` reported **0 errors /
 
 ### `canImport` is not an availability test — and FoundationModels is unavailable per *symbol*
 
-*2026-08-13 (#PLACEHOLDER-PR), from issue #416.* A framework can ship on a
+*2026-08-13 (#449), from issue #416.* A framework can ship on a
 platform with every one of its symbols marked unavailable. Xcode 27's tvOS SDK
 ships `FoundationModels.framework`, so `#if canImport(FoundationModels)` flipped
 from **false to true** on tvOS — admitting code whose every symbol is
@@ -667,7 +667,7 @@ grep -B6 "class SystemLanguageModel" \
 
 ### `make ci` builds macOS only — the other Apple platforms are gated solely by CI
 
-*2026-08-13 (#PLACEHOLDER-PR).* Sibling to the Linux entry above. `make ci`
+*2026-08-13 (#449).* Sibling to the Linux entry above. `make ci`
 compiles for the **macOS host and nothing else**: `swift build` cannot target
 another platform, so iOS, tvOS, watchOS and visionOS are covered *only* by
 `.github/workflows/ci.yml`'s **`build-platforms`** matrix job. A green `make ci`

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -197,6 +197,42 @@ jobs. **Debug-green proves nothing here; run the release build.**
   cascades into member-level access (memberwise inits, nested types) — usually
   not worth it.
 
+### `hashFiles` over a pattern matching nothing returns the empty string
+
+*2026-08-13 (#PLACEHOLDER-PR).* GitHub Actions' `hashFiles(...)` does not error
+when its glob matches no file — it returns `''`. A cache key built from one then
+collapses to a **constant**:
+
+```yaml
+key: ${{ runner.os }}-swift-${{ hashFiles('**/Package.resolved') }}   # -> "macOS-swift-"
+```
+
+This package declares **no external dependencies**, so SwiftPM never writes a
+`Package.resolved` and that key had been constant all along. Because it was also
+byte-identical to its own `restore-keys` prefix, every run was an exact primary-key
+hit — and `actions/cache` **skips the save on an exact hit**, so the cache was
+written once and then never refreshed again. It keeps serving build products from
+whatever toolchain was current the first time, which is a good way to spend an
+afternoon on a "works locally, fails in CI" that is neither.
+
+Hash something that actually exists and actually changes. Hashing the workflow
+file is a useful trick, because it carries the `DEVELOPER_DIR` Xcode pin — so a
+toolchain bump invalidates the cache by itself:
+
+```yaml
+key: ${{ runner.os }}-xcode-${{ matrix.name }}-${{ hashFiles('.github/workflows/ci.yml') }}-${{ hashFiles('Package.swift') }}
+restore-keys: |
+  ${{ runner.os }}-xcode-${{ matrix.name }}-${{ hashFiles('.github/workflows/ci.yml') }}-
+```
+
+**Put the toolchain-bearing hash in the restore *prefix*, not just the key.** A
+bare prefix re-imports the pre-bump cache on the very miss the key exists to
+cause, so the key's promise is quietly undone one line below it.
+
+Same family as the `git ls-tree` entry below — a hashing primitive that degrades
+to a constant instead of failing. **Sanity-check any computed key against its
+degenerate value before trusting it.**
+
 ### `git ls-tree` doesn't support `:!exclude` — and fails into an empty hash
 
 *2026-07-29.* Building a content stamp over "everything except `knowledge/`",
@@ -381,6 +417,33 @@ rather than assuming the tool honoured the name.
   route. See `/review-pr-threads` §1 and
   [ADR-0009](decisions/0009-github-mcp-over-gh-cli.md).
 
+### The `markdownlint --fix` hook turns a line-leading `#416` into an H1
+
+*2026-08-13 (#PLACEHOLDER-PR).* This repo cites issues and PRs as `#NNN`
+everywhere, and prose is wrapped near 80 columns — so sooner or later a
+reference lands at the **start** of a line. The `PostToolUse` hook then runs
+`markdownlint --fix`, reads `#416 ship.` as a malformed ATX heading, and
+"corrects" it by inserting a space:
+
+```markdown
+which is precisely the gap that let issue
+#416 ship.
+```
+
+becomes a literal `# 416 ship` — a top-level heading in the middle of a
+document. The prose is silently destroyed, and the file then fails the gate on
+`MD025/single-title/single-h1` (plus a knock-on `MD001`) pointing at a heading
+you never wrote.
+
+It fails loudly, which is the saving grace — but the error names a heading
+problem, not the rewrite that caused it, so it reads as nonsense until you look
+at the file.
+
+**Keep an issue reference off the start of a line**: reflow the sentence, or
+write it as "issue 416" in words. Worth a glance at `git diff` after editing a
+`knowledge/` file — the hook edits after you write, so what you wrote is not
+necessarily what landed.
+
 ### A `Write` of a Markdown/DocC file can leak `</content>`/`</invoke>` into the file tail
 
 *2026-06-24.* When creating a `.md` file with the `Write` tool, trailing
@@ -550,30 +613,88 @@ members). Every time, `swift build` / `make build-tests` reported **0 errors /
 - There is **no `GetBuildLog` tool** — for build-error detail inside Xcode use
   `mcp__xcode-tools__XcodeRefreshCodeIssuesInFile` on the flagged file(s).
 
-### FoundationModels can't build for watchOS under Xcode 27 beta (CoreImage)
+### `canImport` is not an availability test — and FoundationModels is unavailable per *symbol*
 
-*Undated original; still open as of 2026-07-28 on Xcode 27.0 build `27A5228h` (a
-seed build). **Transient by nature — re-probe and delete once a GM toolchain
-ships**; a watchOS build is the only way to confirm, so it was not re-run during
-the 2026-07-28 audit.*
+*2026-08-13 (#PLACEHOLDER-PR), from issue #416.* A framework can ship on a
+platform with every one of its symbols marked unavailable. Xcode 27's tvOS SDK
+ships `FoundationModels.framework`, so `#if canImport(FoundationModels)` flipped
+from **false to true** on tvOS — admitting code whose every symbol is
+`@available(tvOS, unavailable)`. 149 errors, on guards that had been correct for
+a year.
 
-- Building the package for a **watchOS** destination
-  (`xcodebuild -scheme TMDb -destination 'generic/platform=watchOS Simulator'`)
-  fails during module resolution:
-  `error: Unable to resolve module dependency: 'CoreImage'` inside the watchOS
-  SDK's own `FoundationModels.swiftinterface`. It is an **SDK/toolchain bug**
-  (Xcode 27.0 beta 2 / watchOS 27 beta), not a problem in this code — it fires for
-  **any** `import FoundationModels` on watchOS, including the existing
-  `LanguageModelTools`.
-- Consequence: you **cannot build- or availability-verify** watchOS-gated
-  FoundationModels code locally yet. The error aborts before type-checking, so it
-  even **masks** genuine `@available` violations (a watchOS availability bug and a
-  clean build look identical — both fail on CoreImage). Verify such changes by
-  reasoning + Apple's documented availability instead, and note the gap.
-- Apple **does** document `SystemLanguageModel` / `LanguageModelSession` as
-  `watchOS 27.0+ (Beta)`, so `watchOS 27` is the correct availability floor; the
-  build failure is transient beta breakage, expected to clear in a later toolchain.
-- `make ci` is unaffected — it builds the macOS host only, never watchOS.
+The `@available` did not save it, and this is the sharp edge: a trailing `*` in
+`@available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)` makes **unlisted
+platforms available**, not excluded. `canImport` + a `*`-terminated `@available`
+is not a platform gate. Use `#if canImport(X) && !os(…)`, or
+`@available(tvOS, unavailable)`.
+
+**The availability is asymmetric, so the right exclusion differs per file**
+(read from the shipped SDK interfaces, not the docs):
+
+| Symbol | tvOS | watchOS |
+| --- | --- | --- |
+| `SystemLanguageModel` | unavailable | **unavailable** |
+| `LanguageModelSession` | unavailable | 27.0+ |
+| `Tool`, `Generable`, `GenerationSchema` | unavailable | 27.0+ |
+
+So tvOS needs the whole framework excluded, while watchOS only breaks where
+`SystemLanguageModel` is touched. That is why `LanguageModelTools/` is correctly
+gated `!os(tvOS)` alone while `NaturalLanguageSearch/` needs
+`!os(tvOS) && !os(watchOS)` — an asymmetry that reads like an oversight and is
+not. On watchOS the only `LanguageModel` conformer is
+`PrivateCloudComputeLanguageModel`, which is not on-device, so a watchOS
+Foundation Models planner is a product decision rather than a fix.
+
+**The SDK's own `.swiftinterface` is the authority**, and Apple's published docs
+lagged it here — they listed `SystemLanguageModel` as watchOS 27+ while the
+shipped SDK marks it watchOS-unavailable. Reading it is cheap and settles
+questions no local build can reach:
+
+```bash
+grep -B6 "class SystemLanguageModel" \
+  "$(xcrun --sdk watchsimulator --show-sdk-path)/System/Library/Frameworks/FoundationModels.framework/Modules/FoundationModels.swiftmodule/"*.swiftinterface
+```
+
+> An earlier entry here recorded a watchOS `Unable to resolve module dependency:
+> 'CoreImage'` failure inside the watchOS SDK's own `FoundationModels
+> .swiftinterface`, and concluded you should verify watchOS availability "by
+> reasoning + Apple's documented availability" instead of building. That bug is
+> **fixed** as of Xcode 27.0 build `27A5237l` (re-probed 2026-08-13: zero
+> occurrences, the build type-checks and succeeds). It had been masking a real
+> `@available` violation exactly as it warned it might — issue #416 *is* that
+> violation, and the reason-instead-of-build advice is a fair description of how
+> #416 shipped.
+
+### `make ci` builds macOS only — the other Apple platforms are gated solely by CI
+
+*2026-08-13 (#PLACEHOLDER-PR).* Sibling to the Linux entry above. `make ci`
+compiles for the **macOS host and nothing else**: `swift build` cannot target
+another platform, so iOS, tvOS, watchOS and visionOS are covered *only* by
+`.github/workflows/ci.yml`'s **`build-platforms`** matrix job. A green `make ci`
+says nothing about the other four — and that gap is precisely what let issue
+416 ship.
+
+To check locally, there is no `make` target; go direct, and **sequentially**
+(one Swift process per worktree):
+
+```bash
+xcodebuild build -scheme TMDb-Package -destination 'generic/platform=tvOS Simulator'
+```
+
+Two things that matter in that command:
+
+- **`-scheme TMDb-Package`, never `-scheme TMDb`.** The `TMDb` scheme builds only
+  the core target, so it compiles cleanly straight through a break in
+  `TMDbIntelligence` — which is what #416 was. The CI job that was deleted in
+  `da96567b` used `-scheme TMDb` and would not have caught it.
+- **`xcodebuild build` does not compile the test targets** (unlike
+  `build-for-testing`). Verified from a build log: exactly four library targets
+  compile — `TMDb`, `TMDbIntelligence`, `TMDbTesting`, `TMDbIntelligenceTesting` —
+  and zero test targets. So the CI matrix watches shipped code only.
+
+Prefer `generic/platform=…` over a pinned `name=iPhone 17,OS=26.2` destination:
+it needs the SDK only — no simulator runtime, no boot — and does not rot when the
+runner image changes its device names.
 
 ### Extraneous `CodingKeys` cases break synthesized `Encodable`
 


### PR DESCRIPTION
## Summary

Fixes #416.

Xcode 27's tvOS SDK ships `FoundationModels.framework` with every symbol marked `@available(tvOS, unavailable)`. That flipped `#if canImport(FoundationModels)` from false to **true** on tvOS, and the trailing `*` in `@available(iOS 26, macOS 26, visionOS 26, watchOS 27, *)` makes unlisted platforms *available* rather than excluded — so the code compiled in and produced **149 errors** building `TMDb-Package` for tvOS.

Only `TMDbIntelligence` consumers are affected; the core `TMDb` product builds clean on both platforms.

Reported and diagnosed by @dlev02, who also verified a four-file patch against 18.2.0. The `canImport` analysis was correct and did the hard part.

## The fix is wider than the one proposed, and here's why

**watchOS is broken too, and `&& !os(tvOS)` alone does not fix it.** The watchOS 27 SDK's availability is asymmetric *per symbol*:

| Symbol | tvOS | watchOS |
| --- | --- | --- |
| `SystemLanguageModel` | unavailable | **unavailable** |
| `LanguageModelSession` | unavailable | 27.0+ |
| `Tool`, `Generable`, `GenerationSchema` | unavailable | 27.0+ |

So on watchOS only `FoundationModelsSearchPlanGenerator.swift` — the sole file touching `SystemLanguageModel` — fails, with 19 errors. Hence `&& !os(tvOS) && !os(watchOS)` on the four `NaturalLanguageSearch` guards.

This is also why `Sources/TMDbIntelligence/LanguageModelTools/` is **untouched**: its existing `!os(tvOS)`-only guard is already correct, because `Tool` and `Generable` genuinely are available on watchOS 27. The asymmetry between the two directories reads like an oversight and is not.

Read from the shipped SDK `.swiftinterface` files, not the documentation — the docs lagged here, listing `SystemLanguageModel` as watchOS 27+.

## Changes

**Platform guards:**
- 🐛 Four `#if canImport(FoundationModels)` guards in `Sources/TMDbIntelligence/NaturalLanguageSearch/` widened to `&& !os(tvOS) && !os(watchOS)`, plus the integration-test eval suite for consistency. `@available` annotations are deliberately left alone — inside the `#if` they are inert on the excluded platforms, and `watchOS 27` remains factually correct for the `Generable` types.

**CI — the actual root cause:**
- 👷 New `build-platforms` matrix job (iOS/tvOS/watchOS/visionOS). CI compiled only macOS and Linux, so nothing ever built for the other four Apple platforms. That is why this shipped green and an external contributor found it rather than a gate.
- A `build-and-test-platforms` job existed until `da96567b` removed it. This restores the coverage modernised: **`-scheme TMDb-Package`, not `-scheme TMDb`** (the old job's scheme builds only the core target and would have sailed straight through this bug), `generic/platform=…` destinations rather than pinned simulator names and OS versions, build-only, and `fail-fast: false` so one broken platform cannot mask another.

**Two pre-existing issues found in code review, both in files already being edited:**
- 🐛 The aggregate `ci` job never checked the `changes` job's result. Every job is `if: always()`, so a failed paths-filter left all of them exiting `success` having done nothing — five greens for zero work, on a ruleset that requires `CI` to merge.
- 🔧 The new job's DerivedData cache key hashed `**/Package.resolved`, which this package never generates (no external dependencies). `hashFiles` returns the empty string, making the key a constant that `actions/cache` saves once and never refreshes. Now hashes `ci.yml` (which carries the `DEVELOPER_DIR` Xcode pin) and `Package.swift`.

**Documentation:**
- 📝 Four places claimed Foundation Models enhances natural-language search wherever Apple Intelligence is present — now unconditionally false on tvOS/watchOS. Qualified in the `///`, the DocC catalog, and both README references.
- 📝 `knowledge/gotchas.md`: retired the stale "FoundationModels can't build for watchOS (CoreImage)" entry — that toolchain bug is fixed as of 27A5237l, and it had been masking exactly this `@available` violation, having predicted it would. Replaced with the `canImport`-is-not-an-availability-test entry and the per-symbol table.

## No API change

`GatedSearchPlanGenerator` already accepts a `nil` fallback, so `naturalLanguageSearch` stays available on tvOS and watchOS and degrades to the deterministic Natural Language planner. Verified at binary level: the symbol is present in the compiled tvOS and watchOS `.swiftmodule`, and none of the newly-gated files declares any `public` symbol.

## Verification

| Check | Before | After |
| --- | --- | --- |
| tvOS build | 149 errors | **0** |
| watchOS build | 19 errors | **0** |
| iOS / visionOS / macOS | 0 | **0** |
| Unit tests | 3188 | **3188** |
| Integration tests | — | **315 passed** |

`make ci` green (lint, markdown lint, both suites, release build, docs build); `actionlint` clean.

**No test was added, and that is deliberate.** The unit count is exactly baseline. A compile-time platform break cannot be expressed by any test running on a macOS host — the new CI matrix *is* the regression gate. Note also that `xcodebuild build` (unlike `build-for-testing`) does not compile test targets, so that gate watches shipped code only.

Acceptance criteria for this change were **derived** — from the observable before/after behaviour in #416 plus a local repro on Xcode 27.0 build 27A5237l — rather than supplied. An independent grader returned 7/7 met, running its own platform builds rather than trusting the logs above.

## Out of scope

#448 filed for the same dead `hashFiles('**/Package.resolved')` cache key still present in the `build-test` job at `ci.yml:165`. Fixing one is strictly better than leaving both broken; widening this PR into the job that runs the tests was not a trade worth making.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
