### PR TITLE
✨ Add `/deliver next` — select and plan the top Ready issue off the board

### DIFF
--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -99,6 +99,21 @@ auto-merge they did not ask for until it has happened.
 stop, rather than silently picking one. `next` also takes precedence over a
 plan already in the conversation, and says so before drafting.
 
+**Echo the parse before acting on it** — one line, first thing, before any
+board write, worktree or edit:
+
+```text
+parsed: auto=on · merge=off · next=on · target=(none)
+```
+
+The leading-run rule still can't disambiguate a target whose *first* token is a
+keyword (`/deliver merge conflict handling plan` reads as `merge` + *"conflict
+handling plan"*), and no grammar fixes that without banning reasonable plan
+names. An echo does: a mis-parse becomes visible in the second before it
+matters, rather than at the moment an unrequested squash-merge lands. Phase 0
+already writes this parse to the run file at the same instant, so the line costs
+nothing to produce.
+
 - **`auto`** — unattended; every stop-and-ask becomes a juror panel (below).
 - **`merge`** — squash-merge once the PR is green, instead of stopping at the
   gate (Phase 10).

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -85,9 +85,17 @@ Non-negotiable. Do these by default, without being reminded.
 
 ## Invocation — `/deliver [auto] [merge] [next]`
 
-The three keywords are recognised only as **whole, standalone tokens**, in any
-order; anything else in the argument is the **named plan target** Phase 0
-resolves. `next` and a named target contradict each other — report that and
+The three keywords are recognised only as whole, standalone tokens **in a
+leading run** — parsing stops at the first token that is not one of them, and
+everything from there on is the **named plan target** Phase 0 resolves. So
+`/deliver auto merge next` is three keywords, and `/deliver auto fix the merge
+handling plan` is one keyword plus the target *"fix the merge handling plan"* —
+**not** an auto-merge, even though `merge` appears in it. A keyword found after
+the target has begun is part of the target; say so rather than acting on it,
+because the failure is silent and one-directional: nobody notices an
+auto-merge they did not ask for until it has happened.
+
+`next` and a named target contradict each other — report that and
 stop, rather than silently picking one. `next` also takes precedence over a
 plan already in the conversation, and says so before drafting.
 
@@ -236,10 +244,24 @@ implementation = separate `/deliver` sessions.)
   delivers the same one. Phase 1's move then finds it already set and no-ops.
   The claim carries an obligation: **any stop before the PR opens releases it
   back to `Ready`** ([`references/next-mode.md`](references/next-mode.md)).
-- **Flag a reflexive delivery.** If the plan touches `.claude/skills/**`,
-  `.claude/agents/**` or `.github/CODE_REVIEW.md`, this run is **rewriting the
+- **Flag a reflexive delivery.** If the plan touches any of the **reflexive
+  set** — `.claude/skills/**`, `.claude/agents/**`, `.claude/workflows/**` or
+  `.github/CODE_REVIEW.md` — this run is **rewriting the
   machinery that runs it**. Record `reflexive: true` in the run file and hold
   two consequences for the rest of the pipeline:
+
+  > **This list is the reflexive set, and it is quoted in exactly one other
+  > place** — [`references/next-mode.md`](references/next-mode.md) §5b, which
+  > refuses such an issue in `merge` mode. **Change both or neither.** They were
+  > briefly out of step: this list omitted `.claude/workflows/**`, so
+  > `/deliver auto merge next` could have selected an issue whose plan rewrote
+  > `deliver-panel.js` — the script defining the panel that authorises unattended
+  > work — computed `reflexive: false`, and squash-merged it with nobody
+  > reading the diff. `.claude/workflows/` was already a Phase 5 security
+  > surface and a Phase 4 review surface; it belongs here for the same reason.
+  > **When in doubt about a path, resolve it as reflexive** — the cost of a
+  > false positive is one human merge, and the cost of a false negative is the
+  > pipeline silently editing its own gates.
   1. **It cannot be dogfooded before merge.** The skill registry loaded at
      session start comes from the **main checkout**, so your edits are not what
      executes this run. Verify by reading, and say so in the PR — never claim a

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -300,6 +300,15 @@ implementation = separate `/deliver` sessions.)
      grep -rn '<the old wording>' .claude/ CLAUDE.md .github/CODE_REVIEW.md
      ```
 
+     **Re-sweep after every review-loop fix, not just after the first edit.**
+     A Phase 4 or Phase 5 fix that changes the rule *again* has its own
+     footprint, and a sweep run against the original change's wording will not
+     find it. This is how the recurrence below reached three: the first two
+     commits of a delivery swept clean, and the commit that *fixed* the review's
+     findings reintroduced the drift — into `.github/ISSUE_FILING.md`, which
+     declares itself authoritative over the skills, so the stale copy overrode
+     rather than lagged. Sweep is per-commit-that-changes-a-rule, not per-run.
+
      This has now recurred twice. #441–#443 each fixed `deliver/SKILL.md` and
      left `deliver/references/worktree-lifecycle.md` — the file `SKILL.md`
      points at — still teaching the forbidden `swept:` key, the superseded

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -342,10 +342,10 @@ Procedures and traps:
    [`references/worktree-lifecycle.md`](references/worktree-lifecycle.md).
    **Release stranded `next` claims while you are here — keyed on the PID, not
    on a bucket.** For every run file with a `next` mode, `pr: null`,
-   `status: open`, **no `claimReleased` stamp**, and **`selection.claimed` not
+   `status: open`, **no `claimHandedBack` stamp**, and **`selection.claimed` not
    `false`**, test its `conductorPid` with `kill -0`. **Dead** → that run is
    holding an issue in **In progress** with nobody to release it: move the issue
-   back to **Ready**, **stamp `claimReleased: <iso8601>` on the deliverable**,
+   back to **Ready**, **stamp `claimHandedBack: <iso8601>` on the deliverable**,
    and count it in the `reconciled` line's `claims released` slot. **Alive, or
    the PID is absent/unparseable** → leave it entirely, and report it.
    Both extra predicate clauses prevent the sweep from taking an issue away from
@@ -354,11 +354,25 @@ Procedures and traps:
    - **`claimed: false`** means that run's claim write failed and it proceeded
      unclaimed (`references/next-mode.md` §6). It never held the issue, so there
      is nothing to give back — and by now another run may legitimately hold it.
-   - **`claimReleased`** makes the release **idempotent**. The predicate is
+   - **`claimHandedBack`** makes the release **idempotent**. The predicate is
      otherwise still true after a release, so the next run re-releases the same
      issue; once it has been re-claimed by anyone, that repeat is a theft rather
      than a recovery. Nothing else closes the file: bucket 4 explicitly permits
      a dead run file to be left standing.
+
+   **Evaluate the predicate at two scopes** — it mixes them, and only looks
+   unambiguous at one deliverable. `mode`, `conductorPid` and
+   `selection.claimed` are **run**-scoped; `pr`, `status`, `issue` and
+   `claimHandedBack` are **per-deliverable**. So walk the deliverables: release
+   and stamp **each qualifying one independently**, rather than asking whether
+   "the run" has a PR. A batch where deliverable 1 has merged and 2–3 are still
+   open otherwise either never releases anything or strands the rest behind one
+   stamp. A `next` pick *can* decompose — Phase 0's decomposition runs after
+   selection, and the board currently holds batch-shaped issues.
+   One corollary: `claimed: false` suppresses the release of
+   `selection.picked`'s issue **only**. A batch's other issues reached
+   **In progress** via Phase 1 step 5, not via the `next` claim, so that flag
+   never described them.
    Do **not** key this on the worktree buckets. `resumable` tests the PID, but
    `settled` does not test liveness at all, and — decisively — a `next` run
    holds its claim from **Phase 0, before any worktree exists**, which is the
@@ -390,9 +404,9 @@ Procedures and traps:
    the phase list and the run file, it isn't lost work. Set the run file's
    `entry` to `created`, or to `adopted` when resuming an existing worktree
    via `EnterWorktree(path:)` — **Phase 12's teardown branches on it.**
-   **Adopting a `next` run whose deliverable carries `claimReleased`?** Its
+   **Adopting a `next` run whose deliverable carries `claimHandedBack`?** Its
    issue was handed back to `Ready` while it was dead and may now belong to
-   someone else. Re-run the three-step claim in
+   someone else. Re-run the claim steps in
    [`references/next-mode.md`](references/next-mode.md) §6 before resuming —
    `Status` not `Ready` → stop and say the issue was re-claimed elsewhere.
    Resuming on the strength of a claim the sweep already released is how an

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -197,6 +197,11 @@ implementation = separate `/deliver` sessions.)
   consumes it. Nothing startable, or no Projects MCP → **stop before the
   worktree**; never fall through to the "no plan" stop, which reads as an
   unrelated failure.
+  **Write `mode: next` into the run file when you parse the keywords — before
+  selection runs**, not after. Written afterwards, a run that skipped selection
+  carries no `mode` either and sails through Phase 6's gate as an ordinary run.
+  **Auto:** the approval stop below becomes the `phase0n-selection` panel —
+  proceed with this self-picked issue and self-drafted plan, vs stop.
 - **A plan born from a review finding is a hypothesis** — verify against the
   code (quick `Explore`) *before* planning or asking strategy questions.
 - **State the goal** in a sentence; **judge the weight**; open the ledger.
@@ -330,6 +335,16 @@ Procedures and traps:
    `swept:`, which is Phase 7's knowledge sweep and will silently take the
    slot**. Procedure, buckets and traps:
    [`references/worktree-lifecycle.md`](references/worktree-lifecycle.md).
+   **Release stranded `next` claims while you are here.** Any run file with
+   `mode: next`, `pr: null` and `status: open` whose worktree classified
+   `resumable` or `settled` is a `next` run that died holding an issue in
+   **In progress** — move that issue back to **Ready** and count it in the
+   `reconciled` line. A live conductor releases its own claim on a reported
+   stop, but the commonest end of an unattended run — context exhaustion, a
+   killed session, a dropped MCP — reaches no stop report, and nothing else
+   recovers it: `next` reads only `Ready`, and `/triage-issues` is forbidden to
+   touch `In progress`. This sweep already enumerates the run files, so the
+   strand costs one board write here and otherwise lasts forever.
 2. **Enter** with `EnterWorktree(name: "<prefix>/<slug>")` (`feature/`,
    `fix/`, `chore/`, …) — sanctioned auto-use, don't ask. **Verify the branch
    name afterwards** (`git branch --show-current`; `git branch -m` if the
@@ -493,7 +508,13 @@ Three distinct cases, and they must not be conflated:
   [`references/next-mode.md`](references/next-mode.md) never ran, so nothing
   established that this issue was the right one, still verified, or claimed.
   Without this the `selection` block would be telemetry no phase reads — a
-  green indistinguishable from never having looked.
+  green indistinguishable from never having looked. (`mode` is written at
+  Phase 0's keyword parse, *before* selection, so a skipped selection shows up
+  as `mode: next` with no `selection` rather than as an ordinary run.)
+- **`mode: next` in `auto`, with `planReview` missing** → **hard stop.** That
+  field is the sole record that the forced `/review-plan` actually ran, and a
+  self-picked, self-drafted, unattended plan whose critics were skipped is the
+  least-reviewed thing this pipeline can produce.
 
 How it is graded depends on weight:
 
@@ -597,6 +618,14 @@ worktree**. **Auto:** stuck → panel (retry via `ScheduleWakeup` vs stop); the
 gate itself is not a panel decision — in auto, ready behaves as the `merge`
 opt-in. **Opt-in auto-merge:** only if the user passed `merge`, forward it
 (`/watch-pr merge <number>`) — the gate becomes "report the merge" → Phase 12.
+
+**`merge` is dropped, not honoured, when the run file says `reflexive: true`
+and `mode: next`.** A `next` run chose its own issue, so nobody decided to
+merge a rewrite of the pipeline's own skills unattended — stop at the gate and
+say the opt-in was dropped and why. Selection already refuses a reflexive
+candidate in `merge` mode ([`references/next-mode.md`](references/next-mode.md)
+§5b); this catches the case where the issue's fix sketch understated its
+footprint and Phase 0 discovered the truth from the drafted plan.
 
 ## Phase 11 — Wrap-up (wiki, pattern scan, exceptional retro amendment)
 

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -197,9 +197,14 @@ implementation = separate `/deliver` sessions.)
   consumes it. Nothing startable, or no Projects MCP → **stop before the
   worktree**; never fall through to the "no plan" stop, which reads as an
   unrelated failure.
-  **Write `mode: next` into the run file when you parse the keywords — before
-  selection runs**, not after. Written afterwards, a run that skipped selection
-  carries no `mode` either and sails through Phase 6's gate as an ordinary run.
+  **Write the parsed invocation into the run file when you parse the keywords —
+  before selection runs**, not after. Record **every** keyword, not just this
+  one (`"mode": "auto merge next"`), plus `conductorPid` — this session's PID.
+  Written afterwards, a run that skipped selection carries no `mode` either and
+  sails through Phase 6's gate as an ordinary run; and `auto`/`merge` recorded
+  nowhere durable means Phase 6's `planReview` stop and Phase 10's merge-drop
+  both read a keyword the ledger lost at `EnterWorktree` — they would silently
+  no-op on exactly the resumed and backgrounded paths the run file exists for.
   **Auto:** the approval stop below becomes the `phase0n-selection` panel —
   proceed with this self-picked issue and self-drafted plan, vs stop.
 - **A plan born from a review finding is a hypothesis** — verify against the
@@ -335,16 +340,23 @@ Procedures and traps:
    `swept:`, which is Phase 7's knowledge sweep and will silently take the
    slot**. Procedure, buckets and traps:
    [`references/worktree-lifecycle.md`](references/worktree-lifecycle.md).
-   **Release stranded `next` claims while you are here.** Any run file with
-   `mode: next`, `pr: null` and `status: open` whose worktree classified
-   `resumable` or `settled` is a `next` run that died holding an issue in
-   **In progress** — move that issue back to **Ready** and count it in the
-   `reconciled` line. A live conductor releases its own claim on a reported
-   stop, but the commonest end of an unattended run — context exhaustion, a
-   killed session, a dropped MCP — reaches no stop report, and nothing else
-   recovers it: `next` reads only `Ready`, and `/triage-issues` is forbidden to
-   touch `In progress`. This sweep already enumerates the run files, so the
-   strand costs one board write here and otherwise lasts forever.
+   **Release stranded `next` claims while you are here — keyed on the PID, not
+   on a bucket.** For every run file with a `next` mode, `pr: null` and
+   `status: open`, test its `conductorPid` with `kill -0`. **Dead** → that run
+   is holding an issue in **In progress** with nobody to release it: move the
+   issue back to **Ready** and count it in the `reconciled` line. **Alive, or
+   the PID is absent/unparseable** → leave it entirely, and report it.
+   Do **not** key this on the worktree buckets. `resumable` tests the PID, but
+   `settled` does not test liveness at all, and — decisively — a `next` run
+   holds its claim from **Phase 0, before any worktree exists**, which is the
+   whole reason it claims early. Such a run has no worktree to classify, so a
+   bucket-keyed rule either releases a **live** conductor's claim while it waits
+   at the approval stop (re-opening the double-delivery the claim prevents, in
+   the exact window it was designed for) or never releases it at all. The PID
+   test is the only thing that separates those two, and it covers the
+   pre-worktree window the buckets cannot see. Treat an `EPERM` from `kill -0`
+   as alive, and cross-check a suspiciously old PID against
+   `ps -p <pid> -o lstart=` exactly as the lock-liveness rule does.
 2. **Enter** with `EnterWorktree(name: "<prefix>/<slug>")` (`feature/`,
    `fix/`, `chore/`, …) — sanctioned auto-use, don't ask. **Verify the branch
    name afterwards** (`git branch --show-current`; `git branch -m` if the
@@ -511,10 +523,13 @@ Three distinct cases, and they must not be conflated:
   green indistinguishable from never having looked. (`mode` is written at
   Phase 0's keyword parse, *before* selection, so a skipped selection shows up
   as `mode: next` with no `selection` rather than as an ordinary run.)
-- **`mode: next` in `auto`, with `planReview` missing** → **hard stop.** That
-  field is the sole record that the forced `/review-plan` actually ran, and a
-  self-picked, self-drafted, unattended plan whose critics were skipped is the
-  least-reviewed thing this pipeline can produce.
+- **A `mode` naming both `auto` and `next`, with `planReview` missing** →
+  **hard stop.** That field is the sole record that the forced `/review-plan`
+  actually ran, and a self-picked, self-drafted, unattended plan whose critics
+  were skipped is the least-reviewed thing this pipeline can produce. Read
+  `auto` from the run file's `mode`, never from memory of the invocation — the
+  ledger that held it does not survive `EnterWorktree`, a resume, or Phase 10's
+  background handoff.
 
 How it is graded depends on weight:
 
@@ -620,7 +635,9 @@ opt-in. **Opt-in auto-merge:** only if the user passed `merge`, forward it
 (`/watch-pr merge <number>`) — the gate becomes "report the merge" → Phase 12.
 
 **`merge` is dropped, not honoured, when the run file says `reflexive: true`
-and `mode: next`.** A `next` run chose its own issue, so nobody decided to
+and a `mode` naming `next`** — read both from the run file, since this phase
+runs in the background, potentially long after the invocation. A `next` run
+chose its own issue, so nobody decided to
 merge a rewrite of the pipeline's own skills unattended — stop at the gate and
 say the opt-in was dropped and why. Selection already refuses a reflexive
 candidate in `merge` mode ([`references/next-mode.md`](references/next-mode.md)

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deliver
-description: Take the current plan all the way to a ready-to-merge pull request — review the plan (scaled to risk), implement it test-first, code-review and fix, run the CI gate, open the PR, and watch it green. Use after you have an approved plan (from plan mode, or the Plan agent) and want the rest of the feature pipeline run end-to-end. Invoking it is itself plan approval — it then runs autonomously to a single hard stop: ready-to-merge.
+description: Take a plan all the way to a ready-to-merge pull request — review the plan (scaled to risk), implement it test-first, code-review and fix, run the CI gate, open the PR, and watch it green. Use after you have an approved plan (from plan mode, or the Plan agent), or pass `next` to take the top startable issue off the project board's Ready column and plan it first. Invoking it with a plan already in hand is itself plan approval — it then runs autonomously to a single hard stop: ready-to-merge.
 ---
 
 # Deliver
@@ -15,10 +15,13 @@ rides the delivery's own PR. Every run happens in its **own git worktree**
 (Phase 1; torn down on merge, Phase 12) so the user's main checkout stays
 free. The plan is created first in **plan mode** (or with the `Plan` agent;
 there is no `/plan` skill) — `/deliver`
-picks up from there.
+picks up from there. **`/deliver next` supplies its own plan**: it takes the
+top startable issue off the project board's Ready column and drafts one
+(Phase 0; [`references/next-mode.md`](references/next-mode.md)).
 
 ```text
