### PR TITLE
🔧 Move the board item to In progress on start, and In review when the PR is ready

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -165,6 +165,14 @@ implementation = separate `/deliver` sessions.)
   live where it survives: **the ledger alone is not enough, because Phase 1's
   `EnterWorktree` clears it.** Phase 8 copies it into the retro, which is the
   committed, human-reviewed copy.
+- **Identify the issue this delivers, and record it.** Most deliveries implement
+  a tracked issue — `/deliver auto` takes one off the board's Ready column, and a
+  plan usually names one. Record `issue: <number>` in the **run file** (or
+  `issue: null` when the work is genuinely untracked, which is the honest answer
+  for an ad-hoc fix). Phase 1 moves it to **In progress** and Phase 10 to **In
+  review**, so an unrecorded issue is one the board silently never reflects. It
+  goes in the run file rather than the ledger for the usual reason: `EnterWorktree`
+  clears the ledger, and Phase 10 may run long after that, in the background.
 - **Flag a reflexive delivery.** If the plan touches `.claude/skills/**`,
   `.claude/agents/**` or `.github/CODE_REVIEW.md`, this run is **rewriting the
   machinery that runs it**. Record `reflexive: true` in the run file and hold
@@ -283,7 +291,14 @@ Procedures and traps:
    the phase list and the run file, it isn't lost work. Set the run file's
    `entry` to `created`, or to `adopted` when resuming an existing worktree
    via `EnterWorktree(path:)` — **Phase 12's teardown branches on it.**
-5. **Edit via worktree paths**: re-`Read` anything read before entering, and
+5. **Move the issue to `In progress`** — the run file's `issue`, if it has one.
+   This is the right moment rather than Phase 0: the entry gate can still stop a
+   run, so the worktree is the first step that commits to doing the work. Column
+   vocabulary and the exact call:
+   [`.github/ISSUE_FILING.md`](../../../.github/ISSUE_FILING.md) →
+   *Board status — the column lifecycle*. No issue → skip and say so; a failed
+   board write is reported, never fatal.
+6. **Edit via worktree paths**: re-`Read` anything read before entering, and
    **verify `git status` shows your diff in the worktree before trusting the
    first green build** (empty diff + baseline counts = edits went to `main`).
 
@@ -497,6 +512,13 @@ changes when the conductor moves to the next deliverable's worktree. It
 resolves threads, fixes failing checks (routing unrelated integration
 failures per §4), and loops until **ready** or **stuck**. Ready means
 **mergeable now** (branch brought up to date with `main`, re-run green).
+
+On ready it also moves the issue to **In review**, which it reads from the
+`Closes #NNN` line Phase 9's PR body carries — **not** from an argument. Two bare
+numbers in one invocation (`/watch-pr <pr> <issue>`) would be ambiguous, and the
+PR body is the same link GitHub uses to close the issue on merge, so there is one
+source rather than two that can disagree. The run file's `issue` is what Phase 1
+uses, before any PR exists.
 
 **THE GATE — hard stop.** Ready → stop; hand the merge to the user; report
 the PR URL and state; run Phase 11. The worktree **stays** (torn down only on

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -167,12 +167,13 @@ implementation = separate `/deliver` sessions.)
   committed, human-reviewed copy.
 - **Identify the issue this delivers, and record it.** Most deliveries implement
   a tracked issue — `/deliver auto` takes one off the board's Ready column, and a
-  plan usually names one. Record `issue: <number>` in the **run file** (or
-  `issue: null` when the work is genuinely untracked, which is the honest answer
-  for an ad-hoc fix). Phase 1 moves it to **In progress** and Phase 10 to **In
-  review**, so an unrecorded issue is one the board silently never reflects. It
-  goes in the run file rather than the ledger for the usual reason: `EnterWorktree`
-  clears the ledger, and Phase 10 may run long after that, in the background.
+  plan usually names one. Record `issue: <number>` on **the deliverable** in the
+  run file (or `issue: null` when the work is genuinely untracked, which is the
+  honest answer for an ad-hoc fix). Per-deliverable, not run-scoped: a
+  multi-deliverable plan can close a different issue per PR, or none. Phase 1
+  moves it to **In progress** and Phase 10 to **In review**, so an unrecorded
+  issue is one the board silently never reflects. It goes in the run file rather
+  than the ledger for the usual reason — `EnterWorktree` clears the ledger.
 - **Flag a reflexive delivery.** If the plan touches `.claude/skills/**`,
   `.claude/agents/**` or `.github/CODE_REVIEW.md`, this run is **rewriting the
   machinery that runs it**. Record `reflexive: true` in the run file and hold

