### PR TITLE
🔒 Redact credentials from the error carried by TMDbError.network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Breaking:** `TMDbError.network(_:)` no longer hands your API key to whatever
+  you log the error to. A `URLSession` failure carries the whole URL of the
+  request that failed in its `NSError` `userInfo`, and for a client created with
+  `TMDbClient(apiKey:)` that URL contains the `api_key` query item — so an
+  ordinary timeout, DNS failure or dropped connection put the credential into
+  consumer logs, crash reports and analytics breadcrumbs. The library already
+  scrubbed token-bearing *path* segments from `TMDbErrorContext.endpointPath`;
+  it now covers the failing URL too.
+
+  The value of any credential-bearing query item (`api_key`, `session_id`,
+  `request_token`, `guest_session_id`), and any guest session id or account id
+  in the path, is replaced with `REDACTED`. The attached error keeps its
+  `domain`, `code` and `localizedDescription`, so branching on those is
+  unaffected, and on Apple platforms it still bridges to `URLError`.
+
+  Breaking, and silently so — nothing stops compiling. The other diagnostic
+  `userInfo` entries (`NSUnderlyingError` and the related-task keys) are
+  **dropped** rather than scrubbed, because they can nest a second copy of the
+  same URL, so code reading them will now find them absent. An error with
+  nothing to redact — including one thrown by your own `HTTPClient` — is
+  attached exactly as raised, so its concrete type still matches in a `catch`.
+  `TMDbClient(bearerToken:)` was never affected: that credential is a header.
+
 - A type conforming to one of the service protocols itself, rather than using
   `TMDbTesting`'s mocks, no longer risks an infinite recursion. 54 protocol
   conveniences shared their requirement's signature, differing only by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same URL, so code reading them will now find them absent. An error with
   nothing to redact — including one thrown by your own `HTTPClient` — is
   attached exactly as raised, so its concrete type still matches in a `catch`.
-  `TMDbClient(bearerToken:)` was never affected: that credential is a header.
+
+  The v4 bearer token itself was never at risk — it travels as a header, never
+  in a URL. A `session_id` was: a user-scoped v3 call carries it as a query item
+  whichever way the client was created, so `TMDbClient(bearerToken:)` leaked one
+  too wherever you passed a session id.
 
 - A type conforming to one of the service protocols itself, rather than using
   `TMDbTesting`'s mocks, no longer risks an infinite recursion. 54 protocol