-you approve the plan ─▶ /deliver ─▶ entry gate (ACs?) ─▶ worktree ─▶ [review-plan] ─▶
+you approve the plan ─▶ /deliver ─────▶ entry gate (ACs?) ─▶ worktree ─▶ [review-plan] ─▶
+   (or: /deliver next ─▶ pick a Ready issue ─▶ draft ─▶ approve ─┘)
   implement ─▶ code-review + fix ─▶ security-review + fix ─▶
   rubric check (ACs met?) ─▶ capture ─▶ retro (pre-PR) ─▶ /pr reviewed ─▶ /watch-pr ─▶
   GATE: ready-to-merge ─▶ wrap-up (wiki + recurring-pattern scan)
@@ -37,7 +40,12 @@ Non-negotiable. Do these by default, without being reminded.
 1. **Invoking `/deliver` is plan approval — run autonomously to the one
    gate** (the diagram above), with no second "is the plan ok?" prompt. The
    only legitimate mid-run pauses: a **blocker** from `/review-plan`
-   (Phase 2), or a **red gate you cannot triage** (§4).
+   (Phase 2), a **red gate you cannot triage** (§4), or — **attended `next`
+   only** — the one approval stop on a plan `/deliver` drafted for itself
+   (Phase 0). That third case is not an exception to this rule but its
+   boundary: invoking the skill approves *the plan you brought*, and a `next`
+   run brought none. In `auto` it is not a pause at all — the
+   `phase0n-selection` panel rules instead.
 2. **Delegate to the existing skills — don't reinvent them**: `/review-plan`,
    `/implement-plan`, `/review-changes`, `/security-review`,
    `/capture-knowledge`, `/pr`, `/watch-pr`, `/fix-integration-failures`.
@@ -75,15 +83,35 @@ Non-negotiable. Do these by default, without being reminded.
    start signal — invoke `/deliver` immediately; pause first only if
    Phase 0's entry gate fires.
 
-## Auto mode & async invocation
+## Invocation — `/deliver [auto] [merge] [next]`
+
+The three keywords are recognised only as **whole, standalone tokens**, in any
+order; anything else in the argument is the **named plan target** Phase 0
+resolves. `next` and a named target contradict each other — report that and
+stop, rather than silently picking one. `next` also takes precedence over a
+plan already in the conversation, and says so before drafting.
+
+- **`auto`** — unattended; every stop-and-ask becomes a juror panel (below).
+- **`merge`** — squash-merge once the PR is green, instead of stopping at the
+  gate (Phase 10).
+- **`next`** — no plan needed: take the top startable issue off the board's
+  Ready column and draft one (Phase 0;
+  [`references/next-mode.md`](references/next-mode.md)). Requires the
+  user-scoped GitHub Projects MCP, so it is **unavailable on a GitHub Actions
+  runner**.
+
+### Auto mode & async invocation
 
 `/deliver auto` replaces every stop-and-ask decision with an **adversarial
 panel** of three independent Opus jurors — a dead panel is never a proceed,
 and every panel convened leaves an audit line in the ledger. Decision points
 are marked **Auto:** below. Never delegated: a **data-loss or
-breaking-change plan blocker is a hard stop even in auto**. `/deliver` can
-also be queued headless (the plan + ACs must travel in the trigger prompt).
-Panel procedure and queuing caveats:
+breaking-change plan blocker is a hard stop even in auto**, and in
+`auto merge next` an issue whose **Breaking class is anything but `none` is
+not selectable at all**. `/deliver` can
+also be queued headless (the plan + ACs must travel in the trigger prompt —
+unless `next` supplies them, which only works where the Projects MCP is
+mounted). Panel procedure and queuing caveats:
 [`references/auto-and-async.md`](references/auto-and-async.md). In attended
 mode the **Auto:** branches do not apply — stop and ask, as written.
 
@@ -100,6 +128,14 @@ single-reviewer path. **Full** — anything risky or large ⇒ the three-critic
 (e.g. a pre-reviewed plan with the full review machinery) records as **full**
 with the skipped machinery noted, in the ledger and the retro; never invent a
 third tier.
+
+**One named override exists, and it is not a third tier.** An `auto next` run
+drafted its own plan with no human between the issue and the implementation, so
+it **always** runs `/review-plan`'s critics whatever the weight (Phase 2).
+Record that as `planReview: forced — auto-next` in the run file and the retro,
+leaving `weight` itself untouched; a lite run stays lite for Phases 4 and 5.
+Attended `next` is **not** covered: its Phase 0 approval stop is the same
+consent `ExitPlanMode` gives every other run, so it follows weight as normal.
 
 ## Multi-deliverable plans — one run, several PRs
 
@@ -149,7 +185,18 @@ implementation = separate `/deliver` sessions.)
 ## Phase 0 — Preconditions
 
 - **A plan must exist** (named target → plan-mode plan → most recent in
-  conversation). None → stop; ask for one in plan mode. Never invent one.
+  conversation). None → stop; ask for one in plan mode. Never invent one —
+  **except on the one sanctioned path**: `next` *selects* one instead. It takes
+  the top startable issue off the board's Ready column, re-verifies it against
+  `origin/main`, claims it, and drafts a plan with the `Plan` agent — then
+  continues through the rest of this phase unchanged. Procedure, exclusions and
+  the `selection` block:
+  [`references/next-mode.md`](references/next-mode.md). Selection is part of
+  Phase 0 rather than a phase of its own precisely so the run file keeps one
+  writer and the knowledge consult below still precedes the drafting that
+  consumes it. Nothing startable, or no Projects MCP → **stop before the
+  worktree**; never fall through to the "no plan" stop, which reads as an
+  unrelated failure.
 - **A plan born from a review finding is a hypothesis** — verify against the
   code (quick `Explore`) *before* planning or asking strategy questions.
 - **State the goal** in a sentence; **judge the weight**; open the ledger.
@@ -166,7 +213,7 @@ implementation = separate `/deliver` sessions.)
   `EnterWorktree` clears it.** Phase 8 copies it into the retro, which is the
   committed, human-reviewed copy.
 - **Identify the issue this delivers, and record it.** Most deliveries implement
-  a tracked issue — `/deliver auto` takes one off the board's Ready column, and a
+  a tracked issue — `next` takes one off the board's Ready column, and a
   plan usually names one. Record `issue: <number>` on **the deliverable** in the
   run file (or `issue: null` when the work is genuinely untracked, which is the
   honest answer for an ad-hoc fix). Per-deliverable, not run-scoped: a
@@ -174,6 +221,11 @@ implementation = separate `/deliver` sessions.)
   moves it to **In progress** and Phase 10 to **In review**, so an unrecorded
   issue is one the board silently never reflects. It goes in the run file rather
   than the ledger for the usual reason — `EnterWorktree` clears the ledger.
+  A `next` run has already made the **In progress** move itself, at the pick —
+  it has to claim the issue before the drafting window, or a concurrent session
+  delivers the same one. Phase 1's move then finds it already set and no-ops.
+  The claim carries an obligation: **any stop before the PR opens releases it
+  back to `Ready`** ([`references/next-mode.md`](references/next-mode.md)).
 - **Flag a reflexive delivery.** If the plan touches `.claude/skills/**`,
   `.claude/agents/**` or `.github/CODE_REVIEW.md`, this run is **rewriting the
   machinery that runs it**. Record `reflexive: true` in the run file and hold
@@ -227,6 +279,12 @@ implementation = separate `/deliver` sessions.)
     `rubricProvenance: derived — <the source>`, and say in the PR body that the
     rubric was derived rather than supplied. Bug fixes land here routinely;
     stopping to ask a question the plan already answers is ceremony, not rigour.
+    **A `next`-drafted plan always lands here**, whatever its text contains:
+    record `derived — issue <number>`, **never `supplied`**. The drafted plan
+    will carry ACs — the `Plan` agent writes them — but `supplied` means *a
+    human set the bar*, and here the run that gets graded wrote its own rubric.
+    This is reflexive rule 2 in another costume: the thing being graded must not
+    be the thing that sets the grade. Do not "simplify" it back.
   - **Neither** → stop and ask for them ("Given X, when Y, then Z") — don't
     enter the worktree. **Auto:** panel — proceed rubric-less (Phase 6 no-ops)
     vs stop; record that as `rubric: none`, which is **present-and-empty**, not
@@ -311,7 +369,12 @@ enter, proceed.
 **Lite, or already adversarially reviewed this session** (a converged
 `/review-plan`, or an equivalent in-conversation critique whose findings were
 applied) → skip the critics. `ExitPlanMode` approval alone is consent, not
-review — it does **not** skip. **Full with an unreviewed plan**
+review — it does **not** skip. **`auto next` never skips**, at any weight: no
+human stood between the issue and the plan, so the critics are the only review
+the plan gets before implementation. Record it as `planReview: forced —
+auto-next` (see *Delivery weight*); attended `next` follows weight as normal,
+because its Phase 0 approval stop is that missing human. **Full with an
+unreviewed plan**
 → invoke `/review-plan`, present the revised plan + a one-line change log
 (applied / rejected) as an **FYI**, keep going —
 except a **blocker** (wrong approach, breaking, data-loss), which stops the
@@ -425,6 +488,12 @@ Three distinct cases, and they must not be conflated:
   missing run file is not a pass, exactly as a dead grader is not a pass; and a
   file without `reconciled` means Phase 1's sweep never ran. This is what makes
   both gates real rather than advisory.
+- **`mode: next` with `selection` missing or empty** → **hard stop**, the same
+  way and for the same reason: it means the selection in
+  [`references/next-mode.md`](references/next-mode.md) never ran, so nothing
+  established that this issue was the right one, still verified, or claimed.
+  Without this the `selection` block would be telemetry no phase reads — a
+  green indistinguishable from never having looked.
 
 How it is graded depends on weight:
 
@@ -600,3 +669,9 @@ Wherever it stops — the gate, an untriageable red gate, a stuck PR — end wit
 a concise status: phase reached, branch and PR, what passed, what's blocking,
 and the single next action needed from the user. The destination is a green
 PR ready for their merge — say plainly whether you got there.
+
+A `next` run that stops **before its PR opens** owes one extra line: the issue
+it claimed has been released back to `Ready`, or it is stranded in a column
+nothing else can move it out of.
+
+Arguments: $ARGUMENTS

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -341,11 +341,24 @@ Procedures and traps:
    slot**. Procedure, buckets and traps:
    [`references/worktree-lifecycle.md`](references/worktree-lifecycle.md).
    **Release stranded `next` claims while you are here — keyed on the PID, not
-   on a bucket.** For every run file with a `next` mode, `pr: null` and
-   `status: open`, test its `conductorPid` with `kill -0`. **Dead** → that run
-   is holding an issue in **In progress** with nobody to release it: move the
-   issue back to **Ready** and count it in the `reconciled` line. **Alive, or
+   on a bucket.** For every run file with a `next` mode, `pr: null`,
+   `status: open`, **no `claimReleased` stamp**, and **`selection.claimed` not
+   `false`**, test its `conductorPid` with `kill -0`. **Dead** → that run is
+   holding an issue in **In progress** with nobody to release it: move the issue
+   back to **Ready**, **stamp `claimReleased: <iso8601>` on the deliverable**,
+   and count it in the `reconciled` line's `claims released` slot. **Alive, or
    the PID is absent/unparseable** → leave it entirely, and report it.
+   Both extra predicate clauses prevent the sweep from taking an issue away from
+   a **live** delivery, which is the same harm the claim itself exists to
+   prevent — just reached from the other direction:
+   - **`claimed: false`** means that run's claim write failed and it proceeded
+     unclaimed (`references/next-mode.md` §6). It never held the issue, so there
+     is nothing to give back — and by now another run may legitimately hold it.
+   - **`claimReleased`** makes the release **idempotent**. The predicate is
+     otherwise still true after a release, so the next run re-releases the same
+     issue; once it has been re-claimed by anyone, that repeat is a theft rather
+     than a recovery. Nothing else closes the file: bucket 4 explicitly permits
+     a dead run file to be left standing.
    Do **not** key this on the worktree buckets. `resumable` tests the PID, but
    `settled` does not test liveness at all, and — decisively — a `next` run
    holds its claim from **Phase 0, before any worktree exists**, which is the
@@ -377,6 +390,13 @@ Procedures and traps:
    the phase list and the run file, it isn't lost work. Set the run file's
    `entry` to `created`, or to `adopted` when resuming an existing worktree
    via `EnterWorktree(path:)` — **Phase 12's teardown branches on it.**
+   **Adopting a `next` run whose deliverable carries `claimReleased`?** Its
+   issue was handed back to `Ready` while it was dead and may now belong to
+   someone else. Re-run the three-step claim in
+   [`references/next-mode.md`](references/next-mode.md) §6 before resuming —
+   `Status` not `Ready` → stop and say the issue was re-claimed elsewhere.
+   Resuming on the strength of a claim the sweep already released is how an
+   adopted run comes to "release" an issue a live delivery is holding.
 5. **Move the issue to `In progress`** — the run file's `issue`, if it has one.
    This is the right moment rather than Phase 0: the entry gate can still stop a
    run, so the worktree is the first step that commits to doing the work. Column

--- a/.claude/skills/deliver/references/auto-and-async.md
+++ b/.claude/skills/deliver/references/auto-and-async.md
@@ -92,7 +92,7 @@ unattended run must still be reviewable.
   **not** a panel decision: in auto it behaves as the `merge` opt-in — once
   ready, proceed to wrap-up (and merge if `merge` was passed).
 
-**Not delegable — Phase 11.** The recurring-pattern scan used to be a seventh
+**Not delegable — Phase 11.** The recurring-pattern scan used to be a delegable
 decision point, with the panel approving proposals and **applying them
 directly**. It is now excluded, and the script throws if asked for it: a
 `proceed` there would authorise an unattended run to edit and push the repo's

