### PR TITLE
🔧 Promote fix-pr-checks' diagnoser to a check-diagnoser agent; verify the red in canon-tdd

### DIFF
--- a/.claude/agents/check-diagnoser.md
+++ b/.claude/agents/check-diagnoser.md
@@ -1,0 +1,60 @@
+---
+name: check-diagnoser
+description: Read-only diagnoser for one failing PR status check on the TMDb repo — runs the routed diagnosis skill (/diagnose-ci-failure or /diagnose-integration-failure) and returns only its three-section Summary / Likely cause / Suggested fix result, never raw logs. Spawned by /fix-pr-checks (directly, or via its Workflow fan-out); not for ad-hoc use. Deliberately not model-pinned — the caller chooses Haiku (first attempt) or Opus (repeat) per check from its run ledger.
+permissionMode: auto
+disallowedTools: Edit, Write, NotebookEdit, Agent
+---
+
+# Claude Subagent: Check Diagnoser (read-only)
+
+You diagnose **exactly one** failing PR status check for the TMDb repo and
+report the cause and fix concisely. You are the diagnosis step of
+`/fix-pr-checks`; the act-on-it layer — apply → verify → commit → push — is
+the caller's, never yours.
+
+Your task names the **check**, the **branch**, and the **routed skill**:
+
+- `/diagnose-ci-failure` — any **CI** check: lint, markdown lint, build, or
+  unit tests from `ci.yml`.
+- `/diagnose-integration-failure` — the **Integration** check (live-API suite
+  from `integration.yml`).
+
+Use that skill to diagnose: it locates the failing run, reads the log, and
+maps it to a cause and fix. On a **repeat**, the task also carries the prior
+attempt's Cause/Fix and why it didn't stick — do not re-propose it; find what
+that diagnosis missed.
+
+## No model pin — the caller escalates
+
+This file deliberately sets no `model:`. `/fix-pr-checks` picks the tier per
+check from its run ledger — **Haiku** on a first attempt, **Opus** on a
+repeat — and passes it with each spawn. A frontmatter pin would silently
+override that escalation.
+
+## DO NOT BUILD OR RUN TESTS
+
+No `make`, no `swift build`, no `swift test`, and do not invoke `/build`,
+`/test` or `/integration-test`. Diagnose by **reading** the failing run's log
+and the source. The routed skill tells you to reproduce locally; that step is
+the caller's, not yours — it owns the single build slot for this worktree.
+Reproduction here would collide with it and with any sibling diagnosis
+running beside you.
+
+**Half of this is enforced, half is not — know which.** The frontmatter's
+`disallowedTools` removes `Edit`/`Write`/`NotebookEdit` (you report a
+diagnosis, you never apply the fix) and `Agent` (no fanning out). `Skill` and
+`Bash` you keep — invoking the routed diagnosis skill *is* the job, and its
+log reads (`gh`, `jq`) need the shell — so `make`, `swift build` and the
+build/test skills are still physically reachable, and the rule above rests on
+you.
+
+## Report back ONLY
+
+The routed skill's three-section result — **Summary**, **Likely cause**,
+**Suggested fix** — including the offending `file:line`, plus the `observed:`
+line where the routed skill requires one. Do not paste raw logs.
+
+> **Section names.** `/diagnose-ci-failure` emits *Summary / Cause / Fix*;
+> `/diagnose-integration-failure` emits *Summary / Likely cause / Suggested
+> fix* and adds `observed:` for shape-drift causes. Report the latter shape —
+> it is a superset, so both skills' results can satisfy it.

--- a/.claude/agents/check-diagnoser.md
+++ b/.claude/agents/check-diagnoser.md
@@ -1,11 +1,12 @@
 ---
 name: check-diagnoser
-description: Read-only diagnoser for one failing PR status check on the TMDb repo — runs the routed diagnosis skill (/diagnose-ci-failure or /diagnose-integration-failure) and returns only its three-section Summary / Likely cause / Suggested fix result, never raw logs. Spawned by /fix-pr-checks (directly, or via its Workflow fan-out); not for ad-hoc use. Deliberately not model-pinned — the caller chooses Haiku (first attempt) or Opus (repeat) per check from its run ledger.
+description: No-fix diagnoser for one failing PR status check on the TMDb repo — runs the routed diagnosis skill (/diagnose-ci-failure or /diagnose-integration-failure) and returns only its three-section Summary / Likely cause / Suggested fix result, never raw logs; it reports, never applies. Spawned by /fix-pr-checks (directly, or via its Workflow fan-out); not for ad-hoc use. The Haiku pin is the first-attempt default; the caller's call-site model override wins, so a repeat re-diagnoses on Opus.
+model: haiku
 permissionMode: auto
 disallowedTools: Edit, Write, NotebookEdit, Agent
 ---
 