--- a/Sources/TMDb/Domain/Models/TMDbError.swift
+++ b/Sources/TMDb/Domain/Models/TMDbError.swift
@@ -59,7 +59,26 @@ public enum TMDbError: Equatable, LocalizedError, Sendable {
     /// An error indicating there was a problem encoding data.
     case encode(Error)
 
+    ///
     /// An error indicating there was a network problem.
+    ///
+    /// The associated error is the transport failure, with your credentials
+    /// removed — so it is safe to log, forward to a crash reporter, or attach to
+    /// an analytics breadcrumb.
+    ///
+    /// A `URLSession` failure carries the whole URL of the request that failed
+    /// in its `userInfo`, and for a client created with ``TMDbClient/init(apiKey:configuration:)``
+    /// that URL contains your `api_key`. Before the error is attached here, the
+    /// value of any credential-bearing query item — and any guest session id or
+    /// account id in the path — is replaced with `REDACTED`. The error keeps its
+    /// `domain`, `code` and `localizedDescription`, so branching on those is
+    /// unaffected; other diagnostic `userInfo` entries are dropped, because they
+    /// can nest a copy of the same URL.
+    ///
+    /// An error with nothing to redact — including one thrown by your own
+    /// ``HTTPClient`` — is attached exactly as it was raised, so its concrete
+    /// type still matches in a `catch`.
+    ///
     case network(Error)
 
     /// An error indicating there was a problem decoding data.

--- a/Sources/TMDb/Networking/EndpointPathRedactor.swift
+++ b/Sources/TMDb/Networking/EndpointPathRedactor.swift
@@ -16,7 +16,13 @@ import Foundation
 /// guest session id is a bearer-like credential and the account id is personal
 /// data, so both are replaced with a placeholder before the path leaves the
 /// library. The API key and session id are query items, not path segments, and so
-/// are never present here.
+/// are never present in the value this type is given.
+///
+/// That is a statement about ``TMDbErrorContext/endpointPath``'s input, not about
+/// the library as a whole: a `URLSession` failure carries the failing request's
+/// **whole URL**, query string included, and ``NetworkErrorRedactor`` is what
+/// covers that. The two share one classifier — ``placeholder(forEndpoint:)`` —
+/// so a new token-in-path endpoint is learned by both from a single edit.
 ///
 enum EndpointPathRedactor {
 
@@ -35,7 +41,32 @@ enum EndpointPathRedactor {
             return path
         }
 
-        let placeholder: String? = switch segments[0] {
+        guard let placeholder = placeholder(forEndpoint: segments[0]) else {
+            return path
+        }
+
+        segments[1] = placeholder
+        let joined = segments.joined(separator: "/")
+
+        return hasLeadingSlash ? "/\(joined)" : joined
+    }
+
+    ///
+    /// The placeholder that replaces the identifier segment following `endpoint`,
+    /// or `nil` when `endpoint` carries no token-bearing identifier.
+    ///
+    /// This is the single classifier for *which* endpoints put a credential or
+    /// personal identifier in their path. ``NetworkErrorRedactor`` asks the same
+    /// question of the failing URL in a transport error, and renders its own
+    /// placeholder — one rule, two renderings — so a new token-in-path endpoint
+    /// is learned by both from one edit here.
+    ///
+    /// - Parameter endpoint: The leading path segment naming the endpoint.
+    ///
+    /// - Returns: The placeholder for the following identifier segment, or `nil`.
+    ///
+    static func placeholder(forEndpoint endpoint: String) -> String? {
+        switch endpoint {
         case "guest_session":
             "{guest_session_id}"
 
@@ -45,15 +76,6 @@ enum EndpointPathRedactor {
         default:
             nil
         }
-
-        guard let placeholder else {
-            return path
-        }
-
-        segments[1] = placeholder
-        let joined = segments.joined(separator: "/")
-
-        return hasLeadingSlash ? "/\(joined)" : joined
     }
 
 }

--- a/Sources/TMDb/Networking/NetworkErrorRedactor.swift
+++ b/Sources/TMDb/Networking/NetworkErrorRedactor.swift
@@ -1,0 +1,235 @@
+//
+//  NetworkErrorRedactor.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+///
+/// Redacts the caller's credentials from a transport error before it is wrapped
+/// as the public ``TMDbError/network(_:)``.
+///
+/// A `URLSession` failure is an `NSError` whose `userInfo` carries the **whole**
+/// URL of the request that failed, under `NSErrorFailingURLKey` and
+/// `NSErrorFailingURLStringKey`. For a client created with
+/// ``TMDbClient/init(apiKey:configuration:)`` that URL contains the `api_key`
+/// query item, and a user-scoped v3 request adds `session_id` — so an ordinary
+/// timeout or DNS failure would hand a credential to whatever the consumer logs
+/// the error to. ``EndpointPathRedactor`` never covered this: it scrubs the
+/// *path* of ``TMDbErrorContext/endpointPath``, and states in its own
+/// documentation that the query string is out of its scope.
+///
+/// Two properties of the result are load-bearing, and both are chosen to be safe
+/// rather than merely tidy:
+///
+/// - **An error needing no redaction is returned as the same instance.** A
+///   consumer may supply their own `HTTPClient`, so the value being wrapped is
+///   often their own error type. Rebuilding it as an `NSError` would erase that
+///   type — `catch TMDbError.network(let error as MyTransportError)` would stop
+///   matching — and degrade `localizedDescription` to Foundation's generic
+///   "The operation couldn't be completed." Only a genuine redaction rebuilds.
+/// - **A rebuilt error's `userInfo` is an allowlist, not a scrubbed copy.** A
+///   real `URLSession` failure also carries `NSUnderlyingError` (an `NSError`
+///   with a `userInfo` of its own) and `_NSURLErrorRelatedURLSessionTaskErrorKey`
+///   (an array of tasks, each holding the original request). Walking every
+///   value that *might* nest a URL is unbounded; copying forward only the keys
+///   whose contents are known cannot leak by construction.
+///
+/// `domain` and `code` survive both paths — they are what callers branch on, and
+/// they are the cross-platform property, since a `URLSession` error need not
+/// bridge to `URLError` on swift-corelibs-foundation.
+///
+enum NetworkErrorRedactor {
+
+    /// Replaces a credential value, and any token-bearing path identifier, in a
+    /// redacted URL.
+    ///
+    /// Deliberately not ``EndpointPathRedactor``'s `{guest_session_id}` form:
+    /// `{` and `}` are not legal in a URL path, and
+    /// `URLComponents.percentEncodedPath`'s setter traps — rather than throws —
+    /// on a value it considers badly encoded.
+    static let placeholder = "REDACTED"
+
+    /// Query items whose value is a credential.
+    ///
+    /// Compared lower-cased. These mirror ``APIRequestQueryItem/Name/apiKey``
+    /// and ``APIRequestQueryItem/Name/sessionID``, the two credentials
+    /// ``TMDbAPIClient`` can put in a URL; `request_token` and
+    /// `guest_session_id` are included because TMDb accepts them as query items
+    /// elsewhere and they are bearer-like in exactly the same way.
+    private static let credentialQueryItemNames: Set<String> = [
+        "api_key",
+        "session_id",
+        "request_token",
+        "guest_session_id"
+    ]
+
+    /// The `userInfo` key holding the failing request's URL.
+    private static let failingURLKey = NSURLErrorFailingURLErrorKey
+
+    /// The `userInfo` key holding the failing request's URL as a string.
+    ///
+    /// Spelled as a literal because the Foundation constant for it,
+    /// `NSURLErrorFailingURLStringErrorKey`, is deprecated from macOS 15.4 and
+    /// this package builds warnings-as-errors — naming it fails the build. The
+    /// literal is the key the runtime populates, on Darwin and on Linux.
+    private static let failingURLStringKey = "NSErrorFailingURLStringKey"
+
+    /// `userInfo` keys copied verbatim onto a rebuilt error.
+    ///
+    /// These hold human-readable text, never a URL, so a consumer's
+    /// `localizedDescription` survives redaction unchanged.
+    private static let preservedKeys = [
+        NSLocalizedDescriptionKey,
+        NSLocalizedFailureReasonErrorKey,
+        NSLocalizedRecoverySuggestionErrorKey
+    ]
+
+    ///
+    /// Returns `error` with any credential removed from the failing URL its
+    /// `userInfo` carries.
+    ///
+    /// - Parameter error: The transport error about to be wrapped.
+    ///
+    /// - Returns: The same instance when nothing needed redacting; otherwise an
+    ///   `NSError` with the same `domain` and `code` and a redacted `userInfo`.
+    ///
+    static func redact(_ error: Error) -> Error {
+        let nsError = error as NSError
+        let userInfo = nsError.userInfo
+        guard !userInfo.isEmpty else {
+            return error
+        }
+
+        let original = urlString(from: userInfo[failingURLKey])
+        let originalString = urlString(from: userInfo[failingURLStringKey])
+
+        let redacted = original.flatMap(redacting)
+        let redactedString = originalString.flatMap(redacting)
+
+        guard redacted != nil || redactedString != nil else {
+            return error
+        }
+
+        var redactedUserInfo: [String: Any] = [:]
+        for key in preservedKeys {
+            if let value = userInfo[key] {
+                redactedUserInfo[key] = value
+            }
+        }
+
+        // A value that needed no redaction is carried over as it was; one that
+        // cannot be rebuilt into a URL is dropped rather than passed through.
+        if let value = redacted ?? original, let url = URL(string: value) {
+            redactedUserInfo[failingURLKey] = url
+        }
+
+        if let value = redactedString ?? originalString {
+            redactedUserInfo[failingURLStringKey] = value
+        }
+
+        return NSError(domain: nsError.domain, code: nsError.code, userInfo: redactedUserInfo)
+    }
+
+}
+
+extension NetworkErrorRedactor {
+
+    ///
+    /// Reads a `userInfo` value that should hold a URL.
+    ///
+    /// Both the `URL`/`String` and the `NSURL`/`NSString` forms are accepted: a
+    /// `URLSession` error stores the Objective-C types on Darwin, and a
+    /// `String`-only cast would silently match nothing — a fail-*open* that no
+    /// assertion about an absent credential could detect.
+    ///
+    private static func urlString(from value: Any?) -> String? {
+        switch value {
+        case let value as URL:
+            value.absoluteString
+
+        case let value as String:
+            value
+
+        case let value as NSURL:
+            value.absoluteString
+
+        default:
+            (value as? NSString) as String?
+        }
+    }
+
+    ///
+    /// Returns the redacted form of a failing URL, or `nil` when it carries
+    /// nothing that needs redacting.
+    ///
+    private static func redacting(_ value: String) -> String? {
+        guard var components = URLComponents(string: value) else {
+            // Foundation built this string from a URL of its own, so it should
+            // always parse. That it did not means we cannot show it carries no
+            // credential — fail closed rather than pass it through.
+            return placeholder
+        }
+
+        var didRedact = false
+
+        // `percentEncodedQueryItems`, never `queryItems`: the plain accessor
+        // round-trips a literal `%2B` into `+`, so redacting the credential
+        // would silently corrupt an unrelated `query=` beside it.
+        if var queryItems = components.percentEncodedQueryItems {
+            for index in queryItems.indices
+                where credentialQueryItemNames.contains(queryItems[index].name.lowercased())
+                && queryItems[index].value != nil {
+                queryItems[index].value = placeholder
+                didRedact = true
+            }
+
+            if didRedact {
+                components.percentEncodedQueryItems = queryItems
+            }
+        }
+
+        if let path = redactingPath(components.percentEncodedPath) {
+            components.percentEncodedPath = path
+            didRedact = true
+        }
+
+        guard didRedact else {
+            return nil
+        }
+
+        return components.url?.absoluteString ?? placeholder
+    }
+
+    ///
+    /// Returns the path with a token-bearing identifier segment replaced, or
+    /// `nil` when it holds none.
+    ///
+    /// The failing URL is absolute, so its path begins with the API version
+    /// (`/3` or `/4`) where ``EndpointPathRedactor`` expects the endpoint name.
+    /// Handing it over unstripped makes the first segment `"3"`, the classifier
+    /// match nothing, and the whole redaction a silent no-op that a test fed a
+    /// bare path would never catch.
+    ///
+    private static func redactingPath(_ path: String) -> String? {
+        var segments = path.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+
+        // The endpoint sits after the version prefix; without one, there is no
+        // library-built path here to reason about.
+        guard segments.count >= 3, EndpointPathRedactor.placeholder(forEndpoint: segments[1]) != nil
+        else {
+            return nil
+        }
+
+        segments[2] = placeholder
+
+        return "/\(segments.joined(separator: "/"))"
+    }
+
+}

--- a/Sources/TMDb/Networking/TMDbAPIClient.swift
+++ b/Sources/TMDb/Networking/TMDbAPIClient.swift
@@ -44,7 +44,11 @@ final class TMDbAPIClient: UnmappedAPIClient {
                 throw TMDbAPIError.cancelled
             }
 
-            throw TMDbAPIError.network(error)
+            // Redacted for the same reason as `TMDbErrorContext.endpointPath`:
+            // this error reaches a public case a caller may log, and a
+            // `URLSession` failure carries the whole request URL — `api_key`
+            // and all — in its `userInfo`.
+            throw TMDbAPIError.network(NetworkErrorRedactor.redact(error))
         }
 
         try await validate(response: httpResponse, with: serialiser, path: request.path)

--- a/Sources/TMDb/Networking/TMDbAPIError.swift
+++ b/Sources/TMDb/Networking/TMDbAPIError.swift
@@ -23,6 +23,10 @@ enum TMDbAPIError: Error, Equatable {
     ///
     /// Network error.
     ///
+    /// The associated value is redacted by ``NetworkErrorRedactor``: a
+    /// `URLSession` failure carries the failing request's whole URL — `api_key`
+    /// included — in its `userInfo`.
+    ///
     case network(Error)
 
     ///

--- a/Sources/TMDb/TMDb.docc/HowTos/HandlingErrors.md
+++ b/Sources/TMDb/TMDb.docc/HowTos/HandlingErrors.md
@@ -28,7 +28,7 @@ case.
 | ``TMDbError/serverError(_:)`` | TMDb reported a server-side failure (HTTP 5xx). |
 | ``TMDbError/invalidURL(_:)`` | A request URL could not be constructed from the given value, or was rejected as unsafe. A path segment that could resolve to a different endpoint — an identifier containing `/` or `..` — is refused on-device, before any request is sent. |
 | ``TMDbError/encode(_:)`` | A request body could not be encoded. The underlying error is attached. |
-| ``TMDbError/network(_:)`` | The request never completed — offline, timed out, or a DNS / connection failure. The underlying error is attached. |
+| ``TMDbError/network(_:)`` | The request never completed — offline, timed out, or a DNS / connection failure. The underlying error is attached, with your credentials redacted. |
 | ``TMDbError/decode(_:)`` | A response was received but could not be decoded into the expected model. The underlying error is attached. |
 | ``TMDbError/invalidRating`` | A rating passed to an `addRating` method is out of range; it must be between `0.5` and `10.0` in increments of `0.5`. Validated on-device before any request is sent. |
 | ``TMDbError/cancelled`` | The task performing the request was cancelled — see <doc:#Cancellation>. |
@@ -63,6 +63,20 @@ do {
 - Note: ``TMDbErrorContext/endpointPath`` is safe to log — token-bearing path
   segments such as a guest session id or account id are redacted to a
   placeholder before the error leaves the library.
+
+The error attached to ``TMDbError/network(_:)`` is safe to log for the same
+reason. A `URLSession` failure carries the whole URL of the request that failed
+in its `userInfo`, and for a client created with
+``TMDbClient/init(apiKey:configuration:)`` that URL contains your `api_key`. The
+value of any credential-bearing query item, and any guest session id or account
+id in the path, is replaced with `REDACTED` before the error is attached.
+
+The error keeps its `domain`, `code` and `localizedDescription`, so anything you
+branch on is unaffected; the other diagnostic `userInfo` entries are dropped,
+because they can nest a second copy of the same URL. An error with nothing to
+redact — including one thrown by your own ``HTTPClient`` — is attached exactly as
+it was raised, so `catch TMDbError.network(let error as MyTransportError)` keeps
+matching.
 
 ## Catching Errors
 

--- a/Tests/TMDbTests/Networking/NetworkErrorRedactionEndToEndTests.swift
+++ b/Tests/TMDbTests/Networking/NetworkErrorRedactionEndToEndTests.swift
@@ -1,0 +1,240 @@
+//
+//  NetworkErrorRedactionEndToEndTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+///
+/// The credential redaction of ``NetworkErrorRedactor`` seen from outside: at
+/// the ``TMDbAPIClient`` wrap site, through the whole public stack, and against
+/// a `URLSession` failure nobody in this suite constructed.
+///
+@Suite(.tags(.networking))
+struct NetworkErrorRedactionEndToEndTests {
+
+    private static let failingURLStringKey = "NSErrorFailingURLStringKey"
+
+    private static func transportError(url urlString: String) -> NSError {
+        guard let url = URL(string: urlString) else {
+            preconditionFailure("Test URL is not parseable.")
+        }
+
+        return NSError(
+            domain: NSURLErrorDomain,
+            code: NSURLErrorTimedOut,
+            userInfo: [
+                NSURLErrorFailingURLErrorKey: url,
+                failingURLStringKey: url.absoluteString,
+                NSLocalizedDescriptionKey: "The request timed out."
+            ]
+        )
+    }
+
+    @Test("a transport failure carrying a credential is wrapped with it redacted")
+    @MainActor
+    func transportFailureCarryingCredentialIsWrappedRedacted() async throws {
+        let httpClient = HTTPMockClient()
+        let apiClient = try TMDbAPIClient(
+            credential: .apiKey("abc123secret"),
+            baseURL: #require(URL(string: "https://some.domain.com/3")),
+            serialiser: TMDbJSONSerialiser(),
+            httpClient: httpClient
+        )
+        httpClient.result = .failure(
+            Self.transportError(url: "https://some.domain.com/3/movie/550?api_key=abc123secret")
+        )
+
+        var thrown: Error?
+        do {
+            _ = try await apiClient.perform(APIStubRequest<String, String>(path: "/movie/550"))
+        } catch let error {
+            thrown = error
+        }
+
+        let error = try #require(thrown as? TMDbAPIError)
+        guard case .network(let underlying) = error else {
+            Issue.record("Expected a .network error, got \(error).")
+            return
+        }
+
+        #expect(!String(describing: (underlying as NSError).userInfo).contains("abc123secret"))
+    }
+
+    @Test("a transport failure with nothing to redact keeps its own error type")
+    @MainActor
+    func transportFailureWithNothingToRedactKeepsItsType() async throws {
+        let httpClient = HTTPMockClient()
+        let apiClient = try TMDbAPIClient(
+            credential: .apiKey("abc123secret"),
+            baseURL: #require(URL(string: "https://some.domain.com/3")),
+            serialiser: TMDbJSONSerialiser(),
+            httpClient: httpClient
+        )
+        httpClient.result = .failure(StubTransportFailure.offline)
+
+        var thrown: Error?
+        do {
+            _ = try await apiClient.perform(APIStubRequest<String, String>(path: "/movie/550"))
+        } catch let error {
+            thrown = error
+        }
+
+        let error = try #require(thrown as? TMDbAPIError)
+        guard case .network(let underlying) = error else {
+            Issue.record("Expected a .network error, got \(error).")
+            return
+        }
+
+        // A consumer-supplied `HTTPClient` throws its own error type, and
+        // `catch TMDbError.network(let error as MyTransportError)` must keep
+        // matching after this change.
+        #expect(underlying as? StubTransportFailure == .offline)
+        #expect(underlying.localizedDescription == "The stub transport is offline.")
+    }
+
+    @Test("the public TMDbError.network surfaced by TMDbClient carries no api_key")
+    func publicNetworkErrorCarriesNoAPIKey() async throws {
+        let apiKey = "public-stack-secret"
+
+        // Not `MockURLProtocol`: its `lastRequest` is process-global and other
+        // suites drive it concurrently, so reading it back here passes alone and
+        // fails in the parallel run. This protocol keeps no cross-test state —
+        // it builds the failure from the request in front of it, the way
+        // `URLSession` itself does.
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [EchoingFailureURLProtocol.self]
+
+        let client = TMDbClient(
+            apiKey: apiKey,
+            httpClient: URLSessionHTTPClientAdapter(urlSession: URLSession(configuration: configuration))
+        )
+
+        var thrown: (any Error)?
+        do {
+            _ = try await client.movies.details(forMovie: 550)
+        } catch let error {
+            thrown = error
+        }
+
+        let error = try #require(thrown as? TMDbError)
+        guard case .network(let underlying) = error else {
+            Issue.record("Expected a .network error, got \(error).")
+            return
+        }
+
+        // Closes the loop. The failing URL came from the request the client
+        // actually sent, so the credential provably WAS in it — an "absent"
+        // assertion over a URL this test invented would prove nothing.
+        #expect(EchoingFailureURLProtocol.observedURL(containing: apiKey))
+
+        #expect(!String(describing: (underlying as NSError).userInfo).contains(apiKey))
+        #expect(!underlying.localizedDescription.contains(apiKey))
+    }
+
+    @Test("URLSession still reports the failing URL under the keys the redactor reads")
+    func urlSessionStillReportsFailingURLUnderExpectedKeys() async throws {
+        // A characterisation test, not a test of this package: every other test
+        // here builds the `userInfo` it then asserts on, so if Foundation ever
+        // renamed these keys the redactor would silently stop working while
+        // they all stayed green (`knowledge/gotchas.md` — *False green*).
+        //
+        // Port 1 on loopback refuses immediately: no DNS, no internet, no
+        // credential, and no dependence on a live TMDb.
+        let url = try #require(URL(string: "http://127.0.0.1:1/probe?api_key=characterisation-secret"))
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 5
+        let session = URLSession(configuration: configuration)
+
+        var thrown: Error?
+        do {
+            _ = try await session.data(from: url)
+        } catch let error {
+            thrown = error
+        }
+
+        // Asserted as PRESENCE, deliberately. An "the credential is absent"
+        // assertion here would pass just as happily against a failure carrying
+        // no URL at all, proving nothing.
+        let error = try #require(thrown as NSError?)
+        let userInfo = error.userInfo
+        #expect(userInfo[NSURLErrorFailingURLErrorKey] != nil)
+        #expect(userInfo[Self.failingURLStringKey] != nil)
+        #expect(String(describing: userInfo).contains("characterisation-secret"))
+
+        // And the redactor removes it from exactly that shape.
+        let redacted = NetworkErrorRedactor.redact(error)
+        #expect(!String(describing: (redacted as NSError).userInfo).contains("characterisation-secret"))
+    }
+
+}
+
+///
+/// A `URLProtocol` that fails every request with an `NSError` shaped the way
+/// `URLSession` shapes one — carrying the **request's own** URL under the
+/// failing-URL keys.
+///
+/// Deriving the failure from the request is what makes the end-to-end assertion
+/// meaningful: the credential in the redacted error demonstrably came from the
+/// client, not from the test.
+///
+private final class EchoingFailureURLProtocol: URLProtocol, @unchecked Sendable {
+
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var unsafeObservedURLs: [String] = []
+
+    /// Whether any request seen by this protocol carried `value` in its URL.
+    static func observedURL(containing value: String) -> Bool {
+        lock.withLock { unsafeObservedURLs.contains { $0.contains(value) } }
+    }
+
+    override static func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+
+        Self.lock.withLock { Self.unsafeObservedURLs.append(url.absoluteString) }
+
+        let error = NSError(
+            domain: NSURLErrorDomain,
+            code: NSURLErrorTimedOut,
+            userInfo: [
+                NSURLErrorFailingURLErrorKey: url,
+                "NSErrorFailingURLStringKey": url.absoluteString,
+                NSLocalizedDescriptionKey: "The request timed out."
+            ]
+        )
+
+        client?.urlProtocol(self, didFailWithError: error)
+    }
+
+    override func stopLoading() {}
+
+}
+
+private enum StubTransportFailure: Error, LocalizedError, Equatable {
+
+    case offline
+
+    var errorDescription: String? {
+        "The stub transport is offline."
+    }
+
+}

--- a/Tests/TMDbTests/Networking/NetworkErrorRedactionEndToEndTests.swift
+++ b/Tests/TMDbTests/Networking/NetworkErrorRedactionEndToEndTests.swift
@@ -23,10 +23,8 @@ struct NetworkErrorRedactionEndToEndTests {
 
     private static let failingURLStringKey = "NSErrorFailingURLStringKey"
 
-    private static func transportError(url urlString: String) -> NSError {
-        guard let url = URL(string: urlString) else {
-            preconditionFailure("Test URL is not parseable.")
-        }
+    private static func transportError(url urlString: String) throws -> NSError {
+        let url = try #require(URL(string: urlString))
 
         return NSError(
             domain: NSURLErrorDomain,
@@ -49,7 +47,7 @@ struct NetworkErrorRedactionEndToEndTests {
             serialiser: TMDbJSONSerialiser(),
             httpClient: httpClient
         )
-        httpClient.result = .failure(
+        httpClient.result = try .failure(
             Self.transportError(url: "https://some.domain.com/3/movie/550?api_key=abc123secret")
         )
 

--- a/Tests/TMDbTests/Networking/NetworkErrorRedactionEndToEndTests.swift
+++ b/Tests/TMDbTests/Networking/NetworkErrorRedactionEndToEndTests.swift
@@ -138,6 +138,66 @@ struct NetworkErrorRedactionEndToEndTests {
         #expect(!underlying.localizedDescription.contains(apiKey))
     }
 
+    @Test("a bearer-token client's transport failure never carries the token, and is not rebuilt")
+    func bearerTokenClientTransportFailureIsUntouched() async throws {
+        let bearerToken = "bearer-stack-secret"
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [EchoingFailureURLProtocol.self]
+
+        let client = TMDbClient(
+            bearerToken: bearerToken,
+            httpClient: URLSessionHTTPClientAdapter(urlSession: URLSession(configuration: configuration))
+        )
+
+        var thrown: (any Error)?
+        do {
+            _ = try await client.movies.details(forMovie: 550)
+        } catch let error {
+            thrown = error
+        }
+
+        let error = try #require(thrown as? TMDbError)
+        guard case .network(let underlying) = error else {
+            Issue.record("Expected a .network error, got \(error).")
+            return
+        }
+
+        // The token was genuinely sent — as a header, never in the URL. That is
+        // why it is not at risk here, and asserting it makes the point testable
+        // rather than merely stated.
+        #expect(EchoingFailureURLProtocol.observedHeader(containing: bearerToken))
+        #expect(!EchoingFailureURLProtocol.observedURL(containing: bearerToken))
+
+        #expect(!String(describing: (underlying as NSError).userInfo).contains(bearerToken))
+
+        // `/3/movie/550` carries no credential query item and no token-bearing
+        // path segment, so there is nothing to redact and the error is passed
+        // through untouched — diagnostics intact.
+        let nsError = underlying as NSError
+        #expect(nsError.userInfo[NSURLErrorFailingURLErrorKey] != nil)
+        #expect(nsError.domain == NSURLErrorDomain)
+    }
+
+    @Test("a bearer-token client is not exempt: an account-path failure is still redacted")
+    func bearerTokenClientAccountPathIsStillRedacted() throws {
+        // The redaction keys on what is in the URL, not on how the client was
+        // built. A bearer-token client calling a user-scoped v3 endpoint puts an
+        // account id in the path and a `session_id` in the query, so its failure
+        // IS rebuilt — "bearer clients are unaffected" is true of the bearer
+        // token only, and this pins the distinction.
+        let error = try Self.transportError(
+            url: "https://api.themoviedb.org/3/account/9876543/favorite?session_id=sess123secret"
+        )
+
+        let redacted = NetworkErrorRedactor.redact(error)
+
+        let urlString = try #require((redacted as NSError).userInfo[Self.failingURLStringKey] as? String)
+        #expect(!urlString.contains("sess123secret"))
+        #expect(!urlString.contains("9876543"))
+        #expect(urlString.contains("/3/account/REDACTED/favorite"))
+    }
+
     @Test("URLSession still reports the failing URL under the keys the redactor reads")
     func urlSessionStillReportsFailingURLUnderExpectedKeys() async throws {
         // A characterisation test, not a test of this package: every other test
@@ -188,10 +248,16 @@ private final class EchoingFailureURLProtocol: URLProtocol, @unchecked Sendable 
 
     private static let lock = NSLock()
     private nonisolated(unsafe) static var unsafeObservedURLs: [String] = []
+    private nonisolated(unsafe) static var unsafeObservedHeaders: [String] = []
 
     /// Whether any request seen by this protocol carried `value` in its URL.
     static func observedURL(containing value: String) -> Bool {
         lock.withLock { unsafeObservedURLs.contains { $0.contains(value) } }
+    }
+
+    /// Whether any request seen by this protocol carried `value` in a header.
+    static func observedHeader(containing value: String) -> Bool {
+        lock.withLock { unsafeObservedHeaders.contains { $0.contains(value) } }
     }
 
     override static func canInit(with _: URLRequest) -> Bool {
@@ -208,7 +274,11 @@ private final class EchoingFailureURLProtocol: URLProtocol, @unchecked Sendable 
             return
         }
 
-        Self.lock.withLock { Self.unsafeObservedURLs.append(url.absoluteString) }
+        let headers = String(describing: request.allHTTPHeaderFields ?? [:])
+        Self.lock.withLock {
+            Self.unsafeObservedURLs.append(url.absoluteString)
+            Self.unsafeObservedHeaders.append(headers)
+        }
 
         let error = NSError(
             domain: NSURLErrorDomain,

--- a/Tests/TMDbTests/Networking/NetworkErrorRedactorTests.swift
+++ b/Tests/TMDbTests/Networking/NetworkErrorRedactorTests.swift
@@ -1,0 +1,249 @@
+//
+//  NetworkErrorRedactorTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+@Suite(.tags(.networking))
+struct NetworkErrorRedactorTests {
+
+    /// The literal, not `NSURLErrorFailingURLStringErrorKey`: that symbol is
+    /// deprecated from macOS 15.4 and the package builds warnings-as-errors, so
+    /// naming it fails the build. This is the key the runtime populates.
+    static let failingURLStringKey = "NSErrorFailingURLStringKey"
+
+    static func transportError(
+        url urlString: String,
+        code: Int = NSURLErrorTimedOut,
+        extra: [String: Any] = [:]
+    ) -> NSError {
+        guard let url = URL(string: urlString) else {
+            preconditionFailure("Test URL is not parseable.")
+        }
+
+        var userInfo: [String: Any] = [
+            NSURLErrorFailingURLErrorKey: url,
+            failingURLStringKey: url.absoluteString,
+            NSLocalizedDescriptionKey: "The request timed out."
+        ]
+        userInfo.merge(extra) { _, new in new }
+
+        return NSError(domain: NSURLErrorDomain, code: code, userInfo: userInfo)
+    }
+
+    static func failingURLString(of error: Error) -> String? {
+        (error as NSError).userInfo[failingURLStringKey] as? String
+    }
+
+    static func failingURL(of error: Error) -> URL? {
+        (error as NSError).userInfo[NSURLErrorFailingURLErrorKey] as? URL
+    }
+
+    @Test("redacts the api_key value in the URL-valued failing-URL entry")
+    func redactsAPIKeyInURLValuedEntry() throws {
+        let error = Self.transportError(url: "https://api.themoviedb.org/3/movie/550?api_key=abc123secret")
+
+        let redacted = NetworkErrorRedactor.redact(error)
+
+        let url = try #require(Self.failingURL(of: redacted))
+        #expect(!url.absoluteString.contains("abc123secret"))
+        #expect(url.absoluteString.contains("api_key=REDACTED"))
+    }
+
+    @Test("redacts the api_key value in the String-valued failing-URL entry")
+    func redactsAPIKeyInStringValuedEntry() throws {
+        let error = Self.transportError(url: "https://api.themoviedb.org/3/movie/550?api_key=abc123secret")
+
+        let redacted = NetworkErrorRedactor.redact(error)
+
+        let urlString = try #require(Self.failingURLString(of: redacted))
+        #expect(!urlString.contains("abc123secret"))
+        #expect(urlString.contains("api_key=REDACTED"))
+    }
+
+    @Test("redacts the session_id value")
+    func redactsSessionID() throws {
+        let error = Self.transportError(
+            url: "https://api.themoviedb.org/3/account/12345/favorite?api_key=key&session_id=sess123secret"
+        )
+
+        let redacted = NetworkErrorRedactor.redact(error)
+
+        let urlString = try #require(Self.failingURLString(of: redacted))
+        #expect(!urlString.contains("sess123secret"))
+        #expect(urlString.contains("session_id=REDACTED"))
+    }
+
+    @Test("redacts a guest session id path segment behind the version prefix")
+    func redactsGuestSessionIDPathSegment() throws {
+        let error = Self.transportError(
+            url: "https://api.themoviedb.org/3/guest_session/gs123secret/rated/movies?api_key=key"
+        )
+
+        let redacted = NetworkErrorRedactor.redact(error)
+
+        let urlString = try #require(Self.failingURLString(of: redacted))
+        #expect(!urlString.contains("gs123secret"))
+        #expect(urlString.contains("/3/guest_session/REDACTED/rated/movies"))
+    }
+
+    @Test("redacts an account id path segment behind the version prefix")
+    func redactsAccountIDPathSegment() throws {
+        let error = Self.transportError(
+            url: "https://api.themoviedb.org/3/account/9876543/favorite?api_key=key"
+        )
+
+        let redacted = NetworkErrorRedactor.redact(error)
+
+        let urlString = try #require(Self.failingURLString(of: redacted))
+        #expect(!urlString.contains("9876543"))
+        #expect(urlString.contains("/3/account/REDACTED/favorite"))
+    }
+
+    @Test("leaves a non-credential query item byte-identical, including a literal %2B")
+    func leavesNonCredentialQueryItemsUntouched() throws {
+        // `queryItems` — as opposed to `percentEncodedQueryItems` — decodes
+        // `%2B` to `+` on the way back out, silently corrupting a search term
+        // while redacting the credential beside it.
+        let error = Self.transportError(
+            url: "https://api.themoviedb.org/3/search/movie?api_key=abc123secret&query=Star%2BWars&language=en-GB"
+        )
+
+        let redacted = NetworkErrorRedactor.redact(error)
+
+        let urlString = try #require(Self.failingURLString(of: redacted))
+        #expect(urlString.contains("query=Star%2BWars"))
+        #expect(urlString.contains("language=en-GB"))
+    }
+
+    @Test("keeps the localized description byte-identical")
+    func keepsLocalizedDescription() {
+        let error = Self.transportError(url: "https://api.themoviedb.org/3/movie/550?api_key=abc123secret")
+
+        let redacted = NetworkErrorRedactor.redact(error)
+
+        #expect((redacted as NSError).localizedDescription == error.localizedDescription)
+        #expect((redacted as NSError).localizedDescription == "The request timed out.")
+    }
+
+    @Test("preserves the domain and code")
+    func preservesDomainAndCode() {
+        let error = Self.transportError(
+            url: "https://api.themoviedb.org/3/movie/550?api_key=abc123secret",
+            code: NSURLErrorNotConnectedToInternet
+        )
+
+        let redacted = NetworkErrorRedactor.redact(error) as NSError
+
+        #expect(redacted.domain == NSURLErrorDomain)
+        #expect(redacted.code == NSURLErrorNotConnectedToInternet)
+    }
+
+    @Test("drops a nested underlying error rather than trying to scrub it")
+    func dropsNestedUnderlyingError() {
+        // A real `URLSession` failure nests an `NSError` with a `userInfo` of
+        // its own, and an array of `URLSessionTask`s each holding the original
+        // request. Walking every value that might nest a URL is unbounded, so a
+        // rebuilt error copies forward only the keys whose contents are known.
+        let underlying = NSError(
+            domain: "kCFErrorDomainCFNetwork",
+            code: 1,
+            userInfo: [Self.failingURLStringKey: "https://api.themoviedb.org/3/movie/550?api_key=abc123secret"]
+        )
+        let error = Self.transportError(
+            url: "https://api.themoviedb.org/3/movie/550?api_key=abc123secret",
+            extra: [NSUnderlyingErrorKey: underlying]
+        )
+
+        let redacted = NetworkErrorRedactor.redact(error)
+
+        #expect((redacted as NSError).userInfo[NSUnderlyingErrorKey] == nil)
+        #expect(!String(describing: (redacted as NSError).userInfo).contains("abc123secret"))
+    }
+
+    @Test("returns the original instance when a custom error needs no redaction")
+    func returnsOriginalInstanceForCustomError() {
+        // A consumer may supply their own `HTTPClient`, so the value being
+        // wrapped is often their own error type. Rebuilding it as an `NSError`
+        // would erase that type and degrade its message.
+        let error = StubTransportError.offline
+
+        let redacted = NetworkErrorRedactor.redact(error)
+
+        #expect(redacted as? StubTransportError == .offline)
+        #expect(redacted.localizedDescription == "The stub transport is offline.")
+    }
+
+    @Test("returns the original error when its userInfo is empty")
+    func returnsOriginalErrorWhenUserInfoIsEmpty() {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)
+
+        let redacted = NetworkErrorRedactor.redact(error) as NSError
+
+        #expect(redacted === error)
+    }
+
+    @Test("reads an NSURL-valued entry as well as a URL-valued one")
+    func readsNSURLValuedEntry() throws {
+        // `URLSession` stores the Objective-C types on Darwin. A `URL`-only
+        // cast that silently matched nothing would be a fail-open no assertion
+        // about an absent credential could detect.
+        let urlString = "https://api.themoviedb.org/3/movie/550?api_key=abc123secret"
+        let nsURL = try #require(NSURL(string: urlString))
+        let error = NSError(
+            domain: NSURLErrorDomain,
+            code: NSURLErrorTimedOut,
+            userInfo: [NSURLErrorFailingURLErrorKey: nsURL]
+        )
+
+        let redacted = NetworkErrorRedactor.redact(error)
+
+        let url = try #require(Self.failingURL(of: redacted))
+        #expect(!url.absoluteString.contains("abc123secret"))
+    }
+
+    @Test("leaves a credential-free failing URL untouched")
+    func leavesCredentialFreeURLUntouched() {
+        let error = Self.transportError(url: "https://api.themoviedb.org/3/movie/550?language=en-GB")
+
+        let redacted = NetworkErrorRedactor.redact(error) as NSError
+
+        #expect(redacted === error)
+    }
+
+    #if !canImport(FoundationNetworking)
+        @Test("a redacted error still bridges to URLError")
+        func redactedErrorStillBridgesToURLError() throws {
+            // Darwin only: swift-corelibs-foundation hands back an `NSError` in
+            // `NSURLErrorDomain` that need not bridge to `URLError` — which is
+            // why `domain`/`code` preservation, asserted above, is the
+            // cross-platform property. See `Error+Cancellation.swift`.
+            let error = Self.transportError(url: "https://api.themoviedb.org/3/movie/550?api_key=abc123secret")
+
+            let redacted = NetworkErrorRedactor.redact(error)
+
+            let urlError = try #require(redacted as? URLError)
+            #expect(urlError.code == .timedOut)
+        }
+    #endif
+
+}
+
+private enum StubTransportError: Error, LocalizedError, Equatable {
+
+    case offline
+
+    var errorDescription: String? {
+        "The stub transport is offline."
+    }
+
+}

--- a/Tests/TMDbTests/Networking/NetworkErrorRedactorTests.swift
+++ b/Tests/TMDbTests/Networking/NetworkErrorRedactorTests.swift
@@ -25,10 +25,8 @@ struct NetworkErrorRedactorTests {
         url urlString: String,
         code: Int = NSURLErrorTimedOut,
         extra: [String: Any] = [:]
-    ) -> NSError {
-        guard let url = URL(string: urlString) else {
-            preconditionFailure("Test URL is not parseable.")
-        }
+    ) throws -> NSError {
+        let url = try #require(URL(string: urlString))
 
         var userInfo: [String: Any] = [
             NSURLErrorFailingURLErrorKey: url,
@@ -50,7 +48,7 @@ struct NetworkErrorRedactorTests {
 
     @Test("redacts the api_key value in the URL-valued failing-URL entry")
     func redactsAPIKeyInURLValuedEntry() throws {
-        let error = Self.transportError(url: "https://api.themoviedb.org/3/movie/550?api_key=abc123secret")
+        let error = try Self.transportError(url: "https://api.themoviedb.org/3/movie/550?api_key=abc123secret")
 
         let redacted = NetworkErrorRedactor.redact(error)
 
@@ -61,7 +59,7 @@ struct NetworkErrorRedactorTests {
 
     @Test("redacts the api_key value in the String-valued failing-URL entry")
     func redactsAPIKeyInStringValuedEntry() throws {
-        let error = Self.transportError(url: "https://api.themoviedb.org/3/movie/550?api_key=abc123secret")
+        let error = try Self.transportError(url: "https://api.themoviedb.org/3/movie/550?api_key=abc123secret")
 
         let redacted = NetworkErrorRedactor.redact(error)
 
@@ -70,22 +68,65 @@ struct NetworkErrorRedactorTests {
         #expect(urlString.contains("api_key=REDACTED"))
     }
 
-    @Test("redacts the session_id value")
-    func redactsSessionID() throws {
-        let error = Self.transportError(
-            url: "https://api.themoviedb.org/3/account/12345/favorite?api_key=key&session_id=sess123secret"
+    @Test(
+        "redacts every credential-named query item, whatever its casing",
+        arguments: ["api_key", "session_id", "request_token", "guest_session_id", "API_KEY", "Session_ID"]
+    )
+    func redactsCredentialNamedQueryItem(name: String) throws {
+        let error = try Self.transportError(
+            url: "https://api.themoviedb.org/3/movie/550?\(name)=abc123secret"
+        )
+
+        let redacted = NetworkErrorRedactor.redact(error)
+
+        let urlString = try #require(Self.failingURLString(of: redacted))
+        #expect(!urlString.contains("abc123secret"))
+        #expect(urlString.contains("\(name)=REDACTED"))
+    }
+
+    @Test("redacts a credential alongside the client's own api_key")
+    func redactsSessionIDAlongsideAPIKey() throws {
+        let error = try Self.transportError(
+            url: "https://api.themoviedb.org/3/account/12345/favorite?api_key=key123secret&session_id=sess123secret"
         )
 
         let redacted = NetworkErrorRedactor.redact(error)
 
         let urlString = try #require(Self.failingURLString(of: redacted))
         #expect(!urlString.contains("sess123secret"))
+        #expect(!urlString.contains("key123secret"))
         #expect(urlString.contains("session_id=REDACTED"))
+        #expect(urlString.contains("api_key=REDACTED"))
+    }
+
+    @Test("replaces an unparseable failing URL wholesale rather than passing it through")
+    func replacesUnparseableFailingURLWholesale() {
+        // The fail-closed default, and the one branch where the safe answer and
+        // the tidy answer differ: a string `URLComponents` cannot parse cannot
+        // be shown to be credential-free, so it is dropped entirely rather than
+        // returned as-is. Every other test here feeds a well-formed URL, so
+        // flipping this to fail *open* would leave them all green.
+        let unparseable = "http://[bad/x?api_key=abc123secret"
+
+        // Self-verifying: if Foundation ever starts accepting this, the test
+        // says so instead of quietly exercising the parseable path.
+        #expect(URLComponents(string: unparseable) == nil)
+
+        let error = NSError(
+            domain: NSURLErrorDomain,
+            code: NSURLErrorTimedOut,
+            userInfo: [Self.failingURLStringKey: unparseable]
+        )
+
+        let redacted = NetworkErrorRedactor.redact(error)
+
+        #expect(Self.failingURLString(of: redacted) == "REDACTED")
+        #expect(!String(describing: (redacted as NSError).userInfo).contains("abc123secret"))
     }
 
     @Test("redacts a guest session id path segment behind the version prefix")
     func redactsGuestSessionIDPathSegment() throws {
-        let error = Self.transportError(
+        let error = try Self.transportError(
             url: "https://api.themoviedb.org/3/guest_session/gs123secret/rated/movies?api_key=key"
         )
 
@@ -98,7 +139,7 @@ struct NetworkErrorRedactorTests {
 
     @Test("redacts an account id path segment behind the version prefix")
     func redactsAccountIDPathSegment() throws {
-        let error = Self.transportError(
+        let error = try Self.transportError(
             url: "https://api.themoviedb.org/3/account/9876543/favorite?api_key=key"
         )
 
@@ -114,7 +155,7 @@ struct NetworkErrorRedactorTests {
         // `queryItems` — as opposed to `percentEncodedQueryItems` — decodes
         // `%2B` to `+` on the way back out, silently corrupting a search term
         // while redacting the credential beside it.
-        let error = Self.transportError(
+        let error = try Self.transportError(
             url: "https://api.themoviedb.org/3/search/movie?api_key=abc123secret&query=Star%2BWars&language=en-GB"
         )
 
@@ -126,8 +167,8 @@ struct NetworkErrorRedactorTests {
     }
 
     @Test("keeps the localized description byte-identical")
-    func keepsLocalizedDescription() {
-        let error = Self.transportError(url: "https://api.themoviedb.org/3/movie/550?api_key=abc123secret")
+    func keepsLocalizedDescription() throws {
+        let error = try Self.transportError(url: "https://api.themoviedb.org/3/movie/550?api_key=abc123secret")
 
         let redacted = NetworkErrorRedactor.redact(error)
 
@@ -136,8 +177,8 @@ struct NetworkErrorRedactorTests {
     }
 
     @Test("preserves the domain and code")
-    func preservesDomainAndCode() {
-        let error = Self.transportError(
+    func preservesDomainAndCode() throws {
+        let error = try Self.transportError(
             url: "https://api.themoviedb.org/3/movie/550?api_key=abc123secret",
             code: NSURLErrorNotConnectedToInternet
         )
@@ -149,7 +190,7 @@ struct NetworkErrorRedactorTests {
     }
 
     @Test("drops a nested underlying error rather than trying to scrub it")
-    func dropsNestedUnderlyingError() {
+    func dropsNestedUnderlyingError() throws {
         // A real `URLSession` failure nests an `NSError` with a `userInfo` of
         // its own, and an array of `URLSessionTask`s each holding the original
         // request. Walking every value that might nest a URL is unbounded, so a
@@ -159,7 +200,7 @@ struct NetworkErrorRedactorTests {
             code: 1,
             userInfo: [Self.failingURLStringKey: "https://api.themoviedb.org/3/movie/550?api_key=abc123secret"]
         )
-        let error = Self.transportError(
+        let error = try Self.transportError(
             url: "https://api.themoviedb.org/3/movie/550?api_key=abc123secret",
             extra: [NSUnderlyingErrorKey: underlying]
         )
@@ -212,8 +253,8 @@ struct NetworkErrorRedactorTests {
     }
 
     @Test("leaves a credential-free failing URL untouched")
-    func leavesCredentialFreeURLUntouched() {
-        let error = Self.transportError(url: "https://api.themoviedb.org/3/movie/550?language=en-GB")
+    func leavesCredentialFreeURLUntouched() throws {
+        let error = try Self.transportError(url: "https://api.themoviedb.org/3/movie/550?language=en-GB")
 
         let redacted = NetworkErrorRedactor.redact(error) as NSError
 
@@ -227,7 +268,7 @@ struct NetworkErrorRedactorTests {
             // `NSURLErrorDomain` that need not bridge to `URLError` — which is
             // why `domain`/`code` preservation, asserted above, is the
             // cross-platform property. See `Error+Cancellation.swift`.
-            let error = Self.transportError(url: "https://api.themoviedb.org/3/movie/550?api_key=abc123secret")
+            let error = try Self.transportError(url: "https://api.themoviedb.org/3/movie/550?api_key=abc123secret")
 
             let redacted = NetworkErrorRedactor.redact(error)
 

--- a/knowledge/decisions/0025-redact-transport-error-payload.md
+++ b/knowledge/decisions/0025-redact-transport-error-payload.md
@@ -1,0 +1,103 @@
+# ADR-0025: Redact the transport error carried by `TMDbError.network`
+
+- **Status:** Accepted (in 20.0.0, unreleased)
+- **Date:** 2026-08-20
+- **Deciders:** Adam Young
+
+## Context
+
+`TMDbAPIClient` wraps a transport failure as `TMDbAPIError.network(error)`,
+which [ADR-0001](0001-error-mapping-api-client.md)'s mapping seam turns 1:1 into
+the public `TMDbError.network(_:)`. That associated error is precisely what a
+consumer logs, ships to a crash reporter, or attaches as an analytics
+breadcrumb.
+
+On both Darwin and Linux a `URLSession` failure is an `NSError` whose `userInfo`
+carries the **whole URL of the request that failed**, under `NSErrorFailingURLKey`
+and `NSErrorFailingURLStringKey`. For a client built with `TMDbClient(apiKey:)`
+that URL contains the `api_key` query item, and a user-scoped v3 request adds
+`session_id`. So an ordinary timeout, DNS failure or dropped connection put the
+caller's credential into their logs.
+
+This contradicted a discipline the library had already committed to.
+[ADR-0012](0012-structured-tmdberror-context.md) introduced
+`EndpointPathRedactor` specifically so `TMDbErrorContext.endpointPath` would be
+*safe to log* — it scrubs token-bearing **path** segments. Its own doc comment
+disclaimed the query string, which was true of the value it is given and false
+of the library as a whole: the library scrubbed a session id out of one case
+while handing the API key over in the adjacent one. Issue #434.
+
+## Decision
+
+Redact at the single `.network(_:)` construction site
+(`TMDbAPIClient.perform`), via a new internal `NetworkErrorRedactor`.
+
+- **Read only the two documented failing-URL entries**, by key. Accept the
+  `URL`/`NSURL` and `String`/`NSString` value forms, since Darwin stores the
+  Objective-C types and a `URL`-only cast would match nothing — a fail-*open* no
+  assertion about an absent credential could detect. The string key is spelled
+  as a literal because the Foundation constant for it is deprecated and this
+  package builds warnings-as-errors.
+- **Redact by query-item *name*, not by matching the secret's value** —
+  `api_key`, `session_id`, `request_token`, `guest_session_id`, compared
+  lower-cased — and rewrite through `percentEncodedQueryItems`, because the
+  plain accessor turns a literal `%2B` into `+` and would corrupt an unrelated
+  `query=` beside the credential.
+- **Redact token-bearing path segments too**, sharing one classifier with
+  `EndpointPathRedactor` (`placeholder(forEndpoint:)`) so the two cannot drift.
+  The failing URL is absolute, so the API version prefix is stripped first;
+  without that the classifier sees `"3"` and the redaction is a silent no-op.
+- **Rebuild `userInfo` from an allowlist**, not a scrubbed copy: the localized
+  description keys verbatim plus the two redacted URL entries. Everything else
+  is dropped.
+- **Return the original error instance when nothing needed redacting.**
+- Preserve `domain` and `code` on both paths.
+
+## Consequences
+
+- `TMDbError.network(_:)`'s payload is safe to log, and the library's redaction
+  discipline now covers every credential it can put in a URL.
+- **Breaking, and silently so** — nothing stops compiling. Consumers reading
+  `NSUnderlyingError` or the related-task keys off a network error find them
+  absent. Recorded prominently in `CHANGELOG.md` under 20.0.0.
+- Diagnostics are lost from a *redacted* error only. An error with nothing to
+  redact keeps everything.
+- `domain`, `code` and `localizedDescription` are unchanged, so branching and
+  display are unaffected; on Darwin the rebuilt error still bridges to
+  `URLError`.
+- A consumer-supplied `HTTPClient` throwing its own error type is unaffected:
+  that error has no failing-URL entry, so the original instance is returned and
+  `catch TMDbError.network(let error as MyTransportError)` keeps matching.
+- The credential-name set is a new place to keep current. A TMDb endpoint that
+  starts accepting a credential as some other query item needs a line here.
+
+## Alternatives considered
+
+- **Scrub every `userInfo` value that looks like a URL** — rejected, twice over.
+  It cannot reach a credential nested inside `NSUnderlyingError` or the
+  related-task array, so the "no unknown key can reintroduce the leak"
+  justification is false; and "a `String` that parses as a URL" matches ordinary
+  prose (`URL(string: "The request timed out.")` is non-nil), so writing the
+  value back would percent-mangle the user-facing message. The allowlist is both
+  safer and fewer branches.
+- **Drop the URL entirely** — rejected: the host and endpoint are the most
+  useful part of a transport failure, and they are not secret once the
+  credential is out.
+- **Always rebuild, unconditionally** — rejected: every Swift error bridges to
+  `NSError`, so an unconditional rebuild erases a consumer error's concrete type
+  and degrades its `localizedDescription` to Foundation's generic sentence.
+  `HTTPClient` is a public, consumer-implementable protocol, so this is a real
+  call path, not a hypothetical one.
+- **Redact in `ErrorMappingAPIClient` instead** — rejected: it is the right
+  choke point for *mapping*, but it sees an already-wrapped `TMDbAPIError`, and
+  the redaction wants the raw transport error. The wrap site is one line earlier
+  and equally singular.
+
+## Related
+
+- [ADR-0001](0001-error-mapping-api-client.md) — the mapping choke point this
+  sits one layer beneath.
+- [ADR-0012](0012-structured-tmdberror-context.md) — introduced
+  `EndpointPathRedactor` and the "safe to log" commitment this extends.
+- [ADR-0022](0022-reject-traversal-capable-path-segments.md) — the other
+  credential-in-URL defence at the same client.

--- a/knowledge/decisions/README.md
+++ b/knowledge/decisions/README.md
@@ -42,6 +42,7 @@ always fair game.
 | [0022](0022-reject-traversal-capable-path-segments.md) | Reject traversal-capable path segments at the `TMDbAPIClient` choke point | 2026-08-13 | Accepted (in 20.0.0, unreleased) |
 | [0023](0023-python-strict-parser-for-fixture-hygiene.md) | Enforce fixture hygiene with an independent strict parser, not a Swift test | 2026-08-14 | Accepted (unreleased — tooling only) |
 | [0024](0024-two-way-witness-guard.md) | Keep the defaulted-witness guard, as a two-way completeness oracle | 2026-08-14 | Accepted (in 20.0.0, unreleased) |
+| [0025](0025-redact-transport-error-payload.md) | Redact the transport error carried by `TMDbError.network` | 2026-08-20 | Accepted (in 20.0.0, unreleased) |
 
 > **Keep the Status column true.** "In X, unreleased" becomes "shipped in X" when
 > X is **tagged** — a `CHANGELOG.md` section is not a release. For breaking changes

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -25,6 +25,78 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
 
 ---
 
+## 2026-08-20 — 🔒 Redact credentials from `TMDbError.network`'s payload (PR #TBD) · full
+
+Branch `fix/redact-credentials-in-network-error`. Issue #434 (P0) — item 1 in
+the board's Ready execution order.
+
+- **Phases / skills:** 0–8 pre-PR. Full weight — networking + a public error
+  payload, explicitly non-lite regardless of the diff being small. Skills:
+  `review-plan` (3 critics), `implement-plan`/`canon-tdd`, `review-changes`
+  (5-dimension fan-out + adversarial verify), `security-review`,
+  `capture-knowledge`.
+  `consulted:` gotchas §Networking (*`URL(string:)` rejects almost nothing*,
+  *Percent-encoding is not a traversal defence*, *`percentEncodedPath`'s setter
+  traps*, *`String.contains` compares grapheme clusters*, *Caching a
+  credentialed response*), §Tooling (*the tooling-runner runs in the main
+  checkout*, *Edits can land in the main checkout*), *False green*; ADR-0001,
+  ADR-0012, ADR-0022; plus the personal wiki entry *A diagnostic field added
+  for logging is a publishing surface*, whose closing line already named
+  `URLError.userInfo[NSURLErrorFailingURLErrorKey]` as the uncovered trap —
+  this delivery is that prediction coming true.
+  `reconciled:` 0 in scope / 0 reclaimed / 0 resumable / 0 reported.
+  `swept:` n/a — no infra files in the diff; fallback scan of the neighbouring
+  Networking and Testing entries found nothing invalidated.
+
+- **What worked:** *measuring instead of reasoning*, repeatedly and decisively.
+  Four separate design points were settled by a throwaway `swiftc` probe rather
+  than argument — the deprecated key symbol (a build error, not a style
+  choice), `%2B` corruption, the `/3` prefix defeating a naive
+  `EndpointPathRedactor` delegate, and custom-error identity dying on rebuild.
+  The critics did the same independently, which is why their blockers were
+  actionable rather than speculative. Best single moment: a security-review
+  hypothesis that a bearer token was reachable through the related-task key was
+  **refuted by probe** — the key holds an opaque `String`, not a
+  `URLSessionTask` — which saved a real but unnecessary scope expansion.
+
+- **Friction:**
+  - The plan I took into `/review-plan` was wrong in two structural ways
+    (unconditional rebuild; sweep-by-value-type). Three critics caught both
+    unanimously. Cheap here, expensive if it had reached implementation.
+  - Batching 13 redactor tests into one red/green cycle meant they all went
+    green at once, which is exactly the shape a false green hides in. Cost an
+    extra unwire-and-rerun to prove the fix was load-bearing — worth it, but a
+    tighter loop would not have needed the detour.
+  - `MockURLProtocol`'s process-global statics produced a test that passed
+    under `--filter` and failed in the full run. Captured.
+
+- **Deviations:**
+  - **No new integration test.** All three critics independently argued the
+    planned live-suite test exercised no live behaviour, could pass vacuously
+    (it asserted only absence), and risks the weekly cron opening a spurious
+    PR. Replaced with an offline full-stack test plus a characterisation test
+    that a *real* `URLSession` failure still populates the keys the redactor
+    reads. Deliberate departure from CLAUDE.md's unit-and-integration default,
+    reasoned rather than skipped.
+  - **AC6 was corrected at Phase 6**, not merely fixed. An independent grader
+    marked it not met; the criterion itself was factually wrong ("behaviour is
+    unchanged" for a bearer client, when redaction keys on the URL rather than
+    on how the client was built). The missing test was written and the AC
+    restated, with the original wording and the reason recorded beside it — and
+    a second grader was asked specifically whether that was a legitimate
+    correction or laundering. It ruled correction, on the grounds that the
+    missing evidence was supplied rather than written around.
+
+- **One improvement:** `/deliver` has no step that asks *"would these tests fail
+  if the fix were reverted?"* — I ran it by hand here, on instinct, and it was
+  the single most informative minute of the delivery. For a change whose whole
+  purpose is that something no longer appears, absence-assertions are the
+  default failure mode, and the pipeline currently relies on the conductor
+  thinking of it. Worth considering as an explicit Phase 3 checkpoint for
+  security/redaction-shaped work.
+
+---
+
 ## 2026-08-14 — 🐛 Generation guard for the cache invalidation race (#461) · full
 
 - **Phases / skills:** 0–8 pre-PR. Full weight — small diff (~270 lines,
@@ -746,58 +818,6 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
   entry.
 - **`swept:`** n/a — no infra files touched.
 
-## 2026-08-07 — ✨ TMDb v4 lists, `client.v4Lists` (#411) · full
-
-- **Phases / skills:** 0–8 pre-PR. `consulted:` ADR-0017 (its four open
-  decisions are what this settles), ADR-0005/0008/0011, gotchas *bearer-token
-  URLCache*, *False green*, *file_length*; tmdb-api-notes v4 section; wiki
-  *bridge-a-wire-type-to-a-domain-type*, *prove-an-api-honours-a-field-by-
-  reading-it-back*, *only-auto-retry-idempotent-operations*,
-  *ship-your-packages-test-doubles-as-a-public-product*. Plan Fable-reviewed
-  before delivery (3 majors applied).
-- **Worked — Phase 0 probing changed the shipped API twice, and both were
-  unfixable later.** `details`/`items` take `sortedBy:` because the read-side
-  `sort_by` turned out to be honoured; adding a protocol requirement afterwards
-  is source-breaking. And `create(isPublic:)` ships after all — ADR-0017 had
-  concluded TMDb ignores the field, but it ignores the *boolean* and honours the
-  *integer*. The earlier conclusion came from a probe that sent a bool. Reading
-  the resource back is what caught both.
-- **Worked — the count-reconciliation assertion caught a real drop on its first
-  outing.** The `V4List` round-trip failed because `Show.encode` writes no
-  `media_type`, so every encoded item failed to decode and `FailableDecodable`
-  silently dropped the lot — an empty list, no error. Exactly the failure the
-  assertion was added for, found within minutes of adding it.
-- **Friction — I misread a rate limit as an API verdict.** Ten identical
-  "rejected" results across a `sort_by` sweep looked like a definitive answer
-  about `sort_by`. They were TMDb's spam filter (`status_code` 18) reacting to
-  rapid list creation, and only the error *body* disproved it. A uniform failure
-  across a parameter sweep is evidence about the sweep, not the parameter. Now
-  an api-note.
-- **Friction — my own cleanup didn't run.** A probe script's `EXIT` trap never
-  fired and orphaned four lists on Adam's account until I enumerated and deleted
-  them. The integration suite's teardown therefore *enumerates* the account
-  rather than trusting a remembered id, so an interrupted run self-heals.
-- **Deviations:** (1) A **correction mid-delivery**: I told Adam the API key and
-  password were committed in `Integration.xctestplan`. They are not — the file is
-  gitignored and absent from HEAD. They *were* committed in 2023 and remain in
-  public history, so rotation is still the remedy, but the "blank the values"
-  work item was struck as a no-op. I had read the file off disk and never run
-  `git ls-files`. (2) Adam corrected the cache criterion mid-flight — my flag
-  only covered v4 per-call tokens, leaving v3 session and guest-session responses
-  on disk. Widened to "requires a user's credential", which is the right
-  predicate and should have been the first one.
-- **One improvement:** two of this delivery's three bugs were *my probe scripts*
-  lying — the trap that never ran, and the sweep that misattributed a rate
-  limit. Live-API probing has become a core part of how this repo establishes
-  truth, but the scripts doing it get none of the rigour the Swift does: no
-  review, no assertion that cleanup happened, no check that a uniform result
-  isn't an artifact. A probe worth trusting should end by *verifying its own
-  postcondition* — here, enumerating the account and asserting it is empty.
-- **`swept:`** Makefile, .github/workflows/integration.yml,
-  integration-failure.yml → 1 entry rewritten (gotchas *bearer-token clients
-  share one credential-free URLCache key space*, now false in every particular);
-  skill-improvement-log citations of integration-failure.yml still accurate.
-
 ## Archive (distilled)
 
 Older entries condensed per the rolling window (`knowledge/README.md` →
@@ -805,6 +825,7 @@ Older entries condensed per the rolling window (`knowledge/README.md` →
 
 | Date | PR | Weight | Outcome |
 | --- | --- | --- | --- |
+| 2026-08-07 | #411 | full | TMDb v4 lists (`client.v4Lists`), settling ADR-0017's four open decisions. **Phase 0 probing changed the shipped API twice, both unfixable later**: `sort_by` turned out to be honoured on the read side (so `details`/`items` take `sortedBy:` — adding a protocol requirement afterwards is source-breaking), and `create(isPublic:)` shipped after all because TMDb ignores the *boolean* and honours the *integer* — the earlier "it ignores the field" conclusion came from a probe that sent a bool. Reading the resource back caught both. The count-reconciliation assertion caught a real drop on its first outing (`Show.encode` writes no `media_type`, so every encoded item failed to decode and the whole list vanished silently). Two of the three bugs were **the probe scripts lying**: an `EXIT` trap that never fired and orphaned four lists on a real account, and ten identical "rejected" results across a `sort_by` sweep that were the spam filter (`status_code` 18), not an answer — a uniform failure across a sweep is evidence about the sweep. Both are now standing rules in `CLAUDE.md`: a probe must verify its own postcondition. Also a mid-delivery **correction**: I reported credentials committed in `Integration.xctestplan` having read it off disk without running `git ls-files` — the file is gitignored and absent from HEAD (they were committed in 2023 and remain in public history, so rotation still applies). |
 | 2026-08-07 | #410 | full | Defaulted-witness convenience sweep across 37 sites. The **reference-unit gate earned its keep again**: reviewing one site before replicating caught a DocC-curation regression (the convenience becomes a distinct symbol and falls out of its Topics group unless curated) that would otherwise have shipped 37 times, and settled three open design questions in one pass. The **census was re-derived rather than trusted** — both reviewers independently reproduced 91/15 and the 37/54 split, after the first census came up **17 short** by grepping protocol *declaration* files and missing the two protocols keeping conveniences in a sibling `+Defaults.swift`. Two lasting False-green bullets came from it: a mechanical sweep did a first-occurrence `str.replace` per file, stripping the default from `favouriteMovies` instead of `lists` **while reporting exactly the 36 edits expected**, and the new checker passed on an empty scan (a typo'd path printed success and exited 0) — so a matching count is not evidence, and a checker must compare against an explicit set. Also **shipped a gate that did not gate**: the check went into `make lint`, but no workflow invokes `make` (the `Lint` job runs swiftlint/swiftformat inline), so it was invisible to CI — now its own step and the gotcha *No workflow runs `make`*. Its "one improvement" — have `/capture-knowledge` prompt "what fails if that number changes?" when an entry records a defect count — **shipped**, and is the *When an entry records a count* section of that skill today. |
 | 2026-08-07 | #409 | full | TMDb v4 authentication. The lasting practice is **probing the live API before writing the plan's models**: TMDb's v4 docs are wrong in ways reading cannot surface — documented endpoint *names* 404, the same field has different wire types on different endpoints, `clear` is a state-changing GET, and both `create(public:)` and add-items' `comment` are accepted-then-ignored. Each was found by curl and each would have shipped as a bug. The corollary, now in `tmdb-api-notes.md`: v4 auth-gates *before* routing, so a 401-vs-404 path probe proves nothing until you hold a credential — which is exactly how the wrong paths survived into an approved plan. The adversarial plan review paid for itself twice, both unanimous: patching only `CacheHTTPClient` would still leave the always-on 1 GB on-disk `URLCache` leaking private reads across users, and splitting `V4ListService` across two PRs would have made the second source-breaking — forcing a redraw of the decomposition along a *protocol* boundary, which dissolved a third blocker for free. Its "one improvement" — stop ending the turn at phase boundaries to report status — is the autonomy contract `/deliver` states today. |
 | 2026-07-29 | #407 | full | Hardened the delivery skills themselves. **Review before writing** paid outright: three plan-review rounds (37 + 9 + 11 findings) ran before a file was edited, and round 1 blocked v1 for **data loss** (the worktree sweep would remove unpushed work) and **credential exposure** (a public repo, with a headless job pasting diagnosis text verbatim into an issue); round 2 caught ACs still grading mechanisms the plan had just cut, which would have red-gated Phase 6 by construction. Verifying mechanisms rather than asserting them caught the content-stamp's first form as a false green — `git ls-tree` has no exclude pathspec, so both hashes were git's empty blob and compared equal. Its lasting legacy is the **reflexive-delivery rule**: three defects all came from the pipeline rewriting itself (a rewritten `/deliver` grading its own rewrite, ACs outliving their mechanisms, and a fan-out shipped as prose in the PR arguing prose isn't a gate), and the Phase 0 reflexive flag that pins verification to the original text **shipped** from this entry's one improvement. Also the origin of the post-ready review lesson: a readiness call was declared with CI green, then a review of the newest code returned fix-first with a major — the fan-out validated its args' shape but not their elements, so malformed input spawned agents on `undefined` and reported full coverage. Nothing in five earlier passes had read the last-written code as code. |

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -25,7 +25,7 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
 
 ---
 
-## 2026-08-20 — 🔒 Redact credentials from `TMDbError.network`'s payload (PR #TBD) · full
+## 2026-08-20 — 🔒 Redact credentials from `TMDbError.network`'s payload (#469) · full
 
 Branch `fix/redact-credentials-in-network-error`. Issue #434 (P0) — item 1 in
 the board's Ready execution order.

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -990,6 +990,28 @@ because Linux uses swift-corelibs-foundation's separate implementation.
 
 ## Testing
 
+### `MockURLProtocol`'s statics are process-global — a test that reads them back is order-dependent
+
+*2026-08-20 (#469).* `MockURLProtocol.lastRequest` (and `data`, `failError`,
+`responseStatusCode`) are `static`, and Swift Testing runs suites **in
+parallel**, so several suites drive the same four slots at once. A test that
+sets `failError`, performs a request, then reads `lastRequest` back to assert
+what was sent **passes on its own and fails in the full run** — another suite's
+request overwrote the slot in between. Observed as exactly that: green under
+`--filter`, one failure at 3392 tests.
+
+The lock inside the mock does not help; it makes each access atomic, not the
+set-perform-read sequence. `.serialized` on your own suite does not help
+either — it orders tests *within* the suite, not against other suites.
+
+**Fix:** when a test needs to read back what the client sent, give it a
+`private final class …URLProtocol: URLProtocol` in its own file with its own
+storage, rather than sharing the common mock. Better still, have that protocol
+**derive its response from the request in front of it** — the redaction test
+builds its failure `NSError` from the incoming request's own URL, so the
+assertion is about the URL the client really sent and there is no cross-test
+slot to race on at all.
+
 ### A mock that traps on queue exhaustion turns a regression into a process abort
 
 *2026-08-14 (#461).* `SequencingHTTPMockClient` calls `preconditionFailure` when a
@@ -1466,6 +1488,67 @@ emoji, invalid percent-escapes (`%zz`), `<>`, `\`, `^`, `|`.
   strings) before writing any test that depends on `URL(string:)` returning
   `nil`; the behaviour changed with the swift-foundation rewrite and intuitions
   from older Foundation are wrong.
+- **`URL(string:)` parses ordinary prose**, so "does this string look like a
+  URL?" is not a usable test for anything: `URL(string: "The request timed
+  out.")` is non-nil (percent-encoded to `The%20request%20timed%20out.`), and
+  that is the literal `NSLocalizedDescription` of a real timeout. Key on the
+  documented `userInfo` key instead of sniffing the value.
+- **`URLComponents(string:)` is stricter than `URL(string:)`** and does reject
+  the malformed bracketed host (`"http://[bad/x"`) as well as a raw space in
+  the scheme or host. That makes it the input to reach a "the string could not
+  be parsed" branch in a test — a raw space in the *path* or a `NUL` is
+  accepted, so those do not work.
+
+### What a `URLSession` failure actually puts in `userInfo` — four measured facts
+
+*2026-08-20 (#469).* Redacting the credential out of `TMDbError.network`'s
+payload meant reading a real transport error rather than an imagined one. All
+four of these were measured on macOS 27, and three of them change the code:
+
+- **`NSURLErrorFailingURLStringErrorKey` cannot be named.** It is deprecated
+  from macOS 15.4 (*"Use NSURLErrorFailingURLErrorKey instead"*), and the
+  package builds `-warnings-as-errors`, so referencing it **fails the build**.
+  Its Swift-side alias `NSErrorFailingURLStringKey` is marked *unavailable*.
+  Spell the key as the string literal `"NSErrorFailingURLStringKey"` — that is
+  what the runtime populates, on Darwin and Linux alike.
+  `NSURLErrorFailingURLErrorKey` is fine to name and equals
+  `"NSErrorFailingURLKey"`.
+- **The two task keys hold opaque `String`s, not `URLSessionTask`s.**
+  `_NSURLErrorFailingURLSessionTaskErrorKey` is a string like
+  `LocalDataTask <4B904CDB-…>.<1>`, and
+  `_NSURLErrorRelatedURLSessionTaskErrorKey` is an array of the same. So there
+  is **no route from an error's `userInfo` to the request's headers** — a
+  bearer token in `Authorization` is not reachable from a caught error. Worth
+  knowing because the opposite is a plausible-sounding security claim: it was
+  raised as one during review and only measurement settled it.
+- **The failing URL is absolute**, so its path starts `/3` or `/4`. Handing it
+  to `EndpointPathRedactor` unstripped makes `segments[0]` the string `"3"`,
+  the endpoint classifier match nothing, and the redaction a **silent no-op**
+  — which a test fed a bare `/guest_session/…` path would never catch.
+- **`NSUnderlyingError` is a real nested `NSError`** with a `userInfo` of its
+  own (`_NSURLErrorNWResolutionReportKey`, `_NSURLErrorNWPathKey`, …). Any
+  "scrub the values" pass over the top-level dictionary walks past it, which is
+  why the redactor rebuilds from an allowlist instead
+  ([ADR-0025](decisions/0025-redact-transport-error-payload.md)).
+
+### `URLComponents.queryItems` corrupts a literal `%2B`; `percentEncodedQueryItems` does not
+
+*2026-08-20 (#469).* Reading `URLComponents.queryItems` and assigning the same
+value straight back is **not** a round-trip:
+
+```text
+…?api_key=SECRET&query=Star%2BWars%20II&language=en-GB
+  → queryItems r/t:                query=Star+Wars%20II     ← %2B became +
+  → percentEncodedQueryItems r/t:  query=Star%2BWars%20II   ← unchanged
+```
+
+The getter percent-decodes and the setter re-encodes, and `+` and `%2B` are not
+interchangeable to a peer that decodes the query. Search requests routinely
+carry `query=`, so rewriting one query item (here, blanking a credential) would
+silently corrupt an unrelated search term beside it. Use
+`percentEncodedQueryItems` for **both** the read and the write whenever you are
+editing one item and must leave the others byte-identical. Same family as the
+`percentEncodedPath` note above: the plain accessors are lossy views.
 
 ### Percent-encoding is not a traversal defence when the peer decodes first
 

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -64,6 +64,34 @@ those two runs stay comparable.
 
 ---
 
+### 2026-08-20 — Prove an absence-shaped test fails without the fix (#469) · deferred
+
+- **Pattern:** the **False green** family, in its absence-assertion form. When a
+  fix means "this value must no longer appear", every test asserts a negative —
+  and a negative passes just as happily when the value was never there, when the
+  key was renamed upstream, or when the code path is not reached at all. Nothing
+  in `/deliver` asks for the one check that distinguishes "the fix works" from
+  "the test cannot tell": revert the fix and watch the tests go red. In #469 I
+  ran it by hand, on instinct, and it was the single most informative minute of
+  the delivery — two wiring tests went red, which is the only reason their green
+  meant anything. The family recurs throughout this log (a `ls-tree` hash where
+  "found" and "nothing found" were byte-identical; a cached SwiftLint false
+  green; a check re-read from an earlier tip) and heads `gotchas.md`, but every
+  instance so far has been caught after the fact rather than by a step.
+- **Decision:** **deferred — raised unattended, needs review.** Nothing applied.
+  The candidate is a Phase 3 checkpoint for redaction/absence-shaped work:
+  before declaring implementation done, unwire the fix, confirm the new tests
+  fail, restore. Scope is the open question — a blanket rule would be noise on
+  the many deliveries whose assertions are positive, so it likely wants a
+  trigger ("the acceptance criteria are phrased as *X no longer appears*")
+  rather than an unconditional step.
+- **Rationale:** raised by an autonomous `/deliver auto` run, which must not
+  edit the pipeline's own skills without review. Recording it here rather than
+  applying it is the Phase 11 contract for auto mode.
+- **Reconsider when:** Adam reviews this entry — or when a second delivery whose
+  fix is an absence ships a test that would have passed without the fix, which
+  would make the trigger condition concrete rather than hypothetical.
+
 ### 2026-08-14 — Review granularity keys on risk surface, not diff shape · applied
 
 - **Pattern:** two entries raised the same conflict from opposite directions.


### PR DESCRIPTION
## Summary

Closes #434 (P0 — item 1 in the project board's Ready execution order).

A `URLSession` failure is an `NSError` whose `userInfo` carries the **whole URL of the request that failed**, under `NSErrorFailingURLKey` and `NSErrorFailingURLStringKey`. For a client built with `TMDbClient(apiKey:)` that URL contains the `api_key` query item, and a user-scoped v3 call adds `session_id`. That error is exactly what `TMDbError.network(_:)` hands the caller — so an ordinary timeout, DNS failure or dropped connection put the credential into consumer logs, crash reports and analytics breadcrumbs.

This contradicted a discipline the library already committed to. [ADR-0012](knowledge/decisions/0012-structured-tmdberror-context.md) introduced `EndpointPathRedactor` precisely so `TMDbErrorContext.endpointPath` would be *safe to log* — but it scrubs **path** segments, and its own doc comment disclaimed the query string. The library scrubbed a session id out of one case while handing the API key over in the adjacent one.

Redaction now happens at the package's single `.network(_:)` construction site, so it cannot drift. Design and rejected alternatives: **[ADR-0025](knowledge/decisions/0025-redact-transport-error-payload.md)**.

## Changes

**New component:**

- ✨ `NetworkErrorRedactor` — reads only the two documented failing-URL entries (accepting the `NSURL`/`NSString` forms `URLSession` actually stores), replaces the value of any credential-named query item and any guest-session/account id in the path with `REDACTED`, and rebuilds `userInfo` from an **allowlist**.

**Existing files:**

- 📝 `TMDbAPIClient.perform` — wraps through the redactor.
- 📝 `EndpointPathRedactor` — gains `placeholder(forEndpoint:)`, now the single classifier both redactors share, so a new token-in-path endpoint is learned by both from one edit. Its doc comment no longer contradicts the library's actual coverage.

**Tests:**

- ✅ 22 tests across two suites, including a **characterisation test** that a real `URLSession` failure still populates the keys the redactor reads — every other test builds the `userInfo` it asserts on, so without it a Foundation rename would leave the redactor dead and the suite green.
- ✅ The fail-closed branch is tested, and asserts `URLComponents` really rejects its input so it can't quietly start exercising the parseable path.
- ✅ The end-to-end test derives the failing URL from the request the client **actually sent**, so the credential provably *was* there before being asserted absent.

**Documentation:**

- 📚 DocC on `TMDbError.network(_:)` and `TMDbAPIError.network`, the `HandlingErrors` article, a **Breaking** CHANGELOG entry under the open `20.0.0`, ADR-0025, three `knowledge/gotchas.md` entries, and this delivery's retro.

## Three design points, each settled by measurement rather than argument

- **`queryItems` corrupts a literal `%2B` into `+`** — so the rebuild goes through `percentEncodedQueryItems`, or redacting a credential would silently mangle the `query=` beside it.
- **`NSURLErrorFailingURLStringErrorKey` is deprecated from macOS 15.4** and its Swift alias is *unavailable*; under this package's `-warnings-as-errors` build, naming it is a **compile error**. The key is spelled as a literal.
- **The failing URL is absolute**, so its path starts `/3` — delegating to `EndpointPathRedactor` unstripped makes `segments[0]` the string `"3"` and the whole redaction a silent no-op that a test fed a bare path would never catch.

## Benefits

- **Security**: the credential no longer reaches a public error payload, and the library's redaction discipline now covers every credential it can put in a URL.
- **Compatibility preserved**: `domain`, `code` and `localizedDescription` are unchanged, and on Darwin the error still bridges to `URLError`. An error with **nothing to redact is returned as the same instance**, so a consumer-supplied `HTTPClient`'s own error type still matches in `catch TMDbError.network(let e as MyTransportError)` — an unconditional rebuild would have erased it, since every Swift error bridges to `NSError`.

## Breaking change

**Silently so — nothing stops compiling.** The other diagnostic `userInfo` entries (`NSUnderlyingError`, the related-task keys) are **dropped** rather than scrubbed on a redacted error, because they can nest a second copy of the same URL. Code reading them will find them absent. Recorded prominently in the CHANGELOG under the open, untagged `20.0.0`.

## Review notes — two deviations worth your attention

1. **No new integration test.** The plan called for one; all three plan critics independently argued it exercises no live behaviour, could pass **vacuously** (it asserted only an absence), and that a racy failure would make the weekly `Integration` cron open a spurious PR. Coverage moved to an offline full-stack test plus the characterisation test above. A deliberate, reasoned departure from CLAUDE.md's unit-and-integration default — flagging it rather than burying it.

2. **One acceptance criterion was corrected, not just fixed.** The independent Phase 6 grader marked AC6 not met. The criterion itself was wrong: it said a `bearerToken` client's behaviour is "unchanged", but redaction keys on what is in the URL, not on how the client was built — so a bearer client calling a user-scoped v3 endpoint *is* rebuilt. The missing test was written (nothing had exercised a bearer-token transport failure at all) and the AC restated, with the original wording and reason recorded beside it. A second grader was asked specifically whether that was a legitimate correction or laundering a failure; it ruled correction, because the missing evidence was supplied rather than written around. Including a test that pins the unflattering half — a bearer client is **not** exempt.

Also worth recording: the security review hypothesised that a bearer token was reachable via `_NSURLErrorRelatedURLSessionTaskErrorKey`. Probing refuted it — that key holds an opaque `String` (`"LocalDataTask <UUID>.<1>"`), not a `URLSessionTask`, so there is no route from a caught error to the request's headers.

## Verification

`make ci` green: 0 lint violations, markdown lint clean, **3396 unit tests**, **318 integration tests**, release build and docs build all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwUKhPRFDQFFoi8sJ1Lpyv
