### PR TITLE
♻️ Give TMDbIntelligence's vocabularies room to grow, and stop misreporting TMDb failures

### DIFF
--- a/.claude/skills/implement-plan/SKILL.md
+++ b/.claude/skills/implement-plan/SKILL.md
@@ -284,9 +284,25 @@ When every item is checked off:
    integration tests and `--build-tests` while the release build was broken.
 2. Run `/lint` (and `/format` if needed); run `make build-docs` and
    `/lint`-markdown only if public API or docs changed.
-3. Print the final, fully-checked test list and a short summary of what was
+3. **Changed a literal string, symbol name or code sample? Grep for its
+   siblings before calling it done.** Fixing the one occurrence in front of you
+   and leaving its twins is this repo's commonest half-fix, and `**/*.docc/**`
+   and `README.md` are the habitual blind spot: **no gate compiles a code
+   sample** — `make build-docs` compiles the DocC *catalog*, not the Swift
+   inside a fence. Grep the whole tree for the **old** text, not the new:
+
+   ```bash
+   grep -rn '<the old spelling>' README.md Sources/ Tests/ knowledge/
+   ```
+
+   This applies to an *incidental* one-line fix, which is the gap: a task
+   framed as "fix every instance of X" is already covered by the type-driven
+   enumeration above, and a reflexive `.claude/` change by `/deliver`'s
+   footprint sweep. #452 fixed a stale `search("…")` call in `README.md` and
+   left the identical call in **two** `.docc` catalogs for code review to find.
+4. Print the final, fully-checked test list and a short summary of what was
    implemented.
-4. If a `/goal` was set, it clears automatically once the condition is confirmed.
+5. If a `/goal` was set, it clears automatically once the condition is confirmed.
 
 Do not declare the plan implemented while any test-list item is unchecked or any
 required suite is red. An empty list with green suites — that is the finish line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,15 +33,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.planningFailed`, it compares by cause, so a rate limit can be told from a
   network drop.
 
-- `SearchDegradation.other(String)` (in `TMDbIntelligence`) — a reserved growth
-  slot carrying a stable identifier. New kinds of degradation ship here in a
-  **minor** release and are promoted to a case of their own at the next major, so
-  a `switch` over `SearchDegradation` keeps compiling.
+- **Breaking:** `SearchDegradation` (in `TMDbIntelligence`) gains an
+  `.other(String)` case. This only affects you if you switch **exhaustively** over
+  it — add an `.other` branch, or a `default`.
+
+  It is a reserved growth slot carrying a stable identifier. From here on, new
+  kinds of degradation ship as `.other` in a **minor** release rather than as new
+  cases, so a `switch` written against 20.0.0 keeps compiling. Render `.other` the
+  way you would render a degradation you do not recognise.
 
 - `NaturalLanguageSearchAvailability.Reason.unknown` (in `TMDbIntelligence`) — an
-  availability reason added by a future OS now surfaces here. It was previously
-  reported as `.modelNotReady`, so a caller would wait for a model download that
-  was never pending.
+  availability reason or state added by a future OS now surfaces here. It was
+  previously reported as `.modelNotReady` (an unrecognised unavailability reason)
+  or `.unsupportedOS` (an unrecognised availability state), so a caller would
+  either wait for a model download that was never pending, or tell the user to
+  upgrade an OS that is already current.
 
 ### Fixed
 
@@ -104,10 +110,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `CustomStringConvertible` conformance for one of these, remove it: they now
   conform themselves.
 
-  `SearchPlan.MediaType` and `SearchPlan.RelativeDate` are deliberately unchanged
-  — the first is a closed vocabulary (TMDb has exactly movies, TV series and
-  people), and the second carries payloads the executor must compute year bounds
-  from, where a catch-all member would mean nothing.
+  `SearchPlan.MediaType` and `SearchPlan.RelativeDate` are deliberately unchanged.
+  `MediaType` is bounded by this feature's **result surface** rather than by TMDb's
+  media taxonomy — `NaturalLanguageSearchResult` exposes exactly `movies`,
+  `tvSeries` and `people`, so a fourth media type could not be returned without a
+  larger change than adding a member. (TMDb itself models more, including
+  collections and TV episodes; should the result surface ever grow, `MediaType`
+  should be converted too.) `RelativeDate` carries payloads the executor computes
+  year bounds from, where a catch-all member would mean nothing.
 
 - **Breaking:** a cancelled auto-pagination scan now throws `TMDbError.cancelled`
   rather than `CancellationError`, and stops at the next element even while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   models, plus `MockV4ListService` and samples in `TMDbTesting`. See the
   *Authenticating with the v4 API* article.
 
+- `NaturalLanguageSearchError.searchFailed(TMDbError)` (in `TMDbIntelligence`) —
+  a TMDb request that fails while a natural-language search is being carried out
+  now reports as itself, carrying the underlying `TMDbError`. Unlike
+  `.planningFailed`, it compares by cause, so a rate limit can be told from a
+  network drop.
+
+- `SearchDegradation.other(String)` (in `TMDbIntelligence`) — a reserved growth
+  slot carrying a stable identifier. New kinds of degradation ship here in a
+  **minor** release and are promoted to a case of their own at the next major, so
+  a `switch` over `SearchDegradation` keeps compiling.
+
+- `NaturalLanguageSearchAvailability.Reason.unknown` (in `TMDbIntelligence`) — an
+  availability reason added by a future OS now surfaces here. It was previously
+  reported as `.modelNotReady`, so a caller would wait for a model download that
+  was never pending.
+
 ### Fixed
 
 - **Breaking:** cancelling a task no longer surfaces as `TMDbError.network`. A dismissed
@@ -55,12 +71,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   literal-search fallback, so the library did the very work the caller had
   cancelled.
 
+- **Breaking:** a TMDb request failure during a natural-language search
+  (`TMDbIntelligence`) no longer reports as
+  `NaturalLanguageSearchError.planningFailed`, whose description claims the prompt
+  could not be interpreted. A rate limit or network drop — during plan execution
+  **or** during the literal-search fallback — now throws
+  `NaturalLanguageSearchError.searchFailed` carrying the real `TMDbError`, so a
+  caller branching on TMDb's 429 can see it. If you branch on `.planningFailed`
+  to show "couldn't interpret that", add a `.searchFailed` branch. A
+  `.searchFailed` is never rescued by the literal-search fallback, which would
+  otherwise retry against the API that just failed.
+
 ### Changed
 
 - **Breaking:** `TMDbError` gains a `.cancelled` case, and
   `NaturalLanguageSearchError` (in `TMDbIntelligence`) gains one too. This only
   affects you if you switch **exhaustively** over either — add a `.cancelled`
   branch, or a `default`.
+
+- **Breaking:** `SearchPlan.Intent`, `SearchPlan.ListKind` and
+  `NaturalLanguageSearchAvailability.Reason` (all in `TMDbIntelligence`) change
+  from enums to structs with static members. These vocabularies grow as the
+  planner learns new requests and as Apple and TMDb add their own, and as public
+  enums each addition broke every exhaustive `switch` downstream. As structs they
+  can grow in a **minor** release instead.
+
+  Almost nothing changes at the call site: construction (`SearchPlan(intent:
+  .find)`), `==`, `if case .find = plan.intent`, and a `switch` with a `default:`
+  all compile unchanged, and `Hashable` is **retained** so `Set` and dictionary
+  use is unaffected. What no longer compiles is an **exhaustive** `switch` — add
+  a `default:`. Should you have written your own `Hashable` or
+  `CustomStringConvertible` conformance for one of these, remove it: they now
+  conform themselves.
+
+  `SearchPlan.MediaType` and `SearchPlan.RelativeDate` are deliberately unchanged
+  — the first is a closed vocabulary (TMDb has exactly movies, TV series and
+  people), and the second carries payloads the executor must compute year bounds
+  from, where a catch-all member would mean nothing.
 
 - **Breaking:** a cancelled auto-pagination scan now throws `TMDbError.cancelled`
   rather than `CancellationError`, and stops at the next element even while

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ cross-platform. Add the product and import it alongside `TMDb`:
 import TMDb
 import TMDbIntelligence
 
-let results = try await tmdbClient.naturalLanguageSearch.search("movies with Tom Hanks")
+let results = try await tmdbClient.naturalLanguageSearch.search(matching: "movies with Tom Hanks")
 ```
 
 `TMDbIntelligence` is an Apple-platforms library — it builds on Apple's

--- a/Sources/TMDbIntelligence/NaturalLanguageSearch/FoundationModelsSearchPlanGenerator.swift
+++ b/Sources/TMDbIntelligence/NaturalLanguageSearch/FoundationModelsSearchPlanGenerator.swift
@@ -37,7 +37,8 @@
             case .unavailable(let reason):
                 .unavailable(Self.mapReason(reason))
             @unknown default:
-                .unavailable(.unsupportedOS)
+                // A future availability state, not a known-unsupported OS.
+                .unavailable(.unknown)
             }
         }
 
@@ -156,7 +157,9 @@
             case .appleIntelligenceNotEnabled: .notEnabled
             case .deviceNotEligible: .deviceNotEligible
             case .modelNotReady: .modelNotReady
-            @unknown default: .modelNotReady
+            // Not `.modelNotReady`: reporting an unrecognised reason as a pending
+            // download makes a caller wait for something that will never arrive.
+            @unknown default: .unknown
             }
         }
 

--- a/Sources/TMDbIntelligence/NaturalLanguageSearch/LiveNaturalLanguageSearchDataSource.swift
+++ b/Sources/TMDbIntelligence/NaturalLanguageSearch/LiveNaturalLanguageSearchDataSource.swift
@@ -144,8 +144,8 @@ struct LiveNaturalLanguageSearchDataSource: NaturalLanguageSearchDataSource {
         try await tvSeries.credits(forTVSeries: id)
     }
 