-# Claude Subagent: Check Diagnoser (read-only)
+# Claude Subagent: Check Diagnoser (diagnose, never fix)
 
 You diagnose **exactly one** failing PR status check for the TMDb repo and
 report the cause and fix concisely. You are the diagnosis step of
@@ -24,12 +25,13 @@ maps it to a cause and fix. On a **repeat**, the task also carries the prior
 attempt's Cause/Fix and why it didn't stick — do not re-propose it; find what
 that diagnosis missed.
 
-## No model pin — the caller escalates
+## The Haiku pin is a floor — the caller escalates
 
-This file deliberately sets no `model:`. `/fix-pr-checks` picks the tier per
-check from its run ledger — **Haiku** on a first attempt, **Opus** on a
-repeat — and passes it with each spawn. A frontmatter pin would silently
-override that escalation.
+`model: haiku` above is the first-attempt default, not a ceiling: a call-site
+`model:` beats the frontmatter pin (ADR-0014), so `/fix-pr-checks` escalates a
+repeat to **Opus** by passing `model: opus` with the spawn, per its run
+ledger. The pin exists for the spawn that *forgets* `model` — it lands on
+cheap Haiku instead of inheriting the session model.
 
 ## DO NOT BUILD OR RUN TESTS
 
@@ -42,9 +44,11 @@ running beside you.
 
 **Half of this is enforced, half is not — know which.** The frontmatter's
 `disallowedTools` removes `Edit`/`Write`/`NotebookEdit` (you report a
-diagnosis, you never apply the fix) and `Agent` (no fanning out). `Skill` and
-`Bash` you keep — invoking the routed diagnosis skill *is* the job, and its
-log reads (`gh`, `jq`) need the shell — so `make`, `swift build` and the
+diagnosis, you never apply the fix) and `Agent` (no fanning out — note this
+also unplugs the build skills' `tooling-runner`, but those skills then fall
+back to direct `make`, so the removal blocks fan-out, not builds). `Skill`
+and `Bash` you keep — invoking the routed diagnosis skill *is* the job, and
+its log reads (`gh`, `jq`) need the shell — so `make`, `swift build` and the
 build/test skills are still physically reachable, and the rule above rests on
 you.
 

--- a/.claude/skills/canon-tdd/SKILL.md
+++ b/.claude/skills/canon-tdd/SKILL.md
@@ -36,8 +36,11 @@ The point of this skill: do these by default, without being reminded.
    setup, invocation, and **assertions**. Define *what* the system does and *how
    it's invoked* — not how it works inside. Run it; confirm it fails — and
    **state the failure**: quote the failing assertion/message and check it is
-   the *expected* reason, not a compile error, a missing import, or an
-   unrelated crash. A red for the wrong reason proves nothing about the
+   the *expected* reason. (For brand-new API the first red is normally a
+   compile error — the symbol doesn't exist yet; that is expected. Stub the
+   minimal declaration and re-run so the red becomes the failing assertion.)
+   A compile error in *existing* code, a missing import, or an unrelated
+   crash is a red for the wrong reason — it proves nothing about the
    behaviour, so fix the test and re-run until it is red for the right reason.
 3. **Make it pass** — change the system to satisfy that test with the simplest
    thing that works. Nothing more; resist solving items still on the list.

--- a/.claude/skills/canon-tdd/SKILL.md
+++ b/.claude/skills/canon-tdd/SKILL.md
@@ -34,7 +34,11 @@ The point of this skill: do these by default, without being reminded.
    implementation reveals a new case.
 2. **Write a test** — pick the next item and write one real, automated test:
    setup, invocation, and **assertions**. Define *what* the system does and *how
-   it's invoked* — not how it works inside. Run it; confirm it fails.
+   it's invoked* — not how it works inside. Run it; confirm it fails — and
+   **state the failure**: quote the failing assertion/message and check it is
+   the *expected* reason, not a compile error, a missing import, or an
+   unrelated crash. A red for the wrong reason proves nothing about the
+   behaviour, so fix the test and re-run until it is red for the right reason.
 3. **Make it pass** — change the system to satisfy that test with the simplest
    thing that works. Nothing more; resist solving items still on the list.
 4. **Optionally refactor** — improve names, structure, and duplication while every

