### PR TITLE
🔧 Move the /review-knowledge audit round to Opus

### DIFF
--- a/.claude/skills/review-knowledge/SKILL.md
+++ b/.claude/skills/review-knowledge/SKILL.md
@@ -286,14 +286,19 @@ Present a consensus table: finding · severity · agreement (confirmed / adjudic
 / refuted) · the fix. Then state the **verdict for the base as a whole**, and be
 willing to conclude *no changes needed*.
 
-**Record the run — even a clean one.** Append a dated line to
-[`skill-improvement-log.md`](../../../knowledge/skill-improvement-log.md) giving
-the run's **agent count, total tokens, and consensus findings by severity**. A
-run that finds nothing otherwise leaves no trace at all, and
+**Record the run — even a clean one.** Append a one-line **run record** to
+[`skill-improvement-log.md`](../../../knowledge/skill-improvement-log.md), in the
+fixed shape that file's header defines: agent count, total tokens, and consensus
+findings by severity. Like the `· refuted` entries above, it is written in
+**Apply**, after the user's go-ahead — and, unlike them, it is written **even
+when there is nothing else to apply**, so a clean run's Apply step is this line
+alone. If the user declines outright, record the decline in the line rather than
+omitting it.
+
+A run that finds nothing otherwise leaves no trace at all, and
 [ADR-0020](../../../knowledge/decisions/0020-review-knowledge-audit-tier.md)'s
-revisit trigger reads exactly that number — two consecutive zero-finding runs
-over a tree that has demonstrably moved means the audit tier has stopped earning
-its keep. This line is written whatever the verdict; it is the only one that is.
+revisit trigger compares the counts of **two consecutive** runs — so a missing
+line, or one in a different shape, breaks the comparison that decision rests on.
 
 ## Apply — only after the user agrees
 

--- a/.claude/skills/review-knowledge/SKILL.md
+++ b/.claude/skills/review-knowledge/SKILL.md
@@ -107,7 +107,7 @@ export const meta = {
   description: 'Four adversarial Opus auditors (2 lenses x 2 trees), then a Fable cross-examination',
   phases: [
     { title: 'Audit', detail: 'four opus/high auditors: each lens over each tree' },
-    { title: 'Cross-examine', detail: 'lenses refute each other, paired within a tree', model: 'fable' },
+    { title: 'Cross-examine', detail: 'four fable/high refuters: lenses refute each other, paired within a tree', model: 'fable' },
   ],
   model: 'opus',
 }
@@ -243,6 +243,7 @@ const rebuttals = await parallel(
         `Default to REFUTE when the evidence is thin. A finding that cannot be independently reproduced from the tree should not survive into the consensus. Do not confirm out of collegiality.\n\n` +
         `${READONLY}\n\n` +
         `Finally, in "missedByBoth", note anything their report made you realise you BOTH missed.`,
+        // `fable` is deliberate and load-bearing — refutations are permanent. See ADR-0020.
         { label: `cross:${g.tree.key}:${mine.key}`, phase: 'Cross-examine', model: 'fable', effort: 'high', schema: REBUTTAL_SCHEMA }
       ).then((r) => r && { by: mine.lens, tree: g.tree.key, ...r })
     })
@@ -284,6 +285,15 @@ The critics have already done the reconciling work — read it, don't redo it:
 Present a consensus table: finding · severity · agreement (confirmed / adjudicated
 / refuted) · the fix. Then state the **verdict for the base as a whole**, and be
 willing to conclude *no changes needed*.
+
+**Record the run — even a clean one.** Append a dated line to
+[`skill-improvement-log.md`](../../../knowledge/skill-improvement-log.md) giving
+the run's **agent count, total tokens, and consensus findings by severity**. A
+run that finds nothing otherwise leaves no trace at all, and
+[ADR-0020](../../../knowledge/decisions/0020-review-knowledge-audit-tier.md)'s
+revisit trigger reads exactly that number — two consecutive zero-finding runs
+over a tree that has demonstrably moved means the audit tier has stopped earning
+its keep. This line is written whatever the verdict; it is the only one that is.
 
 ## Apply — only after the user agrees
 

--- a/.claude/skills/review-knowledge/SKILL.md
+++ b/.claude/skills/review-knowledge/SKILL.md
@@ -27,11 +27,17 @@ The point of this skill: do these by default, without being reminded.
 
 1. **Two lenses × two trees, one Workflow.** Run the embedded `Workflow` below.
    It fans out **four** auditors in parallel — each lens against each tree —
-   every one pinned to the **`fable`** model, then runs a **cross-examination**
+   every one pinned to the **`opus`** model, then runs a **cross-examination**
    round **paired within each tree**, so the two lenses challenge each other on
    the same material. Invoking this skill is itself the opt-in to call
    `Workflow`. A tree whose pair doesn't both return is reported
    `unreconciled`, never as consensus.
+   **The cross-examination stays on `fable` — do not unify the two tiers.**
+   The rounds are not symmetric: a refutation is written to the *permanent*
+   refutation memory (item 2) and silently suppresses that finding on every
+   later audit, so a weak refuter costs far more than a weak auditor. An audit
+   miss, by contrast, is re-derivable next run. See
+   [ADR-0020](../../../knowledge/decisions/0020-review-knowledge-audit-tier.md).
 2. **Consult the refutation memory first.** Before reporting, grep
    [`knowledge/skill-improvement-log.md`](../../../knowledge/skill-improvement-log.md)
    for `· refuted` entries and drop any finding already settled there whose
@@ -89,19 +95,21 @@ propagated it upstream.
 
 ## Run the audit (Workflow)
 
-Four auditors run as a single `Workflow` so the **`fable`** model is guaranteed
-per agent and each verdict is schema-validated rather than free-text. No `args`
-are needed — the scope is the repository itself.
+Four auditors run as a single `Workflow` so the **model and effort are
+guaranteed per agent** — `opus` for the audit round, `fable` for the
+cross-examination (Agent Behaviour Contract item 1) — and each verdict is
+schema-validated rather than free-text. No `args` are needed — the scope is the
+repository itself.
 
 ```javascript
 export const meta = {
   name: 'review-knowledge-critics',
-  description: 'Four adversarial Fable auditors (2 lenses x 2 trees), then cross-examine',
+  description: 'Four adversarial Opus auditors (2 lenses x 2 trees), then a Fable cross-examination',
   phases: [
-    { title: 'Audit', detail: 'four fable auditors: each lens over each tree' },
-    { title: 'Cross-examine', detail: 'lenses refute each other, paired within a tree' },
+    { title: 'Audit', detail: 'four opus/high auditors: each lens over each tree' },
+    { title: 'Cross-examine', detail: 'lenses refute each other, paired within a tree', model: 'fable' },
   ],
-  model: 'fable',
+  model: 'opus',
 }
 
 const SEVERITY = `Grade by CONSEQUENCE IF THE ENTRY IS TRUSTED AS WRITTEN, not by your confidence:
