### PR TITLE
📝 Prefer the Swift LSP over grep for symbol-level navigation

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -329,7 +329,11 @@ work is committed; re-confirm the weight from the diff. Three hard checkpoints:
 - **"Fix every instance of pattern X" → enumerate ALL sites up front** with a
   single **type-driven sweep**, listed in the test list before implementing —
   piecemeal discovery ships subsets (incidents:
-  [`references/review-loops.md`](references/review-loops.md)).
+  [`references/review-loops.md`](references/review-loops.md)). Do that sweep
+  with the **LSP** (`ToolSearch("select:LSP")` → `findReferences`,
+  `incomingCalls`, `goToImplementation`), not `grep`: a text pattern
+  under-reports silently — ADR-0008's grep recipe found four of eight path
+  interpolation sites, and the three it missed carried a credential (#421).
 - **Consult the specialist skills — mandatory, topic-triggered, including for
   fanned-out subagents.** `swift-concurrency` the moment actors,
   `@MainActor`, `Sendable`/`@unchecked Sendable`, locks, `Task`/task groups,

--- a/.claude/skills/implement-plan/SKILL.md
+++ b/.claude/skills/implement-plan/SKILL.md
@@ -114,6 +114,23 @@ Test list — <plan goal>
 It is a living list — you will add cases as implementation reveals them. Confirm
 it with the user (or state it explicitly) before proceeding.
 
+**Enumerate by symbol, not by text — use the LSP.** When the list needs "every
+site that does X" (every caller of a helper, every conformer to a protocol,
+every construction of a request type), ask the compiler, not `grep`. Load the
+tool once with `ToolSearch("select:LSP")`, then use `findReferences` /
+`incomingCalls` for call sites, `goToImplementation` for conformers, and `hover`
+for a symbol's real type behind `any`, a generic, or a typealias. Expect a cold
+start — the first call can fail with *server is starting*; retry once. Positions
+are 1-based and the character must land **on** the symbol.
+
+A text pattern silently under-reports, and that is not hypothetical: ADR-0008
+prescribed `grep 'path = "/…\(stringVar)"'` to find every path interpolation. It
+missed three builders whose `let path =` sat on its own line — four sites
+recorded, eight actual, and the three it missed carried a bearer-like credential
+for two months (issue #421). `findReferences` on the request initialiser would
+have listed all eight. Keep `grep` for exact strings, JSON fixtures, Markdown,
+and non-Swift files, where it is the better tool.
+
 **Mirror the family — probe the nearest siblings first.** When an item adds a
 *sibling* to an existing family (another service method, another model, another
 `addRating`-style guarded method, another `@Suite` test), **read the 1–2 closest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,32 @@ then fall back to `make -C <dir>` and say that you did.
 `/lint` and `/format` run `make` directly (they are fast and low-output), and
 `make ci` is run directly before a PR.
 
+### Navigating Swift: prefer the LSP over `grep`
+
+For **symbol-level** questions, ask SourceKit-LSP rather than searching text.
+`LSP` is a *deferred* tool, so load it once per session with
+`ToolSearch("select:LSP")` — until then `Grep` is the reflex and the LSP simply
+goes unused.
+
+- `findReferences` / `incomingCalls` — who actually calls this. Grep hits here
+  are polluted by mocks, DocC comments and string literals.
+- `goToImplementation` — what conforms to this protocol (28 protocol-backed
+  services make this the common question).
+- `hover` — a symbol's real type behind `any`, a generic, or a typealias.
+- `workspaceSymbol` fuzzy-matches **very** loosely (`MovieService` returned 1161
+  symbols); treat it as candidate generation, not lookup.
+
+Two practical notes: the first call can fail with *server is starting* — that is
+a cold start, retry once; and positions are 1-based with the character landing
+**on** the symbol, or you get a silent "no hover information".
+
+**Keep `grep` for** exact strings, JSON fixtures, Markdown, and non-Swift files.
+The distinction that matters: grep answers *"what text appears where"*, the LSP
+answers *"what does the compiler think this is"* — and for "find every site that
+does X", only the second is trustworthy. ADR-0008 prescribed a grep to find
+every path interpolation; it found four of eight, and the three it missed
+carried a bearer-like credential for two months (issue #421).
+
 ### Inside Xcode vs. terminal
 
 Outside Xcode (terminal Claude Code), the skills fall back to `make`

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -64,6 +64,46 @@ those two runs stay comparable.
 
 ---
 
+### 2026-08-13 — Enumerate Swift sites with the LSP, not `grep` · applied
+
+- **Pattern:** the fourth instance of the partial-sweep family, and the one the
+  three existing rules cannot reach — the sweep was performed with the **wrong
+  instrument**. ADR-0008 recorded a discovery recipe for future readers:
+  `grep 'path = "/…\(stringVar)"'`. That pattern is single-line, so it missed
+  three request builders whose `let path =` sat on its own line — four sites
+  recorded, **eight** actual, and the three it missed interpolated a
+  bearer-like guest session id raw for two months (issue #421, fixed in #453).
+  The #364 retro had already recorded the right lesson ("one type-driven
+  enumeration up front") and it *was* applied to `/implement-plan` — but the
+  ADR, which is the artifact the next person actually opens, kept the grep.
+  Adam then asked whether anything instructs using the Swift LSP: the
+  preference existed only in session **memory**
+  (`feedback-prefer-lsp-swift-navigation`, recorded 2026-08-11 at his request)
+  and appeared in no `CLAUDE.md`, skill or knowledge file — so it went unused
+  for an entire delivery, including for the very sweep it would have fixed.
+- **Decision:** **applied**, at Adam's explicit request, in three places so the
+  rule sits where it is executed rather than where it is remembered:
+  `CLAUDE.md` → *Navigating Swift: prefer the LSP over `grep`* (read by every
+  session and every subagent); `/implement-plan` Step 1 → *Enumerate by symbol,
+  not by text*, adjacent to the existing type-driven-sweep guidance; and
+  `/deliver` Phase 3's "fix every instance of pattern X" checkpoint, so the two
+  copies of that rule do not drift.
+- **Rationale:** `grep` answers "what text appears where"; the LSP answers "what
+  does the compiler think this is" — and for "find every site that does X" only
+  the second is trustworthy. The failure mode is the **False green** family: a
+  text sweep that under-reports looks exactly like a clean one. Memory was the
+  wrong home because memory surfaces as background context while a skill step is
+  a thing that gets followed; the same "recorded somewhere other than the
+  artifact people follow" shape as the ADR-0008 grep itself.
+- **Reconsider when:** n/a (applied). Note it is prose, not an enforced gate —
+  nothing fails if a future sweep uses `grep` anyway. If a text-pattern sweep
+  under-reports a **fourth** time, the enforceable version is narrower than a
+  general rule: for a named "every instance of X" task, require the enumeration
+  to be pasted into the test list with its source (LSP query vs grep), so the
+  instrument is visible in review rather than inferred.
+
+---
+
 ### 2026-08-13 — Grep for a changed string's siblings before calling it done · applied
 
 - **Pattern:** partial sweeps keep recurring, but **outside the scope of the two


### PR DESCRIPTION
## Summary

A text pattern silently under-reports, and it has now cost this repo a real vulnerability.

ADR-0008 recorded a *discovery recipe* for future readers — `grep 'path = "/…\(stringVar)"'` — for finding every caller-supplied path interpolation. That pattern is single-line, so it missed three request builders whose `let path =` sat on its own line: **four sites recorded, eight actual**, and the three it missed interpolated a bearer-like guest session id raw for two months (#421, fixed in #453). `findReferences` on the request initialiser would have listed all eight.

The preference for using the LSP already existed — but only in session **memory**, so it surfaced as background context rather than as a step anyone follows, and went unused for the whole of that delivery, *including for the very sweep it would have fixed*. This PR puts it where it is executed rather than where it is remembered.

## Changes

**Existing Files:**

- 📝 `CLAUDE.md` — a new *Navigating Swift: prefer the LSP over `grep`* section under *Build and Test Tooling*, so it reaches every session and every subagent. Covers `findReferences`/`incomingCalls` for call sites, `goToImplementation` for conformers, and `hover` for a real type behind `any`/a generic/a typealias — plus the three things that make the tool look broken when it isn't: it is **deferred** (needs `ToolSearch("select:LSP")` first), the first call can fail with *server is starting* (cold start, retry once), and positions are 1-based with the character landing **on** the symbol. Notes that `workspaceSymbol` fuzzy-matches far too loosely to be a lookup.
- 📝 `.claude/skills/implement-plan/SKILL.md` — a new *Enumerate by symbol, not by text* paragraph in Step 1, adjacent to the existing type-driven-sweep guidance, carrying the ADR-0008 incident as the worked example.
- 📝 `.claude/skills/deliver/SKILL.md` — the same instruction on Phase 3's "fix every instance of pattern X" checkpoint, so the two copies of that rule do not drift apart.

**Documentation:**

- 📚 `knowledge/skill-improvement-log.md` — the decision recorded in the log's five-field format, as the fourth instance of the partial-sweep family and the first one caused by the *instrument* rather than the scope.

## Benefits

- **Closes the gap the three existing sweep rules can't reach.** The reflexivity footprint sweep covers `.claude/` diffs; `/implement-plan`'s type-driven enumeration covers a task *framed* as "fix every instance of X"; the grep-for-siblings rule covers incidental one-line fixes. None of them says *which instrument to sweep with* — which is what actually failed.
- **Right failure mode.** `grep` answers "what text appears where"; the LSP answers "what does the compiler think this is". A text sweep that under-reports looks exactly like a clean one — the **False green** family this repo keeps hitting.
- **Grep keeps what it's better at:** exact strings, JSON fixtures, Markdown, non-Swift files. The rule is explicit about that, so it doesn't over-correct.

## Notes for review

- This is a **reflexive** change — it edits skills the delivery pipeline itself runs. The skill registry loads from the main checkout, so it cannot be dogfooded before merge; it was verified by reading, not by executing.
- The rule is **prose, not an enforced gate** — nothing fails if a future sweep uses `grep` anyway. The log entry records what the enforceable version would look like if this recurs a fourth time.
- Gate: docs/config-only diff (no `*.swift`, `Makefile`, `Package.*`, `*.xctestplan` or workflows), so `/pr`'s sanctioned narrowing applies — `make lint` + `make lint-markdown`, both green. `build-docs` dropped as no `*.docc/**` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)