--- a/.claude/skills/deliver/references/auto-and-async.md
+++ b/.claude/skills/deliver/references/auto-and-async.md
@@ -25,7 +25,7 @@ Workflow({ scriptPath: '.claude/workflows/deliver-panel.js',
 ```
 
 (A repo-relative `scriptPath` resolves — verified 2026-07-29. It lives in a file
-rather than embedded in this doc because it runs at **six** decision points per
+rather than embedded in this doc because it runs at **seven** decision points per
 run: an executed script cannot drift between invocations the way one re-authored
 from prose can, and drift in a *decision procedure* is a correctness bug, not an
 inefficiency. The three review skills embed theirs because each runs once per
@@ -54,7 +54,7 @@ squeamish: `stop` hands back to a human and is recoverable; `proceed` may not be
 **The conductor may not state a preference.** `args` carries facts only —
 `decision`, `context`, `evidence`, `proceedMeans`, `stopMeans`, `artifacts`.
 The script **throws** if passed `recommendation`/`preference`/`suggested`, and
-**throws** on any `decision` outside the six below. That is what keeps the hard
+**throws** on any `decision` outside the seven below. That is what keeps the hard
 stops hard *by construction* rather than by prose: an unattended run cannot
 invent a new delegable decision.
 
@@ -63,8 +63,16 @@ record (per-juror verdicts, tally, live count, `degraded`). Paste the line into
 the ledger for **every** panel convened. Autonomy *with* a full record — an
 unattended run must still be reviewable.
 
-**Panel decision points** — **six** (marked **Auto:** in `SKILL.md`):
+**Panel decision points** — **seven** (marked **Auto:** in `SKILL.md`):
 
+- Phase 0, `next` only — the run picked its own issue and drafted its own plan:
+  proceed with both vs stop. This is the attended approval stop
+  ([`next-mode.md`](next-mode.md) §7) with the jurors standing in for the human.
+  It exists because `next` is the first mode to **add** a stop-and-ask, and auto
+  mode's whole invariant is that such a stop becomes a panel — dropping it
+  unattended would leave the conductor that chose the work and wrote the plan as
+  its own only judge. The jurors rule on **both halves**: is this the right next
+  issue, and does the plan address it.
 - Phase 0 — acceptance criteria neither supplied **nor derivable**: proceed
   without a rubric (Phase 6 becomes a no-op) vs stop. ACs that are *derivable*
   from a linked issue or an explicit test list are **not** a panel decision — the
@@ -115,7 +123,16 @@ If you queue a `/deliver`, mind two things:
 - **Inline the whole plan + acceptance criteria in the trigger prompt.** A
   fresh session has no conversation history, and Phase 0's entry gate
   **requires ACs** — so the plan text and its ACs must travel *in* the prompt,
-  or the run stops at the gate immediately.
+  or the run stops at the gate immediately. **`next` is the one exception, and
+  only in your own environment** — it derives both from the issue it picks, so
+  `/deliver auto merge next` needs no plan in the prompt at all. That works from
+  a CCR-spawned session, which keeps your user-scoped MCP; it does **not** work
+  on a GitHub Actions runner, where the Projects MCP is not mounted and
+  `gh project` fails for want of the `read:project` scope
+  ([ADR-0009](../../../../knowledge/decisions/0009-github-mcp-over-gh-cli.md);
+  `/triage-issues` is unrunnable there for exactly the same reason). A headless
+  `auto next` would fail at its first call, so headless runs still inline the
+  plan.
 - **User-scoped MCP may be absent** (`mcp__github__*`, `wiki`). The `gh`
   fallbacks in `/pr` and `/watch-pr` cover GitHub; the wiki step degrades
   silently. A headless GitHub-Actions run has no user MCP at all (it uses
@@ -125,6 +142,9 @@ If you queue a `/deliver`, mind two things:
 **Recommendation — don't routinise async *feature* delivery here.** This is a
 single-maintainer package with public API surface, where the ready-to-merge
 human gate is deliberate — every change is a compatibility call worth a
-human's eyes. Async earns its place for the *occasional* away-from-keyboard
+human's eyes. That sentence is also why `next` refuses to select a
+non-`none` **Breaking class** in `merge` mode ([`next-mode.md`](next-mode.md)
+§5): `/deliver auto merge next` is the one invocation that could otherwise turn
+a board row into a merged compatibility decision with nobody reading it. Async earns its place for the *occasional* away-from-keyboard
 run and for the self-healing integration cron (which already opens a PR for
 review, never merges) — not as the default path.

--- a/.claude/skills/deliver/references/next-mode.md
+++ b/.claude/skills/deliver/references/next-mode.md
@@ -314,6 +314,20 @@ footprint. The run still delivers; it just stops at the gate.
    do not pretend it landed — both the §6 release obligation and Phase 1's
    sweep key off that flag, and a run that believes it holds a claim it does
    not will "release" an issue another run is delivering.
+4. **Write the claim to the run file *now*, before drafting anything.** The
+   moment the re-read settles, persist three things: `selection.picked`,
+   `selection.claimed`, and the deliverable's `issue`. The rest of `selection`
+   can wait for the end of selection; these three cannot.
+
+   This ordering is the whole recovery mechanism, not bookkeeping. Between the
+   board write and the end of drafting sit a `Plan` agent invocation and,
+   attended, an unbounded wait at the approval stop — and a user who reads the
+   plan, wanders off and closes the terminal is the likeliest way this mode ever
+   dies. A run that dies there with the issue unwritten matches Phase 1's sweep
+   predicate exactly (`next` mode, `pr: null`, `status: open`, no stamp,
+   `claimed` absent) **and names no issue to hand back**, so the strand is
+   unrecoverable by the mechanism built for it, in precisely the window the
+   early claim exists to cover.
 
 Step 1 narrows the race; it does not eliminate it. `update_project_item` is a
 blind overwrite with no compare-and-swap, so two runs that re-read in the same
@@ -346,8 +360,10 @@ Phase 1 reconcile sweep, which releases the issue of any `next` run that never
 opened a PR **and whose `conductorPid` is dead**
 ([`worktree-lifecycle.md`](worktree-lifecycle.md)).
 
-That sweep **stamps `claimReleased` on the run file it released**, and skips any
-file already carrying it — so the release happens once. Left unstamped, the
+That sweep **stamps `claimHandedBack` on the deliverable it released** (not on
+the run file as a whole — a batch releases each qualifying deliverable
+independently), and skips any deliverable already carrying it — so the release
+happens once. Left unstamped, the
 sweep's predicate is still true afterwards and every later run re-releases the
 same issue; the moment it has been legitimately re-claimed, that repeat takes it
 away from a live delivery. It also skips any run recording
@@ -399,7 +415,9 @@ nothing downstream is special-cased.
 
 ## The `selection` block
 
-Written into the run file at the end of selection, and **read by Phase 6**: a
+Written into the run file at the end of selection — **except `picked` and
+`claimed`, which are written at §6 step 4, the instant the claim settles and
+before any drafting** — and **read by Phase 6**: a
 run whose run file records `mode: next` with `selection` missing or empty
 **hard-stops at the exit gate**, exactly as a missing `reconciled` block does.
 Without that, `selection` would be telemetry nobody checks — a green

--- a/.claude/skills/deliver/references/next-mode.md
+++ b/.claude/skills/deliver/references/next-mode.md
@@ -41,8 +41,9 @@ Keep an item only if **both** hold: its `Status` is `Ready`, **and** its issue
 `Ready` for as long as it takes the board's automation to move it, and on
 2026-08-20 the newest run-list was headed by an issue that was already `Done`.
 
-Then remove three classes of candidate. Each is cheap, and each prevents a
-distinct way of delivering the same work twice:
+Then remove the candidates that are unfit before any verifier runs. The first
+two are cheap, and each prevents a distinct way of delivering the same work
+twice; the third defers to §5:
 
 - **Already claimed by a PR** — an open pull request whose body carries
   `Closes #NNN` for that issue. One `mcp__github__list_pull_requests` call
@@ -52,7 +53,8 @@ distinct way of delivering the same work twice:
 - **Already claimed by a live worktree** — a run file under `.git/deliver/`
   whose deliverable names that `issue` and whose worktree is `live` (lock PID
   alive; see [`worktree-lifecycle.md`](worktree-lifecycle.md)).
-- **Breaking, in `merge` mode only** — see §5.
+- **Unfit for `merge` mode** — breaking (§5a) or reflexive (§5b). Only in
+  `merge` mode, and a skip rather than a rejection.
 
 An empty set after filtering → **stop before any worktree**, report the counts,
 and recommend `/triage-issues`.
@@ -130,16 +132,26 @@ Spawn **one read-only subagent per candidate**, given the issue body, its latest
 | --- | --- |
 | `startable` | every claim in the body still holds at the sha; the fix approach is determined; no unsatisfied `dependsOn` |
 | `stale` | a load-bearing claim no longer holds — the code moved, or it was already fixed |
-| `needs-decision` | sound, but the fix approach is not determined (a `**Decision needed:**` line, a `question` label, or an open `dependsOn` from the marker's `deps=`) |
+| `needs-decision` | sound, but the fix approach is not determined — a `**Decision needed:**` line, a `question` label, an open `dependsOn` from the marker's `deps=`, or an explicit `**Breaking class:** needs a decision` |
 
 plus the **one deciding fact** and **what it checked first-hand**. A verifier
 that cannot name what it checked votes `stale`.
 
 **A dead verifier is not a `startable`.** Retry once; still dead or unusable →
-the candidate is **rejected**, and the run moves on. This is deterministic on
-purpose — "fall back to deciding it yourself" would hand the startability call
-to the party with an interest in continuing, which is the whole reason the
-dead-grader rule exists in Phase 6.
+**pass the candidate over** — leave it in `Ready`, do not comment, do not count
+it against the reject cap, and move on. This is deterministic on purpose:
+"fall back to deciding it yourself" would hand the startability call to the
+party with an interest in continuing, which is the whole reason the dead-grader
+rule exists in Phase 6.
+
+Pass over rather than reject, because a dead verifier is a fact about the
+**harness**, not about the issue. Demoting a healthy `Ready` issue and
+commenting on it because a subagent died blames the board for a tooling
+failure — and there is no verdict to put in the comment's marker anyway. For
+the same reason, **two dead verifiers in one run stop the run**: repeated
+verifier death means the harness is broken, and continuing would silently pass
+over the whole queue and report "nothing startable", which reads as a board
+problem. Say which it was.
 
 **`dependsOn` outranks priority.** An open dependency makes a candidate
 `needs-decision` even when it sits at the head — `/triage-issues` Phase 6 sorts
@@ -240,6 +252,14 @@ unclassified compatibility question belongs. Only an issue **explicitly**
 classed `needs a decision` is a §4 rejection, and then because its fix approach
 is undecided — not because of this section.
 
+`auto-and-async.md` already states why this filter is worth its pickiness: this
+is a single-maintainer package with public API surface *"where the
+ready-to-merge human gate is deliberate — every change is a compatibility call
+worth a human's eyes"*. Without it, `/deliver auto merge next` would have
+squash-merged a milestone-20.0.0 behavioural change on the day it shipped.
+Without `merge`, `/deliver auto next` still delivers those issues — it just
+stops at the gate, which is exactly where a compatibility call belongs.
+
 > **Expect `merge` mode to be picky, and say so when it is.** On the board at
 > the time of writing, **3 of the 12** `Ready` issues carry a Breaking-class
 > line at all, so `/deliver auto merge next` will often report "nothing
@@ -269,14 +289,6 @@ the `merge` opt-in** whenever the run file says `reflexive: true` and
 `mode: next` — belt and braces, in case the fix sketch understated the
 footprint. The run still delivers; it just stops at the gate.
 
-This is not belt-and-braces: `auto-and-async.md` already states that this is a
-single-maintainer package with public API surface *"where the ready-to-merge
-human gate is deliberate — every change is a compatibility call worth a human's
-eyes"*. Without the filter, `/deliver auto merge next` would have squash-merged
-a milestone-20.0.0 behavioural change on the day it shipped. Without `merge`,
-`/deliver auto next` still delivers those issues — it just stops at the gate,
-which is exactly where a compatibility call belongs.
-
 ## 6 — Claim the issue, then draft
 
 **Claim before drafting.** The moment a candidate is `startable`:
@@ -290,7 +302,13 @@ which is exactly where a compatibility call belongs.
    [`.github/ISSUE_FILING.md`](../../../../.github/ISSUE_FILING.md) →
    *Board status*).
 3. **Re-read once more to confirm the write landed** — a board write is
-   non-fatal by policy, so a failed one is otherwise silent.
+   non-fatal by policy, so a failed one is otherwise silent. Still not
+   `In progress` → retry once, then **proceed unclaimed**: record
+   `"claimed": false` in `selection` and say in the report that the board does
+   not reflect this run. Do not stop (a board write never fails the work) and
+   do not pretend it landed — both the §6 release obligation and Phase 1's
+   sweep key off that flag, and a run that believes it holds a claim it does
+   not will "release" an issue another run is delivering.
 
 Step 1 narrows the race; it does not eliminate it. `update_project_item` is a
 blind overwrite with no compare-and-swap, so two runs that re-read in the same
@@ -319,12 +337,21 @@ it is in the lifecycle table with the others.
 presupposes reaching a stop report; the commonest end of an unattended run —
 context exhaustion, a killed session, a dropped MCP — reaches none, and leaves
 the claim held forever. So the recovery is **also** owned by the next run's
-Phase 1 reconcile sweep, which releases the issue of any dead `next` run that
-never opened a PR ([`worktree-lifecycle.md`](worktree-lifecycle.md)). Two
-owners for one release is deliberate here, and is not the ambiguity the
-one-owner rule guards against: they cannot both fire, because the first only
-runs while the conductor is alive and the second only once it demonstrably is
-not.
+Phase 1 reconcile sweep, which releases the issue of any `next` run that never
+opened a PR **and whose `conductorPid` is dead**
+([`worktree-lifecycle.md`](worktree-lifecycle.md)).
+
+Two owners for one release is deliberate, and it is not the ambiguity the
+one-owner rule guards against — but only because of that PID test, so do not
+weaken it to something cheaper. They cannot both fire: the first runs only
+while the conductor is alive, the second only once it is **proven** dead. The
+worktree buckets look like they would serve and do not: `settled` performs no
+liveness test at all, and a `next` claim is held from Phase 0, *before any
+worktree exists*. A bucket-keyed sweep would therefore either release a live
+conductor's claim while it sits at the approval stop — handing the issue to a
+concurrent run, which is the double-delivery the early claim exists to
+prevent — or never see the pre-worktree window, which is where the claim
+actually lives.
 
 **Draft with the `Plan` agent**, given the issue body, the verifier's findings,
 and the `knowledge/` entries Phase 0's consult surfaced. From the issue:

--- a/.claude/skills/deliver/references/next-mode.md
+++ b/.claude/skills/deliver/references/next-mode.md
@@ -53,8 +53,9 @@ twice; the third defers to §5:
 - **Already claimed by a live worktree** — a run file under `.git/deliver/`
   whose deliverable names that `issue` and whose worktree is `live` (lock PID
   alive; see [`worktree-lifecycle.md`](worktree-lifecycle.md)).
-- **Unfit for `merge` mode** — breaking (§5a) or reflexive (§5b). Only in
-  `merge` mode, and a skip rather than a rejection.
+- **Unfit for `merge` mode** — breaking (§5a), reflexive (§5b), or written by
+  an untrusted author (§5c). Only in `merge` mode, and a skip rather than a
+  rejection.
 
 An empty set after filtering → **stop before any worktree**, report the counts,
 and recommend `/triage-issues`.
@@ -203,7 +204,8 @@ list, so check a new case against it rather than inventing a third:
 
 - removed by a §2 filter — closed, no longer `Ready`, or already claimed by an
   open `Closes #NNN` PR or a live worktree;
-- skipped by §5's `merge`-mode tests — breaking (5a) or reflexive (5b);
+- skipped by §5's `merge`-mode tests — breaking (5a), reflexive (5b), or an
+  untrusted author (5c);
 - lost to a concurrent claim at §6 step 1;
 - **its verifier died twice** — a fact about the harness, not the issue.
 A "3 consecutive rejects" rule counted from the head would let three stale items

--- a/.claude/skills/deliver/references/next-mode.md
+++ b/.claude/skills/deliver/references/next-mode.md
@@ -196,11 +196,16 @@ longer holds. Both halves matter:
 
 **Cap the rejects per run, not from the head.** Stop when either the whole
 candidate list is exhausted or **5** candidates have been **rejected** in this
-run. Only a §4 verdict is a reject. A candidate removed by a §2 filter (closed,
-not `Ready`, already claimed by a PR or a live worktree), skipped by §5's
-`merge`-mode tests, or lost to a concurrent claim is **passed over, not
-rejected** — it never reached a verifier, nothing is wrong with it, and it does
-not count against the cap or earn a comment.
+run. Only a §4 verdict is a reject. Everything else is **passed over, not
+rejected** — no verifier ruled on it, nothing is wrong with it, and it neither
+counts against the cap nor earns a comment. That is the whole of the other
+list, so check a new case against it rather than inventing a third:
+
+- removed by a §2 filter — closed, no longer `Ready`, or already claimed by an
+  open `Closes #NNN` PR or a live worktree;
+- skipped by §5's `merge`-mode tests — breaking (5a) or reflexive (5b);
+- lost to a concurrent claim at §6 step 1;
+- **its verifier died twice** — a fact about the harness, not the issue.
 A "3 consecutive rejects" rule counted from the head would let three stale items
 brick `next` permanently while startable work sat at position 4. Report
 `n rejected, picked #m` in one line either way.
@@ -341,6 +346,13 @@ Phase 1 reconcile sweep, which releases the issue of any `next` run that never
 opened a PR **and whose `conductorPid` is dead**
 ([`worktree-lifecycle.md`](worktree-lifecycle.md)).
 
+That sweep **stamps `claimReleased` on the run file it released**, and skips any
+file already carrying it — so the release happens once. Left unstamped, the
+sweep's predicate is still true afterwards and every later run re-releases the
+same issue; the moment it has been legitimately re-claimed, that repeat takes it
+away from a live delivery. It also skips any run recording
+`selection.claimed: false`, which never held the issue at all.
+
 Two owners for one release is deliberate, and it is not the ambiguity the
 one-owner rule guards against — but only because of that PID test, so do not
 weaken it to something cheaper. They cannot both fire: the first runs only
@@ -407,9 +419,15 @@ indistinguishable from never having run.
     { "issue": 426, "verdict": "needs-decision", "why": "body offers three competing fixes; demoted to Backlog" }
   ],
   "picked": 448,
-  "breakingClass": "none"
+  "breakingClass": "none",
+  "claimed": true
 }
 ```
+
+`claimed` is **not** decoration. It is read by Phase 1's reconcile sweep, which
+skips any run file recording `claimed: false` — that run never held the issue,
+so there is nothing to hand back, and by the time the sweep runs someone else
+may legitimately hold it. Write it on every `next` run, both values.
 
 Note what the two lists mean, because the distinction is load-bearing:
 `rejected` holds candidates a **verifier** ruled on — each one was demoted and

--- a/.claude/skills/deliver/references/next-mode.md
+++ b/.claude/skills/deliver/references/next-mode.md
@@ -46,7 +46,9 @@ distinct way of delivering the same work twice:
 
 - **Already claimed by a PR** — an open pull request whose body carries
   `Closes #NNN` for that issue. One `mcp__github__list_pull_requests` call
-  (`state: open`), which Phase 1's reconcile sweep already makes.
+  (`state: open`). This is its own call, made here in Phase 0 — Phase 1's
+  reconcile sweep makes a similar one later, with `state: all`, for a different
+  purpose; neither reuses the other's result.
 - **Already claimed by a live worktree** — a run file under `.git/deliver/`
   whose deliverable names that `issue` and whose worktree is `live` (lock PID
   alive; see [`worktree-lifecycle.md`](worktree-lifecycle.md)).
@@ -170,8 +172,23 @@ longer holds. Both halves matter:
   own marker, which makes the issue look touched-since-triage and forces a full
   re-triage next run — here that is the **point**, not a cost.
 
+  **Never skip the comment on a run that actually performed the move.** The
+  demotion's whole exit route is that bumped `updated_at`: a Project field write
+  does **not** touch the issue's own timestamp, so a silent demotion leaves
+  `/triage-issues`' skip condition satisfied, its Phase 3 carries the stale
+  `exit: ready` marker forward, and Phase 7 promotes the issue straight back to
+  `Ready` without re-examining it — the poisoned head returns, unexamined and
+  now with a triage run's apparent blessing. So the idempotency skip applies
+  only when the item was **already** in Backlog; if this run wrote
+  `Ready → Backlog`, always post or refresh the marker comment.
+
 **Cap the rejects per run, not from the head.** Stop when either the whole
-candidate list is exhausted or **5** candidates have been rejected in this run.
+candidate list is exhausted or **5** candidates have been **rejected** in this
+run. Only a §4 verdict is a reject. A candidate removed by a §2 filter (closed,
+not `Ready`, already claimed by a PR or a live worktree), skipped by §5's
+`merge`-mode tests, or lost to a concurrent claim is **passed over, not
+rejected** — it never reached a verifier, nothing is wrong with it, and it does
+not count against the cap or earn a comment.
 A "3 consecutive rejects" rule counted from the head would let three stale items
 brick `next` permanently while startable work sat at position 4. Report
 `n rejected, picked #m` in one line either way.
@@ -179,16 +196,27 @@ brick `next` permanently while startable work sat at position 4. Report
 Nothing startable → **stop before any worktree**, list what was rejected and
 why, and recommend `/triage-issues`.
 
-## 5 — `merge` mode refuses a breaking change
+## 5 — What `merge` mode refuses
+
+Everything in this section is **scoped to `merge` mode** and is a
+**skip**, not a rejection: the candidate is passed over for this run and left
+exactly where it is on the board. Nothing here demotes anything, and outside
+`merge` mode none of it is read at all — §4's verifier alone decides
+startability. Keep that boundary: an earlier draft let the `Breaking class`
+default leak into every mode, which on the board as it stands would have
+demoted nine perfectly good `Ready` issues on the first run.
 
 `/deliver auto merge next` is the only invocation that can take an issue from a
-board to a merged commit with nobody looking. The body template
+board to a merged commit with nobody looking. Two properties make a candidate
+unfit for that, and both are knowable before Phase 1.
+
+### 5a — A breaking change
+
+The body template
 ([`.github/ISSUE_FILING.md`](../../../../.github/ISSUE_FILING.md)) ends every
 issue with `**Breaking class:** none | source-breaking | behavioural | needs a
-decision`.
-
-**In `merge` mode, a candidate is selectable only if its class is `none`.**
-Skip the rest, name them in the report, and take the next candidate.
+decision`. **In `merge` mode, a candidate is selectable only if its class is
+`none`.**
 
 Read the class **defensively — real bodies vary**, and the three shapes seen on
 the live board are not interchangeable:
@@ -197,7 +225,7 @@ the live board are not interchangeable:
 | --- | --- | --- |
 | Inline bold label | issue 437: `**Breaking class:** adding a case … is source-breaking for exhaustive switches` | the label's text, not a bare enum value |
 | Its own heading | issue 448: `## Breaking class` / `None — CI configuration only.` | the section's first sentence |
-| **Absent** | issue 426 carries no class at all | `needs a decision` |
+| **Absent** | issue 426 carries no class at all | **not `none`** — so unselectable in `merge` mode, and nothing more |
 
 So: find the label in either form, take the prose that follows, and treat it as
 `none` **only** when that prose actually says so. Anything else — a qualifier, a