-    func curatedMovies(_ kind: SearchPlan.ListKind) async throws -> [MovieListItem] {
-        switch kind {
+    func curatedMovies(_ listKind: SearchPlan.ListKind) async throws -> [MovieListItem] {
+        switch listKind.kind {
         case .trending: try await trending.movies().results
         case .popular: try await movies.popular().results
         case .topRated: try await movies.topRated().results
@@ -154,8 +154,8 @@ struct LiveNaturalLanguageSearchDataSource: NaturalLanguageSearchDataSource {
         }
     }
 
-    func curatedTVSeries(_ kind: SearchPlan.ListKind) async throws -> [TVSeriesListItem] {
-        switch kind {
+    func curatedTVSeries(_ listKind: SearchPlan.ListKind) async throws -> [TVSeriesListItem] {
+        switch listKind.kind {
         case .trending: try await trending.tvSeries().results
         case .popular: try await tvSeries.popular().results
         case .topRated: try await tvSeries.topRated().results

--- a/Sources/TMDbIntelligence/NaturalLanguageSearch/NaturalLanguageSearchAvailability.swift
+++ b/Sources/TMDbIntelligence/NaturalLanguageSearch/NaturalLanguageSearchAvailability.swift
@@ -21,19 +21,63 @@ public enum NaturalLanguageSearchAvailability: Sendable, Equatable {
     ///
     /// A reason the on-device model is unavailable.
     ///
-    public enum Reason: Sendable, Equatable {
+    /// This mirrors the availability vocabulary of Apple's on-device model, which
+    /// grows with the operating system. It is therefore a struct with static
+    /// members rather than an enum: new reasons can be added in a **minor**
+    /// release without breaking a `switch` you have already written. Match
+    /// against the members you handle and cover the rest with a `default:`, and
+    /// treat ``unknown`` as "a reason this build does not recognise".
+    ///
+    public struct Reason: Sendable, Equatable, Hashable, CustomStringConvertible {
+
+        enum Kind: Hashable {
+            case deviceNotEligible
+            case notEnabled
+            case modelNotReady
+            case unsupportedOS
+            case unknown
+        }
+
+        let kind: Kind
+
+        private init(kind: Kind) {
+            self.kind = kind
+        }
 
         /// The device is not eligible to run the model.
-        case deviceNotEligible
+        public static let deviceNotEligible = Reason(kind: .deviceNotEligible)
 
         /// Apple Intelligence is not enabled.
-        case notEnabled
+        public static let notEnabled = Reason(kind: .notEnabled)
 
         /// The model is not yet downloaded or ready.
-        case modelNotReady
+        public static let modelNotReady = Reason(kind: .modelNotReady)
 
         /// The operating system does not support the model.
-        case unsupportedOS
+        public static let unsupportedOS = Reason(kind: .unsupportedOS)
+
+        ///
+        /// The model is unavailable for a reason this version of the library does
+        /// not recognise.
+        ///
+        /// Apple can add availability reasons in an OS update. One that post-dates
+        /// this build surfaces here rather than being reported as an unrelated
+        /// reason, so a caller never acts on a misidentified cause — such as
+        /// waiting for a download that is not actually pending.
+        ///
+        public static let unknown = Reason(kind: .unknown)
+
+        /// A textual representation of the reason.
+        public var description: String {
+            switch kind {
+            case .deviceNotEligible: "deviceNotEligible"
+            case .notEnabled: "notEnabled"
+            case .modelNotReady: "modelNotReady"
+            case .unsupportedOS: "unsupportedOS"
+            case .unknown: "unknown"
+            }
+        }
+
     }
 
     /// The model is available for use.

--- a/Sources/TMDbIntelligence/NaturalLanguageSearch/NaturalLanguageSearchAvailability.swift
+++ b/Sources/TMDbIntelligence/NaturalLanguageSearch/NaturalLanguageSearchAvailability.swift
@@ -67,7 +67,9 @@ public enum NaturalLanguageSearchAvailability: Sendable, Equatable {
         ///
         public static let unknown = Reason(kind: .unknown)
 
+        ///
         /// A textual representation of the reason.
+        ///
         public var description: String {
             switch kind {
             case .deviceNotEligible: "deviceNotEligible"

--- a/Sources/TMDbIntelligence/NaturalLanguageSearch/NaturalLanguageSearchError.swift
+++ b/Sources/TMDbIntelligence/NaturalLanguageSearch/NaturalLanguageSearchError.swift
@@ -42,7 +42,13 @@ public enum NaturalLanguageSearchError: Error, Equatable, Sendable {
     case unsupportedLanguage
 
     ///
-    /// The session was rate limited. The request may be retried later.
+    /// The on-device model's session was rate limited. The request may be retried
+    /// later.
+    ///
+    /// This is the **on-device model's** own limit, not TMDb's. A TMDb HTTP 429
+    /// arrives as ``searchFailed(_:)`` carrying `TMDbError.tooManyRequests`,
+    /// whose context carries any `Retry-After` delay. The two have different
+    /// remedies, so a caller that retries should branch on which it received.
     ///
     case rateLimited
 
@@ -50,6 +56,22 @@ public enum NaturalLanguageSearchError: Error, Equatable, Sendable {
     /// Planning failed for another reason, such as malformed model output.
     ///
     case planningFailed(underlying: (any Error)?)
+
+    ///
+    /// A request to TMDb failed while the search was being carried out.
+    ///
+    /// Covers both plan execution and the literal-search fallback. It is distinct
+    /// from the planning cases because the prompt was understood — it was the
+    /// TMDb request that failed — so ``planningFailed(underlying:)``'s "could not
+    /// be interpreted" would misreport the cause and hide a retryable condition
+    /// such as a rate limit.
+    ///
+    /// - Note: When the literal-search fallback is what failed, the planning
+    ///   error that triggered the fallback is not carried here. The TMDb failure
+    ///   is the actionable one: had planning succeeded, execution would have
+    ///   issued the same request and hit the same failure.
+    ///
+    case searchFailed(TMDbError)
 
     ///
     /// The task performing the search was cancelled.
@@ -81,6 +103,11 @@ public enum NaturalLanguageSearchError: Error, Equatable, Sendable {
             // The underlying error is not `Equatable`, so any two `.planningFailed`
             // values compare equal regardless of their wrapped cause.
             true
+        case (.searchFailed(let lhsError), .searchFailed(let rhsError)):
+            // `TMDbError` *is* `Equatable`, so unlike `.planningFailed` this
+            // discriminates by cause. Omitting this arm would fall through to
+            // `default: false` below and silently make a value unequal to itself.
+            lhsError == rhsError
         case (.cancelled, .cancelled):
             true
         default:
@@ -108,6 +135,8 @@ extension NaturalLanguageSearchError: LocalizedError {
             "The on-device model is rate limited. Try again shortly."
         case .planningFailed:
             "The request could not be interpreted."
+        case .searchFailed(let error):
+            error.errorDescription ?? "The search request to TMDb failed."
         case .cancelled:
             "The search was cancelled."
         }

--- a/Sources/TMDbIntelligence/NaturalLanguageSearch/NaturalLanguageSearchPlanGenerator.swift
+++ b/Sources/TMDbIntelligence/NaturalLanguageSearch/NaturalLanguageSearchPlanGenerator.swift
@@ -47,7 +47,7 @@ struct NaturalLanguageSearchPlanGenerator: DeterministicSearchPlanning {
             return nil
         }
 
-        switch intent {
+        switch intent.kind {
         case .find:
             return findPlan(prompt: prompt)
 

--- a/Sources/TMDbIntelligence/NaturalLanguageSearch/SearchDegradation.swift
+++ b/Sources/TMDbIntelligence/NaturalLanguageSearch/SearchDegradation.swift
@@ -15,6 +15,11 @@ import TMDb
 /// model-reported confidence score; each one describes a concrete way the
 /// results differ from a literal interpretation of the prompt.
 ///
+/// This vocabulary grows as the planner learns new ways to approximate a prompt.
+/// Cover the degradations you render explicitly and handle the rest with a
+/// `default:` — a new kind arrives as ``other(_:)`` rather than as a new case, so
+/// a `switch` written today keeps compiling.
+///
 public enum SearchDegradation: Sendable, Equatable {
 
     /// A genre name could not be matched to a TMDb genre.
@@ -44,5 +49,20 @@ public enum SearchDegradation: Sendable, Equatable {
 
     /// The model refused the prompt; the associated message explains why.
     case refusalExplained(String)
+
+    ///
+    /// A degradation this version of the library does not model.
+    ///
+    /// This is a reserved growth slot, and it is what keeps the rest of this
+    /// vocabulary stable: a new kind of degradation ships **here** in a minor
+    /// release, carrying a stable identifier, and is promoted to a case of its
+    /// own at the next major version. Without it, every new degradation would
+    /// break exhaustive `switch`es downstream.
+    ///
+    /// The associated value identifies the kind for logging and diagnostics. It
+    /// is not display copy — render it the way you would render a degradation you
+    /// do not recognise.
+    ///
+    case other(String)
 
 }

--- a/Sources/TMDbIntelligence/NaturalLanguageSearch/SearchPlan.swift
+++ b/Sources/TMDbIntelligence/NaturalLanguageSearch/SearchPlan.swift
@@ -23,31 +23,69 @@ public struct SearchPlan: Sendable, Equatable {
     ///
     /// The kind of search the prompt describes.
     ///
-    public enum Intent: Sendable, Equatable {
+    /// This vocabulary grows as the planner learns to recognise new kinds of
+    /// request, so it is a struct with static members rather than an enum: a new
+    /// intent can ship in a **minor** release without breaking a `switch` you
+    /// have already written. Match the intents you handle and cover the rest with
+    /// a `default:`.
+    ///
+    public struct Intent: Sendable, Equatable, Hashable, CustomStringConvertible {
+
+        enum Kind: Hashable {
+            case find
+            case browse
+            case byPerson
+            case castOf
+            case crewRole
+            case similar
+            case list
+            case mood
+        }
+
+        let kind: Kind
+
+        private init(kind: Kind) {
+            self.kind = kind
+        }
 
         /// Look up a title or name directly (a bare query, like a normal search).
-        case find
+        public static let find = Intent(kind: .find)
 
         /// Browse/filter movies or TV series by attributes.
-        case browse
+        public static let browse = Intent(kind: .browse)
 
         /// Movies or TV series featuring particular people.
-        case byPerson
+        public static let byPerson = Intent(kind: .byPerson)
 
         /// The cast of a particular title.
-        case castOf
+        public static let castOf = Intent(kind: .castOf)
 
         /// People in a particular crew role for a title.
-        case crewRole
+        public static let crewRole = Intent(kind: .crewRole)
 
         /// Titles similar to a particular title.
-        case similar
+        public static let similar = Intent(kind: .similar)
 
         /// A top-level curated list (trending, popular, and so on).
-        case list
+        public static let list = Intent(kind: .list)
 
         /// A subjective mood mapped to genres.
-        case mood
+        public static let mood = Intent(kind: .mood)
+
+        /// A textual representation of the intent.
+        public var description: String {
+            switch kind {
+            case .find: "find"
+            case .browse: "browse"
+            case .byPerson: "byPerson"
+            case .castOf: "castOf"
+            case .crewRole: "crewRole"
+            case .similar: "similar"
+            case .list: "list"
+            case .mood: "mood"
+            }
+        }
+
     }
 
     ///
@@ -95,25 +133,58 @@ public struct SearchPlan: Sendable, Equatable {
     ///
     /// A top-level curated list.
     ///
-    public enum ListKind: Sendable, Equatable {
+    /// TMDb adds curated lists over time, so this is a struct with static members
+    /// rather than an enum: a new list kind can ship in a **minor** release
+    /// without breaking a `switch` you have already written. Match the kinds you
+    /// handle and cover the rest with a `default:`.
+    ///
+    public struct ListKind: Sendable, Equatable, Hashable, CustomStringConvertible {
+
+        enum Kind: Hashable {
+            case trending
+            case popular
+            case topRated
+            case nowPlaying
+            case upcoming
+            case airingToday
+        }
+
+        let kind: Kind
+
+        private init(kind: Kind) {
+            self.kind = kind
+        }
 
         /// Trending titles.
-        case trending
+        public static let trending = ListKind(kind: .trending)
 
         /// Popular titles.
-        case popular
+        public static let popular = ListKind(kind: .popular)
 
         /// Top-rated titles.
-        case topRated
+        public static let topRated = ListKind(kind: .topRated)
 
         /// Movies now playing in cinemas.
-        case nowPlaying
+        public static let nowPlaying = ListKind(kind: .nowPlaying)
 
         /// Upcoming movie releases.
-        case upcoming
+        public static let upcoming = ListKind(kind: .upcoming)
 
         /// TV series airing today.
-        case airingToday
+        public static let airingToday = ListKind(kind: .airingToday)
+
+        /// A textual representation of the list kind.
+        public var description: String {
+            switch kind {
+            case .trending: "trending"
+            case .popular: "popular"
+            case .topRated: "topRated"
+            case .nowPlaying: "nowPlaying"
+            case .upcoming: "upcoming"
+            case .airingToday: "airingToday"
+            }
+        }
+
     }
 
     ///

--- a/Sources/TMDbIntelligence/NaturalLanguageSearch/SearchPlan.swift
+++ b/Sources/TMDbIntelligence/NaturalLanguageSearch/SearchPlan.swift
@@ -72,7 +72,9 @@ public struct SearchPlan: Sendable, Equatable {
         /// A subjective mood mapped to genres.
         public static let mood = Intent(kind: .mood)
 
+        ///
         /// A textual representation of the intent.
+        ///
         public var description: String {
             switch kind {
             case .find: "find"
@@ -173,7 +175,9 @@ public struct SearchPlan: Sendable, Equatable {
         /// TV series airing today.
         public static let airingToday = ListKind(kind: .airingToday)
 
+        ///
         /// A textual representation of the list kind.
+        ///
         public var description: String {
             switch kind {
             case .trending: "trending"

--- a/Sources/TMDbIntelligence/NaturalLanguageSearch/SearchPlanExecutor.swift
+++ b/Sources/TMDbIntelligence/NaturalLanguageSearch/SearchPlanExecutor.swift
@@ -49,7 +49,9 @@ struct SearchPlanExecutor {
         let plan = Self.normalize(rawPlan)
         var degradations: [SearchDegradation] = []
 
-        switch plan.intent {
+        // Switched over the internal representation, not the public `Intent`, so
+        // the compiler still requires an arm for every intent we model.
+        switch plan.intent.kind {
         case .find:
             return try await executeFind(plan)
 

--- a/Sources/TMDbIntelligence/NaturalLanguageSearch/TMDbNaturalLanguageSearchService.swift
+++ b/Sources/TMDbIntelligence/NaturalLanguageSearch/TMDbNaturalLanguageSearchService.swift
@@ -78,7 +78,8 @@ final class TMDbNaturalLanguageSearchService: NaturalLanguageSearchService {
             // Distinguishes "the caller withdrew" from "TMDb failed". MUST stay
             // above the `as TMDbError` arm below, which matches every TMDbError
             // including `.cancelled` — reversed, a cancelled search would report
-            // as `.searchFailed(.cancelled)`.
+            // as `.searchFailed(.cancelled)`. Reversing it is a compile error
+            // ("case will never be executed"), so this ordering is enforced.
             throw .cancelled
         } catch let error as TMDbError {
             // Raised by the TMDb service calls behind `executor.execute` and behind

--- a/Sources/TMDbIntelligence/NaturalLanguageSearch/TMDbNaturalLanguageSearchService.swift
+++ b/Sources/TMDbIntelligence/NaturalLanguageSearch/TMDbNaturalLanguageSearchService.swift
@@ -75,10 +75,17 @@ final class TMDbNaturalLanguageSearchService: NaturalLanguageSearchService {
         } catch is CancellationError {
             throw .cancelled
         } catch TMDbError.cancelled {
-            // Raised by `executor.execute`'s service calls. Without this arm it
-            // would be re-labelled a planning failure — the same misreporting
-            // this change exists to remove.
+            // Distinguishes "the caller withdrew" from "TMDb failed". MUST stay
+            // above the `as TMDbError` arm below, which matches every TMDbError
+            // including `.cancelled` — reversed, a cancelled search would report
+            // as `.searchFailed(.cancelled)`.
             throw .cancelled
+        } catch let error as TMDbError {
+            // Raised by the TMDb service calls behind `executor.execute` and behind
+            // the literal-search fallback. The prompt was understood; it is the
+            // request that failed, so reporting a planning failure here would hide
+            // a retryable condition such as a rate limit.
+            throw .searchFailed(error)
         } catch {
             throw .planningFailed(underlying: error)
         }
@@ -106,6 +113,11 @@ extension TMDbNaturalLanguageSearchService {
         case .cancelled:
             // Falling back would issue fresh searches on a task the caller has
             // already abandoned — doing the very work they cancelled.
+            return false
+        case .searchFailed:
+            // The TMDb request just failed; the fallback issues more requests
+            // against the same API, and under a 429 that worsens the limit we
+            // have already hit. Keeps the fallback-failure path terminal.
             return false
         }
     }

--- a/Sources/TMDbIntelligence/TMDbIntelligence.docc/TMDbIntelligence.md
+++ b/Sources/TMDbIntelligence/TMDbIntelligence.docc/TMDbIntelligence.md
@@ -23,7 +23,7 @@ import TMDb
 import TMDbIntelligence
 
 let tmdbClient = TMDbClient(apiKey: "<your-tmdb-api-key>")
-let results = try await tmdbClient.naturalLanguageSearch.search("movies with Tom Hanks")
+let results = try await tmdbClient.naturalLanguageSearch.search(matching: "movies with Tom Hanks")
 ```
 
 - Important: This is an **Apple-platforms** library. Its features are built on

--- a/Sources/TMDbIntelligenceTesting/TMDbIntelligenceTesting.docc/TMDbIntelligenceTesting.md
+++ b/Sources/TMDbIntelligenceTesting/TMDbIntelligenceTesting.docc/TMDbIntelligenceTesting.md
@@ -31,7 +31,7 @@ import TMDbIntelligenceTesting
 let service = MockNaturalLanguageSearchService()
 
 // Zero-config: returns NaturalLanguageSearchResult.sample.
-let result = try await service.search("movies with Tom Hanks")
+let result = try await service.search(matching: "movies with Tom Hanks")
 
 // Inject a specific outcome.
 service.searchResult = .failure(.outOfScope)

--- a/Tests/TMDbIntelligenceTests/NaturalLanguageSearch/Mocks/MockNaturalLanguageSearchDataSource.swift
+++ b/Tests/TMDbIntelligenceTests/NaturalLanguageSearch/Mocks/MockNaturalLanguageSearchDataSource.swift
@@ -37,6 +37,14 @@ final class MockNaturalLanguageSearchDataSource: NaturalLanguageSearchDataSource
     /// *execution* rather than by planning.
     var curatedMoviesError: (any Error)?
 
+    /// Thrown from `searchAll(query:)`, for exercising failures raised by the
+    /// literal-search fallback.
+    ///
+    /// One mock instance backs both the executor and the fallback, so this also
+    /// fires on the `find` execution path — distinguish the two by whether
+    /// `MockSearchPlanGenerator.planError` is set.
+    var searchAllError: (any Error)?
+
     // Captured inputs.
     private(set) var lastMovieFilter: DiscoverMovieFilter?
     private(set) var lastTVFilter: DiscoverTVSeriesFilter?
@@ -92,7 +100,12 @@ final class MockNaturalLanguageSearchDataSource: NaturalLanguageSearchDataSource
     func searchAll(
         query: String
     ) async throws -> (movies: [MovieListItem], tvSeries: [TVSeriesListItem], people: [PersonListItem]) {
+        // Recorded before throwing, so a test can prove the fallback was
+        // attempted and then failed.
         searchAllQueries.append(query)
+        if let searchAllError {
+            throw searchAllError
+        }
         return searchAllResult
     }
 

--- a/Tests/TMDbIntelligenceTests/NaturalLanguageSearch/NaturalLanguageSearchAvailabilityTests.swift
+++ b/Tests/TMDbIntelligenceTests/NaturalLanguageSearch/NaturalLanguageSearchAvailabilityTests.swift
@@ -1,0 +1,89 @@
+//
+//  NaturalLanguageSearchAvailabilityTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDbIntelligence
+
+@Suite("NaturalLanguageSearchAvailability")
+struct NaturalLanguageSearchAvailabilityTests {
+
+    /// 7. every unavailability reason has a distinct, stable description
+    @Test("every unavailability reason has a distinct, stable description")
+    func everyReasonHasADistinctStableDescription() {
+        let expected: [(NaturalLanguageSearchAvailability.Reason, String)] = [
+            (.deviceNotEligible, "deviceNotEligible"),
+            (.notEnabled, "notEnabled"),
+            (.modelNotReady, "modelNotReady"),
+            (.unsupportedOS, "unsupportedOS"),
+            (.unknown, "unknown")
+        ]
+
+        for (reason, description) in expected {
+            #expect(reason.description == description)
+            #expect(description == "\(reason)")
+        }
+
+        #expect(Set(expected.map(\.1)).count == expected.count)
+    }
+
+    /// 8. an unavailable availability equals itself and differs by reason
+    @Test("an unavailable availability equals itself and differs by reason")
+    func unavailableEqualityDiscriminatesByReason() {
+        #expect(
+            NaturalLanguageSearchAvailability.unavailable(.modelNotReady)
+                == NaturalLanguageSearchAvailability.unavailable(.modelNotReady)
+        )
+        #expect(
+            NaturalLanguageSearchAvailability.unavailable(.modelNotReady)
+                != NaturalLanguageSearchAvailability.unavailable(.notEnabled)
+        )
+    }
+
+    /// 9. an unavailable availability never equals `.available`
+    @Test("an unavailable availability never equals available")
+    func unavailableNeverEqualsAvailable() {
+        // Guards the outer enum's synthesized `==` now that its payload is a
+        // struct rather than an enum.
+        #expect(NaturalLanguageSearchAvailability.unavailable(.modelNotReady) != .available)
+        #expect(NaturalLanguageSearchAvailability.unavailable(.unknown) != .available)
+    }
+
+    /// 10. `if case .unavailable(let reason)` binds the reason
+    @Test("pattern matching binds the unavailability reason")
+    func patternMatchingBindsTheReason() {
+        let availability = NaturalLanguageSearchAvailability.unavailable(.deviceNotEligible)
+
+        guard case .unavailable(let reason) = availability else {
+            Issue.record("expected an unavailable availability")
+            return
+        }
+
+        #expect(reason == .deviceNotEligible)
+        #expect(reason != .notEnabled)
+    }
+
+    /// 7b. a reason works as a dictionary key and a Set member
+    @Test("a reason works as a dictionary key and a Set member")
+    func reasonIsUsableAsAKeyAndSetMember() {
+        // A payload-free enum is implicitly Hashable; the struct must keep that.
+        let counts: [NaturalLanguageSearchAvailability.Reason: Int] = [
+            .modelNotReady: 1,
+            .notEnabled: 2
+        ]
+
+        #expect(counts[.modelNotReady] == 1)
+        #expect(counts[.notEnabled] == 2)
+        #expect(counts[.unknown] == nil)
+
+        let reasons: Set<NaturalLanguageSearchAvailability.Reason> = [
+            .modelNotReady, .modelNotReady, .notEnabled
+        ]
+        #expect(reasons.count == 2)
+    }
+
+}

--- a/Tests/TMDbIntelligenceTests/NaturalLanguageSearch/NaturalLanguageSearchErrorTests.swift
+++ b/Tests/TMDbIntelligenceTests/NaturalLanguageSearch/NaturalLanguageSearchErrorTests.swift
@@ -1,0 +1,78 @@
+//
+//  NaturalLanguageSearchErrorTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+@testable import TMDbIntelligence
+
+@Suite("NaturalLanguageSearchError")
+struct NaturalLanguageSearchErrorTests {
+
+    private struct Underlying: Error {}
+
+    /// 13. two `.searchFailed` carrying the same `TMDbError` are equal
+    @Test("two searchFailed carrying the same TMDbError are equal")
+    func searchFailedEqualityIsStructural() {
+        // `==` is hand-written and ends in `default: false`, so a missing arm
+        // compiles silently and makes a value unequal to itself — while every
+        // `#expect(throws:)` using it still *reports* the correct error.
+        #expect(
+            NaturalLanguageSearchError.searchFailed(.tooManyRequests())
+                == NaturalLanguageSearchError.searchFailed(.tooManyRequests())
+        )
+        #expect(
+            NaturalLanguageSearchError.searchFailed(.cancelled)
+                == NaturalLanguageSearchError.searchFailed(.cancelled)
+        )
+    }
+
+    /// 14. `.searchFailed` discriminates by the wrapped error
+    @Test("searchFailed discriminates by the wrapped TMDbError")
+    func searchFailedDiscriminatesByWrappedError() {
+        #expect(
+            NaturalLanguageSearchError.searchFailed(.tooManyRequests())
+                != NaturalLanguageSearchError.searchFailed(.network(Underlying()))
+        )
+        #expect(
+            NaturalLanguageSearchError.searchFailed(.tooManyRequests())
+                != NaturalLanguageSearchError.searchFailed(.notFound())
+        )
+    }
+
+    /// 15. `.searchFailed` is distinct from the planning and cancellation cases
+    @Test("searchFailed is distinct from planningFailed and cancelled")
+    func searchFailedIsDistinctFromOtherCases() {
+        let searchFailed = NaturalLanguageSearchError.searchFailed(.tooManyRequests())
+
+        #expect(searchFailed != .planningFailed(underlying: nil))
+        #expect(searchFailed != .planningFailed(underlying: Underlying()))
+        #expect(searchFailed != .cancelled)
+        #expect(searchFailed != .rateLimited)
+    }
+
+    /// 16. `.searchFailed`'s description is the wrapped error's
+    @Test("searchFailed reports the wrapped TMDbError's description")
+    func searchFailedDescriptionDelegates() {
+        let underlying = TMDbError.tooManyRequests()
+        let error = NaturalLanguageSearchError.searchFailed(underlying)
+
+        #expect(error.errorDescription == underlying.errorDescription)
+        // The bug this change fixes: a TMDb failure claiming the prompt was
+        // uninterpretable.
+        #expect(error.errorDescription != "The request could not be interpreted.")
+    }
+
+    /// 17. `.rateLimited` still describes the on-device model, not TMDb
+    @Test("rateLimited still names the on-device model")
+    func rateLimitedStillNamesTheOnDeviceModel() throws {
+        let description = try #require(NaturalLanguageSearchError.rateLimited.errorDescription)
+
+        #expect(description.contains("on-device model"))
+    }
+
+}

--- a/Tests/TMDbIntelligenceTests/NaturalLanguageSearch/SearchDegradationTests.swift
+++ b/Tests/TMDbIntelligenceTests/NaturalLanguageSearch/SearchDegradationTests.swift
@@ -1,0 +1,32 @@
+//
+//  SearchDegradationTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDbIntelligence
+
+@Suite("SearchDegradation")
+struct SearchDegradationTests {
+
+    /// 11. `.other` compares by its identifier
+    @Test("other compares by its identifier")
+    func otherComparesByIdentifier() {
+        #expect(SearchDegradation.other("unresolvedNetwork") == .other("unresolvedNetwork"))
+        #expect(SearchDegradation.other("unresolvedNetwork") != .other("unresolvedLanguage"))
+    }
+
+    /// 12. `.other` is distinct from the modelled degradations
+    @Test("other is distinct from the modelled degradations")
+    func otherIsDistinctFromModelledDegradations() {
+        let other = SearchDegradation.other("unresolvedNetwork")
+
+        #expect(other != .underspecified)
+        #expect(other != .relaxedConstraints)
+        #expect(other != .unresolvedGenre("unresolvedNetwork"))
+    }
+
+}

--- a/Tests/TMDbIntelligenceTests/NaturalLanguageSearch/SearchPlanVocabularyTests.swift
+++ b/Tests/TMDbIntelligenceTests/NaturalLanguageSearch/SearchPlanVocabularyTests.swift
@@ -1,0 +1,125 @@
+//
+//  SearchPlanVocabularyTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDbIntelligence
+
+@Suite("SearchPlan vocabulary")
+struct SearchPlanVocabularyTests {
+
+    private static let allIntents: [(SearchPlan.Intent, String)] = [
+        (.find, "find"),
+        (.browse, "browse"),
+        (.byPerson, "byPerson"),
+        (.castOf, "castOf"),
+        (.crewRole, "crewRole"),
+        (.similar, "similar"),
+        (.list, "list"),
+        (.mood, "mood")
+    ]
+
+    private static let allListKinds: [(SearchPlan.ListKind, String)] = [
+        (.trending, "trending"),
+        (.popular, "popular"),
+        (.topRated, "topRated"),
+        (.nowPlaying, "nowPlaying"),
+        (.upcoming, "upcoming"),
+        (.airingToday, "airingToday")
+    ]
+
+    /// 1. every intent has a distinct, stable description
+    @Test("every intent has a distinct, stable description")
+    func everyIntentHasADistinctStableDescription() {
+        for (intent, description) in Self.allIntents {
+            #expect(intent.description == description)
+            // Interpolation parity with the enum this replaced — a struct's
+            // default interpolation would be a reflection dump.
+            #expect(description == "\(intent)")
+        }
+
+        #expect(Set(Self.allIntents.map(\.1)).count == Self.allIntents.count)
+    }
+
+    /// 2. every list kind has a distinct, stable description
+    @Test("every list kind has a distinct, stable description")
+    func everyListKindHasADistinctStableDescription() {
+        for (kind, description) in Self.allListKinds {
+            #expect(kind.description == description)
+            #expect(description == "\(kind)")
+        }
+
+        #expect(Set(Self.allListKinds.map(\.1)).count == Self.allListKinds.count)
+    }
+
+    /// 3. an intent equals itself and differs from every other intent
+    @Test("an intent equals itself and differs from every other intent")
+    func intentEqualityIsDiscriminating() {
+        for (outerIndex, (lhs, _)) in Self.allIntents.enumerated() {
+            for (innerIndex, (rhs, _)) in Self.allIntents.enumerated() {
+                if outerIndex == innerIndex {
+                    #expect(lhs == rhs)
+                } else {
+                    #expect(lhs != rhs)
+                }
+            }
+        }
+    }
+
+    /// 4. pattern matching an intent still works
+    @Test("pattern matching an intent still works")
+    func patternMatchingAnIntent() {
+        let plan = SearchPlan(intent: .find)
+
+        // `if case` against a static member resolves through the stdlib `~=` for
+        // Equatable, exactly as it did for an enum case.
+        if case .find = plan.intent {
+            // Expected.
+        } else {
+            Issue.record("expected .find to match")
+        }
+
+        if case .browse = plan.intent {
+            Issue.record("expected .browse not to match")
+        }
+
+        switch plan.intent {
+        case .find: break
+        default: Issue.record("expected .find in a switch with a default")
+        }
+    }
+
+    /// 5. the public initializer round-trips an intent
+    @Test("the public initializer round-trips an intent")
+    func publicInitializerRoundTripsAnIntent() {
+        #expect(SearchPlan(intent: .find).intent == .find)
+        #expect(SearchPlan(intent: .list, list: .popular).intent == .list)
+        #expect(SearchPlan(intent: .list, list: .popular).list == .popular)
+    }
+
+    /// 6. an intent works as a dictionary key and a Set member
+    @Test("an intent works as a dictionary key and a Set member")
+    func intentIsUsableAsAKeyAndSetMember() {
+        // A payload-free enum is implicitly Hashable; the struct must keep that or
+        // consumer code keying off an intent stops compiling.
+        let labels: [SearchPlan.Intent: String] = [
+            .find: "find",
+            .browse: "browse"
+        ]
+
+        #expect(labels[.find] == "find")
+        #expect(labels[.browse] == "browse")
+        #expect(labels[.mood] == nil)
+
+        let intents: Set<SearchPlan.Intent> = [.find, .find, .browse]
+        #expect(intents.count == 2)
+
+        let kinds: Set<SearchPlan.ListKind> = [.popular, .popular, .trending]
+        #expect(kinds.count == 2)
+    }
+
+}

--- a/Tests/TMDbIntelligenceTests/NaturalLanguageSearch/TMDbNaturalLanguageSearchServiceTests.swift
+++ b/Tests/TMDbIntelligenceTests/NaturalLanguageSearch/TMDbNaturalLanguageSearchServiceTests.swift
@@ -147,12 +147,18 @@ struct TMDbNaturalLanguageSearchServiceTests {
         }
     }
 
+    /// 19. regression guard: cancellation still wins over `.searchFailed`
     @Test("cancellation during plan execution surfaces as cancelled")
     func cancellationDuringExecutionSurfacesAsCancelled() async throws {
         // Planning succeeds; the cancellation happens in `executor.execute(plan)`,
         // which reaches the service through an untyped `throws` as a
-        // `TMDbError.cancelled`. Without its own catch arm it would be re-labelled
-        // `.planningFailed`, which is the misreporting this change removes.
+        // `TMDbError.cancelled`.
+        //
+        // This pins the CATCH-ARM ORDER: `catch TMDbError.cancelled` must stay
+        // above `catch let error as TMDbError`, because the latter matches every
+        // TMDbError including `.cancelled`. Reversed, a cancelled search reports
+        // as `.searchFailed(.cancelled)` — a withdrawn search reported as a
+        // failed one, re-breaking #419.
         planner.planResult = SearchPlan(intent: .list, mediaType: .movie, list: .popular)
         dataSource.curatedMoviesError = TMDbError.cancelled
 
@@ -162,6 +168,63 @@ struct TMDbNaturalLanguageSearchServiceTests {
 
         // And it is still not rescued by the fallback at this stage either.
         #expect(dataSource.searchAllQueries.isEmpty)
+    }
+
+    /// 18 + 22. a TMDb failure during plan execution surfaces as `.searchFailed`,
+    /// and is never rescued by the fallback
+    @Test("a TMDb failure during plan execution surfaces as searchFailed")
+    func tmdbFailureDuringExecutionSurfacesAsSearchFailed() async throws {
+        // The bug: a TMDb 429 during execution was reported as `.planningFailed`,
+        // whose description claims the prompt could not be interpreted — so a
+        // consumer branching on rate limiting missed TMDb's real 429 entirely.
+        planner.planResult = SearchPlan(intent: .list, mediaType: .movie, list: .popular)
+        dataSource.curatedMoviesError = TMDbError.tooManyRequests()
+
+        await #expect(throws: NaturalLanguageSearchError.searchFailed(.tooManyRequests())) {
+            try await makeService().search(matching: "popular movies")
+        }
+
+        // Pins `canFallBack` → false: the fallback would issue more requests
+        // against the API that just rate-limited us.
+        #expect(dataSource.searchAllQueries.isEmpty)
+    }
+
+    /// 20. a TMDb failure in the literal fallback surfaces as `.searchFailed`
+    @Test("a TMDb failure in the literal fallback surfaces as searchFailed")
+    func tmdbFailureInLiteralFallbackSurfacesAsSearchFailed() async throws {
+        planner.planError = .guardrailViolation("rephrase")
+        dataSource.searchAllError = TMDbError.tooManyRequests()
+
+        await #expect(throws: NaturalLanguageSearchError.searchFailed(.tooManyRequests())) {
+            try await makeService().search(matching: "Kill Bill")
+        }
+
+        // The fallback was attempted, then failed — the TMDb error wins over the
+        // guardrail violation that triggered it.
+        #expect(dataSource.searchAllQueries == ["Kill Bill"])
+    }
+
+    /// 21. cancellation in the literal fallback surfaces as cancelled
+    @Test("cancellation in the literal fallback surfaces as cancelled")
+    func cancellationInLiteralFallbackSurfacesAsCancelled() async throws {
+        planner.planError = .guardrailViolation("rephrase")
+        dataSource.searchAllError = TMDbError.cancelled
+
+        await #expect(throws: NaturalLanguageSearchError.cancelled) {
+            try await makeService().search(matching: "Kill Bill")
+        }
+    }
+
+    /// 23. an unrecognised error still surfaces as a planning failure
+    @Test("an error that is neither a TMDbError nor an NLS error still surfaces as planningFailed")
+    func unrecognisedErrorStillSurfacesAsPlanningFailed() async throws {
+        struct Unrecognised: Error {}
+
+        planner.planUntypedError = Unrecognised()
+
+        await #expect(throws: NaturalLanguageSearchError.planningFailed(underlying: nil)) {
+            try await makeService().search(matching: "x")
+        }
     }
 
 }

--- a/Tests/TMDbIntelligenceTests/NaturalLanguageSearch/TMDbNaturalLanguageSearchServiceTests.swift
+++ b/Tests/TMDbIntelligenceTests/NaturalLanguageSearch/TMDbNaturalLanguageSearchServiceTests.swift
@@ -170,8 +170,7 @@ struct TMDbNaturalLanguageSearchServiceTests {
         #expect(dataSource.searchAllQueries.isEmpty)
     }
 
-    /// 18 + 22. a TMDb failure during plan execution surfaces as `.searchFailed`,
-    /// and is never rescued by the fallback
+    /// 18. a TMDb failure during plan execution surfaces as `.searchFailed`
     @Test("a TMDb failure during plan execution surfaces as searchFailed")
     func tmdbFailureDuringExecutionSurfacesAsSearchFailed() async throws {
         // The bug: a TMDb 429 during execution was reported as `.planningFailed`,
@@ -184,8 +183,25 @@ struct TMDbNaturalLanguageSearchServiceTests {
             try await makeService().search(matching: "popular movies")
         }
 
-        // Pins `canFallBack` → false: the fallback would issue more requests
-        // against the API that just rate-limited us.
+        // No fallback is attempted after an execution failure. Note this does NOT
+        // exercise `canFallBack`, which is only consulted for errors thrown by
+        // `planner.plan(for:)` — see `searchFailedPlanIsNotRescuedByFallback`.
+        #expect(dataSource.searchAllQueries.isEmpty)
+    }
+
+    /// 22. a `.searchFailed` is never rescued by the literal-search fallback
+    @Test("a searchFailed plan is never rescued by the literal-search fallback")
+    func searchFailedPlanIsNotRescuedByFallback() async throws {
+        // Raised from the PLANNING stage, so `canFallBack(from:)` really is
+        // consulted. Were its `.searchFailed` arm to return true, the fallback
+        // would run and this would return results instead of throwing — retrying
+        // against the API that just failed.
+        planner.planError = .searchFailed(.tooManyRequests())
+
+        await #expect(throws: NaturalLanguageSearchError.searchFailed(.tooManyRequests())) {
+            try await makeService().search(matching: "Kill Bill")
+        }
+
         #expect(dataSource.searchAllQueries.isEmpty)
     }
 
@@ -225,6 +241,11 @@ struct TMDbNaturalLanguageSearchServiceTests {
         await #expect(throws: NaturalLanguageSearchError.planningFailed(underlying: nil)) {
             try await makeService().search(matching: "x")
         }
+
+        // An untyped planning error bypasses the fallback: the inner catch only
+        // matches `NaturalLanguageSearchError`, so it never reaches `canFallBack`
+        // — even though a *typed* `.planningFailed` from the planner is eligible.
+        #expect(dataSource.searchAllQueries.isEmpty)
     }
 
 }

--- a/knowledge/decisions/0019-decode-tolerance-policy.md
+++ b/knowledge/decisions/0019-decode-tolerance-policy.md
@@ -45,7 +45,10 @@ We will apply one policy, in three limbs:
    enclosing tolerant array**, and **counted** there.
 2. An unmodelled value of a closed-vocabulary **value enum** (`Status`,
    `Gender`, `ShowType`, `CreditType`, …) decodes to `.unknown` — the existing
-   codebase-wide idiom. No count; the value is usable as-is.
+   codebase-wide idiom **for wire-decoded vocabularies**. No count; the value is
+   usable as-is. This limb is scoped to types decoded from an untrusted payload;
+   an in-process vocabulary that merely needs room to grow takes a different
+   shape — see [ADR-0021](0021-extensible-public-vocabularies.md).
 3. **Everything else throws.**
 
 Mechanically:

--- a/knowledge/decisions/0021-extensible-public-vocabularies.md
+++ b/knowledge/decisions/0021-extensible-public-vocabularies.md
@@ -1,0 +1,134 @@
+# ADR-0021: Three shapes for a growable public vocabulary
+
+- **Status:** Accepted (in 20.0.0, unreleased)
+- **Date:** 2026-08-13
+- **Deciders:** Adam Young
+
+## Context
+
+`TMDbIntelligence`'s natural-language vocabulary is young and still growing, but
+every public enum in it was a closed enum with no escape valve. This package ships
+as source via SwiftPM — no library evolution, no `@frozen` — so from a consumer's
+point of view **a public enum is already frozen**: adding a case breaks every
+exhaustive `switch` downstream. Each new intent, curated list or degradation was
+therefore a major-version event, permanently.
+
+Two constraints shaped the fix:
+
+1. **A catch-all case does not, on its own, prevent the break.** This was the
+   central assumption of the originating review (issue #420) and it is wrong.
+   Adding `case other(String)` to `SearchDegradation` does nothing to stop a later
+   `case unresolvedNetwork(String)` from breaking exhaustive switches. A valve
+   only works if *all* future growth is routed through it — the commitment, not
+   the case, is the mechanism.
+2. **[ADR-0019](0019-decode-tolerance-policy.md) limb 2's `.unknown` idiom does
+   not transfer.** It calls `.unknown` "the existing codebase-wide idiom", but
+   every instance exists because the value is **decoded from an untrusted wire
+   payload** (`Status`, `ShowType`, `CreditType`, `Gender`, `TMDbStatusCode` —
+   all `Codable`, all `init(from:) → ?? .unknown`). None of the
+   `TMDbIntelligence` vocabularies are `Codable` or decoded from anything; they
+   are constructed in-process by this module's own code. Their problem is
+   *source* compatibility, not decode tolerance, so the two need different
+   answers.
+
+Also relevant: `NaturalLanguageSearchAvailability.Reason` mirrors Apple's
+on-device model availability vocabulary, which grows with the OS, and its two
+`@unknown default:` arms were mapping any Apple-added reason onto
+`.modelNotReady` / `.unsupportedOS` — actively lying to a caller, who would wait
+for a model download that was never pending.
+
+## Decision
+
+We will apply **one rule with three shapes**, chosen by how the value originates
+and whether it carries a payload:
+
+| The vocabulary is… | Shape | Examples |
+| --- | --- | --- |
+| decoded from the wire | enum + `.unknown` case, `init(from:) → ?? .unknown` | `Status`, `ShowType`, `CreditType` (ADR-0019 limb 2) |
+| in-process, payload-free, growable | **extensible struct** | `SearchPlan.Intent`, `SearchPlan.ListKind`, `NaturalLanguageSearchAvailability.Reason` |
+| in-process, payload-carrying, growable | enum + **reserved growth slot** | `SearchDegradation.other(String)` |
+
+The **extensible struct** is a public struct wrapping an `internal` backing enum:
+
+```swift
+public struct Intent: Sendable, Equatable, Hashable, CustomStringConvertible {
+    enum Kind: Hashable { case find, browse, … }   // internal — see Consequences
+    let kind: Kind                                  // internal
+    private init(kind: Kind) { self.kind = kind }
+
+    /// Look up a title or name directly.
+    public static let find = Intent(kind: .find)
+    …
+}
+```
+
+The **reserved growth slot** is a terminal `case other(String)` carrying a stable
+identifier, plus a written commitment: new kinds ship as `.other` in a **minor**
+release and are promoted to cases of their own at the next major.
+
+## Consequences
+
+- **New members ship in a minor release without breaking anyone.** Construction
+  (`SearchPlan(intent: .find)`), `==`, `if case .find = plan.intent` and a
+  `switch` with a `default:` all keep compiling — implicit-member lookup resolves
+  a static property exactly as it did an enum case, through `Optional`, array and
+  variadic element types, ternaries and function returns alike. Only an
+  *exhaustive* `switch` stops compiling, which is the point, and it is a one-time
+  break taken inside the open 20.0.0 window.
+- **Internal code keeps full compiler exhaustiveness.** This is why `Kind` is
+  internal rather than a public `rawValue`: every internal dispatch switches on
+  `x.kind` with no `default:`, so adding a `Kind` case still fails the build until
+  every arm is handled. A `RawRepresentable` public struct would have forfeited
+  that — and would have inherited the rawValue-equality trap recorded in
+  `gotchas.md` for `TMDbStatusCode`.
+- **`Kind` stays `internal`, never `package`.** `package` buys nothing here and
+  costs the DocC-link ban (`gotchas.md` → *A `package` symbol cannot be referenced
+  by a DocC link*). Never write `` ``Kind`` `` or `` ``kind`` `` in a doc comment.
+- **`Hashable` and `CustomStringConvertible` are compatibility requirements, not
+  polish.** A payload-free enum is implicitly `Hashable` and interpolates as its
+  bare case name; a struct is neither. Both must be declared and both must be
+  tested. See `gotchas.md` → *Converting a payload-free public enum to a struct
+  silently drops two implicit conformances*.
+- **`public init(kind:)` is impossible**, since the parameter type is internal —
+  so a consumer physically cannot construct an out-of-vocabulary value. The
+  externally-constructible value space is therefore *narrower* than the enum's,
+  not wider.
+- **Existing DocC links need no change.** `` ``Intent/byPerson`` `` resolves to a
+  `public static let` with byte-identical syntax; `RetryableErrors` is the in-repo
+  precedent. Verified against `make build-docs` under `--warnings-as-errors`
+  before the bulk conversion, by converting `Reason` alone first.
+- **`MediaType` and `RelativeDate` are deliberately excluded.** `MediaType` is
+  bounded by this feature's *result surface* — `NaturalLanguageSearchResult`
+  exposes exactly `movies`, `tvSeries` and `people` — not by TMDb's media taxonomy
+  (core `Media` models four kinds including `.collection`). `RelativeDate` carries
+  payloads the executor computes year bounds from, where a catch-all member would
+  be uncomputable. Both are queued in [`../next-major.md`](../next-major.md) so
+  the exclusion is revisited rather than forgotten.
+- **The `plan(for:)` / `search(matching:)` asymmetry is intentional.** The related
+  `NaturalLanguageSearchError.searchFailed(TMDbError)` arm added alongside this
+  work exists only in `search(matching:)`. `plan(for:)` calls only the on-device
+  planner and issues no TMDb request, so `.searchFailed` there would be a lie —
+  nothing was searched — and `.planningFailed` remains correct.
+- **Watch:** three shapes is two more than one. The table above is the whole
+  point of this ADR — a contributor adding a vocabulary now has a rule to follow
+  rather than three in-tree precedents to choose between.
+
+## Alternatives considered
+
+- **A catch-all case on every vocabulary** (the originating issue's proposal).
+  Rejected as the general answer: it defers the break rather than removing it
+  (see Context 1), and for a payload-free vocabulary it also turns a typed
+  member into a stringly-typed one. Kept only where the struct shape cannot go —
+  `SearchDegradation`, where 6 of 9 cases carry payloads that a struct would
+  strand, breaking `if case .unresolvedGenre(let name)` binding with no clean
+  equivalent.
+- **A `RawRepresentable` struct with a `public let rawValue: String`.** More
+  debuggable and forward-decodable, but it surrenders internal exhaustiveness
+  checking — the compiler would no longer flag a missed arm when *we* add a
+  member — and re-introduces rawValue equality semantics. The internal-`Kind`
+  shape keeps both.
+- **Leave the enums closed and take the break at each major.** Rejected: the
+  vocabulary is expected to grow with planner capability, which would tie ordinary
+  feature work to the major-version cadence indefinitely.
+- **Convert `MediaType` too, for consistency.** Deferred rather than rejected —
+  see Consequences and `next-major.md`.

--- a/knowledge/decisions/README.md
+++ b/knowledge/decisions/README.md
@@ -38,6 +38,7 @@ always fair game.
 | [0018](0018-cancellation-as-tmdberror-case.md) | Surface task cancellation as `TMDbError.cancelled` | 2026-08-12 | Accepted (in 20.0.0, unreleased) |
 | [0019](0019-decode-tolerance-policy.md) | One decode-tolerance policy: skip an unmodelled `media_type`, stay loud otherwise | 2026-08-12 | Accepted (in 20.0.0, unreleased) |
 | [0020](0020-review-knowledge-audit-tier.md) | `/review-knowledge` audits on Opus; cross-examination stays on Fable | 2026-08-13 | Accepted (unreleased — tooling only) |
+| [0021](0021-extensible-public-vocabularies.md) | Three shapes for a growable public vocabulary | 2026-08-13 | Accepted (in 20.0.0, unreleased) |
 
 > **Keep the Status column true.** "In X, unreleased" becomes "shipped in X" when
 > X is **tagged** — a `CHANGELOG.md` section is not a release. For breaking changes

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -25,7 +25,7 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
 
 ---
 
-## 2026-08-13 — ♻️ TMDbIntelligence vocabulary growth valves + `searchFailed` (`feature/tmdbintelligence-enum-valves`) · full
+## 2026-08-13 — ♻️ TMDbIntelligence vocabulary growth valves + `searchFailed` (#452) · full
 
 - **Phases / skills:** 0–8 pre-PR. Full weight (new + breaking public API, error
   paths, 15 Swift files, +664/−36), **with `/review-plan`'s critics skipped** —

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -25,6 +25,86 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
 
 ---
 
+## 2026-08-13 — ♻️ TMDbIntelligence vocabulary growth valves + `searchFailed` (`feature/tmdbintelligence-enum-valves`) · full
+
+- **Phases / skills:** 0–8 pre-PR. Full weight (new + breaking public API, error
+  paths, 15 Swift files, +664/−36), **with `/review-plan`'s critics skipped** —
+  the plan had already taken an adversarial pass this session whose findings were
+  applied. Skills: `implement-plan`, `review-changes` (5-dimension fan-out),
+  `security-review`, `capture-knowledge`.
+  `consulted:` gotchas *Public enums are not implicitly `Sendable`* (:1429),
+  *DocC symbol links don't resolve across modules* (:504 + its 2026-07-24
+  update), *A `package` symbol cannot be referenced by a DocC link* (:761),
+  *The build/test tooling-runner runs in the main checkout* (:265),
+  *A `RawRepresentable` enum … gets rawValue equality* (:1001),
+  *`NaturalLanguageSearchService` is not platform-gated* (:1018),
+  *Renaming a method's internal parameter name* (:1116); **ADR-0018**,
+  **ADR-0019** (both governing), ADR-0010; wiki
+  *treat-review-findings-as-hypotheses-not-approved-work*.
+  `reconciled:` 0 in scope / 0 reclaimed / 0 resumable / 0 reported.
+  `swept:` n/a (no infra files in the diff) → fell back to neighbouring entries:
+  ADR-0019 limb 2 rewritten (its "existing codebase-wide idiom" claim was going
+  stale), ADR-0018 read in full and verified still true, gotchas :504/:761/:1001/
+  :1018 re-read, still true.
+- **Worked — verifying the issue's premises before planning changed the plan.**
+  Per the wiki heuristic, all three of issue #420's load-bearing claims were
+  checked and **three were wrong**: ADR-0019's `.unknown` idiom does not transfer
+  (every instance exists because the value is wire-decoded; none of these types
+  are `Codable`), Half 2 was already half-landed by ADR-0018's
+  `catch TMDbError.cancelled`, and — the one that mattered — **a catch-all case
+  does not on its own prevent the source break**. The issue's literal fix would
+  have shipped a valve that didn't valve: adding `.other` stops nothing unless all
+  future growth is routed through it. That reframing is what turned the change
+  into extensible structs, and became ADR-0021.
+- **Worked — the plan's adversarial pass caught two *silent* breaks.** A
+  payload-free enum is implicitly `Hashable`, and an enum interpolates as its bare
+  case name; a struct is neither. Neither loss produces a diagnostic at the
+  conversion site, and the interpolation one would have compiled while silently
+  destroying the dictionary keys and column alignment of
+  `NaturalLanguageSearchPlannerEvalTests`' accuracy report. Both are now declared,
+  tested, and recorded in `gotchas.md`.
+- **Worked — spending one 30s gate on the biggest unknown first.** Converting
+  `Reason` alone (4 statics) and running `make build-docs` settled whether
+  `` ``Intent/byPerson`` ``-style links survive against a `public static let`
+  before the bulk conversion multiplied the cost of a wrong answer. They do, so
+  zero doc-link churn was needed — evidence rather than the `RetryableErrors`
+  precedent's promise.
+- **Friction — I asserted a compiler behaviour I had not verified, and two agents
+  then disagreed about it.** I told the user the catch-arm ordering was gated by
+  *"case will never be executed"*; the security reviewer said it was unenforced
+  and rested only on a comment. Settled by reversing the two arms and building: it
+  **is** gated, as a hard error under `--Werror`. Cheap to check, expensive to be
+  wrong about — a claim about *what enforces an invariant* deserves the same
+  evidence bar as a claim about behaviour.
+- **Friction — fixed a stale string in one file and didn't sweep for its
+  siblings.** `README.md:154` called `search("…")` where the label is
+  `search(matching:)`; the review found the **identical** call in
+  `TMDbIntelligence.docc` and `TMDbIntelligenceTesting.docc`. DocC code fences
+  aren't compiled, so no gate catches them. Same shape as the recurring
+  "sweep the rule's whole footprint, not the file you opened" defect.
+- **Friction — a test comment claimed to pin an invariant it never reached.** My
+  execution-failure test asserted `searchAllQueries.isEmpty` and commented "pins
+  `canFallBack` → false", but `canFallBack` is only consulted for errors from
+  `planner.plan(for:)`; that failure comes from `executor.execute`, outside the
+  inner `do`. The new arm could have been flipped to `true` with nothing failing.
+  Fixed by raising `.searchFailed` from the *planning* stage instead. **A comment
+  asserting coverage is not coverage** — the reviewer had to catch it because the
+  green suite looked identical either way (**False green**).
+- **Deviations:** (1) Phase 2 critics skipped, as above — recorded as full with
+  the skipped machinery noted. (2) The plan sequenced `ListKind` and `Intent` as
+  separate build cycles; both were done in one, since their switch sites live in
+  *different* files so an error stayed attributable — one build saved, and it
+  compiled clean first time. (3) The `reviewedClean` stamp used the `Sources`/
+  `Tests` **tree hashes** rather than the documented
+  `git ls-tree … | git hash-object` pipe, which the worktree Bash guard refuses as
+  unverifiable; same property, no pipe.
+- **One improvement:** `swept:` disciplines `knowledge/`, but both of this
+  delivery's doc misses were **source-tree** sweep failures a reviewer caught, not
+  the author. Worth a one-line check in `/implement-plan` or the
+  `/review-changes` brief: *changed a literal string, symbol name or code sample?
+  grep the repo for its siblings before calling it done* — the `.docc` catalogs
+  and `README.md` are the habitual blind spot because no gate compiles them.
+
 ## 2026-08-13 — 🔧 Move the `/review-knowledge` audit round to Opus (#451) · full
 
 - **Phases / skills:** 0–8 pre-PR. Full weight and reflexive (`.claude/skills/**`),
@@ -633,80 +713,6 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
   invalidated a Phase 6 entry that had already been committed. Ordering
   capture after grading costs nothing and removes the rewrite.
 
-## 2026-07-27 — ✨ Cached image URL resolver, `client.images` (#401) · full
-
-- **Phases / skills:** 0–8 pre-PR; full weight (new public service + actor,
-  8 commits). `/plan` → adversarial review by a Fable reviewer **plus** an
-  independent Swift-6 design pass, which converged on the same critical flaw, so
-  `/review-plan` was skipped as already-reviewed. `implement-plan` in 4
-  checkpoints. `review-changes` ×2 (5-dimension fan-out) → **0 Critical, 0 High
-  both rounds**, 15 then 7 advisory, all applied. `security-review` → 0 findings.
-  `capture-knowledge` → ADR-0013 + 3 gotchas + 1 correction to an existing entry.
-  Rubric: **6/6 ACs met**, independently graded.
-- **Worked — driving each mechanism out of a genuine red.** Rather than writing
-  the final actor from the plan, each hazard got its own failing test first: the
-  naive memo measured **100 fetches at peak concurrency 76** under 100 concurrent
-  callers, and the refresh ABA returned `["first"]` where `["second"]` was
-  expected. That produced *evidence* those are real regression tests, for free —
-  the plan had asked for a deliberate "revert and watch it fail" step, and this
-  made it unnecessary.
-- **Worked — plan review caught a bug the plan could not have shipped without.**
-  Both plan reviewers independently found that the cache rules said *what* to
-  memoise but never *who writes state*, so a superseded fetch would clobber a
-  newer `refresh()` — a permanently stale cache that **none of the 13 planned
-  tests would have caught**. The generation counter came from that, pre-code.
-- **Friction — I introduced two flaky tests while fixing review round 1, and only
-  round 2 caught them.** A caller that *joins* a shared in-flight fetch never
-  reaches the mock or gate, so a gate-based barrier cannot observe it; both new
-  tests opened the gate and then asserted on coalescing. Neither ever failed
-  locally (one reviewer measured 0/65 reproductions, 25 under load) — they were
-  wrong by construction, not by observation. Fixed with an on-actor entry
-  counter. **Lesson: after a concurrency fix, re-review the tests, not just the
-  code.**
-- **Friction — the one that actually cost the user: ~10 zsh pipelines pinned at
-  100% until they force-quit them.** My first explanation ("parallel agents,
-  build contention") was only half of it, and the smaller half. The real
-  amplifier is **`make build-docs` mutually invalidating every other build**:
-  `Package.swift` branches on `SWIFTCI_DOCC`, and the `=1` path *adds* the
-  swift-docc-plugin dependency while the else path *sets `exclude`* on four
-  targets — two different dependency graphs and two different per-target source
-  lists, sharing **one** `SCRATCH_PATH` (default `.build`). `Makefile:61` even
-  runs a bare `swift package resolve` after the docs build purely to undo the
-  first line's resolution, which is the Makefile conceding the point. Evidence:
-  `Package.resolved` is gitignored (the package normally has *no* dependencies)
-  yet exists, and `.build/checkouts/` holds `swift-docc-plugin` +
-  `swift-docc-symbolkit`.
-  So when I interleaved `build-docs` (×5) with `make test` / `build-release`
-  **while 5–7 review agents were independently building into the same
-  `.build`**, each docs run re-resolved the manifest out from under an in-flight
-  build; they then fought over `.build/.lock` and repeatedly redid work the other
-  had invalidated. Not slow work — *cyclical* work.
-  Two things I had wrongly folded into "CPU": the live integration suite is
-  **deliberately serialised** (40 suites carry `.integrationGate`, a global
-  semaphore), so 300 live tests run one at a time — that is most of the 69- and
-  72-minute wall-clock, and it is by design; and sheer redundancy (full unit
-  suite ×7, `build-docs` ×5, release ×3, a 12× filtered loop, plus a grader that
-  re-ran all of `make ci` unbidden, plus the real `make ci`).
-  `CLAUDE.md` mandates sequential builds within a worktree, but **subagents
-  cannot see each other**, so nothing could enforce it.
-- **Deviations:** (a) `TMDbFactory` was not touched — the issue's AC says
-  "registered in `TMDbFactory.swift`", but the factory vends only plumbing and
-  every service is built in `TMDbClient`'s private init; the grader independently
-  confirmed the criterion is stale. (b) `APIConfigurationStore` carries an
-  internal `entryCount` that exists only so tests can observe joining callers —
-  production state for the test suite, accepted deliberately and flagged by the
-  grader. (c) The ten URL methods are protocol-*extension* members, not
-  requirements, to kill the same-signature default-witness recursion hazard.
-- **Improvement (two, in priority order):** (1) **Give `build-docs` its own
-  scratch path** — `SCRATCH_PATH ?= .build/docs` for that target alone — so the
-  docc manifest never touches the directory every other target builds into. One
-  line, and it removes the invalidation cycle at the source rather than relying
-  on nobody ever running two things at once. (2) `/deliver` should forbid builds
-  in reviewer/grader subagent prompts and serialise its review phases: reviewers
-  have the diff and the conductor has already run every gate, so a reviewer
-  running `make ci` is duplicate CPU — and with N parallel agents on a shared
-  scratch path it is not merely N×, it is cyclical.
-
 ## Archive (distilled)
 
 Older entries condensed per the rolling window (`knowledge/README.md` →
@@ -714,6 +720,7 @@ Older entries condensed per the rolling window (`knowledge/README.md` →
 
 | Date | PR | Weight | Outcome |
 | --- | --- | --- | --- |
+| 2026-07-27 | #401 | full | Cached image URL resolver behind `client.images` (ADR-0013). Two practices worth keeping. **Drive each concurrency hazard out of a genuine red**: the naive memo measured *100 fetches at peak concurrency 76* under 100 concurrent callers and the refresh ABA returned `["first"]` where `["second"]` was expected, which produced evidence those are real regression tests for free. And **plan review caught a bug the plan could not have shipped without** — the cache rules said *what* to memoise but never *who writes state*, so a superseded fetch would clobber a newer `refresh()`, a permanently stale cache that none of the 13 planned tests would have caught; the generation counter came from that, pre-code. Also the source of *a caller that **joins** a shared in-flight fetch is invisible to the mock or gate*, so a gate-based barrier cannot observe coalescing — two tests were wrong by construction, not by observation (0/65 reproductions), fixed with an on-actor entry counter: **after a concurrency fix, re-review the tests, not just the code**. Its real cost was the delivery that made both build-isolation rules concrete: `make build-docs` *mutually invalidates* every other build, because `Package.swift` branches on `SWIFTCI_DOCC` into two different dependency graphs **and** two per-target source lists sharing one `.build` — so interleaving 5 docs runs with unit/release builds while 5–7 review agents built into the same scratch dir produced *cyclical*, not merely slow, work and ~10 `zsh` pipelines pinned at 100% until the user force-quit them. Both improvements shipped: `build-docs` got its own scratch path, and `/deliver` now forbids builds in reviewer/grader prompts and serialises its review phases. Also clarified that the live integration suite is **deliberately serialised** (40 suites on a global `.integrationGate` semaphore), so most of that wall-clock was by design. |
 | 2026-07-24 | #398 | full | Extracted the `TMDbIntelligence` product — ~40 sources, ~110 fixtures and ~30 tests relocated behind new targets. Two lasting rules came out of it. **Run `swift build -c release` before declaring implementation done**: a `@testable import` inside the new *non-test* `TMDbTestFixtures` target broke the release build *only*, while debug, `--build-tests`, 2868 unit and 291 integration tests all passed — now a hard Phase 3 checkpoint and a `gotchas.md` entry. And **share fixtures via a `package`-access target, never a `@testable` one** (now a wiki pattern). The plan critics paid for themselves twice over, catching that `TMDbTestingTests` referenced a symbol that was moving out, and unanimously that the planned `.xctestplan` sweep was **ghost work** — those files are gitignored and untracked. Counting tests rather than trusting green proved the move lossless (2868 → 2868, then 2869 → 2869 after rebasing onto #396/#397, whose `.docc` `exclude` list turned out to be **per target**, so the two new catalogs silently re-introduced the failure that only `make ci` caught). Rubric **self-graded — the independent grader died on a session limit; recorded, not silently passed**. |
 | 2026-07-24 | #397 | full | Enriched `TMDbError` with structured context (ADR-0012). The plan review paid for the delivery on its own: a critic caught, before a line was written, that the new public `endpointPath` would carry `guest_session_id` (a bearer-like credential) and `account_id` (PII) into a loggable field — the redactor and its tests came from that finding, and `security-review` later confirmed the control covers all 137 request-path templates. Now the wiki pattern *a-diagnostic-field-added-for-logging-is-a-publishing-surface*. Capturing **real** error bodies from the live API while planning (`curl -D-`) beat the plan's guesses: 400/code 22 and 422/code 20, not the invented 422/code 5. Environmental friction was severe — the Xcode 27 / Swift 6.4 `.docc` trap made `make ci` unrunnable, and the first attribution (xcsift `--Werror`) was **wrong**: `pipestatus` showed `swift build` exiting 1 and xcsift 0, which is why the build/test skills now say the exit status is the verdict, not the summary. |
 | 2026-07-24 | #390 | full | Migrated model runtimes from `Int` minutes to `Duration` (ADR-0011). The lasting pattern is store-the-raw / expose-the-computed: keep the integer-minute wire value in a private stored property and expose `Duration` as a computed one, so `Codable` stays synthesized and the wire format cannot silently drift — no hand-written 30-property `encode` to maintain. Now the wiki entry *bridge-a-wire-type-to-a-domain-type-inside-the-model*. The `.convertFromSnakeCase` → camelCase-`CodingKeys` check caught the `episodeRunTime` rawValue trap before it broke decode. Its "one improvement" — run the tooling-runner in the *active worktree* rather than the main checkout — recurred verbatim in #397 one delivery later and shipped in #399. |

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -98,12 +98,16 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
   `Tests` **tree hashes** rather than the documented
   `git ls-tree … | git hash-object` pipe, which the worktree Bash guard refuses as
   unverifiable; same property, no pipe.
-- **One improvement:** `swept:` disciplines `knowledge/`, but both of this
-  delivery's doc misses were **source-tree** sweep failures a reviewer caught, not
-  the author. Worth a one-line check in `/implement-plan` or the
-  `/review-changes` brief: *changed a literal string, symbol name or code sample?
-  grep the repo for its siblings before calling it done* — the `.docc` catalogs
-  and `README.md` are the habitual blind spot because no gate compiles them.
+- **One improvement — applied in this PR.** `swept:` disciplines `knowledge/`, but
+  both of this delivery's doc misses were **source-tree** sweep failures a
+  reviewer caught, not the author. `/implement-plan`'s *Done* checklist gained a
+  step 3: *changed a literal string, symbol name or code sample? grep the tree for
+  the old text before calling it done* — the `.docc` catalogs and `README.md`
+  being the habitual blind spot because **no gate compiles a code sample**. The
+  gap it fills is the *incidental* fix: the reflexivity footprint sweep covers
+  `.claude/` diffs and the type-driven enumeration covers tasks framed as sweeps,
+  but neither covers a one-liner changed in passing. Logged in
+  `skill-improvement-log.md`.
 
 ## 2026-08-13 — 🔧 Move the `/review-knowledge` audit round to Opus (#451) · full
 

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -63,6 +63,33 @@ retired; the family heading stays.
 
 ## Tooling
 
+### An unreachable `catch` arm is a compile **error** under `--Werror` — ordering is enforced, not conventional
+
+*2026-08-13 (#TBD).* When a `do`/`catch` chain needs a specific-case arm ahead of
+a broad type arm — `catch TMDbError.cancelled` before
+`catch let error as TMDbError`, because the latter matches **every** `TMDbError`
+including `.cancelled` — that ordering looks like a convention a comment has to
+defend. It isn't. Reverse the two and the compiler reports:
+
+```text
+error: case will never be executed
+```
+
+Verified empirically by reversing the arms and building (two reviewers had
+disagreed about whether the compiler noticed). It surfaces as a *warning* in
+SourceKit live diagnostics but as an **error** through
+`swift build -Xswiftc -warnings-as-errors`, which is what `make build`,
+`make build-tests` and `make build-release` all pass — so a mis-ordering cannot
+reach CI, let alone merge.
+
+- **Why it matters:** ordering here is load-bearing for correctness, not style. In
+  `TMDbNaturalLanguageSearchService.search(matching:)` a reversal would report a
+  *cancelled* search as `.searchFailed(.cancelled)` — re-breaking the
+  cancellation semantics of [ADR-0018](decisions/0018-cancellation-as-tmdberror-case.md).
+- **Still keep the behavioural test.** The compiler catches a reversal of two
+  arms that overlap; it does not catch someone *deleting* the specific arm, which
+  is a silent behaviour change. Belt and braces.
+
 ### No workflow runs `make` — a check added to a `make` target does not reach CI
 
 *2026-08-07.* The `Makefile` and CI are **parallel implementations**, not one
@@ -998,6 +1025,34 @@ fields.
 
 ## Public API
 
+### Converting a payload-free public enum to a struct silently drops two implicit conformances
+
+*2026-08-13 (#TBD).* Making a public vocabulary extensible by replacing
+`public enum X { case a, b }` with a struct + `public static let` members (see
+[ADR-0021](decisions/0021-extensible-public-vocabularies.md)) is *almost*
+source-compatible: construction, `==`, `if case .a = x` and a `switch` with a
+`default:` all keep compiling. Two things do **not** carry over, and neither
+produces a diagnostic at the conversion site:
+
+- **`Hashable`.** An enum with **no associated values** is implicitly `Hashable`
+  even when it declares only `Equatable`, so `Set<X>` and `[X: T]` compile
+  against it. A struct is not, so consumer code keying off the value breaks —
+  with nothing at the declaration hinting the loss was deliberate.
+- **`CustomStringConvertible`.** An enum interpolates as its bare case name; a
+  struct interpolates as a **reflection dump**
+  (`Intent(kind: TMDbIntelligence.SearchPlan.Intent.Kind.find)` instead of
+  `find`). This one is worse than a compile break because it *compiles*:
+  `NaturalLanguageSearchPlannerEvalTests` interpolates a `SearchPlan.Intent`
+  into a **dictionary key** for its accuracy report, so the conversion would
+  have silently destroyed that report's keys and its `%-12@` column alignment.
+
+**Declare both explicitly on the struct, and treat them as compatibility
+requirements rather than polish.** Pin each with a test — a `Set`/dictionary
+round-trip, and a table asserting every member's `description` — because nothing
+else will notice if they regress. Note this is a *conversion* hazard, not a
+general one: a payload-**carrying** enum was never implicitly `Hashable`, so it
+loses nothing.
+
 ### A `RawRepresentable` enum with an associated-value case gets **rawValue** equality, not structural
 
 *2026-07-24.* `TMDbStatusCode` is a hand-rolled
@@ -1441,3 +1496,15 @@ in a '@Sendable' closure"*.
 - **Lesson:** before wrapping a service method in any `@Sendable` closure
   (auto-pagination, `Task {}`, etc.), check that every captured **public** type is
   `Sendable`; don't assume a simple value enum already is.
+
+**The inverse half, and it is a lint failure rather than a build failure**
+(*2026-08-13, #TBD*): because that inference rule is "non-`public` types only", a
+**non-public** type that declares `: Sendable` is redundantly annotated, and
+swiftformat's `redundantSendable` rule fails `make lint` on it — *"Remove
+redundant explicit Sendable conformance from non-public structs and enums."* So
+the two halves point opposite ways and both are enforced: an internal nested type
+(e.g. the `enum Kind` backing an extensible-struct vocabulary — see
+[ADR-0021](decisions/0021-extensible-public-vocabularies.md)) must **omit**
+`Sendable` and inherit it implicitly, while its enclosing `public` struct must
+**declare** it. Declaring it on the internal type passes the build and then fails
+the gate.

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -65,7 +65,7 @@ retired; the family heading stays.
 
 ### An unreachable `catch` arm is a compile **error** under `--Werror` — ordering is enforced, not conventional
 
-*2026-08-13 (#TBD).* When a `do`/`catch` chain needs a specific-case arm ahead of
+*2026-08-13 (#452).* When a `do`/`catch` chain needs a specific-case arm ahead of
 a broad type arm — `catch TMDbError.cancelled` before
 `catch let error as TMDbError`, because the latter matches **every** `TMDbError`
 including `.cancelled` — that ordering looks like a convention a comment has to
@@ -1027,7 +1027,7 @@ fields.
 
 ### Converting a payload-free public enum to a struct silently drops two implicit conformances
 
-*2026-08-13 (#TBD).* Making a public vocabulary extensible by replacing
+*2026-08-13 (#452).* Making a public vocabulary extensible by replacing
 `public enum X { case a, b }` with a struct + `public static let` members (see
 [ADR-0021](decisions/0021-extensible-public-vocabularies.md)) is *almost*
 source-compatible: construction, `==`, `if case .a = x` and a `switch` with a
@@ -1498,7 +1498,7 @@ in a '@Sendable' closure"*.
   `Sendable`; don't assume a simple value enum already is.
 
 **The inverse half, and it is a lint failure rather than a build failure**
-(*2026-08-13, #TBD*): because that inference rule is "non-`public` types only", a
+(*2026-08-13, #452*): because that inference rule is "non-`public` types only", a
 **non-public** type that declares `: Sendable` is redundantly annotated, and
 swiftformat's `redundantSendable` rule fails `make lint` on it — *"Remove
 redundant explicit Sendable conformance from non-public structs and enums."* So

--- a/knowledge/next-major.md
+++ b/knowledge/next-major.md
@@ -21,6 +21,13 @@ CHANGELOG records it) or is rejected outright (record that in
 > `skill-improvement-log.md` entry of the same date. Anything added here now is
 > queued for **21.0.0** unless 20.0.0 is still untagged when you read this.
 >
+> **Still untagged as of 2026-08-13** (latest tag is `19.0.0`), so the two
+> `TMDbIntelligence` vocabulary entries added that day are deferred by **scope
+> choice, not by the window** — they were consciously left out of issue #420's
+> delivery to keep its diff focused, and could still land in 20.0.0 if someone
+> picks them up before the tag. Re-check with `git tag --sort=-v:refname` rather
+> than trusting this line.
+>
 > **This file has earned its keep once.** It was written on 2026-07-27 and read
 > on 2026-07-28, while 19.0.0 was assembled but still untagged — which is the
 > only reason the `Company.logoPath` decode bug (#404) made that release instead
@@ -50,3 +57,37 @@ CHANGELOG records it) or is rejected outright (record that in
   site from that allowlist is part of fixing it**; at empty, delete the script
   and its two invocations.
 - **Source:** 20.0.0 sweep (2026-08-07), which fixed the 37 cheap sites.
+
+### Give `SearchPlan.RelativeDate` an open-ended bound
+
+- **What:** `SearchPlanMapper.swift:94-98` collapses a lone upper bound — "movies
+  up to 2010" — to `.exactYear(2010)`, because `RelativeDate` has no open-ended
+  case. The prompt asks for a range and gets a single year, silently. The mapper's
+  own comment records the gap.
+- **Why it waits:** the fix is a new payload-carrying case (`upTo(Int)` /
+  `from(Int)`, or generalising `between(start:end:)` to optional bounds) on a type
+  that **stays an enum** by decision — [ADR-0021](decisions/0021-extensible-public-vocabularies.md)
+  excludes `RelativeDate` from the extensible-struct shape because a catch-all
+  member would be uncomputable for a constraint the executor must derive year
+  bounds from. So the addition is source-breaking for exhaustive switchers with no
+  valve available.
+- **Note:** this is a *functional* gap, not an extensibility one. It was left out
+  of issue #420 deliberately to keep that diff to the two things the issue asked
+  for.
+- **Source:** issue #420 delivery (2026-08-13).
+
+### Convert `SearchPlan.MediaType` to an extensible struct — if the result surface grows
+
+- **What:** `MediaType` (`movie` / `tv` / `person`) is the one payload-free
+  vocabulary in `SearchPlan` left as a closed public enum after
+  [ADR-0021](decisions/0021-extensible-public-vocabularies.md).
+- **Why it waits — and the condition:** it is bounded by this feature's **result
+  surface**, not by TMDb's media taxonomy. `NaturalLanguageSearchResult` exposes
+  exactly `movies`, `tvSeries` and `people`, so a fourth media type could not be
+  *returned* without a larger change than adding a member. **Convert it when, and
+  only when, that result surface grows** — at which point the conversion is the
+  smaller half of the work. (Beware the tempting wrong rationale: "TMDb has
+  exactly three media types" is false — core `Media` models four including
+  `.collection`, `TaggedImageMedia` adds `.tvEpisode`, and the package ships
+  `CollectionService`. A reviewer caught that claim in #420's first draft.)
+- **Source:** issue #420 delivery (2026-08-13), code review.

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -64,6 +64,38 @@ those two runs stay comparable.
 
 ---
 
+### 2026-08-13 — Grep for a changed string's siblings before calling it done · applied
+
+- **Pattern:** partial sweeps keep recurring, but **outside the scope of the two
+  rules that already address them**. The reflexivity gate's footprint sweep
+  covers `.claude/` diffs (#441-#446, the entry below); `/implement-plan`'s
+  type-driven enumeration covers a task *framed* as "fix every instance of X"
+  (#364, #410). Neither covers an **incidental** one-line fix in ordinary feature
+  work: #452 corrected a stale `search("…")` → `search(matching:)` sample in
+  `README.md` and left the identical call in `TMDbIntelligence.docc` **and**
+  `TMDbIntelligenceTesting.docc`, both found by code review rather than the
+  author. #359 is the same shape caught earlier (a cross-module DocC break found
+  pre-replication).
+- **Decision:** **applied** — a new step 3 in `/implement-plan`'s *Done — when
+  the test list is empty* checklist: changed a literal string, symbol name or
+  code sample, grep the tree for the **old** text before declaring done, with
+  `**/*.docc/**` and `README.md` named as the blind spot. Shipped in #452
+  alongside the delivery that surfaced it.
+- **Rationale:** the mechanism is that **no gate compiles a code sample** —
+  `make build-docs` compiles the DocC catalog, not the Swift inside a fence, and
+  `markdownlint` does not read it either — so a stale sample is invisible to CI
+  by construction and only a reader or a reviewer ever finds it. The two existing
+  rules are both scoped to work the author already knows is a sweep; this class
+  is the one where they *don't* know it, which is why a third, cheaper check
+  earns its place rather than widening either of the others.
+- **Reconsider when:** n/a (applied). Note it is prose in a checklist, not an
+  enforced gate — the honest reason being that a general "did you grep?" check is
+  not mechanisable without knowing what changed semantically. If this recurs a
+  third time, the enforceable version is narrower: a CI step that extracts every
+  ```` ```swift ```` fence from `README.md` and `**/*.docc/**` and compiles them.
+
+---
+
 ### 2026-08-13 — `/review-knowledge` audit tier drops to Opus; cross-examination stays Fable · applied
 
 - **Pattern:** the 2026-08-07 addendum to ADR-0014 pinned `/review-knowledge`'s


### PR DESCRIPTION
## Summary

Closes #420. Two halves, both only cheap while the **20.0.0 window is open** (`19.0.0` is still the latest tag).

`TMDbIntelligence`'s natural-language vocabulary is young and still growing, but every public enum in it was closed. This package ships as source via SwiftPM — no library evolution, no `@frozen` — so from a consumer's point of view a public enum is *already* frozen: adding a case breaks every exhaustive `switch` downstream. Each new intent, curated list or degradation was a major-version event, permanently.

Separately, `search(matching:)` wrapped every non-`NaturalLanguageSearchError` in `.planningFailed`, whose description claims *"The request could not be interpreted."* A TMDb rate limit or network drop was therefore reported as a prompt-interpretation failure, so a consumer branching on rate limiting missed TMDb's real 429 entirely.

### Three of the issue's premises were wrong, and correcting them changed the design

Per the *treat review findings as hypotheses* heuristic, each of #420's load-bearing claims was checked first:

1. **ADR-0019's `.unknown` idiom does not transfer.** Every instance of it exists because the value is decoded from an untrusted wire payload (`Status`, `ShowType`, `CreditType` — all `Codable`). None of these vocabularies are `Codable`; they're constructed in-process. Their problem is *source* compatibility, not decode tolerance.
2. **Half 2 was already half-landed.** ADR-0018 added `catch TMDbError.cancelled`; every *other* `TMDbError` still became `.planningFailed`.
3. **A catch-all case does not, on its own, prevent the source break** — the issue's central assumption. Adding `.other` stops nothing unless *all* future growth is routed through it. The issue's literal fix would have shipped a valve that didn't valve.

That reframing is why this uses extensible structs rather than catch-all cases, and is recorded as **ADR-0021**.

## Changes

**Extensible vocabularies (breaking):**
- ♻️ `SearchPlan.Intent`, `SearchPlan.ListKind` and `NaturalLanguageSearchAvailability.Reason` become structs with `public static let` members over an **internal** backing enum. New members can now ship in a *minor* release.
- Construction, `==`, `if case .find = plan.intent` and `switch` + `default:` all compile unchanged; `Hashable` is **retained**. Only an *exhaustive* `switch` breaks — the point, taken once, inside the open major window.
- Internal code switches on the internal representation, so the compiler still demands an arm for every member we model. `public init(kind:)` is impossible, so the externally-constructible value space is *narrower* than the enum's.
- ✨ `Reason.unknown`, with both `@unknown default:` arms pointed at it. They previously reported an Apple-added reason as `.modelNotReady` / `.unsupportedOS` — so a caller would wait for a download that was never pending, or tell the user to upgrade an OS that is already current.
- ✨ `SearchDegradation.other(String)` as a documented reserved growth slot (it keeps its enum: 6 of 9 cases carry payloads a struct would strand).
- `MediaType` and `RelativeDate` deliberately unchanged, both queued in `next-major.md` with the condition that would change the answer.

**Error reporting (breaking):**
- 🐛 `NaturalLanguageSearchError.searchFailed(TMDbError)`, thrown from a `catch let error as TMDbError` arm. One arm covers **both** paths — `literalSearch` is called from the inner catch body, so its errors escape into the same outer chain.
- The new arm sits *below* `catch TMDbError.cancelled`, which matches every `TMDbError` including `.cancelled`. Reversing them is a **compile error** (`case will never be executed`) under `--Werror` — verified by reversing them — so the ordering is enforced, not merely commented.
- `canFallBack` returns `false` for `.searchFailed`: the fallback would retry against the API that just failed, worsening a 429.
- Unlike `.planningFailed`, `.searchFailed` discriminates by cause in `==`, so a rate limit can be told from a network drop.

**Tests:**
- ✅ 24 new tests across four suites. +18 net (3193 → 3211); 315 integration tests green.
- Each assertion targets an exact value, never `#expect(throws: …Error.self)` — the loose form passes even with a broken `==`, and `NaturalLanguageSearchError`'s hand-written `==` ends in `default: false`, so a missing arm compiles silently and makes a value unequal to itself.
- Adds the `searchAll` error knob the mock lacked, without which the literal-fallback failure path was untestable at all.

**Documentation:**
- 📚 ADR-0021 (three shapes for a growable public vocabulary); ADR-0019 limb 2 scoped to wire-decoded vocabularies and cross-referenced, so the two policies no longer appear to contradict.
- 📝 CHANGELOG entries with the migration each break actually needs.
- 🐛 Fixes a `search("…")` → `search(matching:)` sample in `README.md` **and** both DocC catalogs — a call that could never have compiled. DocC code fences aren't compiled, so no gate catches these.
- 🧠 Three `gotchas.md` entries: the two implicit conformances an enum→struct conversion silently drops, and that an unreachable `catch` arm is a compile error under `--Werror`.

## Benefits

- **Growth without breakage**: three vocabularies can gain members in a minor release, indefinitely, instead of queueing behind a major bump.
- **Internal safety preserved**: keeping `Kind` internal means we lose nothing — the compiler still catches a missed arm when *we* add a member.
- **Actionable errors**: a TMDb 429 during search is now visibly a 429, with its `Retry-After`, rather than "the request could not be interpreted".
- **A recorded rule**: contributors adding a vocabulary now have one rule with three shapes, not three in-tree precedents to choose between.

## Verification

`make ci` green: 3211 unit tests, 315 integration tests, release build, docs build, `swiftlint --strict` (plus a cache-bypassing `--no-cache` run, since four new `.swift` files can otherwise false-green locally), markdown lint.

Reviewed by a 5-dimension fan-out with adversarial verification — **0 Critical, 0 High** (one High refuted on verification), 5 Medium + 4 Low all applied. Security review: **0 findings** — `.searchFailed` re-routes data already public on `TMDbError` rather than widening it, since `endpointPath` redaction happens at the single construction site and predates this change.

> **Note on process:** the delivery rubric was **derived** (from issue #420's stated before/after behaviour plus the plan's Canon TDD test list), not supplied. It was graded independently at 12/12, by a grader given only the criteria and the committed diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