@@ -202,7 +210,7 @@ const audits = await parallel(JOBS.map(({ tree, lens }) => () =>
     `${READONLY}\n\n` +
     `EVERY finding must be VERIFIED against the current tree and cite the evidence that proves it — the file:line or command output that contradicts the text. A finding derived only from reading the documentation is inadmissible; that credulity is the exact failure mode you are auditing. Equally: do NOT manufacture findings to look thorough. If a file is accurate, say so in "verifiedAccurate" and name what you checked.\n\n` +
     `SEVERITY RUBRIC:\n${SEVERITY}`,
-    { label: `audit:${tree.key}:${lens.key}`, phase: 'Audit', model: 'fable', effort: 'high', schema: FINDING_SCHEMA }
+    { label: `audit:${tree.key}:${lens.key}`, phase: 'Audit', model: 'opus', effort: 'high', schema: FINDING_SCHEMA }
   ).then((v) => v && { ...v, lens: lens.title, key: lens.key, tree: tree.key, treeTitle: tree.title })
 ))
 
@@ -211,6 +219,12 @@ const live = audits.filter(Boolean)
 // Cross-examine WITHIN each tree, so the two lenses challenge each other on the
 // same material. A tree with fewer than two survivors is reported UNRECONCILED
 // rather than passed off as consensus — a dead auditor is not a clean bill.
+//
+// This round stays on `fable` while the audit round above runs on `opus`, and
+// the asymmetry is deliberate: a refutation here is written to the PERMANENT
+// refutation memory in skill-improvement-log.md and suppresses that finding on
+// every later audit, whereas a missed finding upstream is re-derived next run.
+// Do not unify the two tiers without reading ADR-0020.
 const groups = TREES.map((tree) => ({ tree, members: live.filter((a) => a.tree === tree.key) }))
 const unreconciled = groups.filter((g) => g.members.length < 2).map((g) => g.tree.key)
 unreconciled.forEach((k) => log(`WARNING: ${k} had fewer than 2 auditors return — its findings are UNRECONCILED, not consensus`))

--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ that automate the development workflow. Invoke any of them with `/<name>`.
 | `/implement-plan` | Implement the plan test-first (Canon TDD) until the test list is empty |
 | `/review-changes` | Review the working-tree changes — one reviewer, or a parallel fan-out with adversarial verification for large diffs |
 | `/capture-knowledge` | Record durable learnings (gotchas, API quirks, ADRs) into `knowledge/` |
-| `/review-knowledge` | Audit `knowledge/` for staleness with two adversarial critics that cross-examine and reach a consensus |
+| `/review-knowledge` | Audit `knowledge/` and `.claude/` for staleness with four adversarial auditors (two lenses over two trees) that cross-examine and reach a consensus |
 | `/pr` | Create a pull request (`/format` → `make ci` → review → open) |
 | `/watch-pr` | Watch the PR: resolve review threads, fix failing checks, optionally merge |
 | `/review-pr-threads` | Resolve the PR's unresolved review threads in one sweep |

--- a/knowledge/decisions/0014-subagent-model-tiers.md
+++ b/knowledge/decisions/0014-subagent-model-tiers.md
@@ -1,6 +1,7 @@
 # ADR-0014: Model-tier policy for skills and subagents
 
-- **Status:** Accepted
+- **Status:** Accepted (amended in part by
+  [ADR-0020](0020-review-knowledge-audit-tier.md))
 - **Date:** 2026-07-06
 - **Deciders:** Adam Young, Claude
 
@@ -61,9 +62,15 @@ re-diagnoses only where judgment demonstrably matters.
   model family shift (e.g. pinning the top judgment calls to a Fable-class
   model) revisits this ADR — the *shape → tier* mapping is the durable part,
   not the model names.
-- *Addendum (2026-08-07):* `/review-knowledge` (added after this ADR) pins its
-  two audit critics to a **Fable-class** model — the first judgment role above
-  the Opus floor, chosen for verification depth on the knowledge audit. The
+- *Addendum (2026-08-07; amended 2026-08-13 by
+  [ADR-0020](0020-review-knowledge-audit-tier.md)):* `/review-knowledge` (added
+  after this ADR) pinned its auditors to a **Fable-class** model — the first
+  judgment role above the Opus floor, chosen for verification depth on the
+  knowledge audit. It fans out **four** auditors (two lenses over two trees)
+  plus a four-agent cross-examination round; "two audit critics" as originally
+  written was a miscount, corrected here. **ADR-0020 splits that pin by round**
+  — the audit round moved to Opus, the cross-examination round stays
+  Fable-class because its refutations are written to permanent memory. The
   shape → tier mapping is unchanged, and the trigger for revisiting the
   remaining Opus pins (the `/review-plan` critics, the `/deliver` panel) stays
   "critics start missing blockers".

--- a/knowledge/decisions/0016-panel-jurors-and-workflows-directory.md
+++ b/knowledge/decisions/0016-panel-jurors-and-workflows-directory.md
@@ -60,9 +60,9 @@ Both guards were verified live: each throws with **zero agents spawned**.
 
 ### The script lives in `.claude/workflows/`, not embedded
 
-The three existing Workflow scripts (`review-plan`, `review-knowledge`,
-`review-changes`) are embedded in their `SKILL.md`, and each runs **once per
-skill invocation**, so re-authoring costs nothing. The panel runs at **six
+The other Workflow scripts (`review-plan`, `review-knowledge`, `review-changes`
+and `fix-pr-checks` — four as of 2026-08-13) are embedded in their `SKILL.md`,
+and each runs **once per skill invocation**, so re-authoring costs nothing. The panel runs at **six
 decision points per run**, from a context that has been compacting for hours.
 
 An embedded script is **re-authored** each time; a file is **executed**. Drift

--- a/knowledge/decisions/0020-review-knowledge-audit-tier.md
+++ b/knowledge/decisions/0020-review-knowledge-audit-tier.md
@@ -57,19 +57,25 @@ DocC quality ever regresses, the Sonnet pin is the first suspect").
   which is the price of keeping the top tier where a mistake is permanent.
 - **One variable moved**, so a regression in audit quality has exactly one
   suspect: the Opus audit pin.