@@ -205,10 +233,41 @@ sentence you are not sure about, or no label at all — is **not** `none`. The
 default matters more than the parse: an unlabelled issue is the one nobody
 classified, which is the last one to merge unread.
 
-**A `needs a decision` class is a rejection in every mode**, not just `merge` —
-an issue whose fix approach is undecided fails re-verification anyway (§4), and
-the two facts should agree. Issue 426 is the live example: no class line, and a
-"Decision needed" section offering three different fixes.
+**Absence is not a verdict about the issue**, only about merging it unattended.
+An unlabelled issue is still perfectly deliverable by `/deliver next` and
+`/deliver auto next`; it just stops at the human gate, which is where an
+unclassified compatibility question belongs. Only an issue **explicitly**
+classed `needs a decision` is a §4 rejection, and then because its fix approach
+is undecided — not because of this section.
+
+> **Expect `merge` mode to be picky, and say so when it is.** On the board at
+> the time of writing, **3 of the 12** `Ready` issues carry a Breaking-class
+> line at all, so `/deliver auto merge next` will often report "nothing
+> selectable" while `/deliver auto next` has plenty to do. That is the template
+> being backfilled over time, not a fault — report which candidates were skipped
+> for a missing class, so the gap is visible rather than mysterious.
+
+### 5b — A reflexive change
+
+An issue whose fix touches `.claude/skills/**`, `.claude/agents/**`,
+`.claude/workflows/**` or `.github/CODE_REVIEW.md` is **not selectable in
+`merge` mode either**, whatever its Breaking class. Judge it from the issue's
+own fix sketch and the files it names, at the same moment as the class.
+
+This closes a hole the Breaking-class filter does not cover: those files carry
+no public API, so a reflexive issue reads as `none`. Issue 467 is the live
+example — P2, small, touches `.claude/agents/**` — and `auto merge next` would
+otherwise have selected it, drafted its own plan, and squash-merged **a rewrite
+of the delivery machinery with nobody reading it**. That is the exact thing
+[`deliver-panel.js`](../../../workflows/deliver-panel.js) says must never
+happen: *"a `proceed` must never authorise an unattended run to edit and push
+the repo's own skill files"*. Before `next`, a human chose to deliver a skill
+change unattended; the machine must not choose it for them.
+
+Phase 0 already computes `reflexive` for the drafted plan, so **Phase 10 drops
+the `merge` opt-in** whenever the run file says `reflexive: true` and
+`mode: next` — belt and braces, in case the fix sketch understated the
+footprint. The run still delivers; it just stops at the gate.
 
 This is not belt-and-braces: `auto-and-async.md` already states that this is a
 single-maintainer package with public API surface *"where the ready-to-merge
@@ -220,10 +279,25 @@ which is exactly where a compatibility call belongs.
 
 ## 6 — Claim the issue, then draft
 
-**Claim before drafting.** The moment a candidate is `startable`, write
-`Status = In progress` (call:
-[`.github/ISSUE_FILING.md`](../../../../.github/ISSUE_FILING.md) → *Board status*),
-then **re-read the item to confirm the write landed**. Only then draft.
+**Claim before drafting.** The moment a candidate is `startable`:
+
+1. **Re-read the item's `Status` immediately before writing.** Anything other
+   than `Ready` means another run claimed it during your verification — a
+   subagent call, so a window of minutes. Treat it as a **lost race**: move to
+   the next candidate, and do not count it against the reject cap (nothing was
+   wrong with the issue).
+2. Write `Status = In progress` (call:
+   [`.github/ISSUE_FILING.md`](../../../../.github/ISSUE_FILING.md) →
+   *Board status*).
+3. **Re-read once more to confirm the write landed** — a board write is
+   non-fatal by policy, so a failed one is otherwise silent.
+
+Step 1 narrows the race; it does not eliminate it. `update_project_item` is a
+blind overwrite with no compare-and-swap, so two runs that re-read in the same
+instant still both proceed. Do not describe this as making concurrent claims
+impossible — it makes them improbable, and the remaining window is small enough
+that the Phase 1 exclusions (an open `Closes #NNN` PR, a live worktree) catch
+what is left.
 
 Claiming here rather than at Phase 1 is deliberate. Phase 1 is the normal owner
 of that move, and for a plan the user brought it is the right moment — the entry
@@ -240,6 +314,17 @@ pick is two deliveries of one issue. Phase 1's write then finds the item already
 this drains the queue into a column `next` can never see again and
 `/triage-issues` is forbidden to touch. `/deliver` owns this reverse transition;
 it is in the lifecycle table with the others.
+
+**And a release that depends on a live conductor is not enough.** The rule above
+presupposes reaching a stop report; the commonest end of an unattended run —
+context exhaustion, a killed session, a dropped MCP — reaches none, and leaves
+the claim held forever. So the recovery is **also** owned by the next run's
+Phase 1 reconcile sweep, which releases the issue of any dead `next` run that
+never opened a PR ([`worktree-lifecycle.md`](worktree-lifecycle.md)). Two
+owners for one release is deliberate here, and is not the ambiguity the
+one-owner rule guards against: they cannot both fire, because the first only
+runs while the conductor is alive and the second only once it demonstrably is
+not.
 
 **Draft with the `Plan` agent**, given the issue body, the verifier's findings,
 and the `knowledge/` entries Phase 0's consult surfaced. From the issue:
@@ -284,13 +369,23 @@ indistinguishable from never having run.
 ```json
 "mode": "next",
 "selection": {
-  "source": "run-list@cc7cba55",
+  "source": "board-fields (no run-list line; deps/contention unknown)",
   "verifiedAt": "527682f7",
   "listed": 12,
-  "picked": 426,
-  "breakingClass": "behavioural",
+  "passedOver": [
+    { "issue": 434, "why": "filtered by §2 — closed, still showing Ready" },
+    { "issue": 437, "why": "skipped by §5a — Breaking class source-breaking, merge mode" }
+  ],
   "rejected": [
-    { "issue": 434, "verdict": "stale", "why": "closed by PR #469; filtered before verification" }
-  ]
+    { "issue": 426, "verdict": "needs-decision", "why": "body offers three competing fixes; demoted to Backlog" }
+  ],
+  "picked": 448,
+  "breakingClass": "none"
 }
 ```
+
+Note what the two lists mean, because the distinction is load-bearing:
+`rejected` holds candidates a **verifier** ruled on — each one was demoted and
+counts against the cap — while `passedOver` holds candidates that never reached
+a verifier and were left exactly as they were. An entry in the wrong list either
+demotes an issue that was fine or hides one that is not.

--- a/.claude/skills/deliver/references/next-mode.md
+++ b/.claude/skills/deliver/references/next-mode.md
@@ -182,13 +182,33 @@ why, and recommend `/triage-issues`.
 ## 5 — `merge` mode refuses a breaking change
 
 `/deliver auto merge next` is the only invocation that can take an issue from a
-board to a merged commit with nobody looking. Every issue body carries a
-`**Breaking class:** none | source-breaking | behavioural | needs a decision`
-line ([`.github/ISSUE_FILING.md`](../../../../.github/ISSUE_FILING.md)).
+board to a merged commit with nobody looking. The body template
+([`.github/ISSUE_FILING.md`](../../../../.github/ISSUE_FILING.md)) ends every
+issue with `**Breaking class:** none | source-breaking | behavioural | needs a
+decision`.
 
 **In `merge` mode, a candidate is selectable only if its class is `none`.**
-Absent or unparseable counts as `needs a decision`, never as `none`. Skip the
-rest, name them in the report, and take the next candidate.
+Skip the rest, name them in the report, and take the next candidate.
+
+Read the class **defensively — real bodies vary**, and the three shapes seen on
+the live board are not interchangeable:
+
+| Shape | Example | Read as |
+| --- | --- | --- |
+| Inline bold label | issue 437: `**Breaking class:** adding a case … is source-breaking for exhaustive switches` | the label's text, not a bare enum value |
+| Its own heading | issue 448: `## Breaking class` / `None — CI configuration only.` | the section's first sentence |
+| **Absent** | issue 426 carries no class at all | `needs a decision` |
+
+So: find the label in either form, take the prose that follows, and treat it as
+`none` **only** when that prose actually says so. Anything else — a qualifier, a
+sentence you are not sure about, or no label at all — is **not** `none`. The
+default matters more than the parse: an unlabelled issue is the one nobody
+classified, which is the last one to merge unread.
+
+**A `needs a decision` class is a rejection in every mode**, not just `merge` —
+an issue whose fix approach is undecided fails re-verification anyway (§4), and
+the two facts should agree. Issue 426 is the live example: no class line, and a
+"Decision needed" section offering three different fixes.
 
 This is not belt-and-braces: `auto-and-async.md` already states that this is a
 single-maintainer package with public API surface *"where the ready-to-merge

--- a/.claude/skills/deliver/references/next-mode.md
+++ b/.claude/skills/deliver/references/next-mode.md
@@ -224,8 +224,13 @@ default leak into every mode, which on the board as it stands would have
 demoted nine perfectly good `Ready` issues on the first run.
 
 `/deliver auto merge next` is the only invocation that can take an issue from a
-board to a merged commit with nobody looking. Two properties make a candidate
-unfit for that, and both are knowable before Phase 1.
+board to a merged commit with nobody looking. Three properties make a candidate
+unfit for that, and all are knowable before Phase 1: it is **breaking** (5a), it
+is **reflexive** (5b), or it was **written by someone outside this repo** (5c).
+
+Two of the three are read out of the issue body, which is why 5c exists — the
+first two ask the issue to certify itself, and 5c asks who signed the
+certificate.
 
 ### 5a — A breaking change
 
@@ -274,10 +279,17 @@ stops at the gate, which is exactly where a compatibility call belongs.
 
 ### 5b — A reflexive change
 
-An issue whose fix touches `.claude/skills/**`, `.claude/agents/**`,
-`.claude/workflows/**` or `.github/CODE_REVIEW.md` is **not selectable in
-`merge` mode either**, whatever its Breaking class. Judge it from the issue's
-own fix sketch and the files it names, at the same moment as the class.
+An issue whose fix touches the **reflexive set** — `.claude/skills/**`,
+`.claude/agents/**`, `.claude/workflows/**` or `.github/CODE_REVIEW.md` — is
+**not selectable in `merge` mode either**, whatever its Breaking class. Judge it
+from the issue's own fix sketch and the files it names, at the same moment as
+the class, and **resolve any doubt as reflexive**.
+
+That set is defined in `SKILL.md` Phase 0 and quoted here; the two must match
+exactly, because Phase 10's backstop keys on Phase 0's computation rather than
+on this test. When they drifted — this list carrying `.claude/workflows/**` and
+Phase 0's not — the backstop covered three quarters of what this gate refuses,
+and the missing quarter was the one holding `deliver-panel.js`.
 
 This closes a hole the Breaking-class filter does not cover: those files carry
 no public API, so a reflexive issue reads as `none`. Issue 467 is the live
@@ -293,6 +305,32 @@ Phase 0 already computes `reflexive` for the drafted plan, so **Phase 10 drops
 the `merge` opt-in** whenever the run file says `reflexive: true` and
 `mode: next` — belt and braces, in case the fix sketch understated the
 footprint. The run still delivers; it just stops at the gate.
+
+### 5c — An issue this repo's maintainers didn't write
+
+Both tests above read the **issue body**, and 5b also reads its fix sketch. That
+text is written by whoever opened the issue. `adamayoung/TMDb` is a **public
+repository**, and `/triage-issues` sweeps *every* open issue onto the board, so
+an issue reaching `Ready` is not evidence that a maintainer chose it.
+
+**In `merge` mode, a candidate is selectable only if its `author_association`
+is `OWNER`, `MEMBER` or `COLLABORATOR`** — and the same is required of the
+`<!-- triaged: … -->` marker comment §4 relies on. Anything else, including
+`CONTRIBUTOR` and `NONE`, is not selectable. Read it from the issue and the
+comment (`mcp__github__issue_read` returns it); absent or unrecognised counts as
+untrusted, like every other default in this section.
+
+Without this, the two properties authorising an unattended merge are **supplied
+by the party whose work is being authorised** — they write the defect, the fix
+sketch, the `Breaking class: none` line, and (via the *Failure scenario* section
+§6 derives the rubric from) the acceptance criteria their own change will be
+graded against. Nothing in the path re-derives any of it from the code. That is
+a supply-chain path into `main` of a published package, and an author check is
+the cheap, decisive cut across it.
+
+This only ever *narrows* `merge`. An outside contributor's issue is still
+delivered by `/deliver next` and `/deliver auto next` — it simply stops at the
+human gate, which is exactly where a stranger's proposal should stop.
 
 ## 6 — Claim the issue, then draft
 

