### PR TITLE
📝 Knowledge-drift audit: fix 10 corroborated findings + capture PR #466's learnings

### DIFF
--- a/.claude/skills/lint/SKILL.md
+++ b/.claude/skills/lint/SKILL.md
@@ -5,13 +5,15 @@ description: Lint code with swiftlint and swiftformat
 
 # Lint code
 
-Run `make lint` from the project root to check code style. It runs **six**
-checks, in order: four Python scripts under `Scripts/` — `lint-witnesses`
+Run `make lint` from the project root to check code style. It runs **seven**
+checks, in order: five Python scripts under `Scripts/` — `lint-witnesses`
 (`check-defaulted-witnesses.py`, protocol conveniences that would witness their
 own requirement), `lint-fixtures` (`check-fixtures.py`, JSON fixture hygiene),
 `lint-curation` (`check-docc-curation.py`, public methods missing from their
-DocC page) and `lint-prose` (`check-prose-call-forms.py`, code samples calling a
-method that does not exist) — then `swiftlint --strict .`, then
+DocC page), `lint-prose` (`check-prose-call-forms.py`, code samples calling a
+method that does not exist) and `lint-readme-version`
+(`check-readme-version.py`, README's `.package(from:)` vs the newest
+`CHANGELOG.md` release) — then `swiftlint --strict .`, then
 `swiftformat --lint .`.
 
 Each script enforces something no single-file linter can see, and a failure in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,10 @@ knowledge; `CLAUDE.md` stays imperative.)
   every skill-improvement proposal and its decision; the recurring-pattern
   scan's dedup memory.
 
-**Before solving a non-trivial problem**, skim the relevant file. **After learning
+**Before solving a non-trivial problem**, skim the relevant file. Concretely:
+when a command or tool fails **twice**, grep `knowledge/gotchas.md` for the
+tool's name before a third attempt — the trap is usually already recorded, and
+re-deriving it costs more than the grep. **After learning
 something durable** (a gotcha, an API quirk, a design decision), record it there —
 run `/capture-knowledge` (it runs automatically before a PR in `/deliver`). Add an
 ADR for any non-obvious design decision.