--- a/.claude/skills/fix-pr-checks/SKILL.md
+++ b/.claude/skills/fix-pr-checks/SKILL.md
@@ -76,10 +76,12 @@ If nothing is failing, return immediately (note any pending checks).
 ## 2. Diagnose each failing check (Haiku first, Opus on a repeat)
 
 For each `fail` check under its attempt cap, spawn the **`check-diagnoser`**
-agent (Agent tool, `subagent_type: check-diagnoser` — its read-only/no-build
-contract, report shape, and deliberately unpinned model live in
+agent (Agent tool, `subagent_type: check-diagnoser` — its no-fix/no-build
+contract, report shape, and Haiku floor-pin live in
 `.claude/agents/check-diagnoser.md`), substituting the check name and the
-routed skill. Pick the model from the check's ledger history:
+routed skill. Pick the model from the check's ledger history and pass it
+explicitly (a call-site `model` beats the agent's frontmatter pin —
+ADR-0014):
 
 - **First attempt** → `model: haiku`.
 - **Repeat** (the ledger shows a prior attempt for this check — a fix that
@@ -87,6 +89,14 @@ routed skill. Pick the model from the check's ledger history:
   prepending one line of prior-attempt context to the prompt: the previous
   Cause/Fix and why it didn't stick. A misdiagnosis costs a full
   fix→push→CI round trip; don't pay it twice on the same model tier.
+
+> **Registry lag.** A freshly merged agent file may not register as a
+> spawnable `subagent_type` until a new session
+> (`knowledge/delivery-retros.md`), and an unrecognised type silently starts a
+> plain general-purpose agent — with no contract at all now that the prompt
+> below carries none. If `check-diagnoser` is not a recognised type, don't
+> fall through silently: say so, and re-spawn as `general-purpose` with
+> `.claude/agents/check-diagnoser.md` read into the prompt as its contract.
 
 ```text
 The `<CHECK NAME>` check failed on the TMDb PR for branch `<branch>`.

--- a/.claude/skills/fix-pr-checks/SKILL.md
+++ b/.claude/skills/fix-pr-checks/SKILL.md
@@ -75,8 +75,10 @@ If nothing is failing, return immediately (note any pending checks).
 
 ## 2. Diagnose each failing check (Haiku first, Opus on a repeat)
 
-For each `fail` check under its attempt cap, spawn a diagnosis subagent — Agent
-tool, `subagent_type: general-purpose` — substituting the check name and the
+For each `fail` check under its attempt cap, spawn the **`check-diagnoser`**
+agent (Agent tool, `subagent_type: check-diagnoser` — its read-only/no-build
+contract, report shape, and deliberately unpinned model live in
+`.claude/agents/check-diagnoser.md`), substituting the check name and the
 routed skill. Pick the model from the check's ledger history:
 
 - **First attempt** → `model: haiku`.
@@ -89,25 +91,8 @@ routed skill. Pick the model from the check's ledger history:
 ```text
 The `<CHECK NAME>` check failed on the TMDb PR for branch `<branch>`.
 
-Use the `<SKILL>` skill to diagnose it. The skill locates the failing run,
-reads the log, and maps it to a cause and fix.
-
-DO NOT BUILD OR RUN TESTS — no `make`, no `swift build`, no `swift test`, and
-do not invoke /build, /test or /integration-test. Diagnose by reading the
-failing run's log and the source. The routed skill tells you to reproduce
-locally; that step is the caller's, not yours — it owns the single build slot
-for this worktree. Reproduction here would collide with it and with any sibling
-diagnosis running beside you.
-
-Report back ONLY the skill's three-section result — Summary, Likely cause,
-Suggested fix — including the offending `file:line`, plus the `observed:` line
-where the routed skill requires one. Do not paste raw logs.
+Use the `<SKILL>` skill to diagnose it.
 ```
-
-> **Section names.** `/diagnose-ci-failure` emits *Summary / Cause / Fix*;
-> `/diagnose-integration-failure` emits *Summary / Likely cause / Suggested
-> fix* and adds `observed:` for shape-drift causes. Ask for the latter shape —
-> it is a superset, so both skills can satisfy it.
 
 ### Two or more failing checks → one Workflow
 
@@ -167,13 +152,6 @@ if (typeof input.branch !== 'string' || !input.branch) {
   throw new Error('fix-pr-checks: args.branch must be a non-empty string.')
 }
 
-const NO_BUILD =
-  `DO NOT BUILD OR RUN TESTS — no \`make\`, no \`swift build\`, no \`swift test\`, and do not invoke ` +
-  `/build, /test or /integration-test. Diagnose by READING the failing run's log and the source. ` +
-  `The routed skill tells you to reproduce locally; that step is the caller's, not yours — it owns the ` +
-  `single build slot for this worktree. Reproduction here would collide with it and with any sibling ` +
-  `diagnosis running beside you.`
-
 const DIAGNOSIS_SCHEMA = {
   type: 'object',
   additionalProperties: false,
@@ -197,17 +175,16 @@ phase('Diagnose')
 const results = await parallel(input.checks.map((c) => () =>
   agent(
     `The \`${c.name}\` check failed on the TMDb PR for branch \`${input.branch}\`.\n\n` +
-      `Use the \`${c.skill}\` skill to diagnose it. The skill locates the failing run, reads the log, ` +
-      `and maps it to a cause and fix.\n\n` +
+      `Use the \`${c.skill}\` skill to diagnose it.` +
       (c.priorAttempt
-        ? `THIS IS A REPEAT. The previous attempt did not stick:\n${c.priorAttempt}\n` +
-          `Do not re-propose it — find what that diagnosis missed.\n\n`
-        : '') +
-      `${NO_BUILD}\n\n` +
-      `Report ONLY the skill's three-section result. Do not paste raw logs.`,
+        ? `\n\nTHIS IS A REPEAT. The previous attempt did not stick:\n${c.priorAttempt}\n` +
+          `Do not re-propose it — find what that diagnosis missed.`
+        : ''),
     {
       label: `diagnose:${c.name}`,
       phase: 'Diagnose',
+      // The agent definition carries the no-build rule and report contract.
+      agentType: 'check-diagnoser',
       // Haiku first; a repeat escalates. The conductor supplies the history —
       // a Workflow cannot see the ledger's per-check attempt counters.
       model: c.priorAttempt ? 'opus' : 'haiku',

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,8 +290,9 @@ skills). Four subagents back the pipeline:
 `code-reviewer` (deep Swift/TMDb review, pinned to Opus),
 `documentation-writer` (bulk DocC generation, pinned to Sonnet),
 `tooling-runner` (build/test execution, pinned to Haiku), and
-`check-diagnoser` (read-only PR-check diagnosis for `/fix-pr-checks`; not
-model-pinned — the caller picks Haiku first, Opus on a repeat).
+`check-diagnoser` (PR-check diagnosis for `/fix-pr-checks` — reports, never
+fixes; pinned to Haiku, with a repeat re-diagnosed on Opus via the caller's
+call-site override).
 
 ## Build and Test Tooling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,10 +286,12 @@ follow one shared spec, [`.github/CODE_REVIEW.md`](.github/CODE_REVIEW.md), and
 reviewers, plus committed `.claude/workflows/` and `Scripts/` for the local one
 (docs/prose-only changes are not reviewed, unless the caller passes
 `force-review` — `/deliver` does for a delivery that rewrites the pipeline's own
-skills). Three subagents back the pipeline:
+skills). Four subagents back the pipeline:
 `code-reviewer` (deep Swift/TMDb review, pinned to Opus),
-`documentation-writer` (bulk DocC generation, pinned to Sonnet), and
-`tooling-runner` (build/test execution, pinned to Haiku).
+`documentation-writer` (bulk DocC generation, pinned to Sonnet),
+`tooling-runner` (build/test execution, pinned to Haiku), and
+`check-diagnoser` (read-only PR-check diagnosis for `/fix-pr-checks`; not
+model-pinned — the caller picks Haiku first, Opus on a repeat).
 
 ## Build and Test Tooling
 

--- a/README.md
+++ b/README.md
@@ -588,8 +588,9 @@ directly.
 Four subagents back the pipeline: `code-reviewer` (deep Swift/TMDb review,
 pinned to Opus), `documentation-writer` (bulk DocC generation, pinned to
 Sonnet), `tooling-runner` (build/test execution, pinned to Haiku), and
-`check-diagnoser` (read-only PR-check diagnosis for `/fix-pr-checks`; not
-model-pinned — the caller picks Haiku first, Opus on a repeat). The
+`check-diagnoser` (PR-check diagnosis for `/fix-pr-checks` — reports, never
+fixes; pinned to Haiku, with a repeat re-diagnosed on Opus via the caller's
+call-site override). The
 reviewer follows the shared spec in
 [`.github/CODE_REVIEW.md`](.github/CODE_REVIEW.md).
 

--- a/README.md
+++ b/README.md
@@ -585,9 +585,11 @@ directly.
 | `/canon-tdd` | Drive test-first development (test list → failing test → pass → refactor) |
 | `/document-swift` | Write DocC documentation for public API per project conventions |
 
-Three subagents back the pipeline: `code-reviewer` (deep Swift/TMDb review,
+Four subagents back the pipeline: `code-reviewer` (deep Swift/TMDb review,
 pinned to Opus), `documentation-writer` (bulk DocC generation, pinned to
-Sonnet), and `tooling-runner` (build/test execution, pinned to Haiku). The
+Sonnet), `tooling-runner` (build/test execution, pinned to Haiku), and
+`check-diagnoser` (read-only PR-check diagnosis for `/fix-pr-checks`; not
+model-pinned — the caller picks Haiku first, Opus on a repeat). The
 reviewer follows the shared spec in
 [`.github/CODE_REVIEW.md`](.github/CODE_REVIEW.md).
 


### PR DESCRIPTION
## Summary

Two `.claude/` changes from the pipeline audit: `/fix-pr-checks`' diagnosis subagent — previously a `subagent_type: general-purpose` spawn carrying its contract as inline prompt prose in two places (the direct Agent call and the embedded Workflow's `NO_BUILD` constant) — is promoted to a named `.claude/agents/check-diagnoser.md`, matching the `tooling-runner`/`code-reviewer` convention; and `canon-tdd` step 2 now requires stating *why* a new test failed before proceeding, closing the "red for the wrong reason" gap (per Böckeler's *TDD in the agent loop*).

## Changes

**New agent:**

- ✨ `.claude/agents/check-diagnoser.md` — the diagnoser's contract moved verbatim-in-substance from the inline prompt: no-build rule (the caller owns the worktree's single build slot; the routed skill's "reproduce locally" step is the caller's), the three-section report shape (Summary / Likely cause / Suggested fix superset, `observed:` where required, no raw logs), repeat-attempt handling, and a `code-reviewer`-style honesty note on which restrictions are structural (`disallowedTools`) vs prose-only.
- Pinned `model: haiku` as a **floor**: a call-site `model:` beats the frontmatter pin (ADR-0014), so the ledger-driven Haiku→Opus escalation still works, and a spawn that forgets `model` lands on Haiku instead of the session model. ⚠️ *Deliberate deviation from the approved plan* (which said no pin) — the plan's rationale ("a pin would override the escalation") was factually wrong, caught by the code review.

**Existing skills:**

- 🔧 `.claude/skills/fix-pr-checks/SKILL.md` — both diagnosis paths now spawn `check-diagnoser` (direct call via `subagent_type`, Workflow fan-out via `agentType`); the duplicated contract prose and `NO_BUILD` constant are deleted. Added a registry-lag fallback: a freshly merged agent file may not register until a new session, and an unrecognised `subagent_type` silently falls back to general-purpose — the conductor must say so and re-spawn with the agent file read into the prompt.
- 🔧 `.claude/skills/canon-tdd/SKILL.md` — step 2 now requires quoting the failure message and confirming it fails for the *expected* reason, with a carve-out for brand-new API (the first red is normally a compile error on the not-yet-existing symbol — that *is* expected; stub minimally so the red becomes the assertion).

**Documentation:**

- 📚 `CLAUDE.md` + `README.md` — the "Three subagents back the pipeline" enumerations updated to four.

## Review

Force-reviewed (single Opus `code-reviewer`, pipeline-reflexive brief): **no Critical/High**. The contract move was verified faithful line-by-line; four Mediums and two Lows were found — M1 (false no-pin rationale), M2 (registry-lag window), M3 (compile-error carve-out), L1 ("read-only" over-claim), L2 (`Agent`-removal precision) are fixed in the second commit. M4 (the diagnoser has no working-directory rule, so inside a `/deliver` worktree it could read main-checkout sources — pre-existing in substance) is filed as a follow-up issue rather than fixed here.

## Benefits

- **One source of truth**: the diagnoser contract lived in two prose copies that could drift — exactly the decay mode `/review-knowledge` audits for; now it's one agent file both paths reference.
- **Trustworthy reds**: a test that fails to compile or crashes elsewhere no longer counts as a verified failing test in the TDD loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G68p39dTjGfgTSCE7cjVZf