--- a/.claude/skills/deliver/references/next-mode.md
+++ b/.claude/skills/deliver/references/next-mode.md
@@ -1,0 +1,276 @@
+# /deliver — `next` mode: selecting the work (reference)
+
+Read on demand when `/deliver next` is invoked. `SKILL.md` Phase 0 summarises
+this; the procedure, the exclusions and the traps live here.
+
+`next` answers one question — *which issue should this delivery deliver?* — and
+then hands a plan to the pipeline that already exists. Everything after the
+plan is unchanged: Phase 0's entry gate, the worktree, the reviews, the gate.
+
+**Requires the user-scoped GitHub Projects MCP.** Every step below is
+`mcp__github__projects_*`, which is **not mounted on a GitHub Actions runner**
+and cannot be replaced by `gh project` — the repo's token lacks the
+`read:project` scope, so the `gh` route fails at the first call
+([ADR-0009](../../../../knowledge/decisions/0009-github-mcp-over-gh-cli.md);
+`/triage-issues` records the same constraint for the same reads). No
+`projects_*` → **stop and say exactly that**. Never degrade into Phase 0's
+"no plan" stop, which reads as an unrelated failure, and never fall back to
+`gh project`.
+
+## 1 — Resolve the board
+
+```text
+mcp__github__projects_list / list_projects   owner: adamayoung, owner_type: user
+→ select the project whose title is exactly "TMDb"
+```
+
+Resolve **by title, never a hard-coded number**. Zero matches or more than one
+→ stop. A hard-coded number fails quietly against the wrong board rather than
+loudly against none.
+
+## 2 — Build the live Ready set
+
+```text
+mcp__github__projects_list / list_project_items
+  project_number: <resolved>   field_names: ["Status", "Priority", "Size"]
+  per_page: 50                 — paginate until pageInfo.hasNextPage is false
+```
+
+Keep an item only if **both** hold: its `Status` is `Ready`, **and** its issue
+`state` is `open`. Both halves are load-bearing — a closed issue can sit in
+`Ready` for as long as it takes the board's automation to move it, and on
+2026-08-20 the newest run-list was headed by an issue that was already `Done`.
+
+Then remove three classes of candidate. Each is cheap, and each prevents a
+distinct way of delivering the same work twice:
+
+- **Already claimed by a PR** — an open pull request whose body carries
+  `Closes #NNN` for that issue. One `mcp__github__list_pull_requests` call
+  (`state: open`), which Phase 1's reconcile sweep already makes.
+- **Already claimed by a live worktree** — a run file under `.git/deliver/`
+  whose deliverable names that `issue` and whose worktree is `live` (lock PID
+  alive; see [`worktree-lifecycle.md`](worktree-lifecycle.md)).
+- **Breaking, in `merge` mode only** — see §5.
+
+An empty set after filtering → **stop before any worktree**, report the counts,
+and recommend `/triage-issues`.
+
+## 3 — Order the candidates
+
+The board has **no rank field**, so ordering lives in the Project status update
+`/triage-issues` publishes. Read it:
+
+```text
+mcp__github__projects_list / list_project_status_updates   per_page: 5
+```
+
+Take the newest update carrying the canonical run-list line. That line has a
+**fixed grammar**, defined once in `/triage-issues` (its Phase 8) and parsed
+here and nowhere else:
+
+```text
+<!-- run-list: <sha> | 426,437,448,428,454,424,425,427,429,435,467,430 -->
+```
+
+Parse **only that line**. Its prose table is for humans and is written afresh
+each run — the 2026-08-18 and 2026-08-20 updates already use different table
+shapes, so a regex over the table is not reproducible, and a near-miss would
+silently discard exactly the dependency and contention ordering the run-list
+exists to carry.
+
+**No status update carries the line → there is no usable run-list.** Say so, in
+those words, and fall back to board fields: order by Priority (P0 → P1 → P2),
+then Size ascending (XS < S < M < L < XL). State in the report that **dependency
+and contention order are unknown on this path** — the fallback reproduces two of
+`/triage-issues`' four sort rules, not all four. Never quietly best-effort the
+prose table into a third ordering authority.
+
+Final order:
+
+1. Run-list entries that survived §2, **in run-list order**. That order already
+   encodes dependency-first sorting, in which a P2 that unblocks a P0 legitimately
+   precedes P0s — so never re-sort it by priority.
+2. Any surviving item **absent** from the run-list, appended **last**, each
+   flagged *"not in the current run-list — order unknown; `/triage-issues` owns
+   it"*. Filing puts new issues in **Backlog**, and only `/triage-issues` writes
+   `Ready` (and republishes the list with it), so this case means someone moved
+   an item by hand. Appending is deliberate: an unordered item must not be
+   interleaved into an order it was never sorted against.
+
+Record the ordering source in the run file's `selection` block — either
+`run-list@<sha>` or `board-fields (no run-list line; deps/contention unknown)`.
+
+## 4 — Re-verify the head candidate
+
+`Ready` means the issue passed `/triage-issues`' Ready test **at some sha**, not
+at the current one. The 2026-08-20 run-list says so itself: 11 of its 13 entries
+"were not re-verified". So re-verify before planning.
+
+**Pin the tree first.** Fetch, then resolve the ref:
+
+```bash
+git fetch origin
+git rev-parse --short origin/main
+```
+
+Verify against **`origin/main`**, not against `HEAD`. `/deliver next` may be
+invoked from a worktree or any feature branch — `CLAUDE.md` makes a non-`main`
+checkout the normal case — so a verifier told to read "HEAD" grades a tree that
+is not the one being delivered against, while claiming to be current. Pin the
+**ref**, not the checkout: hand the resolved sha to the verifier and have it
+read `git show origin/main:<path>` and `git log origin/main`. Record it as
+`verifiedAt` in the `selection` block.
+
+Spawn **one read-only subagent per candidate**, given the issue body, its latest
+`<!-- triaged: … -->` marker comment, and that sha. It returns:
+
+| Verdict | Meaning |
+| --- | --- |
+| `startable` | every claim in the body still holds at the sha; the fix approach is determined; no unsatisfied `dependsOn` |
+| `stale` | a load-bearing claim no longer holds — the code moved, or it was already fixed |
+| `needs-decision` | sound, but the fix approach is not determined (a `**Decision needed:**` line, a `question` label, or an open `dependsOn` from the marker's `deps=`) |
+
+plus the **one deciding fact** and **what it checked first-hand**. A verifier
+that cannot name what it checked votes `stale`.
+
+**A dead verifier is not a `startable`.** Retry once; still dead or unusable →
+the candidate is **rejected**, and the run moves on. This is deterministic on
+purpose — "fall back to deciding it yourself" would hand the startability call
+to the party with an interest in continuing, which is the whole reason the
+dead-grader rule exists in Phase 6.
+
+**`dependsOn` outranks priority.** An open dependency makes a candidate
+`needs-decision` even when it sits at the head — `/triage-issues` Phase 6 sorts
+dependencies first, and its `deps=` marker field is where that fact survives for
+an issue no agent re-read this run.
+
+### Rejecting a candidate
+
+A rejected candidate is **moved to `Backlog`**, with a comment naming what no
+longer holds. Both halves matter:
+
+- **The move is what gives it an exit.** `/triage-issues` is scoped to Backlog
+  and never re-examines a `Ready` item, so leaving it in `Ready` would mean the
+  same poisoned head is re-verified, re-rejected and re-commented on every future
+  run, while the items behind it stay unreachable. `/deliver next` **owns the
+  `Ready` → `Backlog` transition** — recorded in
+  [`.github/ISSUE_FILING.md`](../../../../.github/ISSUE_FILING.md)'s lifecycle
+  table, so the column still has exactly one owner per transition. Leave
+  `Priority` and `Size` untouched: they are `/triage-issues`' output and the
+  verdict does not re-size anything.
+- **The comment ends with a marker**, so it is idempotent and so triage picks
+  the issue up next run:
+
+  ```text
+  <!-- deliver-next: rejected <sha> | <verdict> -->
+  ```
+
+  Read the last `deliver-next:` marker first and skip the comment when the
+  verdict and sha are unchanged. The comment deliberately lands *after* triage's
+  own marker, which makes the issue look touched-since-triage and forces a full
+  re-triage next run — here that is the **point**, not a cost.
+
+**Cap the rejects per run, not from the head.** Stop when either the whole
+candidate list is exhausted or **5** candidates have been rejected in this run.
+A "3 consecutive rejects" rule counted from the head would let three stale items
+brick `next` permanently while startable work sat at position 4. Report
+`n rejected, picked #m` in one line either way.
+
+Nothing startable → **stop before any worktree**, list what was rejected and
+why, and recommend `/triage-issues`.
+
+## 5 — `merge` mode refuses a breaking change
+
+`/deliver auto merge next` is the only invocation that can take an issue from a
+board to a merged commit with nobody looking. Every issue body carries a
+`**Breaking class:** none | source-breaking | behavioural | needs a decision`
+line ([`.github/ISSUE_FILING.md`](../../../../.github/ISSUE_FILING.md)).
+
+**In `merge` mode, a candidate is selectable only if its class is `none`.**
+Absent or unparseable counts as `needs a decision`, never as `none`. Skip the
+rest, name them in the report, and take the next candidate.
+
+This is not belt-and-braces: `auto-and-async.md` already states that this is a
+single-maintainer package with public API surface *"where the ready-to-merge
+human gate is deliberate — every change is a compatibility call worth a human's
+eyes"*. Without the filter, `/deliver auto merge next` would have squash-merged
+a milestone-20.0.0 behavioural change on the day it shipped. Without `merge`,
+`/deliver auto next` still delivers those issues — it just stops at the gate,
+which is exactly where a compatibility call belongs.
+
+## 6 — Claim the issue, then draft
+
+**Claim before drafting.** The moment a candidate is `startable`, write
+`Status = In progress` (call:
+[`.github/ISSUE_FILING.md`](../../../../.github/ISSUE_FILING.md) → *Board status*),
+then **re-read the item to confirm the write landed**. Only then draft.
+
+Claiming here rather than at Phase 1 is deliberate. Phase 1 is the normal owner
+of that move, and for a plan the user brought it is the right moment — the entry
+gate can still stop the run. But `next` inserts a long window between the pick
+and Phase 1: a `Plan` agent invocation and, attended, an unbounded wait for a
+human. Concurrent `/deliver` sessions are explicitly sanctioned, so an unclaimed
+pick is two deliveries of one issue. Phase 1's write then finds the item already
+`In progress` and is a no-op.
+
+**A claim must be releasable.** Nothing else in the repo moves an issue *out* of
+`In progress`, so on **any stop before the PR opens** — a rejected plan, a
+`/review-plan` blocker, a red gate, a panel `stop` — move the issue back to
+`Ready` (Priority and Size untouched) and say so in the stop report. Skipping
+this drains the queue into a column `next` can never see again and
+`/triage-issues` is forbidden to touch. `/deliver` owns this reverse transition;
+it is in the lifecycle table with the others.
+
+**Draft with the `Plan` agent**, given the issue body, the verifier's findings,
+and the `knowledge/` entries Phase 0's consult surfaced. From the issue:
+
+- **The rubric.** The issue's *Failure scenario* section is already
+  observable before/after behaviour — derive the ACs from it in
+  "Given X, when Y, then Z" form. Record
+  `rubricProvenance: derived — issue <number>`, **never `supplied`**, even
+  though the drafted plan text carries ACs: `supplied` means a human set the
+  bar, and here the same run that will be graded wrote them. Drop
+  knowledge-shaped ACs exactly as Phase 0's entry gate requires.
+- **The branch prefix** — `bug` → `fix/`, `enhancement` → `feature/`,
+  `documentation` → `docs/`, anything else → `chore/`.
+- **`issue: <number>`** on the deliverable in the run file.
+
+## 7 — Approve, then continue
+
+- **Attended** (`/deliver next`) → present the plan, its derived ACs, and one
+  line on why this issue was picked, and **stop for approval**. Invoking
+  `/deliver` is plan approval for a plan the user wrote; it cannot be approval
+  for one that did not exist at invocation. This is the only pause `next` adds,
+  and Contract §1 names it.
+- **Auto** (`/deliver auto next`) → no stop. The decision is put to the
+  **`phase0n-selection` panel** — three independent jurors ruling on whether to
+  proceed with a machine-drafted plan for a machine-picked issue. Auto mode's
+  invariant is that every stop-and-ask becomes a panel; dropping the stop
+  silently would leave the conductor that chose the issue *and* wrote the plan
+  as its own only judge. Procedure:
+  [`auto-and-async.md`](auto-and-async.md).
+
+Then continue through the rest of Phase 0 unchanged. A plan now exists, so
+nothing downstream is special-cased.
+
+## The `selection` block
+
+Written into the run file at the end of selection, and **read by Phase 6**: a
+run whose run file records `mode: next` with `selection` missing or empty
+**hard-stops at the exit gate**, exactly as a missing `reconciled` block does.
+Without that, `selection` would be telemetry nobody checks — a green
+indistinguishable from never having run.
+
+```json
+"mode": "next",
+"selection": {
+  "source": "run-list@cc7cba55",
+  "verifiedAt": "527682f7",
+  "listed": 12,
+  "picked": 426,
+  "breakingClass": "behavioural",
+  "rejected": [
+    { "issue": 434, "verdict": "stale", "why": "closed by PR #469; filtered before verification" }
+  ]
+}
+```

--- a/.claude/skills/deliver/references/worktree-lifecycle.md
+++ b/.claude/skills/deliver/references/worktree-lifecycle.md
@@ -51,13 +51,13 @@ git worktree list --porcelain | awk -v r="$main_root/.claude/worktrees/" \
    can never brick the pipeline on an unrecognised state.
 
 3. **Release stranded `next` claims.** For every run file with a `next` mode,
-   `pr: null`, `status: open`, no `claimReleased`, and `selection.claimed` not
+   `pr: null`, `status: open`, no `claimHandedBack`, and `selection.claimed` not
    `false`, test its `conductorPid` with `kill -0`. Dead → move that issue back
-   to **Ready**, stamp `claimReleased: <iso8601>` on the deliverable, and count
+   to **Ready**, stamp `claimHandedBack: <iso8601>` on the deliverable, and count
    it. Alive, `EPERM`, or no parseable PID → leave it and report it. Key this on
    the **PID**, never on the worktree buckets: `settled` tests no liveness, and
    a `next` run holds its claim from Phase 0, *before any worktree exists*.
-   The `claimReleased` stamp is what makes this **idempotent** — without it the
+   The `claimHandedBack` stamp is what makes this **idempotent** — without it the
    predicate stays true after the release, so every later run re-releases the
    same issue, and once it has been legitimately re-claimed the repeat release
    takes it out from under a live delivery.
@@ -182,7 +182,7 @@ is a claim that a human set the bar.
     "worktree": "…/.claude/worktrees/chore+harden-delivery-skills",
     "branch": "chore/harden-delivery-skills",
     "entry": "created",
-    "claimReleased": null,
+    "claimHandedBack": null,
     "rubric": ["Given …, when …, then …"],
     "rubricProvenance": "supplied",
     "stamps": { "reviewedClean": "<content hash>", "securityClean": null,
@@ -244,7 +244,7 @@ sweep reads `claimed` to decide whether this run has a claim worth releasing at
 all. Both fields are absent on an ordinary run, and `mode: next` without
 `selection` is the failure the gate exists to catch — not a default.
 
-**`claimReleased`** sits on the **deliverable**, not here, because it is written
+**`claimHandedBack`** sits on the **deliverable**, not here, because it is written
 by a *later* run than the one it describes: Phase 1's sweep stamps it when it
 hands a dead run's issue back to `Ready`. Its presence excludes that run file
 from the sweep for good, which is what stops the release repeating and

--- a/.claude/skills/deliver/references/worktree-lifecycle.md
+++ b/.claude/skills/deliver/references/worktree-lifecycle.md
@@ -153,10 +153,13 @@ is a claim that a human set the bar.
   "consulted": "gotchas §False green, §Docs scratch path; ADR-0014",
   "reconciled": { "inScope": 1, "reclaimed": 0, "resumable": 0, "reported": 0 },
   "mode": "next",
+  "planReview": "forced — auto-next",
   "selection": {
-    "source": "run-list@cc7cba55", "verifiedAt": "527682f7",
-    "listed": 12, "picked": 426, "breakingClass": "behavioural",
-    "rejected": [{ "issue": 434, "verdict": "stale", "why": "closed by PR #469" }]
+    "source": "board-fields (no run-list line; deps/contention unknown)",
+    "verifiedAt": "527682f7",
+    "listed": 12, "picked": 448, "breakingClass": "none",
+    "passedOver": [{ "issue": 434, "why": "filtered — closed, still showing Ready" }],
+    "rejected": [{ "issue": 426, "verdict": "needs-decision", "why": "three competing fixes; demoted" }]
   },
   "deliverables": [{
     "title": "…", "issue": 434, "dependsOn": [],
@@ -177,7 +180,7 @@ A **batch is the N=1 case generalised** — more entries in `deliverables[]`. No
 separate mechanism, and it is the only state that survives Phase 10's
 background-watch handoff, where the conductor moves to the next worktree.
 
-Four run-scoped fields sit outside `deliverables[]` because they describe the
+Five run-scoped fields sit outside `deliverables[]` because they describe the
 run, not a deliverable. **`consulted`** is Phase 0's knowledge-consult proof —
 the ledger that would otherwise hold it does not survive `EnterWorktree`, so
 this is its durable home, and Phase 8 copies it into the retro.
@@ -186,8 +189,19 @@ this is its durable home, and Phase 8 copies it into the retro.
 and 5 do (see `SKILL.md` Phase 0). A field mandated by a phase but absent from
 this schema is a field nothing ends up writing.
 
+**`planReview`** records the one sanctioned override of the weight rule: an
+`auto next` run always runs `/review-plan`'s critics, because nobody read its
+self-drafted plan. Its value is the literal `forced — auto-next`. It exists as a
+field rather than a habit for the reason this whole file exists — Phase 6
+hard-stops when an `auto` `next` run reaches the gate without it, so "the
+critics were skipped" cannot look identical to "the critics ran".
+
 **`mode`** and **`selection`** belong to `next` runs
-([`next-mode.md`](next-mode.md)). `selection` records how the issue was chosen —
+([`next-mode.md`](next-mode.md)). **`mode` is written when Phase 0 parses the
+invocation keywords — before selection runs**, not after it. That ordering is
+the whole point: written afterwards, a run that skipped selection would carry
+neither field and grade as an ordinary run, which is precisely the green the
+gate exists to catch. `selection` records how the issue was chosen —
 the ordering source and its sha, the sha every candidate was re-verified
 against, the pick, its `Breaking class`, and every rejected candidate with its
 verdict. It is **read, not merely written**: Phase 6 hard-stops when `mode` is
@@ -196,7 +210,7 @@ verdict. It is **read, not merely written**: Phase 6 hard-stops when `mode` is
 without `selection` is the failure the gate exists to catch — not a default.
 
 `rubricProvenance` on a `next` run is always `derived — issue <number>`; see
-the note below on why it is never `supplied`.
+the note above on why it is never `supplied`.
 
 **`issue`** is per-*deliverable*, not run-scoped: a batch can implement several
 issues, or none. It is the GitHub issue number this deliverable closes, or

--- a/.claude/skills/deliver/references/worktree-lifecycle.md
+++ b/.claude/skills/deliver/references/worktree-lifecycle.md
@@ -50,8 +50,22 @@ git worktree list --porcelain | awk -v r="$main_root/.claude/worktrees/" \
    Rows 2 and 6 make this total: **nothing can fail to classify**, so the sweep
    can never brick the pipeline on an unrecognised state.
 
-3. Record one ledger line: `reconciled: <n> in scope / <k> reclaimed / <r>
-   resumable / <o> reported`, and carry it into the retro (Phase 8).
+3. **Release stranded `next` claims.** For every run file with a `next` mode,
+   `pr: null`, `status: open`, no `claimReleased`, and `selection.claimed` not
+   `false`, test its `conductorPid` with `kill -0`. Dead → move that issue back
+   to **Ready**, stamp `claimReleased: <iso8601>` on the deliverable, and count
+   it. Alive, `EPERM`, or no parseable PID → leave it and report it. Key this on
+   the **PID**, never on the worktree buckets: `settled` tests no liveness, and
+   a `next` run holds its claim from Phase 0, *before any worktree exists*.
+   The `claimReleased` stamp is what makes this **idempotent** — without it the
+   predicate stays true after the release, so every later run re-releases the
+   same issue, and once it has been legitimately re-claimed the repeat release
+   takes it out from under a live delivery.
+4. Record one ledger line: `reconciled: <n> in scope / <k> reclaimed / <r>
+   resumable / <o> reported / <c> claims released`, and carry it into the retro
+   (Phase 8). **Claims released needs its own slot**, not a share of an existing
+   one — see the `swept:`/`reconciled:` incident below for what happens when two
+   counts contend for one key.
    **The key is `reconciled:`, never `swept:`** — `swept:` belongs to Phase 7's
    knowledge-retirement sweep, and when both wrote the same key the Phase 7 form
    occupied the slot for four consecutive deliveries while this tripwire went
@@ -151,14 +165,15 @@ is a claim that a human set the bar.
   "goal": "…", "weight": "full",
   "reflexive": false,
   "consulted": "gotchas §False green, §Docs scratch path; ADR-0014",
-  "reconciled": { "inScope": 1, "reclaimed": 0, "resumable": 0, "reported": 0 },
+  "reconciled": { "inScope": 1, "reclaimed": 0, "resumable": 0, "reported": 0,
+                  "claimsReleased": 0 },
   "mode": "auto merge next",
   "conductorPid": 90982,
   "planReview": "forced — auto-next",
   "selection": {
     "source": "board-fields (no run-list line; deps/contention unknown)",
     "verifiedAt": "527682f7",
-    "listed": 12, "picked": 448, "breakingClass": "none",
+    "listed": 12, "picked": 448, "breakingClass": "none", "claimed": true,
     "passedOver": [{ "issue": 434, "why": "filtered — closed, still showing Ready" }],
     "rejected": [{ "issue": 426, "verdict": "needs-decision", "why": "three competing fixes; demoted" }]
   },
@@ -167,6 +182,7 @@ is a claim that a human set the bar.
     "worktree": "…/.claude/worktrees/chore+harden-delivery-skills",
     "branch": "chore/harden-delivery-skills",
     "entry": "created",
+    "claimReleased": null,
     "rubric": ["Given …, when …, then …"],
     "rubricProvenance": "supplied",
     "stamps": { "reviewedClean": "<content hash>", "securityClean": null,
@@ -219,11 +235,21 @@ dead while a conductor is live at its approval stop, or never swept at all.
 
 `selection` records how the issue was chosen —
 the ordering source and its sha, the sha every candidate was re-verified
-against, the pick, its `Breaking class`, and every rejected candidate with its
-verdict. It is **read, not merely written**: Phase 6 hard-stops when `mode` is
-`next` and `selection` is missing or empty, the same way it does on a missing
-`reconciled` block. Both fields are absent on an ordinary run, and `mode: next`
-without `selection` is the failure the gate exists to catch — not a default.
+against, the pick, its `Breaking class`, whether the claim actually landed
+(**`claimed`**), every candidate a verifier **`rejected`** with its verdict, and
+every candidate **`passedOver`** without one. It is **read, not merely
+written**: Phase 6 hard-stops when `mode` is `next` and `selection` is missing
+or empty, the same way it does on a missing `reconciled` block, and Phase 1's
+sweep reads `claimed` to decide whether this run has a claim worth releasing at
+all. Both fields are absent on an ordinary run, and `mode: next` without
+`selection` is the failure the gate exists to catch — not a default.
+
+**`claimReleased`** sits on the **deliverable**, not here, because it is written
+by a *later* run than the one it describes: Phase 1's sweep stamps it when it
+hands a dead run's issue back to `Ready`. Its presence excludes that run file
+from the sweep for good, which is what stops the release repeating and
+eventually taking an issue away from whoever legitimately re-claimed it. An
+adopt of a run carrying it must re-claim before resuming (`SKILL.md` Phase 1).
 
 `rubricProvenance` on a `next` run is always `derived — issue <number>`; see
 the note above on why it is never `supplied`.

--- a/.claude/skills/deliver/references/worktree-lifecycle.md
+++ b/.claude/skills/deliver/references/worktree-lifecycle.md
@@ -152,7 +152,8 @@ is a claim that a human set the bar.
   "reflexive": false,
   "consulted": "gotchas §False green, §Docs scratch path; ADR-0014",
   "reconciled": { "inScope": 1, "reclaimed": 0, "resumable": 0, "reported": 0 },
-  "mode": "next",
+  "mode": "auto merge next",
+  "conductorPid": 90982,
   "planReview": "forced — auto-next",
   "selection": {
     "source": "board-fields (no run-list line; deps/contention unknown)",
@@ -180,7 +181,7 @@ A **batch is the N=1 case generalised** — more entries in `deliverables[]`. No
 separate mechanism, and it is the only state that survives Phase 10's
 background-watch handoff, where the conductor moves to the next worktree.
 
-Five run-scoped fields sit outside `deliverables[]` because they describe the
+Six run-scoped fields sit outside `deliverables[]` because they describe the
 run, not a deliverable. **`consulted`** is Phase 0's knowledge-consult proof —
 the ledger that would otherwise hold it does not survive `EnterWorktree`, so
 this is its durable home, and Phase 8 copies it into the retro.
@@ -196,12 +197,27 @@ field rather than a habit for the reason this whole file exists — Phase 6
 hard-stops when an `auto` `next` run reaches the gate without it, so "the
 critics were skipped" cannot look identical to "the critics ran".
 
-**`mode`** and **`selection`** belong to `next` runs
-([`next-mode.md`](next-mode.md)). **`mode` is written when Phase 0 parses the
-invocation keywords — before selection runs**, not after it. That ordering is
-the whole point: written afterwards, a run that skipped selection would carry
-neither field and grade as an ordinary run, which is precisely the green the
-gate exists to catch. `selection` records how the issue was chosen —
+**`mode`**, **`conductorPid`** and **`selection`** belong to `next` runs
+([`next-mode.md`](next-mode.md)). `mode` and `conductorPid` are written **when
+Phase 0 parses the invocation keywords — before selection runs**, not after it.
+That ordering is the whole point: written afterwards, a run that skipped
+selection would carry neither field and grade as an ordinary run, which is
+precisely the green the gate exists to catch.
+
+`mode` records the **whole parsed invocation** — `"auto merge next"`, not
+`"next"`. `auto` and `merge` are read after the point where they could still be
+remembered: Phase 6's `planReview` stop runs past an `EnterWorktree`, and Phase
+10's merge-drop runs in the background, potentially in a resumed session. A
+keyword kept only in the ledger is a keyword those two phases silently no-op on.
+
+**`conductorPid`** is this session's PID, and it is what makes a stranded claim
+recoverable. Phase 1 releases a dead `next` run's issue **on the PID test
+alone** — never on the worktree buckets, because `settled` performs no liveness
+test and, more importantly, a `next` run holds its claim from Phase 0, *before
+any worktree exists to classify*. Without a PID, that window is either swept as
+dead while a conductor is live at its approval stop, or never swept at all.
+
+`selection` records how the issue was chosen —
 the ordering source and its sha, the sha every candidate was re-verified
 against, the pick, its `Breaking class`, and every rejected candidate with its
 verdict. It is **read, not merely written**: Phase 6 hard-stops when `mode` is

--- a/.claude/skills/deliver/references/worktree-lifecycle.md
+++ b/.claude/skills/deliver/references/worktree-lifecycle.md
@@ -141,7 +141,9 @@ carried them, or `derived — <source>` when Phase 0 derived them from a linked
 issue or an explicit test list (its second entry-gate case). It exists so a
 derived rubric is auditable rather than indistinguishable from a supplied one:
 Phase 6 grades both identically, but a reader can tell which was which, and the
-PR body is required to say so.
+PR body is required to say so. A **`next`-drafted plan is never `supplied`**,
+however many ACs its text carries — the `Plan` agent wrote them, and `supplied`
+is a claim that a human set the bar.
 
 ```json
 {
@@ -150,6 +152,12 @@ PR body is required to say so.
   "reflexive": false,
   "consulted": "gotchas §False green, §Docs scratch path; ADR-0014",
   "reconciled": { "inScope": 1, "reclaimed": 0, "resumable": 0, "reported": 0 },
+  "mode": "next",
+  "selection": {
+    "source": "run-list@cc7cba55", "verifiedAt": "527682f7",
+    "listed": 12, "picked": 426, "breakingClass": "behavioural",
+    "rejected": [{ "issue": 434, "verdict": "stale", "why": "closed by PR #469" }]
+  },
   "deliverables": [{
     "title": "…", "issue": 434, "dependsOn": [],
     "worktree": "…/.claude/worktrees/chore+harden-delivery-skills",
@@ -169,7 +177,7 @@ A **batch is the N=1 case generalised** — more entries in `deliverables[]`. No
 separate mechanism, and it is the only state that survives Phase 10's
 background-watch handoff, where the conductor moves to the next worktree.
 
-Two run-scoped fields sit outside `deliverables[]` because they describe the
+Four run-scoped fields sit outside `deliverables[]` because they describe the
 run, not a deliverable. **`consulted`** is Phase 0's knowledge-consult proof —
 the ledger that would otherwise hold it does not survive `EnterWorktree`, so
 this is its durable home, and Phase 8 copies it into the retro.
@@ -177,6 +185,18 @@ this is its durable home, and Phase 8 copies it into the retro.
 `.claude/agents/**` or `.github/CODE_REVIEW.md`, which changes what Phases 4
 and 5 do (see `SKILL.md` Phase 0). A field mandated by a phase but absent from
 this schema is a field nothing ends up writing.
+
+**`mode`** and **`selection`** belong to `next` runs
+([`next-mode.md`](next-mode.md)). `selection` records how the issue was chosen —
+the ordering source and its sha, the sha every candidate was re-verified
+against, the pick, its `Breaking class`, and every rejected candidate with its
+verdict. It is **read, not merely written**: Phase 6 hard-stops when `mode` is
+`next` and `selection` is missing or empty, the same way it does on a missing
+`reconciled` block. Both fields are absent on an ordinary run, and `mode: next`
+without `selection` is the failure the gate exists to catch — not a default.
+
+`rubricProvenance` on a `next` run is always `derived — issue <number>`; see
+the note below on why it is never `supplied`.
 
 **`issue`** is per-*deliverable*, not run-scoped: a batch can implement several
 issues, or none. It is the GitHub issue number this deliverable closes, or

--- a/.claude/skills/deliver/references/wrap-up.md
+++ b/.claude/skills/deliver/references/wrap-up.md
@@ -19,8 +19,11 @@ not a ceremony (a handful of bullets):
 - **`consulted:`** — Phase 0's knowledge-consult proof, copied from the run
   file: the `knowledge/` entries and ADRs read at entry, or `none relevant`.
 - **`reconciled:`** — Phase 1's worktree sweep, e.g.
-  `reconciled: 2 in scope / 1 reclaimed / 0 resumable / 1 reported`. Named for
-  the run file's own `reconciled` block.
+  `reconciled: 2 in scope / 1 reclaimed / 0 resumable / 1 reported / 0 claims
+  released`. Named for the run file's own `reconciled` block. The last slot is
+  `next`-specific — issues released from **In progress** because the run holding
+  them died; it is `0` on almost every delivery, and a non-zero value is worth a
+  sentence in the retro rather than just a number.
 - **`swept:`** — Phase 7's knowledge-retirement sweep, verbatim from
   `/capture-knowledge`'s report line, e.g.
   `swept: Makefile, ci.yml → 1 entry rewritten`, or `swept: n/a`.

--- a/.claude/skills/triage-issues/SKILL.md
+++ b/.claude/skills/triage-issues/SKILL.md
@@ -275,6 +275,37 @@ then dependency edges, then contention warnings, then the Backlog-blocked items
 each with its one-sentence decision. Keep it scannable — it is read at a glance,
 and it is the diff between one run and the next.
 
+### The run-list line — write it verbatim
+
+End the body with **exactly this line**, and nothing else after it:
+
+```text
+<!-- run-list: <short sha> | <issue numbers, in order, comma-separated, no spaces> -->
+```
+
+`/deliver next` parses **this line and nothing else** to decide what to work on
+([`.claude/skills/deliver/references/next-mode.md`](../deliver/references/next-mode.md)).
+The prose table above it is for humans and is rewritten from scratch every run —
+the 2026-08-18 and 2026-08-20 updates already use different column headers and
+different cell formats, so anything parsing the table is parsing a moving target,
+and a near-miss would silently discard the dependency and contention ordering
+this phase exists to publish.
+
+So: **assemble the line mechanically** — join the ordered issue numbers with
+commas — and do not reword, prettify, annotate or wrap it. It is the same
+discipline as the per-issue marker, for the same reason (an LLM re-authoring a
+fixed format from prose produces a different string each time), with the same
+consequence if it drifts: a consumer that quietly falls back rather than failing
+loudly. A status update **without** this line is *not a usable run-list*, and
+`next` will say so and fall back to board fields — which reproduces two of this
+phase's four sort rules and loses the other two.
+
+> The line is currently written by this skill, not built by
+> [`.claude/workflows/triage-issues.js`](../../workflows/triage-issues.js) the
+> way the marker is, because the ordering is decided in Phase 6 — after the
+> script has returned. Moving Phase 6's sort into the script would close that
+> gap; it is tracked, not done.
+
 Mark `AT_RISK` when a P0 sits in `blocked`: the highest-priority work being
 un-startable is exactly the state a status colour exists to surface.
 

--- a/.claude/workflows/deliver-panel.js
+++ b/.claude/workflows/deliver-panel.js
@@ -10,9 +10,18 @@ export const meta = {
 // rather than by prose. Phase 11 is deliberately ABSENT: a `proceed` must never
 // authorise an unattended run to edit and push the repo's own skill files,
 // least of all this script.
+//
+// A mode that adds a stop-and-ask MUST add its point here. `next` added the
+// Phase 0 plan-approval stop; leaving it off this list would not have made auto
+// mode safer, it would have made the stop vanish unattended — with the
+// conductor that chose the issue and wrote the plan left as its only judge.
+// "This mode delegates no decision" is a claim to check against the stops it
+// introduces, not a property to assert.
 const POINTS = {
+  'phase0n-selection':
+    'A `next` run has picked an issue off the board and drafted its own plan for it. Attended, this is where the human reads both and approves; unattended, you are that reader. Proceeding commits the pipeline to THIS issue and THIS self-authored plan. Nobody else has looked: the conductor chose the work and then wrote the plan for it, so the usual independence between "what to build" and "who approved it" is absent. Judge both halves — is this issue genuinely the right next one (still reproducing, fix approach determined, correctly ordered), and does the plan actually address it?',
   'phase0-no-acs':
-    'The plan arrived with no acceptance criteria AND none derivable from a linked issue or an explicit test list (derivable ACs are handled by the entry gate, not panelled). Proceeding makes Phase 6 (rubric verification) a no-op for the whole delivery — it ships with no exit gate.',
+    'The plan arrived with no acceptance criteria AND none derivable from a linked issue or an explicit test list (derivable ACs are handled by the entry gate, not panelled). Proceeding makes Phase 6 (rubric verification) a no-op for the whole delivery — it ships with no exit gate. NOTE: this point is about a plan the USER brought. A plan the conductor drafted for itself in `next` mode is `phase0n-selection`, and always derives its rubric from the issue — it never reaches this point.',
   'phase2-blocker':
     'A /review-plan blocker that is NOT data loss and NOT a breaking change. (Those two never reach this panel.)',
   'phase4-findings':

--- a/.github/ISSUE_FILING.md
+++ b/.github/ISSUE_FILING.md
@@ -120,9 +120,27 @@ through four skills.
 | --- | --- | --- |
 | **Backlog** | whoever files (this spec) | the issue is created |
 | **Ready** | `/triage-issues` | it passes the Ready test; Priority + Size are set with it |
-| **In progress** | `/deliver` (Phase 1) | the worktree is entered — work has actually begun |
+| **In progress** | `/deliver` (Phase 1, or Phase 0 for `next`) | the worktree is entered — or, in `next` mode, the moment the issue is picked |
 | **In review** | `/watch-pr` (§3, at *ready*) | the PR is green and mergeable, waiting on a human |
 | **Done** | the board's own "item closed" automation | the PR merges and closes the issue |
+
+Two **reverse** transitions exist, both owned by `/deliver next`, both there
+because that mode is the only thing in the repo that takes work off the board
+without a human choosing it:
+
+| Column | Set by | When |
+| --- | --- | --- |
+| **Ready → Backlog** | `/deliver next` (selection) | a Ready candidate fails re-verification against `origin/main` — its claims no longer hold, or its fix approach turns out to be undecided |
+| **In progress → Ready** | `/deliver next` | the run stops before its PR opens, releasing an issue it had claimed |
+
+Neither gives a column a second owner: `/triage-issues` still owns *promotion*
+into Ready, and `/deliver` still owns the move into In progress. What these add
+is an owner for undoing each — which nothing had. A `next` run that rejects a
+candidate but leaves it in Ready re-rejects the same issue on every future run
+while the queue behind it stays unreachable, because `/triage-issues` is scoped
+to Backlog and never re-examines a Ready item. A `next` run that claims an issue
+and then stops strands it in In progress, which nothing else can move it out of
+at all. Both are silent, and both drain the queue.
 
 **Done is deliberately not written by any skill.** It is the one transition
 observed to happen unaided: `/triage-issues` closes `wontfix` issues without

--- a/.github/ISSUE_FILING.md
+++ b/.github/ISSUE_FILING.md
@@ -124,23 +124,33 @@ through four skills.
 | **In review** | `/watch-pr` (§3, at *ready*) | the PR is green and mergeable, waiting on a human |
 | **Done** | the board's own "item closed" automation | the PR merges and closes the issue |
 
-Two **reverse** transitions exist, both owned by `/deliver next`, both there
-because that mode is the only thing in the repo that takes work off the board
+Three **reverse** transitions exist, all belonging to `/deliver`, all there
+because `next` is the only thing in the repo that takes work off the board
 without a human choosing it:
 
 | Column | Set by | When |
 | --- | --- | --- |
 | **Ready → Backlog** | `/deliver next` (selection) | a Ready candidate fails re-verification against `origin/main` — its claims no longer hold, or its fix approach turns out to be undecided |
 | **In progress → Ready** | `/deliver next` | the run stops before its PR opens, releasing an issue it had claimed |
+| **In progress → Ready** | `/deliver` Phase 1 reconcile, **any mode** | a *different*, dead `next` run left a claim behind — released by the next run's sweep, on a `conductorPid` liveness test |
 
-Neither gives a column a second owner: `/triage-issues` still owns *promotion*
-into Ready, and `/deliver` still owns the move into In progress. What these add
-is an owner for undoing each — which nothing had. A `next` run that rejects a
-candidate but leaves it in Ready re-rejects the same issue on every future run
-while the queue behind it stays unreachable, because `/triage-issues` is scoped
-to Backlog and never re-examines a Ready item. A `next` run that claims an issue
-and then stops strands it in In progress, which nothing else can move it out of
-at all. Both are silent, and both drain the queue.
+The last two are one obligation with two writers, and they cannot both fire:
+the first runs only while that run's conductor is alive to reach its stop
+report, the second only once that conductor's PID is proven dead. Splitting
+them is what makes the claim recoverable at all — a run killed by context
+exhaustion, a dropped MCP or a closed terminal reaches no stop report, and
+would otherwise hold its issue forever.
+
+None of the three gives a column a second owner: `/triage-issues` still owns
+*promotion* into Ready, and `/deliver` still owns the move into In progress.
+What they add is an owner for undoing each — which nothing had. A `next` run
+that rejects a candidate but leaves it in Ready re-rejects the same issue on
+every future run while the queue behind it stays unreachable, because
+`/triage-issues` is scoped to Backlog and never re-examines a Ready item. A
+`next` run that claims an issue and then dies strands it in In progress, which
+**only that reconcile sweep** can move it out of — `/triage-issues` is
+forbidden to touch the column, and `next` itself reads only Ready. Both are
+silent, and both drain the queue.
 
 **Done is deliberately not written by any skill.** It is the one transition
 observed to happen unaided: `/triage-issues` closes `wontfix` issues without

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,7 +233,10 @@ Feature work is **skill-driven**. Draft and approve a plan in **plan mode**
 `/deliver` to carry it through to a ready-to-merge PR. **Invoking `/deliver` is
 itself the plan-approval gate** — it then runs autonomously to a single hard stop,
 **ready-to-merge**, pausing only for a plan-review blocker or a red gate it can't
-triage. It **auto-scales** its review machinery to the change's risk (lite vs
+triage. **`/deliver next` needs no plan**: it takes the top startable issue off
+the project board's Ready column, re-verifies it, claims it and drafts one —
+adding a single approval stop for the plan it wrote (none in `auto`, where a
+juror panel rules instead). It **auto-scales** its review machinery to the change's risk (lite vs
 full), **triages** an unrelated red CI gate to `/fix-integration-failures` rather
 than stalling, and records each delivery's short retrospective into
 [`knowledge/delivery-retros.md`](knowledge/delivery-retros.md) **before the PR
@@ -245,7 +248,8 @@ branch → (`/review-plan` for risky/large changes) → `/implement-plan` →
 
 Key skills (the README's *Claude Code Skills* tables list them all):
 
-- **`/deliver`** — run the whole pipeline from an approved plan.
+- **`/deliver`** — run the whole pipeline from an approved plan; `/deliver next`
+  picks its own work off the board's Ready column first.
 - **`/review-plan`** — adversarial 3-critic review of a plan; apply the consensus.
 - **`/implement-plan`** — implement test-first (`canon-tdd`) to an empty test
   list, committing at logical checkpoints.
@@ -286,10 +290,13 @@ the other's rules.
 That spec also carries the **board's column lifecycle** — the one place the
 column names and the `update_project_item` idiom are written down. An issue moves
 Backlog → Ready (`/triage-issues`) → **In progress** (`/deliver`, on entering the
-worktree) → **In review** (`/watch-pr`, when the PR is green and waiting on you)
+worktree — or at the pick, in `next` mode) → **In review** (`/watch-pr`, when the
+PR is green and waiting on you)
 → Done (the board's own "item closed" automation, via the `Closes #NNN` line
-`/pr` puts in every PR body). Each column has exactly one owner; a board write
-that fails is reported, never fatal.
+`/pr` puts in every PR body). Two **reverse** moves belong to `/deliver next`
+alone — Ready → Backlog when a candidate fails re-verification, and In progress →
+Ready when a claimed run stops before its PR opens. Each transition has exactly
+one owner; a board write that fails is reported, never fatal.
 
 **Code review** — both the local `/review-changes` and the GitHub Actions reviewer
 follow one shared spec, [`.github/CODE_REVIEW.md`](.github/CODE_REVIEW.md), and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,10 +293,12 @@ Backlog → Ready (`/triage-issues`) → **In progress** (`/deliver`, on enterin
 worktree — or at the pick, in `next` mode) → **In review** (`/watch-pr`, when the
 PR is green and waiting on you)
 → Done (the board's own "item closed" automation, via the `Closes #NNN` line
-`/pr` puts in every PR body). Two **reverse** moves belong to `/deliver next`
-alone — Ready → Backlog when a candidate fails re-verification, and In progress →
-Ready when a claimed run stops before its PR opens. Each transition has exactly
-one owner; a board write that fails is reported, never fatal.
+`/pr` puts in every PR body). Three **reverse** moves belong to `/deliver` —
+Ready → Backlog when a `next` candidate fails re-verification, In progress →
+Ready when a claimed run stops before its PR opens, and In progress → Ready
+again from Phase 1's reconcile sweep, which releases the claim of a `next` run
+that died without stopping. Each transition has exactly one owner; a board
+write that fails is reported, never fatal.
 
 **Code review** — both the local `/review-changes` and the GitHub Actions reviewer
 follow one shared spec, [`.github/CODE_REVIEW.md`](.github/CODE_REVIEW.md), and

--- a/README.md
+++ b/README.md
@@ -682,9 +682,12 @@ Three constraints are worth knowing before you reach for it:
 * **It needs the user-scoped Projects MCP**, so it runs in your own environment
   (including a CCR-triggered session) but **not** on a GitHub Actions runner,
   where that MCP is not mounted — the same limit `/triage-issues` has.
-* **The issue is claimed at the pick**, not at the worktree, so two concurrent
-  runs can't take the same one; if the run stops before its PR opens, the claim
-  is released back to `Ready`.
+* **The issue is claimed at the pick**, not at the worktree, which narrows the
+  window in which two concurrent runs could take the same one down to the
+  verification call (the board has no compare-and-swap, so it isn't zero).
+  If the run stops before its PR opens the claim is released back to `Ready`,
+  and a run that dies without stopping has its claim released by the next
+  run's reconcile sweep.
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ that automate the development workflow. Invoke any of them with `/<name>`.
 
 | Skill | Purpose |
 | --- | --- |
-| `/deliver` | Orchestrate the full pipeline from an approved plan to a ready-to-merge PR |
+| `/deliver` | Orchestrate the full pipeline from an approved plan to a ready-to-merge PR — or `/deliver next` to take the top startable issue off the board's Ready column and plan it first |
 | `/review-plan` | Adversarially review the current plan with three independent critics and apply the consensus |
 | `/implement-plan` | Implement the plan test-first (Canon TDD) until the test list is empty |
 | `/review-changes` | Review the working-tree changes — one reviewer, or a parallel fan-out with adversarial verification for large diffs |
@@ -615,16 +615,23 @@ never auto-merges), then files/updates a tracking issue linking the fix. See
 the skill for the headless contract and the `INTEGRATION_FIX_PR_TOKEN` secret
 it needs.
 
-### Feature Workflow (`/plan` → `/deliver`)
+### Feature Workflow (plan mode → `/deliver`)
 
-To build a feature end-to-end, draft and approve a plan with `/plan` (Claude
-Code plan mode), then run `/deliver` to carry it all the way to a ready-to-merge
-pull request. **Invoking `/deliver` is itself the plan-approval gate** — it then
-runs autonomously to a single hard stop, **ready-to-merge**, and ends with a
-short retrospective.
+To build a feature end-to-end, draft and approve a plan in Claude Code **plan
+mode** (or with the `Plan` agent — there is no `/plan` skill), then run
+`/deliver` to carry it all the way to a ready-to-merge pull request.
+**Invoking `/deliver` is itself the plan-approval gate** — it then runs
+autonomously to a single hard stop, **ready-to-merge**, and ends with a short
+retrospective.
+
+Working from the issue tracker instead? **`/deliver next`** needs no plan: it
+takes the top startable issue off the project board's **Ready** column,
+re-verifies it against `origin/main`, claims it, drafts a plan and shows it to
+you for approval, then runs the same pipeline. See *Picking the next issue*
+below.
 
 ```text
-/plan                    ← you draft AND approve the plan
+plan mode                ← you draft AND approve the plan
   │
   ▼  invoking /deliver = plan approval; it then runs autonomously:
   ├─ (feature branch)
@@ -647,6 +654,37 @@ short retrospective.
 
 Each step is also usable on its own — e.g. `/review-changes` to review local
 changes, or `/watch-pr` to babysit an existing PR.
+
+#### Picking the next issue (`/deliver next`)
+
+`/triage-issues` grooms the Backlog into an ordered **Ready** queue and
+publishes that order as a Project status update. `/deliver next` is its
+consumer — one command from "what should I do now?" to a green PR:
+
+```text
+/deliver next              pick + plan + approve, then the pipeline above
+/deliver auto next         same, unattended — jurors rule instead of you
+/deliver auto merge next   same, and squash-merge once green
+```
+
+Selection reads the status update's canonical run-list line, drops anything no
+longer open-and-`Ready`, and re-verifies the head candidate against
+`origin/main` before planning it — a `Ready` verdict was true at some sha, not
+necessarily at today's. A candidate whose claims no longer hold goes back to
+**Backlog** with a comment, and the run moves on.
+
+Three constraints are worth knowing before you reach for it:
+
+* **`merge` refuses a breaking change.** In `merge` mode an issue is selectable
+  only if its `Breaking class` is `none` — absent or unparseable counts as
+  "needs a decision". Every other change still gets a human at the
+  ready-to-merge gate, which is where a compatibility call belongs.
+* **It needs the user-scoped Projects MCP**, so it runs in your own environment
+  (including a CCR-triggered session) but **not** on a GitHub Actions runner,
+  where that MCP is not mounted — the same limit `/triage-issues` has.
+* **The issue is claimed at the pick**, not at the worktree, so two concurrent
+  runs can't take the same one; if the run stops before its PR opens, the claim
+  is released back to `Ready`.
 
 ## Acknowledgments
 

--- a/knowledge/decisions/0016-panel-jurors-and-workflows-directory.md
+++ b/knowledge/decisions/0016-panel-jurors-and-workflows-directory.md
@@ -27,7 +27,7 @@ decision procedure.
 Role pre-commitment helps *build* a case and invalidates *reaching* one. A
 two-round design (assigned advocates brief, independent jurors rule) was
 considered and rejected as speculative generality: it costs five `opus`/`xhigh`
-agents per decision, at six decision points, for a mode that **has never been
+agents per decision, at every decision point, for a mode that **has never been
 exercised by a real delivery**. Nothing downstream consumed the briefs.
 
 So: **one round of three independent jurors**, `opus`/`xhigh`,
@@ -62,8 +62,13 @@ Both guards were verified live: each throws with **zero agents spawned**.
 
 The other Workflow scripts (`review-plan`, `review-knowledge`, `review-changes`
 and `fix-pr-checks` — four as of 2026-08-13) are embedded in their `SKILL.md`,
-and each runs **once per skill invocation**, so re-authoring costs nothing. The panel runs at **six
-decision points per run**, from a context that has been compacting for hours.
+and each runs **once per skill invocation**, so re-authoring costs nothing. The
+panel runs at **many decision points per run** — seven as of 2026-08-20, and the
+count grows whenever a mode adds a stop-and-ask — from a context that has been
+compacting for hours. The exact number lives in
+`.claude/workflows/deliver-panel.js`'s `POINTS` enum and in
+`deliver/references/auto-and-async.md`; it is deliberately not restated here,
+because a count in a third place is one more thing to drift.
 
 An embedded script is **re-authored** each time; a file is **executed**. Drift
 between invocations in a *decision procedure* — the tally rule, the dead-agent

--- a/knowledge/decisions/0026-unattended-selection-needs-an-author-check.md
+++ b/knowledge/decisions/0026-unattended-selection-needs-an-author-check.md
@@ -1,0 +1,88 @@
+# ADR-0026: An unattended run must not read its authorisation from the work it selected
+
+- **Status:** Accepted (unreleased — tooling only)
+- **Date:** 2026-08-20
+- **Deciders:** Adam Young
+
+## Context
+
+`/deliver next` lets the delivery pipeline choose its own work: it reads the
+project board's `Ready` column, picks a candidate, drafts a plan for it, and —
+as `/deliver auto merge next` — carries it to a squash-merge on `main` with no
+human in the loop.
+
+Two properties decide whether a candidate may take that unattended path, and
+both were parsed out of the **issue body**:
+
+- its `**Breaking class:**` line, which must read `none`;
+- whether its fix is *reflexive* — touching `.claude/skills/**`,
+  `.claude/agents/**`, `.claude/workflows/**` or `.github/CODE_REVIEW.md` —
+  judged from the issue's own fix sketch and the files it names.
+
+Three facts about this repository combine badly with that. It is **public**, so
+anyone can open an issue. `/triage-issues` adopts **every** open issue onto the
+board's Backlog, so reaching the board is automatic rather than a maintainer's
+choice. And `/deliver next` derives its acceptance criteria from the issue's
+*Failure scenario* section, so the rubric the work is graded against comes from
+the same text.
+
+The result was a self-attesting authorisation: an outsider could write the
+defect, the fix sketch, the line certifying it non-breaking, and the criteria
+their own change would be graded by. Nothing in the path re-derived any of it
+from the code, and nothing checked who wrote it. A security review of PR #474
+rated it HIGH with a concrete end-to-end path into `main` of a published
+package.
+
+## Decision
+
+**In `merge` mode, a candidate is selectable only if its `author_association`
+is `OWNER`, `MEMBER` or `COLLABORATOR` — and the same is required of the
+`<!-- triaged: … -->` marker comment the re-verification step relies on.**
+Absent or unrecognised counts as untrusted.
+
+`CONTRIBUTOR` is **excluded by name**. GitHub assigns it permanently once an
+account has had anything merged, so a one-line typo PR would otherwise buy a
+standing credential — an association check that stopped at "has contributed
+before" would be bypassable by design rather than by accident.
+
+The check is scoped to `merge` alone, and it **skips** rather than rejects: the
+candidate is passed over for this run and left exactly where it sits on the
+board, with no comment and no column change.
+
+## Consequences
+
+- `/deliver auto merge next` can only ever unattended-merge work that a
+  maintainer wrote. Every outside proposal still gets delivered by
+  `/deliver next` and `/deliver auto next` — it simply stops at the
+  ready-to-merge gate, which is where a stranger's proposal should stop.
+- The gate narrows what `merge` mode can pick. Combined with the Breaking-class
+  filter, `auto merge next` will often report "nothing selectable" and do
+  nothing, which is the intended failure direction but should be reported
+  clearly rather than read as a fault.
+- A residual remains and is filed as issue #473: `/triage-issues` still honours
+  a `<!-- triaged: … -->` marker from any author, so a forged marker can promote
+  an issue to `Ready` with a chosen Priority and Size, unexamined. With this ADR
+  in force that is a **board-integrity** problem — it can steer what the
+  pipeline picks up next — but no longer a path to a merge.
+- The reflexive glob set is now load-bearing for a security property, so it must
+  stay identical in its two homes. Both copies name each other and say *change
+  both or neither*; see `knowledge/gotchas.md` → *A rule written in two files
+  drifts*.
+
+## Alternatives considered
+
+- **Re-derive the facts from the code instead of trusting the body.** Correct in
+  principle and far more expensive: judging "is this change breaking?" before
+  the change exists means planning it first, and the reflexivity question is
+  only answerable from a drafted plan. The backstop already does the latter at
+  Phase 10; the author check is what makes the cheap up-front test safe.
+- **Drop `merge` from `next` entirely.** Removes the hazard completely, and the
+  feature with it. The gate is a narrower cut that keeps the useful case (the
+  maintainer's own small, non-breaking, non-reflexive work) intact.
+- **Require an explicit label such as `auto-mergeable`.** Equivalent security
+  from a different direction, but it adds a labelling step to every issue and
+  the label is itself writable by anyone with triage rights. The association is
+  already computed by GitHub and cannot be self-assigned.
+- **Trust the board, on the grounds that `Ready` implies a maintainer looked.**
+  False here: `/triage-issues` runs unattended and adopts orphans automatically,
+  so `Ready` is a machine's verdict, not a human's.

--- a/knowledge/decisions/README.md
+++ b/knowledge/decisions/README.md
@@ -43,6 +43,7 @@ always fair game.
 | [0023](0023-python-strict-parser-for-fixture-hygiene.md) | Enforce fixture hygiene with an independent strict parser, not a Swift test | 2026-08-14 | Accepted (unreleased — tooling only) |
 | [0024](0024-two-way-witness-guard.md) | Keep the defaulted-witness guard, as a two-way completeness oracle | 2026-08-14 | Accepted (in 20.0.0, unreleased) |
 | [0025](0025-redact-transport-error-payload.md) | Redact the transport error carried by `TMDbError.network` | 2026-08-20 | Accepted (in 20.0.0, unreleased) |
+| [0026](0026-unattended-selection-needs-an-author-check.md) | An unattended run must not read its authorisation from the work it selected | 2026-08-20 | Accepted (unreleased — tooling only) |
 
 > **Keep the Status column true.** "In X, unreleased" becomes "shipped in X" when
 > X is **tagged** — a `CHANGELOG.md` section is not a release. For breaking changes

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -25,7 +25,7 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
 
 ---
 
-## 2026-08-20 — ✨ `/deliver next` — select and plan the top Ready issue (`feature/deliver-next-mode`) · full
+## 2026-08-20 — ✨ `/deliver next` — select and plan the top Ready issue (#474) · full
 
 - **Phases / skills:** 0–8 pre-PR. Full weight — prose-only diff (~900 lines,
   12 files), but reflexive and it rewrites the pipeline's own contract, so

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -99,6 +99,19 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
   stale copy overrode rather than lagged. That is the third instance of one
   pattern in one delivery, now a gotcha in its own right.
 
+- **`watch:`** the readiness test nearly passed on a PR that could not merge.
+  `gh pr checks --watch` exited **0 twice**, minutes apart, with every printed
+  row reading `pass` — while eight of the `main` ruleset's ten required checks
+  had not reported at all, because the `CI` workflow was still **queued** and a
+  workflow that has not started produces **no check runs**. `/watch-pr` §3's
+  positive test ("every check run is completed and success") is vacuously true
+  over an empty-ish set, so it does not catch this; only `mergeStateStatus:
+  BLOCKED` did, and the first cause I inferred for that — a review requirement —
+  was wrong. The correct test compares against the ruleset's **required
+  contexts**, which needs `gh api repos/:owner/:repo/rules/branches/main`. Filed
+  as issue #475. Fourth instance of the False-green family this delivery, and
+  the purest: "not yet run" and "nothing wrong" were byte-identical.
+
 ## 2026-08-20 — 🔒 Redact credentials from `TMDbError.network`'s payload (#469) · full
 
 Branch `fix/redact-credentials-in-network-error`. Issue #434 (P0) — item 1 in

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -25,6 +25,80 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
 
 ---
 
+## 2026-08-20 — ✨ `/deliver next` — select and plan the top Ready issue (`feature/deliver-next-mode`) · full
+
+- **Phases / skills:** 0–8 pre-PR. Full weight — prose-only diff (~900 lines,
+  12 files), but reflexive and it rewrites the pipeline's own contract, so
+  `reflexive: true` overrode both self-skips. Skills: `review-plan` (3 critics),
+  `review-changes` (`force-review`, single-reviewer path — the fan-out's five
+  lenses are all Swift-specific and would have had nothing to read),
+  `security-review`, `capture-knowledge`.
+  `consulted:` gotchas *In a worktree session, Bash refuses commands it can't
+  prove stay inside it*, *`EnterWorktree` no longer uses the requested name*,
+  *`markdownlint --fix` turns a line-leading `#NNN` into an H1*, *A `Write` of a
+  Markdown file can leak `</content>`*, *Edits can land in the main checkout*;
+  ADR-0009.
+  `reconciled:` 0 in scope / 0 reclaimed / 0 resumable / 0 reported / 0 claims
+  released. One settled run file closed (PR #469, merged as `cabb3846`).
+  `swept:` `.claude/skills/deliver/**`, `.claude/skills/triage-issues/SKILL.md`,
+  `.claude/workflows/deliver-panel.js` → ADR-0016 rewritten (its "six decision
+  points", stated twice, was stale the moment the enum grew to seven; it now
+  points at the `POINTS` enum instead of restating a count).
+  `skill-improvement-log.md` left as-is — a decision log records what was
+  decided *then*.
+
+- **The dry-run of the selection step paid for itself twice.** Running §1–§6
+  read-only against the live board before writing any more prose found (a) that
+  real issue bodies express `Breaking class` three different ways, so my
+  one-shape parser would have misread two of three; and (b) that the head of the
+  queue, issue 426, is not startable at all — it carries three competing fix
+  options. Both became commits; (b) became issue #472. A feature that reads a
+  live system should be exercised against it before the spec is finished, not
+  after.
+
+- **Four review passes, and passes 2–4 mostly found defects the previous fix
+  created.** 12 → 8 → 3 → 2 findings. Nearly every one lived in a single seam —
+  the claim/release machinery that makes concurrent `next` runs safe — while the
+  selection logic was essentially right from the first draft. Worth remembering
+  when scoping a review budget: an adversarial loop over prose-as-program is not
+  converging on a fixed target, and the cost concentrates in whichever part
+  models concurrency.
+
+- **Friction — the ledger tool did not exist this session.** `/deliver`'s
+  Contract §6 mandates *two* records, a `TaskCreate` ledger and the run file;
+  no `TaskCreate`/`TodoWrite` tool was available, so the contract silently
+  degraded to one. The run file carried everything, which is the right
+  half to survive — but a mandated record that may simply be absent should say
+  so, rather than reading as unconditional.
+
+- **Friction — writes to `.git/deliver/` from inside a worktree fail *silently*.**
+  A `python3` heredoc rewriting the run file produced no output, no error and no
+  write; only a follow-up `grep` caught it. The existing gotcha documents the
+  *loud* refusal. Captured the silent variant and the staged-`cp` workaround.
+
+- **Deviation — the review-loop cap was exceeded by one, with the user's
+  authorisation.** Phase 4's 3-iteration cap was reached with three blockers
+  still open, all in one seam and all precisely specified. Rather than proceed
+  unverified or loop silently, the state went to the user with the option to cut
+  the whole concurrency seam instead; they chose one more pass. Passes 3 and 4
+  then closed six further findings, two of which (a live conductor's claim being
+  swept, and a claim held with no issue recorded) would have shipped.
+
+- **Deviation — AC 3 and AC 4 graded `not met`, deliberately.** AC 3's
+  script-assembled run-list line was narrowed at planning time and filed as
+  issue #471 (the ordering is computed after that script returns, so it needs
+  Phase 6's sort moved too). AC 4 says a dead verifier *rejects* the candidate;
+  review finding N3 showed that demotes a healthy issue and blames the board for
+  a harness failure, so it now *passes over*. Neither AC was reworded to pass —
+  the divergence is the record.
+
+- **One improvement:** the reflexive sweep rule now says **re-sweep after every
+  review-loop fix**, not just after the first edit. This delivery's fix commit
+  reintroduced exactly the drift its first two commits had avoided, into
+  `.github/ISSUE_FILING.md` — a file that declares itself authoritative, so the
+  stale copy overrode rather than lagged. That is the third instance of one
+  pattern in one delivery, now a gotcha in its own right.
+
 ## 2026-08-20 — 🔒 Redact credentials from `TMDbError.network`'s payload (#469) · full
 
 Branch `fix/redact-credentials-in-network-error`. Issue #434 (P0) — item 1 in
@@ -788,36 +862,6 @@ the board's Ready execution order.
   here ad hoc — instead of forcing a choice between a hard stop and
   `rubric: none`.
 
-## 2026-08-07 — ♻️ Rename `Network.homepage` to `homepageURL` (#412) · lite
-
-- **Phases / skills:** 0–8 pre-PR; lite, so no `/review-plan` critics and the
-  single-reviewer path. `consulted:` next-major.md (the source), gotchas
-  *Renaming a method's internal parameter name is source- and ABI-compatible*
-  (this is the opposite case — a public *property* rename **is** breaking).
-- **Worked — the queue fired for the second time.** `next-major.md` existed
-  precisely so a deferred breaking change would resurface at the next major
-  rather than be forgotten. This entry was written on 2026-07-27, deferred out
-  of 19.0.0 as cosmetic scope creep on a bug fix, and shipped here because the
-  file was read when the 20.0.0 window opened. That is the whole design working
-  end to end.
-- **Worked — the entry that did *not* ship was recorded, not skipped.** The
-  `TMDbError.invalidRating` item stays deferred because its own condition is
-  unmet: it is only worth doing inside a wider `TMDbError` review, and 20.0.0
-  did not open one. Recorded explicitly, so the next reader can tell
-  "considered and declined" from "missed".
-- **Friction:** none material. The rename is three files plus fixtures; the JSON
-  key is unchanged so only Swift call sites move. `Translation.homepage` was
-  deliberately left alone — it is a `String`, a different type, and outside the
-  entry's scope.
-- **Deviations:** stacked on `feature/v4-lists` rather than branched from
-  `main`, because both edit `CHANGELOG.md`'s `[20.0.0]` section and would
-  otherwise conflict. Rebase onto `main` once #411 merges.
-- **One improvement:** the file now carries a status line saying the 20.0.0
-  window is open, so a future entry is not filed against a version that has
-  already shipped. Worth `/capture-knowledge` asserting that whenever it adds an
-  entry.
-- **`swept:`** n/a — no infra files touched.
-
 ## Archive (distilled)
 
 Older entries condensed per the rolling window (`knowledge/README.md` →
@@ -825,6 +869,7 @@ Older entries condensed per the rolling window (`knowledge/README.md` →
 
 | Date | PR | Weight | Outcome |
 | --- | --- | --- | --- |
+| 2026-08-07 | #412 | lite | Renamed `Network.homepage` to `homepageURL`, the second firing of the `next-major.md` queue: the item was deferred out of 19.0.0 on 2026-07-27 as cosmetic scope creep on a bug fix, and shipped here because the file was read when the 20.0.0 window opened — the deferral mechanism working end to end. Equally deliberate was the entry that did **not** ship: `TMDbError.invalidRating` stayed deferred because its own condition (a wider `TMDbError` review) was unmet, and that was recorded rather than skipped, so a later reader can tell "considered and declined" from "missed". Stacked on `feature/v4-lists` rather than branched from `main`, since both edit the same `CHANGELOG` section. Its "one improvement" — have `next-major.md` carry a status line naming the open major window, so an entry cannot be filed against a version that already shipped — **shipped**, and `/capture-knowledge` asserts it on every addition today. |
 | 2026-08-07 | #411 | full | TMDb v4 lists (`client.v4Lists`), settling ADR-0017's four open decisions. **Phase 0 probing changed the shipped API twice, both unfixable later**: `sort_by` turned out to be honoured on the read side (so `details`/`items` take `sortedBy:` — adding a protocol requirement afterwards is source-breaking), and `create(isPublic:)` shipped after all because TMDb ignores the *boolean* and honours the *integer* — the earlier "it ignores the field" conclusion came from a probe that sent a bool. Reading the resource back caught both. The count-reconciliation assertion caught a real drop on its first outing (`Show.encode` writes no `media_type`, so every encoded item failed to decode and the whole list vanished silently). Two of the three bugs were **the probe scripts lying**: an `EXIT` trap that never fired and orphaned four lists on a real account, and ten identical "rejected" results across a `sort_by` sweep that were the spam filter (`status_code` 18), not an answer — a uniform failure across a sweep is evidence about the sweep. Both are now standing rules in `CLAUDE.md`: a probe must verify its own postcondition. Also a mid-delivery **correction**: I reported credentials committed in `Integration.xctestplan` having read it off disk without running `git ls-files` — the file is gitignored and absent from HEAD (they were committed in 2023 and remain in public history, so rotation still applies). |
 | 2026-08-07 | #410 | full | Defaulted-witness convenience sweep across 37 sites. The **reference-unit gate earned its keep again**: reviewing one site before replicating caught a DocC-curation regression (the convenience becomes a distinct symbol and falls out of its Topics group unless curated) that would otherwise have shipped 37 times, and settled three open design questions in one pass. The **census was re-derived rather than trusted** — both reviewers independently reproduced 91/15 and the 37/54 split, after the first census came up **17 short** by grepping protocol *declaration* files and missing the two protocols keeping conveniences in a sibling `+Defaults.swift`. Two lasting False-green bullets came from it: a mechanical sweep did a first-occurrence `str.replace` per file, stripping the default from `favouriteMovies` instead of `lists` **while reporting exactly the 36 edits expected**, and the new checker passed on an empty scan (a typo'd path printed success and exited 0) — so a matching count is not evidence, and a checker must compare against an explicit set. Also **shipped a gate that did not gate**: the check went into `make lint`, but no workflow invokes `make` (the `Lint` job runs swiftlint/swiftformat inline), so it was invisible to CI — now its own step and the gotcha *No workflow runs `make`*. Its "one improvement" — have `/capture-knowledge` prompt "what fails if that number changes?" when an entry records a defect count — **shipped**, and is the *When an entry records a count* section of that skill today. |
 | 2026-08-07 | #409 | full | TMDb v4 authentication. The lasting practice is **probing the live API before writing the plan's models**: TMDb's v4 docs are wrong in ways reading cannot surface — documented endpoint *names* 404, the same field has different wire types on different endpoints, `clear` is a state-changing GET, and both `create(public:)` and add-items' `comment` are accepted-then-ignored. Each was found by curl and each would have shipped as a bug. The corollary, now in `tmdb-api-notes.md`: v4 auth-gates *before* routing, so a 401-vs-404 path probe proves nothing until you hold a credential — which is exactly how the wrong paths survived into an approved plan. The adversarial plan review paid for itself twice, both unanimous: patching only `CacheHTTPClient` would still leave the always-on 1 GB on-disk `URLCache` leaking private reads across users, and splitting `V4ListService` across two PRs would have made the second source-breaking — forcing a redraw of the decomposition along a *protocol* boundary, which dissolved a third blocker for free. Its "one improvement" — stop ending the turn at phase boundaries to report status — is the autonomy contract `/deliver` states today. |

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -63,6 +63,75 @@ retired; the family heading stays.
 
 ## Tooling
 
+### An issue template's field is a convention, not a schema — parse it defensively
+
+*2026-08-20 (PR #474).* `.github/ISSUE_FILING.md` ends every issue body with
+`**Breaking class:** none | source-breaking | behavioural | needs a decision`.
+A read-only sweep of the board's `Ready` column found it written **three
+different ways**, and a parser expecting the documented shape gets two of the
+three wrong:
+
+| Shape | Live example |
+| --- | --- |
+| Inline bold label, mid-paragraph, followed by prose rather than a bare value | issue 437 |
+| Its own `## Breaking class` heading with the value in the sentence below | issue 448 |
+| **Absent entirely** | issue 426 |
+
+At the time, only 3 of the 12 issues in `Ready` carried the line at all. So any
+automation gating on a template field needs (a) to accept more than one shape,
+and (b) a **fail-closed default for absence** — the unlabelled issue is the one
+nobody classified, which makes it the *last* thing to auto-approve, not a
+convenient default. Same reasoning as *A fixture you invented tests your belief,
+not the API*: read what is actually there, in quantity, before deciding what the
+field means.
+
+### GitHub Projects MCP: one `list_project_items` call gives status, fields and pagination
+
+*2026-08-20 (PR #474).* `mcp__github__projects_list` /
+`list_project_items` returns each item's `content.state` (`open`/`closed`)
+alongside the requested `field_names`, plus `pageInfo.hasNextPage` and
+`nextCursor`. So filtering a column to *open* issues with their `Priority` and
+`Size` is **one paginated call**, not a per-issue follow-up — verified live.
+
+Worth knowing because the two facts disagree in practice: a **closed** issue can
+sit in a `Ready` column for as long as the board's automation takes to move it,
+so `Status` alone is not a liveness test. Filter on both.
+
+### A rule written in two files drifts, and the copy you didn't edit is the one that wins
+
+*2026-08-20 (PR #474).* One delivery produced **three** instances, one of them a
+security HIGH — so treat a rule stated in more than one place as a defect to fix
+at the moment you notice it, not a tidiness issue.
+
+- **The reflexive glob set.** `/deliver`'s Phase 0 listed three globs;
+  `next-mode.md` §5b listed four. Phase 10's merge-drop keys on Phase 0's
+  computation, so the missing glob — `.claude/workflows/**` — meant
+  `/deliver auto merge next` could have squash-merged a rewrite of
+  `deliver-panel.js`, the script defining the panel that authorises unattended
+  work, with nobody reading the diff.
+- **A board transition's owner.** A rule changed in `deliver/SKILL.md` was left
+  stale in `.github/ISSUE_FILING.md` — a file whose own first lines say *"If this
+  file and a skill ever disagree, this file is right."* A stale authoritative
+  copy doesn't lag, it **overrides**: an agent reconciling the two concludes the
+  new behaviour is unsanctioned.
+- **An enumeration inside a single file.** A third test was added to a section,
+  and two other lists in the *same file* still enumerated only the first two.
+
+What makes this worse than ordinary duplication is that the *reader* picks the
+copy, so which one wins is unpredictable. Countermeasures, cheapest first:
+
+- **Name the set once and quote it by name** ("the reflexive set"), with each
+  copy pointing at the other and saying *change both or neither*. Prose can't be
+  compiled, so the cross-reference is the only thing making drift visible to
+  someone reading one file alone.
+- **Grep for the *old* wording after every edit** — including after a
+  review-loop fix that changes the rule a second time. The first two commits of
+  that delivery passed the sweep; the commit that *fixed* everything else
+  reintroduced the drift, because the sweep had been run against the original
+  change's wording rather than the fix's.
+- **Prefer fail-closed defaults** where two lists gate the same thing, so a
+  drifted copy under-permits rather than over-permits.
+
 ### A gate keyed on `git tag` passes vacuously in CI — the checkout has no tags
 
 *2026-08-19 (#464).* `actions/checkout` fetches no tags by default, so any
@@ -537,6 +606,25 @@ under `.build/` (gitignored); or delegate the work to a subagent, which is not
 subject to the caller's guard. `Edit`/`Write` on a path outside the worktree are
 refused too, with a pointer to the worktree copy — which is wrong for
 `.git/`-relative state, so reach for `sed` there.
+
+**Some refusals are silent — assume nothing landed until you check.** *2026-08-20
+(PR #474).* A `python3 - <<'EOF'` heredoc rewriting the `/deliver` run file in
+`.git/deliver/` produced **no output, no error and no write**. The refusal above
+at least announces itself; this one is indistinguishable from success, which is
+the **False green** family again — and the file it silently failed to write was
+the durable half of the delivery's state. The fix that worked, and generalises:
+**stage the new content inside the worktree, then move it with a single
+two-literal-path `cp`**.
+
+```bash
+python3 - <<'EOF'                     # writes .build/deliver-tmp/run.json — inside
+...
+EOF
+cp /abs/literal/worktree/.build/deliver-tmp/run.json /abs/literal/.git/deliver/<id>.json
+```
+
+Whatever route you take, **verify with a `grep` for a string you just wrote**.
+A write to `.git/` that reports nothing has told you nothing.
 
 ### The `Workflow` tool resolves a repo-relative `scriptPath`
 


### PR DESCRIPTION
## Summary

`/deliver` required a plan to already exist, so the ordered Ready run-list `/triage-issues` publishes had no consumer: you read the board, opened plan mode, wrote the plan, then invoked `/deliver`. **`/deliver next` closes that loop** — it resolves the board, filters to open-and-Ready issues, orders them, re-verifies the head candidate against `origin/main`, claims it, drafts a plan and runs the normal pipeline.

Composes with the existing keywords: `/deliver next`, `/deliver auto next`, `/deliver auto merge next`.

No `Closes` line — this work was user-requested and untracked.

## ⚠️ Reflexive delivery — this was **not** dogfooded

The skill registry loaded at session start comes from the **main checkout**, so the edits in this PR are not what executed this run. `/deliver next` was verified by **reading**, plus a **read-only dry-run of its selection step** against the live board. It has never been run end to end, and nothing here should be read as claiming otherwise.

### Dry-run transcript — 2026-08-20, board `TMDb` (#7), verified at `origin/main` `527682f7`

Read-only: no comments posted, no board writes.

| Step | Result |
| --- | --- |
| Resolve board by title | project 7, single match |
| Live Ready set | **12** items — **issue 434 filtered out**: it heads the newest run-list but is `Done`/closed |
| Ordering | no status update carries a run-list line yet, so the **board-fields fallback** was exercised and announced, rather than regexing the prose table |
| Computed order | `426, 437, 448, 428, 454, 424, 425, 427, 429, 435, 467, 430` |
| Exclusions | 0 open PRs, so no `Closes #NNN` claims; 1 live worktree (this one) |

Then the head candidate turned out not to be startable, which is the interesting part:

- **issue 426** → `needs-decision`. Its body offers three competing fixes and carries no Breaking-class line.
- **issue 437** → `startable`, but Breaking class is **source-breaking**. `/deliver next` and `auto next` pick it; **`auto merge next` skips it.**
- **issue 448** → `startable`, Breaking class **"None — CI configuration only"** — what `auto merge next` would actually take.

All three filters demonstrated on real data.

## Changes

**New:**

- ✨ `.claude/skills/deliver/references/next-mode.md` — the selection procedure: board resolution, the live-Ready filter, ordering, re-verification, the `merge`-mode refusals (§5a breaking, §5b reflexive, §5c untrusted author), the claim, and the `selection` block.
- 📚 `knowledge/decisions/0026-unattended-selection-needs-an-author-check.md`.

**Existing:**

- 🔧 `deliver/SKILL.md` — `next` folded into **Phase 0** (not a new phase, so the run file keeps one writer); the invocation grammar; Contract §1's pause list; Phase 1's stranded-claim release; Phase 2's `auto next` critic override; Phase 6's two new hard stops; Phase 10's merge-drop.
- 🔧 `deliver-panel.js` — a `phase0n-selection` entry in the closed `POINTS` enum. `next` adds a stop-and-ask, so it adds a panel point rather than letting that stop vanish unattended.
- 🔧 `references/{auto-and-async,worktree-lifecycle,wrap-up}.md`, `triage-issues/SKILL.md`, `.github/ISSUE_FILING.md`, `CLAUDE.md`, `README.md`.
- 📝 `knowledge/gotchas.md` — three new entries + one updated; `delivery-retros.md` — this delivery's retro, window rolled.

**Tests:** none — there is no test harness for skill prose. Verification is the dry-run above, the gate, and four adversarial review passes.

## Rubric — 10 of 12 met

Two graded **not met**, deliberately, and neither AC was reworded to pass:

- **AC 3** — the run-list line's grammar is specified and strictly parsed, but its *assembly* was not moved into `triage-issues.js`. The ordering is computed in `/triage-issues` Phase 6, **after** that script returns, so emitting it from the script needs Phase 6's sort moved too. Narrowed at planning time and filed as **issue #471**.
- **AC 4** — says a dead verifier *rejects* the candidate. Code review showed that demotes a healthy `Ready` issue and blames the board for a harness failure, with no verdict to put in the comment marker. It now **passes over** instead, with a two-dead-verifiers stop. The implementation is right and the AC is wrong; leaving it unedited keeps the divergence visible.

## Review

**Code review — 4 passes** (12 → 8 → 3 → 2 findings). The 3-iteration cap was exceeded by one with explicit authorisation, after being surfaced along with the option to cut the concurrency machinery entirely. Passes 2–4 predominantly found defects the *previous fix* created, nearly all in one seam — the claim/release machinery for concurrent runs — while the selection logic was right from the first draft.

Notable catches: three rules composing into "demote every unlabelled issue" (9 of 12 live Ready issues carry no Breaking-class line); a claim release keyed on a worktree bucket that performs no liveness test, over a window that predates any worktree; and a claim held with no issue recorded, unrecoverable by the mechanism built for it.

**Security review — 2 HIGH, both fixed and re-verified:**

1. **The reflexive glob set was defined twice and disagreed.** §5b refused four globs; Phase 0 computed three, omitting `.claude/workflows/**`. Phase 10's backstop keys on Phase 0 — so an issue whose plan edited `deliver-panel.js` would have computed `reflexive: false` and squash-merged unattended, rewriting the closed `POINTS` enum and the dead-panel tally with nobody reading the diff.
2. **The merge gates were self-attested.** Both properties authorising an unattended merge are parsed from the issue body; this repo is public and `/triage-issues` sweeps every open issue onto the board. An outsider could write the defect, the fix sketch, the `Breaking class: none` line, and — via the *Failure scenario* the rubric derives from — the criteria their own change is graded against. New §5c requires `author_association` `OWNER`/`MEMBER`/`COLLABORATOR` on both the issue and its triage marker; `CONTRIBUTOR` is excluded by name, since one merged typo PR grants it permanently.

## Benefits

- **One command from "what next?" to a green PR**, and the triage run-list finally has a consumer.
- **Unattended merge is narrowed, not widened** — `auto merge next` refuses breaking, reflexive, and outsider-authored work, and drops the `merge` opt-in outright if the drafted plan turns out reflexive.
- **A claimed issue is recoverable**: released on any stop before the PR opens, and by the next run's reconcile sweep if the run dies without stopping.

## Issues filed by this delivery

- **#471** — `/triage-issues`' run-list line is agent-written, so the one format `next` parses can drift.
- **#472** — issue 426 sits in Ready with three competing fix options; the Ready test is passing undecided issues.
- **#473** — `/triage-issues` Phase 3 trusts a `triaged` marker from any author.

## Gate

Docs/config-only narrowing (no `*.swift`, `Makefile`, `Package*`, `*.xctestplan`, workflows, JSON fixtures, or `*.docc/**`): **`make lint && make lint-markdown`, both green.** Narrowed, not skipped — the PR's own CI still runs the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