@@ -539,9 +542,12 @@ build input of `TMDbTests`) runs `make lint && make lint-markdown && make build-
 instead (drop `build-docs` only if no `*.docc/**` changed). `/pr` owns that rule;
 if this paraphrase and `/pr` ever disagree, `/pr` is right.
 
-**The one thing `make ci` cannot check is `README.md`** — `build-docs` compiles
-DocC but cannot see a stale README. If the public API changed, keep it in sync
-by hand (see `/document-swift`). Record durable learnings with
+**What `make ci` still cannot check in `README.md` is the narrative prose** —
+`make lint` now gates the Swift code samples (`check-prose-call-forms.py`,
+README + DocC articles) and the `.package(from:)` version
+(`check-readme-version.py`), but feature lists, service tables and described
+behaviour compile through no gate. If the public API changed, keep that prose
+in sync by hand (see `/document-swift`). Record durable learnings with
 `/capture-knowledge`.
 
 `/deliver` runs this checklist, the self-review (`/review-changes`), and the PR

--- a/knowledge/decisions/0014-subagent-model-tiers.md
+++ b/knowledge/decisions/0014-subagent-model-tiers.md
@@ -51,7 +51,8 @@ re-diagnoses only where judgment demonstrably matters.
 ## Consequences
 
 - Model choice is no longer a caller responsibility for the runners — the
-  pin lives in `tooling-runner.md` and can't be forgotten.
+  pin lives in `tooling-runner.md` (and, since PR #466, `check-diagnoser.md`
+  for the `/fix-pr-checks` first attempt) and can't be forgotten.
 - Review quality has a floor: `code-reviewer` never silently degrades below
   Opus in a cheaper session, while call sites may still override upward.
 - Bulk documentation gets cheaper without a quality change worth caring
@@ -74,6 +75,14 @@ re-diagnoses only where judgment demonstrably matters.
   shape → tier mapping is unchanged, and the trigger for revisiting the
   remaining Opus pins (the `/review-plan` critics, the `/deliver` panel) stays
   "critics start missing blockers".
+- *Addendum (2026-08-19, PR #466):* the `/fix-pr-checks` first-attempt Haiku
+  pin moved from call-site prose into the new `check-diagnoser.md` agent's
+  frontmatter — the floor mechanic above, exercised: the call-site
+  `model: opus` re-diagnosis still overrides it, and a spawn that forgets
+  `model` now lands on Haiku instead of the session model. (The PR's plan
+  originally said *no* pin, reasoning a pin would block the escalation —
+  the review caught that as contradicting this ADR's mechanic.) Tier mapping
+  unchanged.
 
 ## Alternatives considered
 

--- a/knowledge/decisions/0016-panel-jurors-and-workflows-directory.md
+++ b/knowledge/decisions/0016-panel-jurors-and-workflows-directory.md
@@ -80,9 +80,28 @@ before committing to this placement.
   `.claude/settings*`. This ADR's placement decision is what creates that
   surface, so closing it is part of the same change.
 - The repo now has **two conventions** for Workflow scripts. The rule is
-  frequency: **once per invocation → embed; many times per run → file.**
+  drift-sensitivity: **orchestration-only scripts embed in their `SKILL.md`;
+  a script that encodes a decision procedure (rubrics, tally rules,
+  guard thresholds) or runs headless lives in `.claude/workflows/`** — an
+  executed file cannot drift between invocations the way a re-authored
+  embedded script can, and for decisions that drift is a correctness bug.
+  (As originally written the rule keyed on *frequency* — "once per
+  invocation → embed; many times per run → file" — see the 2026-08-19
+  addendum for why that proxy was replaced.)
 - Phase 11 proposals now always wait for a human, so the default auto path
   pushes nothing after the ready gate.
 - **The jurors themselves remain unexercised** — only the guards have run. Auto
   mode has still never completed a real delivery, and this ADR does not change
   that.
+- *Addendum (2026-08-19, knowledge-drift audit):* PR #464 committed
+  `.claude/workflows/triage-issues.js` — a once-per-invocation script — as a
+  file, violating the frequency rule while matching this ADR's own deeper
+  rationale (it carries the triage `RUBRIC` constants and runs headless, so
+  re-authoring drift would corrupt decisions). The rule failed because it
+  named the proxy (frequency) instead of the criterion (drift-sensitivity of
+  decisions); the Consequences bullet above now states the criterion. The
+  census is six scripts: four embedded (`review-plan`, `review-knowledge`,
+  `review-changes`, `fix-pr-checks`), two files (`deliver-panel.js`,
+  `triage-issues.js`). Placement has no mechanical gate; the standing hook is
+  that `.claude/workflows/` sits on the security-surface list, so every new
+  file there passes a reviewer — who should check it against this rule.

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -63,6 +63,39 @@ retired; the family heading stays.
 
 ## Tooling
 
+### A gate keyed on `git tag` passes vacuously in CI — the checkout has no tags
+
+*2026-08-19 (#464).* `actions/checkout` fetches no tags by default, so any
+check that compares against "the latest tag" sees an empty list in CI and
+passes on the degenerate path — the **False green** family, one level down.
+`Scripts/check-readme-version.py` therefore treats `CHANGELOG.md` as the
+authoritative shipped-version record, not `git tag`. Two facts worth keeping
+with it:
+
+- **README's `.package(from:)` silently caps consumers.** SemVer reads
+  `from: X.Y.Z` as `>= X.Y.Z, < (X+1).0.0`, so a stale major in the README
+  snippet pins every copy-pasting consumer below the current release. #406
+  caught exactly this by hand while preparing 19.0.0; the script now gates it.
+- **The check has two arms by design** — README may match the newest *dated*
+  release **or** the newest undated/unreleased section — so `/cut-release`'s
+  pre-tag housekeeping PR (which bumps README before the tag exists) is not
+  blocked by the very gate it feeds.
+
+### Swift code fences in README and the DocC articles are prose — nothing compiles them
+
+*2026-08-19 (#460).* A stale call form in a README or `*.docc` article code
+sample is invisible to `make ci` and to `build-docs` (DocC renders fences, it
+does not compile them), and fixing one occurrence leaves identical siblings
+stale — #452 fixed a dead `search("…")` call in README while the same call
+survived in two DocC articles; #459's README documented a
+`tmdbClient.search.multi(query:)` that never existed. It took three
+recurrences (PRs #359, #452 and #459) before #460 added
+`Scripts/check-prose-call-forms.py`, which
+resolves every `<service>.<method>(<labels>)` in those fences against
+`TMDbClient`'s real service API. Two shapes to know: the one false positive is
+a **local binding shadowing a service name**; and parsing whole fences rather
+than line-by-line nearly doubled coverage (44 → 83 call forms).
+
 ### A new `.claude/agents/*.md` is spawnable immediately — but only in the session that wrote it
 
 *2026-08-19 (#466).* Two observations that look contradictory and are both
@@ -197,8 +230,9 @@ shipped this way for one review round before it was caught.
 paths-filter *and* `on.push.paths` — otherwise a PR touching only that script
 skips the whole job that runs it.
 
-Four checks are mirrored this way today — `check-defaulted-witnesses.py`,
-`check-fixtures.py`, `check-docc-curation.py` and `check-prose-call-forms.py`,
+Five checks are mirrored this way today — `check-defaulted-witnesses.py`,
+`check-fixtures.py`, `check-docc-curation.py`, `check-prose-call-forms.py` and
+`check-readme-version.py` (paths-filter input: `CHANGELOG.md`),
 each a `make lint` prerequisite *and* its own step in the CI `Lint` job. Prefer an **existing**
 paths-filter key over a new `outputs:` entry: a filter key with no matching line
 under `outputs:` makes `needs.changes.outputs.<key>` the empty string, so the

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -63,6 +63,26 @@ retired; the family heading stays.
 
 ## Tooling
 
+### A new `.claude/agents/*.md` is spawnable immediately — but only in the session that wrote it
+
+*2026-08-19 (#466).* Two observations that look contradictory and are both
+true:
+
+- **The authoring session sees it at once.** Writing
+  `.claude/agents/check-diagnoser.md` made the harness announce the new
+  `subagent_type` in the same session, before any restart — no lag.
+- **Every other context lags.** A session already running when the file merges
+  (and a worktree, whose skill/agent registry loads from the main checkout —
+  see `knowledge/delivery-retros.md`) may not have the type until a fresh
+  session. The failure is **silent**: the Agent tool starts a plain
+  general-purpose agent for an unrecognised `subagent_type` rather than
+  erroring, so the spawn "works" with none of the agent file's contract.
+
+`/fix-pr-checks` §2 carries the operational fallback (announce, then re-spawn
+as `general-purpose` with the agent file read into the prompt). The durable
+fact is the asymmetry: don't fear the lag in the session that authored the
+file, and don't trust type recognition anywhere else until a restart.
+
 ### `build-docs` cannot see a *missing* curation line — only a broken or ambiguous one
 
 *2026-08-14 (#459).* `make build-docs` runs


### PR DESCRIPTION
## Summary

Consolidated PR from two pieces of held-back work: the `/capture-knowledge` pass for PR #466 (first commit, previously held at Adam's request), and the corrections from a 30-day knowledge-drift audit (second commit). The audit ran as a 2×2 panel — two Opus auditors with complementary lenses (STALE/UNCITED and MISSING/IGNORED) over CLAUDE.md, `knowledge/`, the skills/agents, the session memory files and the personal wiki, checked against the 47 PRs merged since 2026-07-20 — then two independent Fable-class corroborators who received only the bare claims and verified each against the tree themselves. **Every reported finding has ≥2 independent supporters (auditor + both corroborators confirmed all 10); zero findings were dropped as refuted.**

## Changes

**Capture (commit 1):**

- 📚 `knowledge/gotchas.md` — new-agent-file registration asymmetry (spawnable immediately in the authoring session; other sessions lag, silently).
- 📚 ADR-0014 — pin-location line + addendum for PR #466's `check-diagnoser` frontmatter floor-pin.

**Audit corrections (commit 2):**

- 🐛 **STALE, found independently by both auditors**: the mirrored-checks census said *four* scripts are wired into both `make lint` and the CI Lint job; PR #464's `check-readme-version.py` made it five (`knowledge/gotchas.md`) — and `/lint`'s parallel "six checks / four scripts" enumeration is now "seven / five" (`.claude/skills/lint/SKILL.md`).
- 🐛 **STALE**: CLAUDE.md's Completion Checklist claimed "the one thing `make ci` cannot check is `README.md`" — false since PRs #460/#464 gated the code samples and `.package(from:)` version. Rewritten to name what is actually ungated: narrative prose.
- ✨ **MISSING** (PR #464): new gotcha — a gate keyed on `git tag` passes vacuously in CI (the checkout has no tags); `CHANGELOG.md` is the authoritative shipped-version record; plus the `.package(from:)` consumer-capping trap (#406) and why the version check has two arms.
- ✨ **MISSING** (PR #460): new gotcha — Swift fences in README/DocC compile through nothing; a stale call form rots invisibly and fixing one leaves siblings stale (three recurrences: #359, #452, #459) before `check-prose-call-forms.py` gated it; known false-positive shape included.
- 🔧 **IGNORED** (ADR-0016): PR #464 committed a once-per-invocation Workflow script as a file, violating the ADR's embed-vs-file *frequency* rule while matching its own deeper rationale. Diagnosis: the rule named a proxy (frequency) instead of the criterion (drift-sensitivity of decision procedures). The rule is rewritten to the criterion, with an addendum recording the violation, the new six-script census, and the honest enforcement status (no mechanical gate; `.claude/workflows/` sits on the security-surface review list).
- 🔧 CLAUDE.md's knowledge-consult rule gains a mechanically-checkable trigger — a command failing **twice** → grep `knowledge/gotchas.md` before a third attempt — replacing pure aspiration. (Motivated by a same-session recurrence: the auditing session itself re-derived the recorded `node --check` workflow-script trick, then hit the recorded `#NNN`-at-line-start markdown trap while writing these very entries.)

**Outside this PR** (no repo trace): four stale session-memory files fixed directly (a nonexistent `/plan` skill, pre-`tooling-runner` spawn shape, three sets of outdated `/deliver` phase numbers) plus their MEMORY.md index lines. The wiki was audited read-only: relation graph clean (0 broken links), the one present-tense repo claim verified true; no wiki writes (they require explicit approval).

## Verification

- `make lint` + `make lint-markdown` green locally (docs-only diff → the `/pr`-sanctioned narrowed gate; no `*.docc` changed, so no docs build).
- Intra-repo link check: 172 relative links, zero broken (3 known false positives: a regex literal, the ADR template placeholder, the DocC logo resolved via `Resources/`).
- Wiki relation graph: `lint_wiki` reports 0 broken links, 0 missing supersession reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G68p39dTjGfgTSCE7cjVZf