-- **The tier split is now load-bearing and easy to "tidy" away.** Both the
-  skill's contract and a comment beside the cross-examine `agent()` call say why
-  the rounds differ and point here, because the natural instinct on reading a
-  two-tier workflow is to unify it.
+- **The tier split is now load-bearing and easy to "tidy" away.** The skill's
+  contract, the block comment above the cross-examination section, and a
+  one-line note on the `agent()` options object itself all say why the rounds
+  differ and point here — because the natural instinct on reading a two-tier
+  workflow is to unify it, and the reader doing that greps `model:` and lands on
+  the call site, not on the prose.
 - **The saving is projected, not measured** — no run at the new tier exists yet.
-  The first post-merge `/review-knowledge` run should have its agent count and
-  token usage recorded in the retro, so the next reviewer has a baseline.
+  So the skill's report contract now requires **every** run to record its agent
+  count, total tokens, and consensus findings by severity in
+  [`skill-improvement-log.md`](../skill-improvement-log.md) — the skill's own
+  memory, and the reader of the trigger below.
 
-**Revisit when** (deliberately observable, unlike "starts missing staleness",
-which is only visible once a bug ships): two consecutive `/review-knowledge`
-runs return **zero** `major`-or-`critical` consensus findings while the tree has
-demonstrably moved — check `delivery-retros.md` for deliveries that changed
-build config, target layout or the skills in between.
+**Revisit when** two consecutive `/review-knowledge` runs record **zero**
+`major`-or-`critical` consensus findings while the tree has demonstrably moved
+(intervening deliveries that changed build config, target layout or the skills —
+`delivery-retros.md` lists them). That is checkable from the log rather than
+only after a bug ships, which is *why* the run-record line above is part of this
+decision rather than a nicety: without it a zero-finding run leaves no trace and
+the trigger has nothing to read.
 
 ## Alternatives considered
 
@@ -97,5 +103,6 @@ they start missing blockers"*. A conditional variant of that escalation was
 drafted alongside this change and **dropped before implementation**: it delivered
 no cost saving, its trigger could never fire for the reflexive `.claude/` changes
 this repo's defect record is made of, and it collided with the recorded decision