--- a/.claude/skills/deliver/references/worktree-lifecycle.md
+++ b/.claude/skills/deliver/references/worktree-lifecycle.md
@@ -151,7 +151,7 @@ PR body is required to say so.
   "consulted": "gotchas §False green, §Docs scratch path; ADR-0014",
   "reconciled": { "inScope": 1, "reclaimed": 0, "resumable": 0, "reported": 0 },
   "deliverables": [{
-    "title": "…", "dependsOn": [],
+    "title": "…", "issue": 434, "dependsOn": [],
     "worktree": "…/.claude/worktrees/chore+harden-delivery-skills",
     "branch": "chore/harden-delivery-skills",
     "entry": "created",
@@ -177,6 +177,15 @@ this is its durable home, and Phase 8 copies it into the retro.
 `.claude/agents/**` or `.github/CODE_REVIEW.md`, which changes what Phases 4
 and 5 do (see `SKILL.md` Phase 0). A field mandated by a phase but absent from
 this schema is a field nothing ends up writing.
+
+**`issue`** is per-*deliverable*, not run-scoped: a batch can implement several
+issues, or none. It is the GitHub issue number this deliverable closes, or
+`null` when the work is untracked. Phase 1 reads it to move the issue to **In
+progress** and Phase 10 to move it to **In review** (columns and call:
+[`.github/ISSUE_FILING.md`](../../../../.github/ISSUE_FILING.md) → *Board status
+— the column lifecycle*). It lives here rather than in the ledger for the reason
+the whole file exists — `EnterWorktree` clears the ledger, and Phase 10 runs in
+the background, potentially long after the conductor has moved on.
 
 ### Stamps: hash content, never a commit
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -90,10 +90,14 @@ git diff --name-only origin/main...HEAD \
 
     Example: `✨ Add createdBy property to TVSeries`.
 
-    **Body** — fill this skeleton, keeping only the sections that apply, and end with the attribution line exactly as shown:
+    **Body** — fill this skeleton, keeping only the sections that apply, and end with the attribution line exactly as shown.
+
+    **`Closes #NNN` is required whenever the work has a tracked issue** — drop the line only when it genuinely has none. It is not decoration: GitHub uses it to close the issue on merge, which is what carries the board item to **Done**, and `/watch-pr` reads it to move that item to **In review** when the PR goes green (see [`.github/ISSUE_FILING.md`](../../../.github/ISSUE_FILING.md) → *Board status — the column lifecycle*). Omit it and the issue stays open after merge and never leaves its column — silently, since nothing fails.
 
     ```markdown
     ## Summary
+
+    Closes #NNN.
 
     [Brief description of what this PR does and why]
 

--- a/.claude/skills/triage-issues/SKILL.md
+++ b/.claude/skills/triage-issues/SKILL.md
@@ -304,7 +304,11 @@ that is what `verifiedBy` is for, and "read the issue body" forces `blocked`.
 
 **Scope.** Backlog only, plus the orphan sweep. Never touch In progress, In
 review or Done; someone is working there and a status change under them is
-hostile.
+hostile. Those three columns have owners of their own — `/deliver` sets In
+progress, `/watch-pr` sets In review, and the board's own automation sets Done;
+the whole lifecycle is tabulated in
+[`.github/ISSUE_FILING.md`](../../../.github/ISSUE_FILING.md) → *Board status —
+the column lifecycle*.
 
 ## Rubrics
 

--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -181,9 +181,28 @@ ready and leave the user waiting on a rebase + re-run. Update **once** at the re
 point, not eagerly on every `main` advance — each update re-runs the full ~4–7 min
 CI matrix.
 
+**On ready, move the issue to `In review` — before reporting.** Ready means the
+PR is waiting on a human, which is exactly what that column tells them, and the
+board is how they see it without reading this run's output. Take the issue number
+from the **closing keyword in the PR body** (`Closes #NNN` / `Fixes #NNN`), which
+`/pr` requires on every PR that has an issue. That is deliberately the only
+source: it is the same link GitHub uses to close the issue on merge, so it cannot
+disagree with what actually happens, and it needs no extra argument — a second
+bare number beside the PR number would be ambiguous to parse.
+Column vocabulary and the exact call:
+[`.github/ISSUE_FILING.md`](../../../.github/ISSUE_FILING.md) → *Board status —
+the column lifecycle*. No issue reference → skip the move and say so in the
+summary; a failed board write is reported, never fatal, and never a reason to
+withhold a ready PR.
+
+Do this in **both** modes. In merge-when-ready it is momentary — the merge closes
+the issue and the board's own automation takes it to Done — but it is still
+correct while the merge is in flight, and it is what the board shows if the merge
+then fails.
+
 - **Watch-only**: report "PR is ready" with a short summary (threads handled,
-  checks green, branch up to date) and stop — wait for the user's explicit
-  go-ahead before merging.
+  checks green, branch up to date, issue moved to `In review`) and stop — wait
+  for the user's explicit go-ahead before merging.
 - **Merge-when-ready**: on ready, **capture the head branch name first** (you need it
   to delete the remote branch — `merge_pull_request` has no delete-branch option),
   merge with `mcp__github__merge_pull_request` (owner/repo from `origin`,

--- a/.github/ISSUE_FILING.md
+++ b/.github/ISSUE_FILING.md
@@ -109,6 +109,50 @@ with no Status is one `/triage-issues` will never groom.
 Do **not** set Priority or Size. Those are `/triage-issues`' output; guessing them
 at filing time gives one judgement two owners.
 
+## Board status — the column lifecycle
+
+Filing owns only the first column. Each later move is owned by the skill that
+causes it, and this table is the **one place the column names and the write idiom
+are written down** — so a renamed column is a one-file fix rather than a hunt
+through four skills.
+
+| Column | Set by | When |
+| --- | --- | --- |
+| **Backlog** | whoever files (this spec) | the issue is created |
+| **Ready** | `/triage-issues` | it passes the Ready test; Priority + Size are set with it |
+| **In progress** | `/deliver` (Phase 1) | the worktree is entered — work has actually begun |
+| **In review** | `/watch-pr` (§3, at *ready*) | the PR is green and mergeable, waiting on a human |
+| **Done** | the board's own "item closed" automation | the PR merges and closes the issue |
+
+**Done is deliberately not written by any skill.** It is the one transition
+observed to happen unaided: `/triage-issues` closes `wontfix` issues without
+touching Status and they land in Done regardless. A write for it would give one
+column two owners. If a merged issue is ever seen *not* reaching Done, that
+automation has been turned off — and this row is where to record that.
+
+The call is the same for every row, so it is stated once, here:
+
+```text
+mcp__github__projects_write / update_project_item
+  owner: adamayoung · project_number: <resolve "TMDb" via projects_list>
+  item_owner: adamayoung · item_repo: TMDb · issue_number: <n>
+  updated_field: { "name": "Status", "value": "<column name>" }
+```
+
+Four things that are easy to get wrong:
+
+- **Pass the option *name*, not its id.** The name form resolves server-side; an
+  id is opaque, unreviewable in a diff, and silently wrong if a column is ever
+  recreated.
+- **Resolve the project number; don't hardcode it.** A hardcoded number fails
+  quietly against the wrong board rather than loudly against none.
+- **A board write must never fail the work.** These moves are bookkeeping. If one
+  errors, say so in the run's summary and carry on — a red board write is not a
+  red delivery.
+- **No issue means no move.** Plenty of changes are untracked (an ad-hoc fix, a
+  follow-up to a review). Skip the move and say you skipped it; never invent an
+  issue so that something can be moved.
+
 ## Titles
 
 The title is what someone scans in a list of forty. Lead with the symptom and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,6 +283,14 @@ worked queue, and owns the Ready test and the priority/size rubrics in turn. The
 split matters: filing and triage are separate judgements, so neither file states
 the other's rules.
 
+That spec also carries the **board's column lifecycle** — the one place the
+column names and the `update_project_item` idiom are written down. An issue moves
+Backlog → Ready (`/triage-issues`) → **In progress** (`/deliver`, on entering the
+worktree) → **In review** (`/watch-pr`, when the PR is green and waiting on you)
+→ Done (the board's own "item closed" automation, via the `Closes #NNN` line
+`/pr` puts in every PR body). Each column has exactly one owner; a board write
+that fails is reported, never fatal.
+
 **Code review** — both the local `/review-changes` and the GitHub Actions reviewer
 follow one shared spec, [`.github/CODE_REVIEW.md`](.github/CODE_REVIEW.md), and
 **run only when the change touches reviewable code** — Swift for both


### PR DESCRIPTION
## Summary

No tracked issue — this implements a request made directly in conversation, so there is no `Closes #NNN` line.

**Ready was the last column any skill ever set.** Work would start, a PR would go green and sit waiting for review, and the board item still read *"This is ready to be picked up"*. Two transitions close that gap.

## Changes

**The two transitions:**

- 🔧 **In progress** — `/deliver` **Phase 1**, on entering the worktree. Deliberately not Phase 0: the entry gate can still stop a run, so the worktree is the first step that commits to doing the work.
- 🔧 **In review** — `/watch-pr` **§3, at ready**, in both watch-only and merge modes. Ready means the PR is green and waiting on a human, which is exactly what the column says.

**Supporting changes each of these forced:**

- 📝 `/deliver` Phase 0 records `issue:` on the deliverable in the run file — the only record that survives `EnterWorktree`, and Phase 1 needs it before any PR exists. Added to the run-file schema in `references/worktree-lifecycle.md`, which warns in its own words that *"a field mandated by a phase but absent from this schema is a field nothing ends up writing."*
- 📝 `/pr` now **requires** `Closes #NNN` in the body. `/watch-pr` resolves the issue from that line rather than from an argument, so the keyword became load-bearing.
- 📝 `/triage-issues` gains a pointer from its existing *"never touch In progress, In review or Done"* scope note to the owners of those columns.
- 📚 `CLAUDE.md` gains the end-to-end lifecycle in one sentence.

## Two decisions worth checking

**Done is left alone, on purpose.** `/triage-issues` closes `wontfix` issues without touching Status and they land in Done anyway, so the board's own *"item closed"* automation already owns that column. Adding a write would give one column two owners. If a merged issue is ever seen not reaching Done, that automation has been switched off — the lifecycle table says so and is where to record it.

**The column names and the `update_project_item` call live in exactly one place** — `.github/ISSUE_FILING.md`, which already owned *"an issue starts in Backlog"* and the MCP-not-`gh project` rationale. Four skills now state only *when* they move an item and point there for *how*, so a renamed column is a one-file fix. The alternative is the shape this repo has already been burned by: the cache contract stated in four places went stale in three of them.

## Verified, not assumed

The write was exercised against the live board before being documented: the `updated_field` **name** form resolves server-side and the item resolves by issue number, so no opaque option ids (`df73e18b` and friends) appear in any skill. Issue **#434** moved to *In review* in the process — which is where it should already have been, since PR #469 is green and waiting on review.

## Review notes

- **This is a reflexive change** — it rewrites rules four skills follow, and the skill registry loads from the main checkout, so none of it was exercised end-to-end by the session that wrote it. Verified by reading.
- **No independent reviewer ran.** The diff is markdown-only, so `.github/CODE_REVIEW.md`'s gate makes the GitHub Actions reviewer skip it, and per standing instruction I did not spawn a local reviewer. What did run is the footprint sweep `/deliver` mandates for skill edits — and it earned its keep: the first draft cross-referenced `/pr`'s template as already carrying `Closes #NNN`, which it did not. That claim would have shipped as a quietly false pointer.
- Gate: docs/config-only fast gate (`make lint` + `make lint-markdown`), both clean. No `*.swift`, `Makefile`, `Package.*`, workflow or fixture files in the diff, and no `*.docc/**`, so `build-docs` is correctly dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwUKhPRFDQFFoi8sJ1Lpyv