-that the delivery-weight vocabulary stays binary. It is filed as an issue against
-ADR-0014's existing revisit trigger instead.
+that the delivery-weight vocabulary stays binary. It is filed instead as issue
+[#450](https://github.com/adamayoung/TMDb/issues/450), against ADR-0014's
+existing revisit trigger.

--- a/knowledge/decisions/0020-review-knowledge-audit-tier.md
+++ b/knowledge/decisions/0020-review-knowledge-audit-tier.md
@@ -1,0 +1,101 @@
+# ADR-0020: `/review-knowledge` audits on Opus; cross-examination stays on Fable
+
+- **Status:** Accepted (unreleased — tooling only)
+- **Date:** 2026-08-13
+- **Deciders:** Adam Young, Claude
+- **Amends in part:** [ADR-0014](0014-subagent-model-tiers.md)
+
+## Context
+
+[ADR-0014](0014-subagent-model-tiers.md) set the durable part of the policy —
+the *shape → tier* mapping — and its 2026-08-07 addendum pinned
+`/review-knowledge`'s auditors to a **Fable-class** model, "chosen for
+verification depth on the knowledge audit".
+
+Two things prompted revisiting it.
+
+**Cost.** Fable-class pricing is $10/$50 per MTok against Opus at $5/$25, and
+the skill fans out **eight** agents per run — four auditors (two lenses × two
+trees) plus a four-agent cross-examination round. That made a periodic prose
+audit the single most expensive configuration in `.claude/`. Nothing in
+`knowledge/` or the retros records the Fable tier catching staleness an Opus
+tier missed: the pin was chosen on *expected* depth, never on measured yield.
+
+**The two rounds are not symmetric.** An auditor that misses a finding costs one
+cycle — the next audit re-derives it. A cross-examiner that wrongly *refutes* a
+finding writes a `· refuted` entry into
+[`skill-improvement-log.md`](../skill-improvement-log.md), and the skill's own
+Agent Behaviour Contract then makes every later audit **drop that finding
+without re-deriving it**. A weak refutation is therefore durable, self-concealing
+suppression; a weak audit is not.
+
+> The addendum also miscounted the fan-out as "two audit critics". Correcting a
+> factual error is explicitly not a change of mind
+> ([`decisions/README.md`](README.md) → *Immutability*), so it is fixed in place
+> rather than carried forward.
+
+## Decision
+
+Split the tier by round rather than by skill:
+
+- **Audit round** (four auditors, two lenses × two trees) → **`opus`** at
+  `effort: 'high'`.
+- **Cross-examination round** (up to four refuters) → **stays `fable`** at
+  `effort: 'high'`.
+
+`effort` is deliberately **unchanged** on both rounds. An earlier draft paired
+the model change with `high → xhigh`; three independent plan critics observed
+that `xhigh` raises thinking tokens — billed as *output*, at 5× the input rate —
+so moving both variables at once would have made the saving unmeasurable and
+broken the one-variable diagnostic convention ADR-0014 itself relies on ("if
+DocC quality ever regresses, the Sonnet pin is the first suspect").
+
+## Consequences
+
+- **Cost falls roughly a quarter.** Eight Fable-tier agents ≈ 16 Opus-equivalents;
+  four Opus + four Fable ≈ 12. Less than a blanket downgrade would have saved,
+  which is the price of keeping the top tier where a mistake is permanent.
+- **One variable moved**, so a regression in audit quality has exactly one
+  suspect: the Opus audit pin.
+- **The tier split is now load-bearing and easy to "tidy" away.** Both the
+  skill's contract and a comment beside the cross-examine `agent()` call say why
+  the rounds differ and point here, because the natural instinct on reading a
+  two-tier workflow is to unify it.
+- **The saving is projected, not measured** — no run at the new tier exists yet.
+  The first post-merge `/review-knowledge` run should have its agent count and
+  token usage recorded in the retro, so the next reviewer has a baseline.
+
+**Revisit when** (deliberately observable, unlike "starts missing staleness",
+which is only visible once a bug ships): two consecutive `/review-knowledge`
+runs return **zero** `major`-or-`critical` consensus findings while the tree has
+demonstrably moved — check `delivery-retros.md` for deliveries that changed
+build config, target layout or the skills in between.
+
+## Alternatives considered
+
+- **All eight agents on Opus.** The full ~50% saving and a simpler one-tier
+  story, but it moves the refutation round — the only stage whose mistakes are
+  written to permanent memory — to a lower tier on cost grounds alone. Rejected:
+  the asymmetry above is a real mechanism, not a hypothetical.
+- **Leave all eight on Fable.** No change, no risk, no saving. Rejected: the
+  original pin was never evidence-backed, and the audit round is bulk repo
+  reading, which is the shape ADR-0014 already assigns below the top tier.
+- **All eight on Opus, plus adjudicating every refutation against the tree before
+  it is written to the log.** Fixes the underlying hazard rather than paying a
+  model tier to mask it — a Fable refuter can be wrong too — and is probably the
+  right long-term shape. Rejected *here* only as scope: it rewrites the skill's
+  consensus procedure, which this delivery does not otherwise touch.
+
+## What this does not change
+
+ADR-0014's Haiku (`tooling-runner`, first-pass CI diagnosis), Sonnet
+(`documentation-writer`) and Opus (`code-reviewer`, `/review-changes`,
+`/review-plan` critics, the `/deliver` panel) mappings stand unamended, as does
+its rejection of Fable-class `/review-plan` critics — *"the price on every plan
+review isn't justified while Opus-tier critics are converging fine; revisit if
+they start missing blockers"*. A conditional variant of that escalation was
+drafted alongside this change and **dropped before implementation**: it delivered
+no cost saving, its trigger could never fire for the reflexive `.claude/` changes
+this repo's defect record is made of, and it collided with the recorded decision
+that the delivery-weight vocabulary stays binary. It is filed as an issue against
+ADR-0014's existing revisit trigger instead.

--- a/knowledge/decisions/README.md
+++ b/knowledge/decisions/README.md
@@ -31,12 +31,13 @@ always fair game.
 | [0011](0011-duration-for-runtime.md) | Represent runtimes as `Duration`, bridging integer minutes at the wire boundary | 2026-07-24 | Accepted (shipped in 19.0.0) |
 | [0012](0012-structured-tmdberror-context.md) | Enrich `TMDbError` with structured context | 2026-07-24 | Accepted (shipped in 19.0.0) |
 | [0013](0013-cached-image-url-resolver.md) | Cache the image configuration in an actor behind `client.images` | 2026-07-27 | Accepted (shipped in 19.0.0; one consequence superseded by [0018](0018-cancellation-as-tmdberror-case.md)) |
-| [0014](0014-subagent-model-tiers.md) | Model-tier policy for skills and subagents | 2026-07-06 | Accepted |
+| [0014](0014-subagent-model-tiers.md) | Model-tier policy for skills and subagents | 2026-07-06 | Accepted (amended in part by [0020](0020-review-knowledge-audit-tier.md)) |
 | [0015](0015-durable-deliver-run-state.md) | Durable `/deliver` run state in `.git/deliver/` | 2026-07-29 | Accepted (unreleased — tooling only) |
 | [0016](0016-panel-jurors-and-workflows-directory.md) | Auto-mode panel as three independent jurors, in `.claude/workflows/` | 2026-07-29 | Accepted (unreleased — tooling only) |
 | [0017](0017-v4-api-client.md) | A third `TMDbAPIClient` instance for the v4 API | 2026-08-07 | Accepted (in 20.0.0, unreleased) |
 | [0018](0018-cancellation-as-tmdberror-case.md) | Surface task cancellation as `TMDbError.cancelled` | 2026-08-12 | Accepted (in 20.0.0, unreleased) |
 | [0019](0019-decode-tolerance-policy.md) | One decode-tolerance policy: skip an unmodelled `media_type`, stay loud otherwise | 2026-08-12 | Accepted (in 20.0.0, unreleased) |
+| [0020](0020-review-knowledge-audit-tier.md) | `/review-knowledge` audits on Opus; cross-examination stays on Fable | 2026-08-13 | Accepted (unreleased — tooling only) |
 
 > **Keep the Status column true.** "In X, unreleased" becomes "shipped in X" when
 > X is **tagged** — a `CHANGELOG.md` section is not a release. For breaking changes

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -25,6 +25,80 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
 
 ---
 
+## 2026-08-13 — 🔧 Move the `/review-knowledge` audit round to Opus (`chore/review-skill-model-tiers`) · full
+
+- **Phases / skills:** 0–8 pre-PR. Full weight and reflexive (`.claude/skills/**`),
+  so Phases 4 and 5 ran with their no-Swift self-skip overridden. Skills:
+  `review-plan`, `review-changes` (`force-review`), `security-review`,
+  `capture-knowledge`.
+  `consulted:` gotchas *False green*, *Edits can land in the main checkout*,
+  *In a worktree session Bash refuses commands it can't prove stay inside it*,
+  *EnterWorktree branch name*, *Workflow resolves a repo-relative scriptPath*,
+  *git ls-tree empty hash*, *markdownlint line-leading number-sign*;
+  **ADR-0014** (governing — both proposed changes contradicted it), ADR-0016;
+  wiki *keep-adversarial-reviewers-independent*,
+  *a-detector-whose-green-looks-the-same-when-it-didnt-run*,
+  *an-unenforceable-process-rule-gets-silently-skipped*.
+  `reconciled:` 0 in scope / 0 reclaimed / 0 resumable / 0 reported.
+  `swept:` `.claude/skills/review-knowledge/SKILL.md` → 3 `gotchas.md` entries
+  written or extended, 1 factual correction in `decisions/0016` (embedded-script
+  count 3 → 4); historical `skill-improvement-log.md` entries left untouched
+  (append-only decision memory); `gotchas.md:59` re-read, still true.
+- **Worked — Phase 0's knowledge consult caught that the whole plan was
+  ADR-governed.** ADR-0014 pins every model tier in `.claude/`, and both proposed
+  changes contradicted it: one reversed its six-day-old addendum, the other
+  partially re-opened an alternative it had explicitly rejected with a revisit
+  trigger that had not fired. Without that read this would have shipped as a
+  config tweak that silently reversed a recorded decision.
+- **Worked — the plan critics changed the shape of the delivery, not just its
+  details.** They killed `effort: high → xhigh` (thinking bills as output at 5×
+  input, so moving two variables would have made the saving unmeasurable and left
+  a regression with two suspects); caught that a conditional `meta.model` would be
+  a temporal-dead-zone `ReferenceError` shipping unexercised, since a reflexive
+  delivery cannot dogfood; and showed the second change's trigger could never fire
+  for reflexive `.claude/` diffs — the class this repo's defect record is made of.
+  Scope went from two changes to one on that evidence; the dropped one is issue
+  #450.
+- **Worked — the code reviewer caught a falsehood in the durable record.**
+  ADR-0020 and the log both claimed *in the past tense* that a GitHub issue had
+  been filed. None had. In a delivery specifically about sharpening the audit that
+  hunts exactly that class of claim.
+- **Worked — a reviewer conceding cleanly on evidence it lacked.** It flagged
+  `meta.phases[].model` as an invented key (High, correctly, from where it sat —
+  the `code-reviewer` agent has no `Workflow` tool and the schema is documented
+  nowhere in the tree). Given the contract it withdrew in full and named its own
+  reasoning error: it had read *absence of the situation* as *avoidance of the
+  field*. Captured as a gotcha.
+- **Friction — the review machinery cost far more than the change saves.**
+  ~1.36M subagent tokens on the plan review, ~284k across two code-review rounds,
+  ~74k grading — for a 6-file markdown diff whose benefit is roughly a quarter off
+  one periodic skill's run. Full weight was the right call for a reflexive change;
+  the problem is that full weight currently means the same machinery for a
+  6-file prose diff as for a multi-service Swift feature.
+- **Friction — the worktree `Bash` guard cost ~8 extra round trips.** Every
+  run-file update, the content stamp and the script parse-check had to be
+  decomposed into single-purpose commands; `$'\t'` quoting was refused outright.
+  Captured.
+- **Deviations:** (1) the ADR was authored in **Phase 3, inside the diff**, not
+  Phase 7 — on the critics' finding that Phase 7's contract permits writing
+  nothing, so a governance record deferred to it is unenforced. This is the
+  sanctioned inline-capture exception. (2) Phase 5 was analysed directly rather
+  than fanned out: every changed file is markdown and the skill's own rule 16
+  excludes documentation findings, so a fan-out was structurally guaranteed
+  empty. Recorded as a visible choice rather than a silent narrowing.
+- **One improvement:** scale Phase 2 and Phase 4 by **diff shape**, not weight
+  alone. `full` currently fixes both risk *and* machinery, so a reflexive prose
+  change — which genuinely needs the adversarial lens — pays for fan-out breadth
+  sized for a multi-service Swift diff. A reflexive-but-small shape wants the
+  critics (they earned their keep here) at a smaller fan-out. Raise against the
+  binary-weight decision deliberately, since that vocabulary is itself a recorded
+  narrowing.
+- **Also noted:** my own AC3 was written too literally — its second clause
+  required *every* `fable` hit to sit in one of two named buckets, which would
+  have demanded deleting true, unrelated history. The independent grader graded
+  the reasonable reading and disclosed the strict one rather than silently
+  passing. Write rubric clauses that scope to the change, not to the whole tree.
+
 ## 2026-08-13 — 🐛 Exclude tvOS/watchOS from the FoundationModels planner (#449) · full
 
 - **Phases / skills:** 0–8 pre-PR. Full weight, but with two pieces of machinery
@@ -633,56 +707,6 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
   running `make ci` is duplicate CPU — and with N parallel agents on a shared
   scratch path it is not merely N×, it is cyclical.
 
-## 2026-07-24 — 📦 Extract the `TMDbIntelligence` product (#398) · full
-
-- **Phases / skills:** phases 0–8 pre-PR; full weight (~40 sources + ~110
-  fixtures + ~30 tests relocated, new targets, CI/docs infra). `/plan` refreshed
-  the pre-existing `plans/tmdb-intelligence-product-extraction.md` after a
-  3-agent drift check. `review-plan` (3 Opus critics) → **2 blockers + 6
-  findings, all applied**. `implement-plan` in 4 checkpoints.
-  `review-changes` → **1 Critical**, 3 Medium, 2 Low. `security-review` → 0
-  findings ≥ conf-8. `capture-knowledge` → 1 new gotcha + **2 corrections to
-  existing ones**. Rubric: 7/7 ACs met (**self-graded — the independent grader
-  subagent died on a session limit; recorded, not silently passed**).
-- **Worked:** the plan critics paid for themselves twice over — they caught that
-  `TMDbTestingTests` tests `SearchPlan.sample` (which moves out, so the target
-  would not compile), that the integration inventory was 5 files not 3, and
-  unanimously that the **`.xctestplan` sweep was ghost work** (the files are
-  gitignored and untracked — the plan would have had me edit non-existent
-  files). Counting tests rather than trusting green proved the move lossless:
-  **2868 before, 2868 after**, reconciled against the true base `c22a336`.
-- **Friction — the one that mattered:** `@testable import TMDb` inside the new
-  **non-test** `TMDbTestFixtures` target broke `swift build -c release` *only*.
-  Debug builds, `--build-tests`, all 2868 unit tests and 291 integration tests
-  passed while `make build-release` — i.e. `make ci` and both CI release jobs —
-  was red. I never ran a release build before declaring implementation
-  complete; the code reviewer caught it. Whole-module-optimization then
-  misreported the culprit file, so the grep for `@testable` mattered more than
-  the compiler's own pointer.
-- **Deviations:** (a) the shared-fixtures target was **not** in the plan — the
-  review blocker forced a decision between duplicating ~100 fixtures, keeping
-  tests in place, or a shared target; the user chose the shared target after I
-  corrected my own under-estimate of the blast radius (494 of 572 files touch
-  those fixtures). (b) `make ci` could not pass locally for most of the
-  delivery — the Xcode 27 `.docc` trap, verified to fail **identically on
-  `origin/main`**, so every stage was run individually instead; **#396 fixed it
-  upstream mid-delivery**, and the rebase onto it made `make ci` green once the
-  two new catalogs were added to its `exclude` list. (c) M3 left as documented
-  duplication rather than promoting two internal DTOs, which cascades into
-  member-level access.
-- **Rebase (onto `cea296c`):** picked up #396 (Xcode 27) and #397 (`TMDbError`
-  context — the 19.0.0 train partner, now merged). Two conflicts, both in
-  append-at-top files (CHANGELOG, retros). The load-bearing catch was silent:
-  #396's `.docc` `exclude` list is **per target**, so the two new catalogs
-  re-introduced the build failure — a clean textual rebase and a green
-  `swift build` both missed it; only `make ci` caught it. Tests reconciled
-  again: **2869 on the new base, 2869 after**.
-- **Improvement:** **`/deliver` Phase 3 should run `swift build -c release`
-  before declaring implementation done.** Debug + tests green is not evidence
-  the release gate passes, and the two diverge precisely on access-level and
-  `@testable` mistakes — exactly what a target-extraction PR is made of. Cheap
-  check, would have caught the only Critical in this delivery.
-
 ## Archive (distilled)
 
 Older entries condensed per the rolling window (`knowledge/README.md` →
@@ -690,6 +714,7 @@ Older entries condensed per the rolling window (`knowledge/README.md` →
 
 | Date | PR | Weight | Outcome |
 | --- | --- | --- | --- |
+| 2026-07-24 | #398 | full | Extracted the `TMDbIntelligence` product — ~40 sources, ~110 fixtures and ~30 tests relocated behind new targets. Two lasting rules came out of it. **Run `swift build -c release` before declaring implementation done**: a `@testable import` inside the new *non-test* `TMDbTestFixtures` target broke the release build *only*, while debug, `--build-tests`, 2868 unit and 291 integration tests all passed — now a hard Phase 3 checkpoint and a `gotchas.md` entry. And **share fixtures via a `package`-access target, never a `@testable` one** (now a wiki pattern). The plan critics paid for themselves twice over, catching that `TMDbTestingTests` referenced a symbol that was moving out, and unanimously that the planned `.xctestplan` sweep was **ghost work** — those files are gitignored and untracked. Counting tests rather than trusting green proved the move lossless (2868 → 2868, then 2869 → 2869 after rebasing onto #396/#397, whose `.docc` `exclude` list turned out to be **per target**, so the two new catalogs silently re-introduced the failure that only `make ci` caught). Rubric **self-graded — the independent grader died on a session limit; recorded, not silently passed**. |
 | 2026-07-24 | #397 | full | Enriched `TMDbError` with structured context (ADR-0012). The plan review paid for the delivery on its own: a critic caught, before a line was written, that the new public `endpointPath` would carry `guest_session_id` (a bearer-like credential) and `account_id` (PII) into a loggable field — the redactor and its tests came from that finding, and `security-review` later confirmed the control covers all 137 request-path templates. Now the wiki pattern *a-diagnostic-field-added-for-logging-is-a-publishing-surface*. Capturing **real** error bodies from the live API while planning (`curl -D-`) beat the plan's guesses: 400/code 22 and 422/code 20, not the invented 422/code 5. Environmental friction was severe — the Xcode 27 / Swift 6.4 `.docc` trap made `make ci` unrunnable, and the first attribution (xcsift `--Werror`) was **wrong**: `pipestatus` showed `swift build` exiting 1 and xcsift 0, which is why the build/test skills now say the exit status is the verdict, not the summary. |
 | 2026-07-24 | #390 | full | Migrated model runtimes from `Int` minutes to `Duration` (ADR-0011). The lasting pattern is store-the-raw / expose-the-computed: keep the integer-minute wire value in a private stored property and expose `Duration` as a computed one, so `Codable` stays synthesized and the wire format cannot silently drift — no hand-written 30-property `encode` to maintain. Now the wiki entry *bridge-a-wire-type-to-a-domain-type-inside-the-model*. The `.convertFromSnakeCase` → camelCase-`CodingKeys` check caught the `episodeRunTime` rawValue trap before it broke decode. Its "one improvement" — run the tooling-runner in the *active worktree* rather than the main checkout — recurred verbatim in #397 one delivery later and shipped in #399. |
 | 2026-07-08 | #387 | lite | Bumped the CI workflows to Xcode 26.6. The lasting practice: a plan-time `WebFetch` of the `macos-26` runner-image README confirmed `/Applications/Xcode_26.6.app` exists (build 17F113) **before** pinning it — retiring the one real risk of a toolchain-version bump, pinning a version the runner does not ship, at plan time rather than in CI. Now the wiki heuristic *before-bumping-a-pinned-ci-toolchain-version-verify-the-runner-image-ships-it*. `security-review` ran (workflows are security-relevant) and returned 0 findings. |

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -25,7 +25,7 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
 
 ---
 
-## 2026-08-13 — 🔧 Move the `/review-knowledge` audit round to Opus (`chore/review-skill-model-tiers`) · full
+## 2026-08-13 — 🔧 Move the `/review-knowledge` audit round to Opus (#451) · full
 
 - **Phases / skills:** 0–8 pre-PR. Full weight and reflexive (`.claude/skills/**`),
   so Phases 4 and 5 ran with their no-Swift self-skip overridden. Skills:

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -360,6 +360,10 @@ so it also blocks commands that were never leaving. Seen refusing:
   outside the worktree path by design.
 - Multi-stage pipelines with `$(…)` substitution, `for`/`while` loops over
   `curl`, and `cd "$SOMEWHERE"` followed by a redirect.
+- *2026-08-13:* **ANSI-C quoting** — `grep -v $'\tknowledge/' in.txt > out.txt`
+  was refused although both paths are worktree-relative. Any `$'…'` word seems to
+  defeat the static check. Rewrite the pattern without it (here,
+  `awk '$4 !~ /^knowledge\//'` over `git ls-tree`'s tab-separated output).
 
 Workarounds, in order of preference: keep each command **single-purpose with
 fully literal paths** (`sed -i '' 's/…/…/' /abs/literal/path` succeeded where the
@@ -378,11 +382,53 @@ also accepts a **repo-relative path** — `Workflow({ scriptPath:
 makes a committed, version-controlled workflow script viable rather than
 re-authored prose.
 
-Two testing notes: a script's **argument-validation `throw`s run before any
+Three testing notes. A script's **argument-validation `throw`s run before any
 agent spawns**, so guard rails can be exercised for free (the run fails with
-`agent_count: 0`); and such a script **cannot be run standalone** with `node` —
-it uses harness globals (`agent`, `parallel`, `phase`, `log`, `args`) and a
-top-level `return`. Test it by extracting the body and supplying stubs.
+`agent_count: 0`). Such a script **cannot be run standalone** with `node` — it
+uses harness globals (`agent`, `parallel`, `phase`, `log`, `args`) and a
+top-level `return`; run it by extracting the body and supplying stubs.
+
+And to **parse-check** one without running it — the only pre-merge verification
+available for a reflexive delivery, since the skill registry loads from the main
+checkout and the edited script is never what executes — wrap it first. A bare
+`node --check script.mjs` reports `SyntaxError: Illegal return statement` on the
+harness's legal top-level `return`, which reads exactly like a real defect:
+
+```bash
+awk '/^```javascript$/{f=1;next} /^```$/{f=0} f' <skill>/SKILL.md > .build/s.mjs
+sed -i '' 's/^export const meta/const meta/' .build/s.mjs   # export is illegal once wrapped
+printf '(async () => {\n' > .build/w.mjs
+cat .build/s.mjs >> .build/w.mjs
+printf '})()\n' >> .build/w.mjs
+node --check .build/w.mjs
+```
+
+The async IIFE reproduces the harness's async context, making both top-level
+`return` and top-level `await` legal. Keep each command separate — the worktree
+Bash guard refuses the `{ …; } > file` one-liner (see the entry above).
+
+### The `Workflow` tool's contract is the schema authority — the sibling scripts are not
+
+*2026-08-13.* `/review-knowledge` became the first workflow here to need a
+**per-phase** model, and used the documented field for it:
+`phases: [{ title, detail, model: 'fable' }]` — the `Workflow` contract says
+plainly *"Add `model` to a phase entry when that phase uses a specific model
+override."* No other script in `.claude/` had ever set it, because none had ever
+had a per-phase split (`fix-pr-checks` varies model *per agent within one
+phase*, where a phase-level key cannot apply).
+
+The review agent flagged it **High** as an invented key that would either be
+ignored — leaving the file asserting a mechanism that does not exist — or throw
+at load. That was the right call from where it sat: the `code-reviewer` agent
+has no `Workflow` tool, and the tool's `meta` schema is documented **nowhere in
+this tree**, so it reasoned from the only evidence it had (four siblings, none
+using the field) and read absence-of-the-situation as avoidance-of-the-field.
+The finding was withdrawn once the contract was quoted back to it.
+
+So: when a review disputes a `Workflow` schema question, settle it by quoting
+the tool contract, not by surveying `.claude/`. And expect to have to — a
+reviewer cannot verify these fields, so **the first use of any `Workflow` field
+in this repo will read as fabricated**.
 
 ### `EnterWorktree` no longer uses the requested name as the branch name
 

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -81,8 +81,9 @@ two fields the dedup step keys on.
   tier when a plan is "complex", keeping Opus otherwise — raised alongside the
   audit-tier change above, and reviewed by the three-critic pass.
 - **Decision:** **deferred**, before implementation. `/review-plan` and
-  `/deliver` Phase 2 were left untouched; filed as a GitHub issue against
-  ADR-0014's existing revisit trigger.
+  `/deliver` Phase 2 were left untouched; filed as issue
+  [#450](https://github.com/adamayoung/TMDb/issues/450) against ADR-0014's
+  existing revisit trigger.
 - **Rationale:** three independent failures. (1) It delivers none of the stated
   goal — the default path is today's behaviour and the escalated path costs
   *more*. (2) The trigger, expressed in the lite/full rule's risky-surface

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -48,6 +48,56 @@ two fields the dedup step keys on.
 
 ---
 
+### 2026-08-13 — `/review-knowledge` audit tier drops to Opus; cross-examination stays Fable · applied
+
+- **Pattern:** the 2026-08-07 addendum to ADR-0014 pinned `/review-knowledge`'s
+  auditors to a Fable-class model on *expected* verification depth, never on
+  measured yield. At $10/$50 per MTok against Opus's $5/$25, and with eight
+  agents per run (four auditors plus a four-agent cross-examination), a periodic
+  prose audit had become the most expensive configuration in `.claude/`.
+- **Decision:** **applied** (user-approved). Audit round → `opus`; the
+  cross-examination round **stays** Fable-class. `effort` unchanged at `high` on
+  both. Recorded as [ADR-0020](decisions/0020-review-knowledge-audit-tier.md),
+  which amends ADR-0014 *in part* — the Haiku/Sonnet/Opus mappings and the
+  rejection of Fable `/review-plan` critics are untouched. The addendum's
+  "two audit critics" miscount was corrected in place as a factual error.
+- **Rationale:** the rounds are not symmetric. A missed finding is re-derived
+  next run; a wrong *refutation* is written to this log and makes every later
+  audit drop that finding without re-deriving it — durable, self-concealing
+  suppression. So the cheap tier goes where mistakes are recoverable, and the
+  top tier stays where they are not. Three plan critics separately killed an
+  earlier draft that also moved `high → xhigh`: thinking bills as output at 5×
+  input, so moving two variables at once would have made the saving
+  unmeasurable and left a regression with two suspects.
+- **Reconsider when:** two consecutive `/review-knowledge` runs return zero
+  `major`-or-`critical` consensus findings while the tree has demonstrably moved
+  (check `delivery-retros.md` for intervening deliveries that changed build
+  config, target layout or the skills). Also revisit if the projected ~25% saving
+  fails to appear once a run at the new tier is recorded.
+
+### 2026-08-13 — Conditional Fable escalation for `/review-plan` critics · deferred
+
+- **Pattern:** proposal to give `/review-plan`'s three critics a Fable-class
+  tier when a plan is "complex", keeping Opus otherwise — raised alongside the
+  audit-tier change above, and reviewed by the three-critic pass.
+- **Decision:** **deferred**, before implementation. `/review-plan` and
+  `/deliver` Phase 2 were left untouched; filed as a GitHub issue against
+  ADR-0014's existing revisit trigger.
+- **Rationale:** three independent failures. (1) It delivers none of the stated
+  goal — the default path is today's behaviour and the escalated path costs
+  *more*. (2) The trigger, expressed in the lite/full rule's risky-surface
+  vocabulary, is Swift-only, so it could never fire for a reflexive `.claude/`
+  change — the very class this repo's defect record is made of (see the Phase 0
+  reflexive rule and PRs #441-#447). (3) Splitting `full` into
+  full-because-risky and full-because-large is a third scaling shape, colliding
+  with the 2026-08-07 decision that the weight vocabulary stays binary. A fourth,
+  smaller point: the flag defaulted silently, so a forgotten escalation would
+  have been indistinguishable from a correct cheap run.
+- **Reconsider when:** ADR-0014's own trigger fires — an Opus critic pass misses
+  a blocker that later ships as a defect — *and* the escalation is expressed as
+  a pointer to the weight rule rather than a copy of it, with the selected tier
+  logged and recorded in the run file so a missed escalation is visible.
+
 ### 2026-08-13 — Full pipeline audit: 39 findings across five PRs (#441-#446) · applied
 
 - **Pattern:** a full review of `CLAUDE.md`, all 21 skills, the 3 agents and

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -11,7 +11,8 @@ the decision on it. Newest at the top. Two producers write here:
 
 - **`/deliver`'s wrap-up recurring-pattern scan** — proposals to change a skill.
 - **`/review-knowledge`** — audit findings that were **refuted**, and any
-  finding accepted as a standing exception rather than fixed.
+  finding accepted as a standing exception rather than fixed. It also appends a
+  one-line **run record** per audit (see below) — telemetry, not a proposal.
 
 **Why this exists:** both producers surface candidates and wait for approval.
 Without a memory of past decisions they re-raise what is already **applied** or
@@ -45,6 +46,21 @@ Format per entry:
 Keep this five-field shape on every entry so the scan can parse the log
 consistently — in particular **Decision** (status) and **Reconsider when** are the
 two fields the dedup step keys on.
+
+**One sanctioned exception — `/review-knowledge` run records.** Every audit
+appends a single dated line, whatever it found:
+
+```text
+### <date> — /review-knowledge run · <N> agents · <T> tokens · <c> critical / <m> major / <n> minor
+```
+
+It carries no **Decision** and no **Reconsider when**, so **the dedup scan skips
+it**: it is telemetry, not a settled call, and there is nothing for a producer to
+re-raise. It exists because
+[ADR-0020](decisions/0020-review-knowledge-audit-tier.md)'s revisit trigger
+compares the finding counts of two *consecutive* runs — and a run that finds
+nothing would otherwise leave no trace at all. The shape is fixed precisely so
+those two runs stay comparable.
 
 ---
 


### PR DESCRIPTION
## Summary

`/review-knowledge` fans out **eight** agents per run: four auditors (two lenses × two trees) and a four-agent cross-examination round. All eight were pinned to a Fable-class model, which made a periodic prose audit the most expensive configuration in `.claude/` — $10/$50 per MTok against Opus's $5/$25.

The four **auditors** now run on `opus`. The four **cross-examiners** deliberately **stay** on `fable`. `effort` is unchanged at `high` on both rounds.

**Why split the tier rather than downgrade all eight.** The rounds are not symmetric. An auditor that misses a finding costs one cycle — the next audit re-derives it. A cross-examiner that wrongly *refutes* a finding writes a `· refuted` entry into `skill-improvement-log.md`, and the skill's own Agent Behaviour Contract then makes every later audit **drop that finding without re-deriving it**. A weak refutation is durable, self-concealing suppression; a weak audit is not. So the cheap tier goes where mistakes are recoverable, and the top tier stays where they are not.

Cost falls roughly a quarter (8 Fable-tier agents ≈ 16 Opus-equivalents → 4 + 4 ≈ 12), rather than the ~50% a blanket move would have given. That difference is the price of keeping the top tier where a mistake is permanent.

## Changes

**Skill:**
- 🔧 `review-knowledge/SKILL.md` — audit `agent()` → `model: 'opus'`; cross-examine `agent()` stays `'fable'`; `meta.model: 'opus'` with a `model: 'fable'` override on the Cross-examine phase. The contract, a block comment, and a note on the `agent()` options object each say why the rounds differ and point at ADR-0020 — because the instinct on reading a two-tier workflow is to unify it, and whoever does that greps `model:` and lands on the call site.
- 🔧 New **run record** requirement: every audit, including a clean one, appends a one-line record (agent count, tokens, findings by severity) to `skill-improvement-log.md`. Without it a zero-finding run leaves no trace and ADR-0020's revisit trigger has nothing to read.

**Decisions:**
- 📝 **ADR-0020** (new) — **amends ADR-0014 in part**. 0014's Haiku/Sonnet/Opus mappings and its rejection of Fable `/review-plan` critics stand unamended.
- 📝 `ADR-0014` — status line, and its 2026-08-07 addendum amended with a forward link. Its "two audit critics" was a **miscount** (four auditors plus a four-agent cross-examination) and is corrected in place, which `decisions/README.md` explicitly exempts from immutability.
- 📝 `ADR-0016` — embedded-Workflow-script count corrected 3 → 4 (`fix-pr-checks` gained one after that ADR was written).
- 📝 `decisions/README.md` — 0020 row added, 0014's status updated.

**Knowledge:**
- 📝 `skill-improvement-log.md` — the run record sanctioned in the header with a fixed shape and a note that the dedup scan skips it; one `· applied` entry and one `· deferred`.
- 📝 `gotchas.md` — a parse-check recipe for embedded Workflow scripts; the `Workflow` tool contract being the schema authority over sibling scripts; ANSI-C quoting as a worktree Bash-guard trigger.
- 📝 `delivery-retros.md` — this delivery's retro; #398 distilled into the archive table.
- 📝 `README.md` — the `/review-knowledge` row understated the skill as "two adversarial critics" auditing only `knowledge/`.

## Notes for review

**The reversal is on cost grounds, not quality evidence.** Nothing in `knowledge/` or the retros records the Fable tier catching staleness an Opus tier missed — the original pin was chosen on *expected* depth. ADR-0020 says so plainly and carries an observable revisit trigger.

**Scope was narrowed mid-run.** A second change — a conditional Fable escalation for `/review-plan`'s critics — was **dropped before implementation** after the three-critic plan review found that it delivered none of the cost goal (its default path is today's behaviour, its escalated path costs more), that its trigger could never fire for reflexive `.claude/` changes (the class this repo's defect record is made of), and that it collided with the recorded decision that the delivery-weight vocabulary stays binary. Filed as #450 against ADR-0014's own revisit trigger. **`/review-plan` and `/deliver` are untouched by this PR.**

**Reflexive delivery — this was not dogfooded.** This PR rewrites part of the pipeline that reviewed it, and the skill registry loads from the **main checkout**, so the changed skill is *not* what executed during this run. No claim is made that it was exercised end-to-end. Verification was by reading, plus a static parse check of the extracted Workflow script (`node --check` with the body wrapped in an async IIFE to reproduce the harness's async context — the naive check reports a false `Illegal return statement` on the harness's legal top-level `return`). Phases 4 and 5 both ran with their no-Swift self-skip deliberately overridden.

**Rubric provenance: derived.** The acceptance criteria were derived from the agreed design in conversation rather than supplied with a formal plan. All four were graded `met` by an independent grader given only the ACs and the committed diff. It disclosed one ambiguity rather than silently passing: AC3's second clause, read strictly, would have required deleting unrelated historical retro lines; it graded the reasonable reading and said so.

**Known and deliberately unresolved:** the saving is **projected, not measured** — no run at the new tier exists yet. That is what the run-record requirement is for.

## Benefits

- **Cost**: ~25% off every `/review-knowledge` run, with the top tier retained where a mistake is permanent rather than recoverable.
- **One variable moved**: `effort` held at `high`, so a regression in audit quality has exactly one suspect. An earlier draft paired the model change with `high → xhigh`; thinking bills as output at 5× input, which would have made the saving unmeasurable.
- **A falsifiable decision**: ADR-0020's revisit trigger reads a number the skill now actually writes, instead of waiting for a bug to ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
