### PR TITLE
✨ Assemble `/triage-issues`' run-list line in code, not prose

### DIFF
--- a/.claude/skills/deliver/references/next-mode.md
+++ b/.claude/skills/deliver/references/next-mode.md
@@ -70,12 +70,22 @@ mcp__github__projects_list / list_project_status_updates   per_page: 5
 ```
 
 Take the newest update carrying the canonical run-list line. That line has a
-**fixed grammar**, defined once in `/triage-issues` (its Phase 8) and parsed
-here and nowhere else:
+**fixed grammar**, and the grammar is **not defined in prose** — it is defined by
+`build_run_list_line` in
+[`Scripts/build_run_list.py`](../../../../Scripts/build_run_list.py) and parsed
+by `RUN_LIST_RE` in that same module, which is what keeps the written and parsed
+forms from drifting apart. `/triage-issues` Phase 8 pastes what that function
+returned. An example of what lands on the board:
 
 ```text
-<!-- run-list: <sha> | 426,437,448,428,454,424,425,427,429,435,467,430 -->
+<!-- run-list: cc7cba55 | 426,437,448,428,454,424,425,427,429,435,467,430 -->
 ```
+
+> **Change all three together or none**: the builder, this section, and
+> `/triage-issues` Phase 8. `Scripts/tests/test_build_run_list.py` asserts that
+> every `<!-- run-list:` example in *this file* still parses under `RUN_LIST_RE`,
+> so a drifted example fails a test rather than waiting for a reader to pick the
+> wrong copy.
 
 Parse **only that line**. Its prose table is for humans and is written afresh
 each run — the 2026-08-18 and 2026-08-20 updates already use different table
@@ -83,12 +93,33 @@ shapes, so a regex over the table is not reproducible, and a near-miss would
 silently discard exactly the dependency and contention ordering the run-list
 exists to carry.
 
-**No status update carries the line → there is no usable run-list.** Say so, in
-those words, and fall back to board fields: order by Priority (P0 → P1 → P2),
-then Size ascending (XS < S < M < L < XL). State in the report that **dependency
-and contention order are unknown on this path** — the fallback reproduces two of
-`/triage-issues`' four sort rules, not all four. Never quietly best-effort the
-prose table into a third ordering authority.
+**No status update carries the line → there is no usable run-list**, and what
+happens next depends on **whether anyone is watching**:
+
+- **Attended (`/deliver next`)** — say "there is no usable run-list", in those
+  words, and fall back to board fields: Priority (P0 → P1 → P2), then Size
+  ascending (XS < S < M < L < XL). Report **prominently** that **contention
+  spacing and dependency-driven promotion are unavailable on this path** — the
+  fallback reproduces two of `/triage-issues`' four sort rules, not all four.
+  The human can weigh that and decide whether to proceed or go run
+  `/triage-issues`.
+- **Unattended (`/deliver auto next`, `/deliver auto merge next`)** — **stop**,
+  and recommend `/triage-issues`. A warning is only loud if someone reads it,
+  and unattended nobody does.
+
+This split is the same principle §5 already applies to the Breaking-class and
+reflexive refusals: unattended runs get tighter constraints than attended ones.
+
+**The fallback is degraded, not unsafe — and the reason is §4, not this
+section.** §4's *"`dependsOn` outranks priority"* rule makes an open dependency
+from the marker's `deps=` field a `needs-decision` **rejection**, so even with no
+run-list `next` cannot pick a dependent ahead of its dependency; it rejects it.
+What the fallback loses is ordering *quality*: contention spacing, and the
+promotion in which a P2 that unblocks a P0 legitimately goes first. **Do not
+simplify this section without re-reading §4's `deps=` check** — remove that and
+the fallback stops being safe.
+
+Never quietly best-effort the prose table into a third ordering authority.
 
 Final order:
 

--- a/.claude/skills/deliver/references/worktree-lifecycle.md
+++ b/.claude/skills/deliver/references/worktree-lifecycle.md
@@ -171,7 +171,7 @@ is a claim that a human set the bar.
   "conductorPid": 90982,
   "planReview": "forced — auto-next",
   "selection": {
-    "source": "board-fields (no run-list line; deps/contention unknown)",
+    "source": "run-list@cc7cba55",
     "verifiedAt": "527682f7",
     "listed": 12, "picked": 448, "breakingClass": "none", "claimed": true,
     "passedOver": [{ "issue": 434, "why": "filtered — closed, still showing Ready" }],

--- a/.claude/skills/lint/SKILL.md
+++ b/.claude/skills/lint/SKILL.md
@@ -5,16 +5,18 @@ description: Lint code with swiftlint and swiftformat
 
 # Lint code
 
-Run `make lint` from the project root to check code style. It runs **seven**
-checks, in order: five Python scripts under `Scripts/` — `lint-witnesses`
+Run `make lint` from the project root to check code style. It runs **eight**
+checks, in order: six Python scripts under `Scripts/` — `lint-witnesses`
 (`check-defaulted-witnesses.py`, protocol conveniences that would witness their
 own requirement), `lint-fixtures` (`check-fixtures.py`, JSON fixture hygiene),
 `lint-curation` (`check-docc-curation.py`, public methods missing from their
 DocC page), `lint-prose` (`check-prose-call-forms.py`, code samples calling a
-method that does not exist) and `lint-readme-version`
+method that does not exist), `lint-readme-version`
 (`check-readme-version.py`, README's `.package(from:)` vs the newest
-`CHANGELOG.md` release) — then `swiftlint --strict .`, then
-`swiftformat --lint .`.
+`CHANGELOG.md` release) and `lint-run-list` (`run-script-tests.py`, the
+`/triage-issues` run-list builder's own suite, including whether the skill prose
+still agrees with the grammar the builder defines) — then `swiftlint --strict .`,
+then `swiftformat --lint .`.
 
 Each script enforces something no single-file linter can see, and a failure in
 any of them is **not** a formatting problem: `/format` will not fix it.

--- a/.claude/skills/triage-issues/SKILL.md
+++ b/.claude/skills/triage-issues/SKILL.md
@@ -193,19 +193,44 @@ The agents saw one issue each; the cross-issue judgements are yours.
 
 ## Phase 6 — Order
 
-Sort the Ready set:
+**The ordering is computed, not composed.** Run it:
 
-1. `dependsOn` order — a dependency always precedes its dependent.
-2. Priority — P0, then P1, then P2.
-3. Contention — do not schedule two file-contending issues adjacently when
-   something else can sit between them. This is computed only over **freshly
-   triaged** issues: the marker carries no `filesTouched`, so a skipped issue
-   contributes no contention edges. Say so in the run-list rather than implying
-   full coverage.
-4. Size ascending — smallest first inside a band, so the board drains.
+```bash
+python3 Scripts/build_run_list.py .build/run-list-input.json
+```
 
-Rule 1 outranks rule 2: a P2 that unblocks a P0 goes first. Say so explicitly in
-the run-list when it happens, or it reads as a mis-sort.
+Input is `{ head, ready, closed }`. `ready` uses **`triage-issues.js`'
+`VERDICT_SCHEMA` field names** (`issue`, `priority`, `size`, `dependsOn`,
+`filesTouched`), so a freshly-triaged verdict is passed through **untouched** —
+re-shaping records by hand would put back, at the input, the transcription risk
+the script removes at the output. A **skipped** issue is assembled from its
+marker (`issue`, `priority`, `size`, `dependsOn`; it carries no `filesTouched`).
+`closed` lists the issues Phase 5 discharged edges onto.
+
+It returns `ordered`, `runListLine`, and the three disclosures Phase 8 needs:
+`depsOutrankPriority`, `dischargedEdges`, `unseparableContention`.
+
+The four sort rules — dependency order, priority, contention, size — are
+**defined in [`Scripts/build_run_list.py`](../../../Scripts/build_run_list.py)**,
+which is the copy that actually decides. Read them there; do not restate them
+here. That is the same single-ownership rule this file already applies to the
+[rubrics](#rubrics), and for the same reason: a second copy drifted from the
+script within a day of being written. What is worth knowing without opening it:
+rule 1 outranks rule 2 (a P2 that unblocks a P0 goes first, which the script
+implements as *effective priority* — a plain topological sort does **not** do
+this), rule 2 outranks rule 3 (separating contenders never crosses a priority
+band), and contention is computed only over freshly-triaged issues because a
+marker carries no `filesTouched`.
+
+**Do not re-sort what it returns.** Phase 8 pastes `ordered` and `runListLine`
+as they came back.
+
+**If it exits non-zero**, it has found something Phase 5 should have resolved — a
+cycle, an edge onto an issue that is neither Ready nor closed, or a malformed
+record. Fix the input and re-invoke. **Never hand-write the line**: a
+hand-assembled line is the exact defect this phase was changed to remove. If it
+cannot be fixed this run, publish the status update **without** the line and say
+why — no line is honest, a wrong line is not.
 
 ## Phase 7 — Write
 
@@ -275,36 +300,41 @@ then dependency edges, then contention warnings, then the Backlog-blocked items
 each with its one-sentence decision. Keep it scannable — it is read at a glance,
 and it is the diff between one run and the next.
 
-### The run-list line — write it verbatim
+### The run-list line — paste what the script returned
 
-End the body with **exactly this line**, and nothing else after it:
+End the body with Phase 6's **`runListLine`, exactly as it came back**, and
+nothing after it. Do not reword, prettify, annotate, wrap, or re-derive it — you
+are pasting a **field**, not writing to a format.
 
-```text
-<!-- run-list: <short sha> | <issue numbers, in order, comma-separated, no spaces> -->
-```
+`/deliver next` parses **that line and nothing else** to decide what to work on
+([`.claude/skills/deliver/references/next-mode.md`](../deliver/references/next-mode.md)
+§3). The prose table above it is for humans and is rewritten from scratch every
+run — the 2026-08-18 and 2026-08-20 updates already use different column headers
+and different cell formats, so anything parsing the table is parsing a moving
+target, and a near-miss would silently discard the dependency and contention
+ordering this phase exists to publish.
 
-`/deliver next` parses **this line and nothing else** to decide what to work on
-([`.claude/skills/deliver/references/next-mode.md`](../deliver/references/next-mode.md)).
-The prose table above it is for humans and is rewritten from scratch every run —
-the 2026-08-18 and 2026-08-20 updates already use different column headers and
-different cell formats, so anything parsing the table is parsing a moving target,
-and a near-miss would silently discard the dependency and contention ordering
-this phase exists to publish.
+The grammar is **defined by `build_run_list_line` in
+[`Scripts/build_run_list.py`](../../../Scripts/build_run_list.py)** and parsed by
+`RUN_LIST_RE` in that same module, so the written form and the parsed form cannot
+drift apart — the same discipline as the per-issue marker, for the same reason.
+It is not restated here; if you need to see it, read it there.
 
-So: **assemble the line mechanically** — join the ordered issue numbers with
-commas — and do not reword, prettify, annotate or wrap it. It is the same
-discipline as the per-issue marker, for the same reason (an LLM re-authoring a
-fixed format from prose produces a different string each time), with the same
-consequence if it drifts: a consumer that quietly falls back rather than failing
-loudly. A status update **without** this line is *not a usable run-list*, and
-`next` will say so and fall back to board fields — which reproduces two of this
-phase's four sort rules and loses the other two.
+A status update **without** the line is *not a usable run-list*: `next` says so
+and falls back to board fields, which reproduces two of Phase 6's four sort rules
+and loses the other two.
 
-> The line is currently written by this skill, not built by
-> [`.claude/workflows/triage-issues.js`](../../workflows/triage-issues.js) the
-> way the marker is, because the ordering is decided in Phase 6 — after the
-> script has returned. Moving Phase 6's sort into the script would close that
-> gap; it is tracked, not done.
+Also carry, in prose, the three disclosures Phase 6 returns — they are facts the
+script supplies so this phase need not remember them:
+
+- **`depsOutrankPriority`** — each case where a lower-priority issue precedes a
+  higher one because it unblocks it. Say so, or the order reads as a mis-sort.
+- **`unseparableContention`** — contending pairs left adjacent because nothing
+  could sit between them.
+- **`dischargedEdges`** — dependencies dropped because their target is closed.
+
+Contention is computed only over freshly-triaged issues, since a marker carries
+no `filesTouched`. Say that, rather than implying full coverage.
 
 Mark `AT_RISK` when a P0 sits in `blocked`: the highest-priority work being
 un-startable is exactly the state a status colour exists to surface.

--- a/.claude/skills/triage-issues/SKILL.md
+++ b/.claude/skills/triage-issues/SKILL.md
@@ -210,6 +210,11 @@ marker (`issue`, `priority`, `size`, `dependsOn`; it carries no `filesTouched`).
 It returns `ordered`, `runListLine`, and the three disclosures Phase 8 needs:
 `depsOutrankPriority`, `dischargedEdges`, `unseparableContention`.
 
+**An empty Ready set returns `runListLine: null`** with a `note` saying why —
+deliberately, because a line with an empty issue list would parse as a
+well-formed run-list containing nothing, which is worse than no line at all.
+Publish the update without the line in that case, and carry the note.
+
 The four sort rules — dependency order, priority, contention, size — are
 **defined in [`Scripts/build_run_list.py`](../../../Scripts/build_run_list.py)**,
 which is the copy that actually decides. Read them there; do not restate them
@@ -320,9 +325,11 @@ The grammar is **defined by `build_run_list_line` in
 drift apart — the same discipline as the per-issue marker, for the same reason.
 It is not restated here; if you need to see it, read it there.
 
-A status update **without** the line is *not a usable run-list*: `next` says so
-and falls back to board fields, which reproduces two of Phase 6's four sort rules
-and loses the other two.
+A status update **without** the line is *not a usable run-list*. Attended,
+`/deliver next` says so and falls back to board fields — which reproduces two of
+Phase 6's four sort rules and loses the other two. **Unattended, `auto next` and
+`auto merge next` stop outright**, because a warning nobody reads is not a
+warning. So an omitted line does not merely degrade the next run; it can halt it.
 
 Also carry, in prose, the three disclosures Phase 6 returns — they are facts the
 script supplies so this phase need not remember them:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
         if: >-
           needs.changes.outputs.swift == 'true' || needs.changes.outputs.markdown == 'true'
           || github.event_name == 'workflow_dispatch'
-        run: python3 -m unittest discover -s Scripts/tests -t Scripts/tests
+        run: python3 Scripts/run-script-tests.py
 
   lint-markdown:
     name: Lint Markdown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,11 +90,20 @@ jobs:
       SWIFTFORMAT_VERSION: 0.61.1
     steps:
       - name: No changes detected
-        if: needs.changes.outputs.swift != 'true' && github.event_name != 'workflow_dispatch'
-        run: echo "No Swift changes detected, skipping lint"
+        if: >-
+          needs.changes.outputs.swift != 'true' && needs.changes.outputs.markdown != 'true'
+          && github.event_name != 'workflow_dispatch'
+        run: echo "No Swift or Markdown changes detected, skipping lint"
 
+      # Also gated on `markdown`, not `swift` alone: the run-list builder check
+      # below reads the skill prose off disk, so a prose-only change is exactly
+      # when it must run — and without a checkout it would have nothing to read.
+      # Every swiftlint/swiftformat step below stays gated on `swift`, and the
+      # runner falls to ubuntu-latest when `swift` is false, where python3 ships.
       - name: Checkout
-        if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
+        if: >-
+          needs.changes.outputs.swift == 'true' || needs.changes.outputs.markdown == 'true'
+          || github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v7
 
       - name: Install SwiftLint and SwiftFormat
@@ -142,6 +151,16 @@ jobs:
       - name: README version check
         if: needs.changes.outputs.swift == 'true' || github.event_name == 'workflow_dispatch'
         run: python3 Scripts/check-readme-version.py
+
+      # Mirrors `make lint-run-list`. No new paths-filter output is needed: the
+      # builder lives under `Scripts/**` (already in the `swift` key) and its
+      # anti-drift cases read `.claude/**/*.md` (already in the `markdown` key),
+      # so gating on either covers both of its inputs.
+      - name: Run-list builder check
+        if: >-
+          needs.changes.outputs.swift == 'true' || needs.changes.outputs.markdown == 'true'
+          || github.event_name == 'workflow_dispatch'
+        run: python3 -m unittest discover -s Scripts/tests -t Scripts/tests
 
   lint-markdown:
     name: Lint Markdown

--- a/Makefile
+++ b/Makefile
@@ -95,13 +95,14 @@ lint-readme-version:
 # are covered: the sort rules, and — reading the skill files off disk — that the
 # prose still agrees with the grammar the module defines.
 #
-# `-t` repeats the start directory because Python 3.9's discover requires the
-# start directory to be importable; the repo's python3 is Xcode's 3.9.
+# Run via the wrapper, never `unittest discover` directly: a bare discover exits
+# 0 when it collects NOTHING on Python 3.9, so a renamed file would empty this
+# gate while it still reported green. The wrapper asserts a collection floor.
 # Mirrored as the `Run-list builder check` step in .github/workflows/ci.yml —
 # see the note above lint-witnesses.
 .PHONY: lint-run-list
 lint-run-list:
-	@python3 -m unittest discover -s Scripts/tests -t Scripts/tests
+	@python3 Scripts/run-script-tests.py
 
 .PHONY: lint-markdown
 lint-markdown:

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ format:
 	@swiftformat .
 
 .PHONY: lint
-lint: lint-witnesses lint-fixtures lint-curation lint-prose lint-readme-version
+lint: lint-witnesses lint-fixtures lint-curation lint-prose lint-readme-version lint-run-list
 	@swiftlint --strict .
 	@swiftformat --lint .
 
@@ -88,6 +88,20 @@ lint-prose:
 .PHONY: lint-readme-version
 lint-readme-version:
 	@python3 Scripts/check-readme-version.py
+
+# The run-list builder's own suite. /triage-issues Phase 8 publishes one line
+# that /deliver next parses and nothing else, so a wrong ORDER is as damaging as
+# a wrong format and neither is visible at write time (issue #471). Two things
+# are covered: the sort rules, and — reading the skill files off disk — that the
+# prose still agrees with the grammar the module defines.
+#
+# `-t` repeats the start directory because Python 3.9's discover requires the
+# start directory to be importable; the repo's python3 is Xcode's 3.9.
+# Mirrored as the `Run-list builder check` step in .github/workflows/ci.yml —
+# see the note above lint-witnesses.
+.PHONY: lint-run-list
+lint-run-list:
+	@python3 -m unittest discover -s Scripts/tests -t Scripts/tests
 
 .PHONY: lint-markdown
 lint-markdown:

--- a/README.md
+++ b/README.md
@@ -673,12 +673,24 @@ longer open-and-`Ready`, and re-verifies the head candidate against
 necessarily at today's. A candidate whose claims no longer hold goes back to
 **Backlog** with a comment, and the run moves on.
 
-Three constraints are worth knowing before you reach for it:
+That line is **assembled by `Scripts/build_run_list.py`**, not written by hand:
+it carries the whole of `/triage-issues`' ordering — dependency order,
+contention spacing, and the promotion in which a P2 that unblocks a P0 goes
+first — and a re-worded line would lose exactly that while still looking
+correct.
+
+Four constraints are worth knowing before you reach for it:
 
 * **`merge` refuses a breaking change.** In `merge` mode an issue is selectable
   only if its `Breaking class` is `none` — absent or unparseable counts as
   "needs a decision". Every other change still gets a human at the
   ready-to-merge gate, which is where a compatibility call belongs.
+* **No run-list line, no unattended run.** If no status update carries the
+  line, `/deliver next` falls back to ordering by Priority then Size and says
+  loudly that contention spacing and dependency-driven promotion are
+  unavailable — but `auto` and `auto merge` **stop** and send you to
+  `/triage-issues`, since a warning nobody reads is not a warning. The fallback
+  is degraded, not unsafe: an open dependency still rejects a candidate outright.
 * **It needs the user-scoped Projects MCP**, so it runs in your own environment
   (including a CCR-triggered session) but **not** on a GitHub Actions runner,
   where that MCP is not mounted — the same limit `/triage-issues` has.

--- a/Scripts/build_run_list.py
+++ b/Scripts/build_run_list.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Order `/triage-issues`' Ready set and assemble its canonical run-list line.
+
+`/deliver next` picks its work by parsing ONE line out of the Project status
+update `/triage-issues` publishes:
+
+    <!-- run-list: <sha> | 426,437,448,428,454,424,425,427,429,435,467,430 -->
+
+Until this script existed that line was written by the AGENT following
+`.claude/skills/triage-issues/SKILL.md` Phase 8. Asking a model to reproduce a
+fixed string is the same defect `evidenceDigest` was moved into code to avoid
+(`.claude/workflows/triage-issues.js:149-186`): two runs that reach identical
+conclusions word them differently, so the consumer's strict parse misses, and
+`next` falls back to ordering by board fields — which reproduces two of Phase 6's
+four sort rules and silently drops dependency order and contention. Nothing fails
+at write time, so the failure is invisible (issue #471).
+
+**This module is the definition of the grammar.** `RUN_LIST_RE` parses what
+`build_run_list_line` writes, so the written and parsed forms cannot drift apart.
+The prose in `triage-issues/SKILL.md` Phase 8 and
+`deliver/references/next-mode.md` §3 quote it by name and must not restate it —
+see `knowledge/gotchas.md`, "A rule written in two files drifts, and the copy you
+didn't edit is the one that wins".
+
+**Why underscores in the filename**, where every sibling in `Scripts/` uses
+hyphens: those are standalone gates that are only ever executed. This one is a
+library with a CLI — its tests import it — and `import build-run-list` is not
+valid Python.
+
+WHAT IT DOES NOT DO. Phase 5's reconcile — cycle resolution, duplicate
+resolution, deciding which edges are discharged — stays with the conductor,
+because those are judgement calls needing tool access. This script runs AFTER
+that, and treats anything Phase 5 should have resolved as a caller bug it
+refuses loudly rather than papering over.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+# The canonical grammar. `<sha>` (7-40 lowercase hex, matching the range
+# `/triage-issues` Phase 1 may hand over), then the issue numbers in order,
+# comma-separated with NO spaces. Anchored at both ends so a trailing period or
+# a wrapping sentence cannot half-match.
+#
+# The empty-list case is deliberately unmatchable: `<!-- run-list: <sha> | -->`
+# would parse as a well-formed run-list containing nothing, which is worse than
+# publishing no line at all. An empty Ready set returns `runListLine: None`.
+RUN_LIST_RE = re.compile(r"^<!-- run-list: [0-9a-f]{7,40} \| \d+(?:,\d+)* -->$")
+
+HEAD_RE = re.compile(r"^[0-9a-f]{7,40}$")
+
+PRIORITIES = {"P0": 0, "P1": 1, "P2": 2}
+SIZES = {"XS": 0, "S": 1, "M": 2, "L": 3, "XL": 4}
+
+
+class RunListError(Exception):
+    """A caller bug: input Phase 5 should have resolved, or a malformed record.
+
+    Never raised for a *legitimate* degenerate case — an empty Ready set and an
+    edge onto a closed issue both return normally, with the fact reported.
+    """
+
+
+def _validate(head, ready, closed):
+    if not isinstance(head, str) or not HEAD_RE.match(head):
+        raise RunListError(
+            f"head must be a lowercase git sha (7-40 hex), got {head!r}. "
+            "A branch name or an abbreviated-too-far sha writes a line that can never match."
+        )
+    if not isinstance(ready, list):
+        raise RunListError(f"ready must be a list, got {type(ready).__name__}.")
+    if not isinstance(closed, (list, tuple, set)):
+        raise RunListError(f"closed must be a list, got {type(closed).__name__}.")
+
+    seen = set()
+    for index, item in enumerate(ready):
+        if not isinstance(item, dict):
+            raise RunListError(f"ready[{index}] is not an object: {item!r}.")
+
+        number = item.get("issue")
+        # `bool` is an `int` in Python, so exclude it explicitly.
+        if not isinstance(number, int) or isinstance(number, bool) or number <= 0:
+            raise RunListError(f"ready[{index}].issue is not a positive integer: {number!r}.")
+        if number in seen:
+            raise RunListError(
+                f"ready[{index}] repeats issue #{number}. A duplicate would take two places "
+                "in the run-list and make the order ambiguous."
+            )
+        seen.add(number)
+
+        if item.get("priority") not in PRIORITIES:
+            raise RunListError(
+                f"#{number}: priority must be one of {sorted(PRIORITIES)}, got {item.get('priority')!r}."
+            )
+        if item.get("size") not in SIZES:
+            raise RunListError(
+                f"#{number}: size must be one of {sorted(SIZES, key=SIZES.get)}, got {item.get('size')!r}."
+            )
+
+        depends_on = item.get("dependsOn", [])
+        if not isinstance(depends_on, list) or any(
+            not isinstance(d, int) or isinstance(d, bool) or d <= 0 for d in depends_on
+        ):
+            raise RunListError(f"#{number}: dependsOn must be a list of positive integers, got {depends_on!r}.")
+
+        files = item.get("filesTouched")
+        if files is not None and (not isinstance(files, list) or any(not isinstance(f, str) for f in files)):
+            raise RunListError(f"#{number}: filesTouched must be a list of strings, got {files!r}.")
+
+
+def _resolve_edges(ready, closed):
+    """Split each `dependsOn` edge into: kept, discharged, or a caller bug.
+
+    An edge onto a **closed** issue is legitimately discharged — Phase 5 does
+    exactly that. An edge onto an issue that is neither Ready nor closed is
+    Phase 5's Ready-demotion rule violated ("an issue is `ready` only if every
+    issue it `dependsOn` is closed or also becoming Ready ahead of it"), so the
+    run-list would otherwise carry an issue whose dependency is not landing.
+    """
+    in_ready = {item["issue"] for item in ready}
+    closed_set = set(closed)
+
+    deps = {}
+    discharged = []
+    for item in ready:
+        number = item["issue"]
+        kept = []
+        for target in item.get("dependsOn", []):
+            if target in in_ready:
+                kept.append(target)
+            elif target in closed_set:
+                discharged.append({"from": number, "to": target})
+            else:
+                raise RunListError(
+                    f"#{number} dependsOn #{target}, which is neither in the Ready set nor "
+                    "listed as closed. Either it should not be Ready yet (Phase 5's Ready "
+                    "demotion), or #{0} closed and belongs in `closed`.".format(target)
+                )
+        deps[number] = sorted(set(kept))
+
+    discharged.sort(key=lambda edge: (edge["from"], edge["to"]))
+    return deps, discharged
+
+
+def _assert_acyclic(deps):
+    """Kahn's, for detection only. A cycle is Phase 5's job, not this script's.
+
+    SKILL.md Phase 5: "A cycle means at least one edge is wrong — re-read both
+    issues rather than picking one to break." Breaking it here would silently
+    pick, which is precisely the judgement the conductor is meant to make.
+    """
+    indegree = {n: len(deps[n]) for n in deps}
+    queue = sorted(n for n, d in indegree.items() if d == 0)
+    emitted = 0
+    while queue:
+        node = queue.pop(0)
+        emitted += 1
+        for other in sorted(deps):
+            if node in deps[other]:
+                indegree[other] -= 1
+                if indegree[other] == 0:
+                    queue.append(other)
+        queue.sort()
+    if emitted != len(deps):
+        stuck = sorted(n for n in deps if indegree[n] > 0)
+        raise RunListError(
+            "dependsOn contains a cycle among issues "
+            + ", ".join(f"#{n}" for n in stuck)
+            + ". Phase 5 resolves cycles by re-reading both issues; this script will not "
+            "pick an edge to break."
+        )
+
+
+def _effective_priorities(items, deps):
+    """`min(own priority, best priority over all transitive DEPENDENTS)`.
+
+    This is what makes SKILL.md:207 true — "Rule 1 outranks rule 2: a P2 that
+    unblocks a P0 goes first." Plain greedy Kahn's does not do it: it guarantees
+    only that a dependency precedes its dependent, so a P2 unblocker with no
+    other constraint still sorts behind every independent P1. Promotion has to
+    be computed before the sort, not discovered during it.
+    """
+    own = {n: PRIORITIES[items[n]["priority"]] for n in items}
+    dependents = {n: [] for n in items}
+    for node, targets in deps.items():
+        for target in targets:
+            dependents[target].append(node)
+
+    memo = {}
+
+    def resolve(node):
+        if node in memo:
+            return memo[node]
+        best = own[node]
+        # Safe to recurse: _assert_acyclic has already run.
+        for child in dependents[node]:
+            best = min(best, resolve(child))
+        memo[node] = best
+        return best
+
+    return {n: resolve(n) for n in items}
+
+
+def _topological_order(items, deps, effective):
+    """Kahn's, emitting the best-keyed available node at each step.
+
+    The key is (effective priority, own priority, size, issue number). The issue
+    number is load-bearing, not cosmetic: without a total order two runs over the
+    same input can emit different lines, which is the defect being fixed.
+    """
+    remaining = dict(deps)
+    satisfied = set()
+    order = []
+
+    def key(node):
+        item = items[node]
+        return (effective[node], PRIORITIES[item["priority"]], SIZES[item["size"]], node)
+
+    while remaining:
+        available = [n for n, targets in remaining.items() if set(targets) <= satisfied]
+        node = min(available, key=key)
+        order.append(node)
+        satisfied.add(node)
+        del remaining[node]
+
+    return order
+
+
+def _contends(items, a, b):
+    """Two issues contend when their `filesTouched` overlap.
+
+    A **skipped** issue carries no `filesTouched` — its triage marker holds
+    `deps=`, `priority` and `size` but not the file list — so it contributes no
+    edges. SKILL.md Phase 6 requires this be disclosed rather than presented as
+    full coverage; the caller reports it from the `source` it already knows.
+    """
+    files_a = items[a].get("filesTouched")
+    files_b = items[b].get("filesTouched")
+    if not files_a or not files_b:
+        return False
+    return bool(set(files_a) & set(files_b))
+
+
+def _is_valid_order(order, deps):
+    position = {node: index for index, node in enumerate(order)}
+    return all(position[target] < position[node] for node in order for target in deps[node])
+
+
+def _separate_contenders(order, items, deps):
+    """One deterministic left-to-right pass; move a non-contender between a pair.
+
+    The primitive is a MOVE (remove and re-insert), not a swap. Swapping the two
+    contending issues with each other leaves them adjacent — it does nothing —
+    and swapping one of them with a later element reorders that element's own
+    neighbourhood, which can break a dependency that a move would not. SKILL.md's
+    wording is "when something else can sit between them": insertion.
+
+    Constraints on the element moved in, in the order they are checked:
+      * same OWN priority band — rule 2 outranks rule 3, so separating two
+        contenders may never promote or demote across priorities;
+      * it must not itself contend with the left-hand issue, or the pair is
+        merely replaced by a new one;
+      * the resulting order must still be a valid topological order.
+
+    Smallest qualifying index wins, one pass, no re-scan — so the output is a
+    deterministic function of the input, and the pass is a fixed point on its own
+    output. A pair with no qualifying separator is REPORTED, never forced: rule 3
+    is conditional ("when something else can sit between them"), so sometimes
+    nothing can.
+    """
+    order = list(order)
+    unseparable = []
+
+    index = 0
+    while index < len(order) - 1:
+        left, right = order[index], order[index + 1]
+        if _contends(items, left, right):
+            for candidate_index in range(index + 2, len(order)):
+                candidate = order[candidate_index]
+                if PRIORITIES[items[candidate]["priority"]] != PRIORITIES[items[right]["priority"]]:
+                    continue
+                if _contends(items, left, candidate):
+                    continue
+                moved = list(order)
+                moved.insert(index + 1, moved.pop(candidate_index))
+                if _is_valid_order(moved, deps):
+                    order = moved
+                    break
+            else:
+                unseparable.append([left, right])
+        index += 1
+
+    return order, unseparable
+
+
+def _deps_outrank_priority(items, deps):
+    """Edges where a lower-priority issue legitimately precedes a higher one.
+
+    SKILL.md Phase 6: "Say so explicitly in the run-list when it happens, or it
+    reads as a mis-sort." Returned as structured pairs so Phase 8 writes the
+    prose and this module does not.
+    """
+    pairs = [
+        {"before": target, "after": node}
+        for node in sorted(deps)
+        for target in deps[node]
+        if PRIORITIES[items[target]["priority"]] > PRIORITIES[items[node]["priority"]]
+    ]
+    pairs.sort(key=lambda pair: (pair["before"], pair["after"]))
+    return pairs
+
+
+def build_run_list_line(head, ordered):
+    """Assemble the canonical run-list line. This is the grammar's definition.
+
+    Paste the result verbatim; never reword, prettify, annotate or wrap it.
+    """
+    return "<!-- run-list: {0} | {1} -->".format(head, ",".join(str(n) for n in ordered))
+
+
+def build(head, ready, closed=()):
+    """Order the Ready set and build its run-list line.
+
+    `ready` elements use `triage-issues.js`' own `VERDICT_SCHEMA` field names
+    (`issue`, `priority`, `size`, `dependsOn`, `filesTouched`) so a freshly
+    triaged verdict is passed through untouched — the caller re-shaping records
+    by hand would reintroduce, at the input, exactly the transcription risk this
+    script removes at the output.
+    """
+    _validate(head, ready, closed)
+
+    if not ready:
+        return {
+            "head": head,
+            "ordered": [],
+            "runListLine": None,
+            "note": "Ready set is empty — no run-list line published this run.",
+            "depsOutrankPriority": [],
+            "dischargedEdges": [],
+            "unseparableContention": [],
+        }
+
+    items = {item["issue"]: item for item in ready}
+    deps, discharged = _resolve_edges(ready, closed)
+    _assert_acyclic(deps)
+
+    effective = _effective_priorities(items, deps)
+    ordered = _topological_order(items, deps, effective)
+    ordered, unseparable = _separate_contenders(ordered, items, deps)
+
+    return {
+        "head": head,
+        "ordered": ordered,
+        "runListLine": build_run_list_line(head, ordered),
+        "note": "",
+        "depsOutrankPriority": _deps_outrank_priority(items, deps),
+        "dischargedEdges": discharged,
+        "unseparableContention": unseparable,
+    }
+
+
+def main():
+    """Read `{head, ready, closed}` as JSON from a file argument or stdin."""
+    source = Path(sys.argv[1]).read_text(encoding="utf-8") if len(sys.argv) > 1 else sys.stdin.read()
+    try:
+        payload = json.loads(source)
+    except json.JSONDecodeError as error:
+        print(f"build-run-list: input is not valid JSON: {error}", file=sys.stderr)
+        sys.exit(1)
+
+    if not isinstance(payload, dict):
+        print("build-run-list: input must be a JSON object with `head` and `ready`.", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        result = build(payload.get("head"), payload.get("ready", []), payload.get("closed", []))
+    except RunListError as error:
+        print(f"build-run-list: {error}", file=sys.stderr)
+        sys.exit(1)
+
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/build_run_list.py
+++ b/Scripts/build_run_list.py
@@ -49,9 +49,12 @@ from pathlib import Path
 # The empty-list case is deliberately unmatchable: `<!-- run-list: <sha> | -->`
 # would parse as a well-formed run-list containing nothing, which is worse than
 # publishing no line at all. An empty Ready set returns `runListLine: None`.
-RUN_LIST_RE = re.compile(r"^<!-- run-list: [0-9a-f]{7,40} \| \d+(?:,\d+)* -->$")
+# `\Z`, never `$`: in Python `$` also matches just *before* a trailing newline,
+# so `"36552a4d\n"` would satisfy a `$`-anchored check and then be interpolated
+# into a line no parser could match. Match against the stripped line.
+RUN_LIST_RE = re.compile(r"^<!-- run-list: [0-9a-f]{7,40} \| \d+(?:,\d+)* -->\Z")
 
-HEAD_RE = re.compile(r"^[0-9a-f]{7,40}$")
+HEAD_RE = re.compile(r"^[0-9a-f]{7,40}\Z")
 
 PRIORITIES = {"P0": 0, "P1": 1, "P2": 2}
 SIZES = {"XS": 0, "S": 1, "M": 2, "L": 3, "XL": 4}
@@ -75,6 +78,12 @@ def _validate(head, ready, closed):
         raise RunListError(f"ready must be a list, got {type(ready).__name__}.")
     if not isinstance(closed, (list, tuple, set)):
         raise RunListError(f"closed must be a list, got {type(closed).__name__}.")
+    for target in closed:
+        # Checked to the same standard as every other collection here: a string
+        # "393" would never match the integer 393 an edge carries, so the edge
+        # would be reported as a dangling caller bug instead of discharged.
+        if not isinstance(target, int) or isinstance(target, bool) or target <= 0:
+            raise RunListError(f"closed contains a non-positive-integer element: {target!r}.")
 
     seen = set()
     for index, item in enumerate(ready):
@@ -92,13 +101,17 @@ def _validate(head, ready, closed):
             )
         seen.add(number)
 
-        if item.get("priority") not in PRIORITIES:
+        # `isinstance(..., str)` first: `x in PRIORITIES` raises TypeError for an
+        # unhashable value, which would escape as a traceback rather than the
+        # RunListError the caller is told to expect.
+        priority = item.get("priority")
+        if not isinstance(priority, str) or priority not in PRIORITIES:
+            raise RunListError(f"#{number}: priority must be one of {sorted(PRIORITIES)}, got {priority!r}.")
+
+        size = item.get("size")
+        if not isinstance(size, str) or size not in SIZES:
             raise RunListError(
-                f"#{number}: priority must be one of {sorted(PRIORITIES)}, got {item.get('priority')!r}."
-            )
-        if item.get("size") not in SIZES:
-            raise RunListError(
-                f"#{number}: size must be one of {sorted(SIZES, key=SIZES.get)}, got {item.get('size')!r}."
+                f"#{number}: size must be one of {sorted(SIZES, key=SIZES.get)}, got {size!r}."
             )
 
         depends_on = item.get("dependsOn", [])
@@ -129,7 +142,9 @@ def _resolve_edges(ready, closed):
     for item in ready:
         number = item["issue"]
         kept = []
-        for target in item.get("dependsOn", []):
+        # `sorted(set(...))`: a repeated target is one edge, and reporting a
+        # duplicate twice in `dischargedEdges` would overstate what was dropped.
+        for target in sorted(set(item.get("dependsOn", []))):
             if target in in_ready:
                 kept.append(target)
             elif target in closed_set:
@@ -250,7 +265,7 @@ def _is_valid_order(order, deps):
     return all(position[target] < position[node] for node in order for target in deps[node])
 
 
-def _separate_contenders(order, items, deps):
+def _separate_contenders(order, items, deps, effective):
     """One deterministic left-to-right pass; move a non-contender between a pair.
 
     The primitive is a MOVE (remove and re-insert), not a swap. Swapping the two
@@ -262,6 +277,14 @@ def _separate_contenders(order, items, deps):
     Constraints on the element moved in, in the order they are checked:
       * same OWN priority band — rule 2 outranks rule 3, so separating two
         contenders may never promote or demote across priorities;
+      * it must not LEAPFROG anything better-ranked. Checking the candidate
+        against its new right-hand neighbour alone is not enough: the move jumps
+        every element in between, so a same-band candidate can still overtake a
+        higher-priority issue sitting in that gap. That inversion would carry no
+        dependency edge, so `depsOutrankPriority` would not disclose it either —
+        an undisclosed mis-sort, which is the one thing Phase 6 must not publish.
+        Rank is compared as `(effective, own)` so a rule-1 promotion cannot be
+        undone here either;
       * it must not itself contend with the left-hand issue, or the pair is
         merely replaced by a new one;
       * the resulting order must still be a valid topological order.
@@ -272,6 +295,9 @@ def _separate_contenders(order, items, deps):
     is conditional ("when something else can sit between them"), so sometimes
     nothing can.
     """
+    def rank(node):
+        return (effective[node], PRIORITIES[items[node]["priority"]])
+
     order = list(order)
     unseparable = []
 
@@ -282,6 +308,9 @@ def _separate_contenders(order, items, deps):
             for candidate_index in range(index + 2, len(order)):
                 candidate = order[candidate_index]
                 if PRIORITIES[items[candidate]["priority"]] != PRIORITIES[items[right]["priority"]]:
+                    continue
+                # Everything in [index+1, candidate_index) is jumped by the move.
+                if any(rank(node) < rank(candidate) for node in order[index + 1 : candidate_index]):
                     continue
                 if _contends(items, left, candidate):
                     continue
@@ -350,7 +379,7 @@ def build(head, ready, closed=()):
 
     effective = _effective_priorities(items, deps)
     ordered = _topological_order(items, deps, effective)
-    ordered, unseparable = _separate_contenders(ordered, items, deps)
+    ordered, unseparable = _separate_contenders(ordered, items, deps, effective)
 
     return {
         "head": head,
@@ -365,7 +394,14 @@ def build(head, ready, closed=()):
 
 def main():
     """Read `{head, ready, closed}` as JSON from a file argument or stdin."""
-    source = Path(sys.argv[1]).read_text(encoding="utf-8") if len(sys.argv) > 1 else sys.stdin.read()
+    try:
+        source = Path(sys.argv[1]).read_text(encoding="utf-8") if len(sys.argv) > 1 else sys.stdin.read()
+    except OSError as error:
+        # Inside the try so a missing or unreadable path gets the repo's
+        # `build-run-list: ...` stderr line rather than a raw traceback.
+        print(f"build-run-list: cannot read input: {error}", file=sys.stderr)
+        sys.exit(1)
+
     try:
         payload = json.loads(source)
     except json.JSONDecodeError as error:

--- a/Scripts/run-script-tests.py
+++ b/Scripts/run-script-tests.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Run the `Scripts/tests` suites, and fail if it collected suspiciously few.
+
+`python3 -m unittest discover` **exits 0 when it collects nothing**. Python 3.9's
+`unittest/main.py` ends with `sys.exit(not self.result.wasSuccessful())`, and
+`wasSuccessful()` is True when `testsRun == 0`; the `_NO_TESTS_EXITCODE = 5`
+that would have caught it did not arrive until 3.12, and the `python3` on this
+repo's PATH is Xcode's 3.9.6.
+
+So a bare `discover` would let a renamed test file, a renamed directory, a wrong
+working directory, or a file that stops matching the `test*.py` pattern turn the
+gate into a no-op whose green is **byte-identical** to a passing suite. That is
+the *False green* family this repo keeps hitting
+(`knowledge/gotchas.md`), and `Scripts/check-fixtures.py` already
+states the rule outright: a checker whose green is indistinguishable from "it
+never ran" is not a checker.
+
+The floor is a floor, not `> 0`, because the default `test*.py` pattern is itself
+a silent filter: a future `Scripts/tests/build_run_list_test.py` would be
+collected by nothing while the existing file keeps the count non-zero. Raise it
+when suites are added — a drop is exactly the signal worth failing on.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TESTS = ROOT / "Scripts" / "tests"
+
+# Bump when suites are added. Lower than the current count only if tests are
+# deliberately removed — never to make a red run go green.
+EXPECTED_MINIMUM = 30
+
+
+def main() -> None:
+    if not TESTS.is_dir():
+        print(f"run-script-tests: {TESTS} does not exist.", file=sys.stderr)
+        sys.exit(1)
+
+    suite = unittest.defaultTestLoader.discover(str(TESTS), top_level_dir=str(TESTS))
+
+    # `discover` reports an import failure as a synthetic _FailedTest rather than
+    # raising, so it would otherwise be counted as a collected test and run to a
+    # normal red. That is fine — but it must not be mistaken for coverage.
+    count = suite.countTestCases()
+    if count < EXPECTED_MINIMUM:
+        print(
+            f"run-script-tests: collected {count} tests under {TESTS.relative_to(ROOT)}, "
+            f"expected at least {EXPECTED_MINIMUM}.\n"
+            "  A renamed file, a renamed directory, or a filename no longer matching the\n"
+            "  `test*.py` discovery pattern silently empties this gate — and an empty run\n"
+            "  exits 0 on Python 3.9, so it would look identical to a pass.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(f"run-script-tests: {count} tests collected under {TESTS.relative_to(ROOT)}.")
+    result = unittest.TextTestRunner(verbosity=1).run(suite)
+    sys.exit(not result.wasSuccessful())
+
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/run-script-tests.py
+++ b/Scripts/run-script-tests.py
@@ -30,9 +30,14 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 TESTS = ROOT / "Scripts" / "tests"
 
-# Bump when suites are added. Lower than the current count only if tests are
-# deliberately removed — never to make a red run go green.
-EXPECTED_MINIMUM = 30
+# The EXACT current count, not a loose floor. Slack is what lets a whole class
+# vanish unnoticed: at 30 against an actual 38, the five AntiDriftTests — the
+# only cases that read `.claude/**/*.md` off disk, and the entire reason the CI
+# step is gated on `markdown` as well as `swift` — could be deleted and both
+# `make lint` and CI would stay green. An exact count also forces a one-line,
+# diff-visible bump in the same commit that adds a test, which is the only
+# enforcement a "remember to update this" comment ever really has.
+EXPECTED_MINIMUM = 38
 
 
 def main() -> None:
@@ -59,7 +64,26 @@ def main() -> None:
 
     print(f"run-script-tests: {count} tests collected under {TESTS.relative_to(ROOT)}.")
     result = unittest.TextTestRunner(verbosity=1).run(suite)
-    sys.exit(not result.wasSuccessful())
+
+    if not result.wasSuccessful():
+        sys.exit(1)
+
+    # Re-assert the floor against what actually EXECUTED. `wasSuccessful()`
+    # counts a skip as a success, so a `@unittest.skip` on a class — or a
+    # `raise unittest.SkipTest` in `setUpModule` — would keep both the
+    # collection count and the exit status green while running no assertions
+    # at all. That is the same "green means nobody looked" shape the collection
+    # floor above exists to close, one step further along.
+    executed = result.testsRun - len(result.skipped) - len(result.expectedFailures)
+    if executed < EXPECTED_MINIMUM:
+        print(
+            f"run-script-tests: only {executed} of {count} tests actually ran "
+            f"({len(result.skipped)} skipped), expected {EXPECTED_MINIMUM}.\n"
+            "  A skipped suite passes without asserting anything — remove the skip, or\n"
+            "  lower EXPECTED_MINIMUM deliberately if the tests were genuinely retired.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/Scripts/tests/test_build_run_list.py
+++ b/Scripts/tests/test_build_run_list.py
@@ -20,6 +20,7 @@ prose: `Scripts/check-prose-call-forms.py`.
 
 from __future__ import annotations
 
+import itertools
 import sys
 import unittest
 from pathlib import Path
@@ -308,11 +309,18 @@ class LineFormatTests(unittest.TestCase):
             f"<!-- run-list: {HEAD} | 426,437 -->",
         )
 
-    def test_same_input_twice_is_byte_identical(self):
+    def test_line_is_invariant_under_permutation_of_the_input(self):
+        # Calling build() twice with the SAME list cannot fail — there is no
+        # hash- or iteration-order dependence in the output path, so it reduces
+        # to `once == once`. Permuting the input is the property that actually
+        # has force: the conductor assembles `ready` from a fan-out plus a set
+        # of skipped markers, in no guaranteed order, and the published line
+        # must not depend on which order they arrived in.
         ready = [issue(9), issue(3, depends_on=[7]), issue(7)]
-        first = brl.build(HEAD, ready)["runListLine"]
-        second = brl.build(HEAD, ready)["runListLine"]
-        self.assertEqual(first, second)
+        baseline = brl.build(HEAD, ready)["runListLine"]
+        for permutation in itertools.permutations(ready):
+            with self.subTest(order=[i["issue"] for i in permutation]):
+                self.assertEqual(brl.build(HEAD, list(permutation))["runListLine"], baseline)
 
     def test_regex_rejects_the_near_misses_that_motivated_this(self):
         # Each of these is a plausible LLM rewording of the line. All must fail
@@ -334,9 +342,15 @@ class AntiDriftTests(unittest.TestCase):
     picks the wrong one."""
 
     def test_next_mode_still_carries_the_grammar_markers(self):
-        text = NEXT_MODE.read_text(encoding="utf-8")
-        self.assertIn("<!-- run-list: ", text)
-        self.assertIn(" -->", text)
+        # Both markers must appear on the SAME line. Asserting " -->" against the
+        # whole file cannot fail — next-mode.md carries unrelated HTML comments
+        # (`<!-- triaged: … -->`, `<!-- deliver-next: … -->`) that satisfy it
+        # even if the run-list example were deleted outright.
+        lines = NEXT_MODE.read_text(encoding="utf-8").splitlines()
+        self.assertTrue(
+            any(line.strip().startswith("<!-- run-list: ") and line.strip().endswith(" -->") for line in lines),
+            msg=f"{NEXT_MODE.name} no longer carries a complete run-list example line.",
+        )
 
     def test_next_mode_names_the_builder_as_the_definition(self):
         text = NEXT_MODE.read_text(encoding="utf-8")

--- a/Scripts/tests/test_build_run_list.py
+++ b/Scripts/tests/test_build_run_list.py
@@ -150,6 +150,26 @@ class ContentionTests(unittest.TestCase):
         self.assertEqual(result["ordered"], [1, 2, 3])
         self.assertEqual(result["unseparableContention"], [[1, 2]])
 
+    def test_separator_is_not_promoted_past_a_higher_priority_issue(self):
+        # Regression: checking the candidate's band against `right` alone is not
+        # enough — the move JUMPS every element between, so a same-band candidate
+        # can still leapfrog a higher-priority issue sitting in that gap.
+        #
+        # 1 and 2 contend and are both promoted to effective P0 by 3. The first
+        # same-band candidate is 4 (P1), and moving it to index 1 would put it
+        # ahead of 3 (P0) — an undisclosed mis-sort, since depsOutrankPriority
+        # only reports dependency edges and 4 has none. Rule 2 outranks rule 3,
+        # so the pair must be reported instead.
+        ready = [
+            issue(1, priority="P1", size="XS", files=["a.swift"]),
+            issue(2, priority="P1", size="S", depends_on=[1], files=["a.swift"]),
+            issue(3, priority="P0", size="M", depends_on=[2], files=["c.swift"]),
+            issue(4, priority="P1", size="L", files=["b.swift"]),
+        ]
+        result = brl.build(HEAD, ready)
+        self.assertEqual(result["ordered"], [1, 2, 3, 4])
+        self.assertEqual(result["unseparableContention"], [[1, 2]])
+
     def test_an_unseparable_pair_is_reported(self):
         ready = [
             issue(1, files=["a.swift"]),
@@ -159,17 +179,27 @@ class ContentionTests(unittest.TestCase):
         self.assertEqual(result["ordered"], [1, 2])
         self.assertEqual(result["unseparableContention"], [[1, 2]])
 
-    def test_contention_pass_is_idempotent(self):
+    def test_contention_pass_is_a_fixed_point_on_its_own_output(self):
+        # Exercise `_separate_contenders` DIRECTLY. Re-feeding `build()` its own
+        # output proves nothing: the topological sort selects with a total key,
+        # so `build()` is invariant under permutation of `ready` and the
+        # assertion would reduce to `once == once` — it would still pass if the
+        # pass swapped instead of moved, which is the mistake being guarded.
         ready = [
             issue(1, size="XS", files=["a.swift"]),
             issue(2, size="S", files=["a.swift"]),
             issue(3, size="M", files=["b.swift"]),
         ]
-        once = brl.build(HEAD, ready)["ordered"]
-        # Re-feed the produced order back in; the pass must be a fixed point.
-        by_number = {i["issue"]: i for i in ready}
-        twice = brl.build(HEAD, [by_number[n] for n in once])["ordered"]
-        self.assertEqual(once, twice)
+        items = {i["issue"]: i for i in ready}
+        deps = {i["issue"]: [] for i in ready}
+        effective = {i["issue"]: 1 for i in ready}
+
+        once, unseparable_once = brl._separate_contenders([1, 2, 3], items, deps, effective)
+        self.assertEqual(once, [1, 3, 2])
+
+        twice, unseparable_twice = brl._separate_contenders(once, items, deps, effective)
+        self.assertEqual(twice, once)
+        self.assertEqual(unseparable_twice, unseparable_once)
 
     def test_skipped_issues_contribute_no_contention_edges(self):
         # Both touch a.swift, but neither declares filesTouched (skipped), so
@@ -232,9 +262,31 @@ class ErrorTests(unittest.TestCase):
             brl.build(HEAD, [issue(1), issue(1)])
 
     def test_a_bad_head_sha_is_an_error(self):
-        for bad in ("", "not-a-sha", "ABCDEF1", "36552a"):
+        # The trailing-newline case is the subtle one: Python's `$` also matches
+        # just before a trailing newline, so a `$`-anchored check would accept
+        # "36552a4d\n" and emit a line no parser could ever match.
+        for bad in ("", "not-a-sha", "ABCDEF1", "36552a", "36552a4d\n", " 36552a4d"):
             with self.subTest(head=bad), self.assertRaises(brl.RunListError):
                 brl.build(bad, [issue(1)])
+
+    def test_a_non_integer_closed_element_is_an_error(self):
+        # "393" would never match the integer 393 an edge carries, so the edge
+        # would be misreported as a dangling caller bug instead of discharged.
+        with self.assertRaises(brl.RunListError):
+            brl.build(HEAD, [issue(1, depends_on=[393])], closed=["393"])
+
+    def test_an_unhashable_priority_raises_run_list_error_not_type_error(self):
+        with self.assertRaises(brl.RunListError):
+            brl.build(HEAD, [issue(1, priority={"a": 1})])
+
+    def test_a_self_dependency_is_reported_as_a_cycle(self):
+        with self.assertRaises(brl.RunListError) as ctx:
+            brl.build(HEAD, [issue(1, depends_on=[1])])
+        self.assertIn("cycle", str(ctx.exception).lower())
+
+    def test_a_repeated_closed_target_is_discharged_once(self):
+        result = brl.build(HEAD, [issue(1, depends_on=[999, 999])], closed=[999])
+        self.assertEqual(result["dischargedEdges"], [{"from": 1, "to": 999}])
 
     def test_an_empty_ready_set_returns_a_note_and_no_line(self):
         # Never `<!-- run-list: <sha> | -->` — the parser would accept that as a
@@ -294,20 +346,45 @@ class AntiDriftTests(unittest.TestCase):
         text = TRIAGE_SKILL.read_text(encoding="utf-8")
         self.assertIn("build_run_list_line", text)
 
-    def test_next_modes_example_line_parses(self):
-        # Pull the documented example straight out of the prose and run it
-        # through the real parser. If someone edits the example into something
-        # the parser rejects, this fails.
-        text = NEXT_MODE.read_text(encoding="utf-8")
-        examples = [
-            line.strip()
-            for line in text.splitlines()
-            if line.strip().startswith("<!-- run-list:")
-        ]
-        self.assertTrue(examples, "next-mode.md carries no run-list example line")
-        for example in examples:
-            with self.subTest(example=example):
-                self.assertRegex(example, brl.RUN_LIST_RE)
+    def test_every_documented_example_line_parses(self):
+        # Pull documented examples straight out of the prose and run them
+        # through the real parser. Checked across BOTH files that mention the
+        # line, not just next-mode.md: the hand-written grammar template this
+        # change deleted lived in triage-issues/SKILL.md, so that is exactly
+        # where a re-introduced one would land.
+        found_any = False
+        for path in (NEXT_MODE, TRIAGE_SKILL):
+            examples = [
+                line.strip()
+                for line in path.read_text(encoding="utf-8").splitlines()
+                if line.strip().startswith("<!-- run-list:")
+            ]
+            for example in examples:
+                found_any = True
+                with self.subTest(path=path.name, example=example):
+                    self.assertRegex(example, brl.RUN_LIST_RE)
+        self.assertTrue(found_any, "no run-list example line found in either file")
+
+    def test_triage_skill_does_not_restate_the_grammar(self):
+        # Phase 8 now pastes a FIELD. A `<sha>`-style placeholder template
+        # reappearing here would be a second definition of the grammar — the
+        # drift this change exists to remove.
+        # Custom messages: a bare assertNotIn dumps the entire ~40KB skill file
+        # into the failure output, which buries the one line that matters.
+        text = TRIAGE_SKILL.read_text(encoding="utf-8")
+        self.assertNotIn(
+            "<!-- run-list: <",
+            text,
+            msg=f"{TRIAGE_SKILL.name} restates the run-list grammar as a template. "
+            "Phase 8 pastes the `runListLine` field; the grammar is defined only by "
+            "build_run_list_line in Scripts/build_run_list.py.",
+        )
+        self.assertNotIn(
+            "short sha",
+            text,
+            msg=f"{TRIAGE_SKILL.name} says 'short sha'; the grammar accepts 7-40 hex "
+            "and next-mode.md §3 documents it as <sha>. Those two must not disagree.",
+        )
 
 
 if __name__ == "__main__":

--- a/Scripts/tests/test_build_run_list.py
+++ b/Scripts/tests/test_build_run_list.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Tests for `Scripts/build_run_list.py`.
+
+Two distinct jobs here, and the second is the one that is easy to get wrong.
+
+**Behaviour** — the ordering rules, each in isolation. The interesting cases are
+the two the plan review caught: a plain greedy topological sort does NOT promote
+an unblocker (`test_p2_unblocking_a_p0_precedes_an_independent_p1`), and a
+contention pass that swaps the contending pair with each other leaves it adjacent
+(`test_a_non_contender_is_moved_between_two_contending_issues`).
+
+**Anti-drift** — asserting the built line against a string literal *here* would
+make this file a second copy of the grammar, not a check on the real ones. So the
+format cases assert against `RUN_LIST_RE` exported by the module under test, and
+the prose cases READ THE SKILL FILES OFF DISK. That is what makes
+`knowledge/gotchas.md`'s "a rule written in two files drifts" detectable by a
+test rather than only by a cross-reference. Precedent for a check that greps
+prose: `Scripts/check-prose-call-forms.py`.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT / "Scripts"))
+
+import build_run_list as brl  # noqa: E402
+
+NEXT_MODE = ROOT / ".claude" / "skills" / "deliver" / "references" / "next-mode.md"
+TRIAGE_SKILL = ROOT / ".claude" / "skills" / "triage-issues" / "SKILL.md"
+
+HEAD = "36552a4d"
+
+
+def issue(number, priority="P1", size="S", depends_on=(), files=None):
+    """Build one Ready-set element. `files=None` models a SKIPPED issue.
+
+    A skipped issue's marker carries `deps=`, `priority` and `size` but no
+    `filesTouched`, so it contributes no contention edges — the distinction the
+    `noEdgeData` case turns on.
+    """
+    item = {
+        "issue": number,
+        "priority": priority,
+        "size": size,
+        "dependsOn": list(depends_on),
+    }
+    if files is not None:
+        item["filesTouched"] = list(files)
+    return item
+
+
+def order(ready, closed=()):
+    return brl.build(HEAD, ready, closed=closed)["ordered"]
+
+
+class DependencyOrderTests(unittest.TestCase):
+    def test_a_dependency_precedes_its_dependent(self):
+        ready = [issue(100, depends_on=[200]), issue(200)]
+        self.assertEqual(order(ready), [200, 100])
+
+    def test_p2_unblocking_a_p0_precedes_an_independent_p1(self):
+        # SKILL.md:207 — "Rule 1 outranks rule 2: a P2 that unblocks a P0 goes
+        # first." Plain greedy Kahn's emits 437, 430, 426 here, because 430's OWN
+        # priority is P2. Only effective priority (min over transitive
+        # dependents) promotes it.
+        ready = [
+            issue(430, priority="P2", depends_on=[]),
+            issue(426, priority="P0", depends_on=[430]),
+            issue(437, priority="P1"),
+        ]
+        self.assertEqual(order(ready), [430, 426, 437])
+
+    def test_effective_priority_propagates_transitively(self):
+        # 300 <- 301 <- 302(P0). 300 must be promoted by its GRANDCHILD.
+        ready = [
+            issue(300, priority="P2"),
+            issue(301, priority="P2", depends_on=[300]),
+            issue(302, priority="P0", depends_on=[301]),
+            issue(310, priority="P1"),
+        ]
+        self.assertEqual(order(ready), [300, 301, 302, 310])
+
+    def test_deps_outranking_priority_is_reported(self):
+        ready = [
+            issue(430, priority="P2"),
+            issue(426, priority="P0", depends_on=[430]),
+        ]
+        result = brl.build(HEAD, ready)
+        self.assertIn({"before": 430, "after": 426}, result["depsOutrankPriority"])
+
+    def test_no_deps_outrank_report_when_priorities_agree(self):
+        ready = [issue(1, priority="P0"), issue(2, priority="P1", depends_on=[1])]
+        self.assertEqual(brl.build(HEAD, ready)["depsOutrankPriority"], [])
+
+
+class PrioritySizeTiebreakTests(unittest.TestCase):
+    def test_priority_orders_before_size(self):
+        ready = [issue(1, priority="P2", size="XS"), issue(2, priority="P0", size="L")]
+        self.assertEqual(order(ready), [2, 1])
+
+    def test_size_ascending_within_a_priority_band(self):
+        ready = [issue(1, size="L"), issue(2, size="XS"), issue(3, size="M")]
+        self.assertEqual(order(ready), [2, 3, 1])
+
+    def test_issue_number_ascending_is_the_final_tiebreak(self):
+        ready = [issue(9), issue(3), issue(7)]
+        self.assertEqual(order(ready), [3, 7, 9])
+
+    def test_reproduces_the_published_2026_08_20_run_list(self):
+        # The real Ready set from the 2026-08-20 status update. That run had no
+        # dependency edges and no contention, so this pins rules 2-4 against
+        # real data; rules 1 and 3 are covered by the synthetic cases above.
+        published = [434, 426, 437, 448, 428, 454, 424, 425, 427, 429, 435, 467, 430]
+        ready = [
+            issue(434, "P0", "S"), issue(426, "P0", "M"), issue(437, "P0", "M"),
+            issue(448, "P1", "XS"), issue(428, "P1", "S"), issue(454, "P1", "S"),
+            issue(424, "P1", "M"), issue(425, "P1", "M"), issue(427, "P1", "L"),
+            issue(429, "P1", "L"), issue(435, "P2", "XS"), issue(467, "P2", "S"),
+            issue(430, "P2", "L"),
+        ]
+        self.assertEqual(order(ready), published)
+
+
+class ContentionTests(unittest.TestCase):
+    def test_a_non_contender_is_moved_between_two_contending_issues(self):
+        # 1 and 2 contend. Swapping them with each other would leave them
+        # adjacent — the separation must bring 3 in.
+        ready = [
+            issue(1, size="XS", files=["a.swift"]),
+            issue(2, size="S", files=["a.swift"]),
+            issue(3, size="M", files=["b.swift"]),
+        ]
+        result = brl.build(HEAD, ready)
+        self.assertEqual(result["ordered"], [1, 3, 2])
+        self.assertEqual(result["unseparableContention"], [])
+
+    def test_contention_never_moves_an_item_across_a_priority_band(self):
+        # 1 and 2 contend, but the only non-contender is a P2. Rule 2 outranks
+        # rule 3, so the pair stays adjacent and is REPORTED instead.
+        ready = [
+            issue(1, priority="P0", size="XS", files=["a.swift"]),
+            issue(2, priority="P0", size="S", files=["a.swift"]),
+            issue(3, priority="P2", size="M", files=["b.swift"]),
+        ]
+        result = brl.build(HEAD, ready)
+        self.assertEqual(result["ordered"], [1, 2, 3])
+        self.assertEqual(result["unseparableContention"], [[1, 2]])
+
+    def test_an_unseparable_pair_is_reported(self):
+        ready = [
+            issue(1, files=["a.swift"]),
+            issue(2, files=["a.swift"]),
+        ]
+        result = brl.build(HEAD, ready)
+        self.assertEqual(result["ordered"], [1, 2])
+        self.assertEqual(result["unseparableContention"], [[1, 2]])
+
+    def test_contention_pass_is_idempotent(self):
+        ready = [
+            issue(1, size="XS", files=["a.swift"]),
+            issue(2, size="S", files=["a.swift"]),
+            issue(3, size="M", files=["b.swift"]),
+        ]
+        once = brl.build(HEAD, ready)["ordered"]
+        # Re-feed the produced order back in; the pass must be a fixed point.
+        by_number = {i["issue"]: i for i in ready}
+        twice = brl.build(HEAD, [by_number[n] for n in once])["ordered"]
+        self.assertEqual(once, twice)
+
+    def test_skipped_issues_contribute_no_contention_edges(self):
+        # Both touch a.swift, but neither declares filesTouched (skipped), so
+        # there is no edge to detect and nothing to separate.
+        ready = [issue(1, size="XS"), issue(2, size="S"), issue(3, size="M")]
+        result = brl.build(HEAD, ready)
+        self.assertEqual(result["ordered"], [1, 2, 3])
+        self.assertEqual(result["unseparableContention"], [])
+
+    def test_separation_never_violates_dependency_order(self):
+        # 1 and 2 contend; 3 would separate them but 3 depends on 2, so moving
+        # 3 before 2 is illegal. 4 is the legal separator.
+        ready = [
+            issue(1, size="XS", files=["a.swift"]),
+            issue(2, size="S", files=["a.swift"]),
+            issue(3, size="M", depends_on=[2], files=["b.swift"]),
+            issue(4, size="L", files=["c.swift"]),
+        ]
+        result = brl.build(HEAD, ready)
+        self.assertEqual(result["ordered"], [1, 4, 2, 3])
+        self.assertEqual(result["unseparableContention"], [])
+
+
+class ErrorTests(unittest.TestCase):
+    def test_a_cycle_is_an_error_naming_the_nodes(self):
+        ready = [issue(1, depends_on=[2]), issue(2, depends_on=[1])]
+        with self.assertRaises(brl.RunListError) as ctx:
+            brl.build(HEAD, ready)
+        self.assertIn("1", str(ctx.exception))
+        self.assertIn("2", str(ctx.exception))
+
+    def test_an_edge_onto_an_unknown_issue_is_an_error(self):
+        # Neither Ready nor declared closed: this is Phase 5's Ready-demotion
+        # rule violated — a Ready issue depending on something not landing.
+        ready = [issue(1, depends_on=[999])]
+        with self.assertRaises(brl.RunListError) as ctx:
+            brl.build(HEAD, ready)
+        self.assertIn("999", str(ctx.exception))
+
+    def test_an_edge_onto_a_closed_issue_is_discharged(self):
+        ready = [issue(1, depends_on=[999])]
+        result = brl.build(HEAD, ready, closed=[999])
+        self.assertEqual(result["ordered"], [1])
+        self.assertEqual(result["dischargedEdges"], [{"from": 1, "to": 999}])
+
+    def test_a_bad_priority_is_an_error(self):
+        with self.assertRaises(brl.RunListError):
+            brl.build(HEAD, [issue(1, priority="P9")])
+
+    def test_a_bad_size_is_an_error(self):
+        with self.assertRaises(brl.RunListError):
+            brl.build(HEAD, [issue(1, size="XXL")])
+
+    def test_a_non_integer_issue_number_is_an_error(self):
+        with self.assertRaises(brl.RunListError):
+            brl.build(HEAD, [issue("426")])
+
+    def test_a_duplicate_issue_number_is_an_error(self):
+        with self.assertRaises(brl.RunListError):
+            brl.build(HEAD, [issue(1), issue(1)])
+
+    def test_a_bad_head_sha_is_an_error(self):
+        for bad in ("", "not-a-sha", "ABCDEF1", "36552a"):
+            with self.subTest(head=bad), self.assertRaises(brl.RunListError):
+                brl.build(bad, [issue(1)])
+
+    def test_an_empty_ready_set_returns_a_note_and_no_line(self):
+        # Never `<!-- run-list: <sha> | -->` — the parser would accept that as a
+        # well-formed empty run-list, which is worse than no line at all.
+        result = brl.build(HEAD, [])
+        self.assertEqual(result["ordered"], [])
+        self.assertIsNone(result["runListLine"])
+        self.assertTrue(result["note"])
+
+
+class LineFormatTests(unittest.TestCase):
+    def test_line_matches_the_exported_regex(self):
+        line = brl.build_run_list_line(HEAD, [426, 437, 448])
+        self.assertRegex(line, brl.RUN_LIST_RE)
+
+    def test_exact_byte_format(self):
+        self.assertEqual(
+            brl.build_run_list_line(HEAD, [426, 437]),
+            f"<!-- run-list: {HEAD} | 426,437 -->",
+        )
+
+    def test_same_input_twice_is_byte_identical(self):
+        ready = [issue(9), issue(3, depends_on=[7]), issue(7)]
+        first = brl.build(HEAD, ready)["runListLine"]
+        second = brl.build(HEAD, ready)["runListLine"]
+        self.assertEqual(first, second)
+
+    def test_regex_rejects_the_near_misses_that_motivated_this(self):
+        # Each of these is a plausible LLM rewording of the line. All must fail
+        # the parse rather than half-match — that is the whole point of #471.
+        for bad in (
+            f"<!-- run-list: {HEAD} | 426, 437 -->",
+            f"<!-- run-list: {HEAD} | #426,#437 -->",
+            f"<!-- run-list: {HEAD} | 426,437 -->.",
+            f"<!-- run-list:{HEAD} | 426,437 -->",
+            f"<!-- run-list: {HEAD} | -->",
+        ):
+            with self.subTest(line=bad):
+                self.assertNotRegex(bad, brl.RUN_LIST_RE)
+
+
+class AntiDriftTests(unittest.TestCase):
+    """The grammar is stated in code and quoted in prose. Prove the prose still
+    agrees, so a drifted copy fails a test instead of being read by a human who
+    picks the wrong one."""
+
+    def test_next_mode_still_carries_the_grammar_markers(self):
+        text = NEXT_MODE.read_text(encoding="utf-8")
+        self.assertIn("<!-- run-list: ", text)
+        self.assertIn(" -->", text)
+
+    def test_next_mode_names_the_builder_as_the_definition(self):
+        text = NEXT_MODE.read_text(encoding="utf-8")
+        self.assertIn("build_run_list_line", text)
+
+    def test_triage_skill_phase_8_names_the_builder(self):
+        text = TRIAGE_SKILL.read_text(encoding="utf-8")
+        self.assertIn("build_run_list_line", text)
+
+    def test_next_modes_example_line_parses(self):
+        # Pull the documented example straight out of the prose and run it
+        # through the real parser. If someone edits the example into something
+        # the parser rejects, this fails.
+        text = NEXT_MODE.read_text(encoding="utf-8")
+        examples = [
+            line.strip()
+            for line in text.splitlines()
+            if line.strip().startswith("<!-- run-list:")
+        ]
+        self.assertTrue(examples, "next-mode.md carries no run-list example line")
+        for example in examples:
+            with self.subTest(example=example):
+                self.assertRegex(example, brl.RUN_LIST_RE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/knowledge/decisions/0027-run-list-ordering-in-scripts.md
+++ b/knowledge/decisions/0027-run-list-ordering-in-scripts.md
@@ -1,0 +1,118 @@
+# 0027 — Compute the triage run-list in `Scripts/`, not in a workflow
+
+* **Status:** Accepted (unreleased — tooling only)
+* **Date:** 2026-08-20
+
+## Context
+
+`/triage-issues` Phase 8 publishes one canonical line to a Project status update:
+
+```text
+<!-- run-list: <sha> | 426,437,448,428,454,424,425,427,429,435,467,430 -->
+```
+
+`/deliver next` parses **that line and nothing else** to choose its work. Until
+now the line was written by the agent from a prose spec, and the ordering behind
+it was computed by the agent too. That is the defect `evidenceDigest` already
+moved into code (`.claude/workflows/triage-issues.js`): an LLM asked to reproduce
+a fixed string words it differently each run, so the consumer's strict parse
+misses, `next` falls back to board fields, and the dependency and contention
+ordering is lost — silently, because nothing fails at write time (issue #471).
+
+Two constraints shaped where the fix could live.
+
+**The sort cannot fold into the existing fan-out.** `triage-issues.js` returns
+one verdict per issue; Phase 5's *reconcile* then runs — cycle resolution
+("re-read both issues rather than picking one to break"), duplicate resolution,
+and discharging edges onto closed issues. Those are judgement calls needing tool
+access the script does not have, and they change the Ready set. So the ordering
+must run **after** the script returns: it is necessarily a second invocation.
+
+**A workflow script cannot be imported by a test.** Workflow scripts use a
+top-level `return` and harness globals (`args`, `agent`, `log`), so they are not
+ES modules. Putting deterministic, unit-testable logic there would have forced a
+wrapper shim and a main-guard test hook — and left open whether a zero-agent
+`Workflow` run is even treated as a success.
+
+## Decision
+
+Put the ordering and the grammar in **`Scripts/build_run_list.py`**, invoked
+synchronously from Phase 6 with a JSON file, and have Phase 8 paste the returned
+`runListLine` field verbatim.
+
+`.claude/workflows/` is the **agent-orchestration** namespace and `Scripts/` the
+**deterministic** one — a distinction `.claude/skills/review-changes/SKILL.md`
+already draws. A pure sort belongs in the second. `python3` matches the five
+existing `Scripts/` checkers and is already a repo prerequisite, so no new
+toolchain enters `make lint` or CI, and `Scripts/**` is already in both CI paths
+filters.
+
+The module exports `RUN_LIST_RE` alongside `build_run_list_line`, so the written
+form and the parsed form are defined together and cannot drift apart. Phase 6 and
+Phase 8 state each rule's *intent* and delegate the definition to the script —
+the same single-ownership rule `/triage-issues` already applies to its rubrics.
+
+## Consequences
+
+**The ordering is now testable, and two defects fell out of testing it that had
+been specified wrongly in prose for as long as the prose existed:**
+
+* *A topological sort does not satisfy "a P2 that unblocks a P0 goes first."*
+  Precedence is not promotion — greedy Kahn's keyed on own priority emits an
+  independent P1 before a P2 unblocker. The script computes an **effective
+  priority** (`min(own, best over transitive dependents)`) before sorting.
+* *Separating two contending issues by swapping them is a no-op* — they stay
+  adjacent. The primitive is a **move**, and its priority-band check must cover
+  the whole **jumped range**, not just the new neighbour, or the separator
+  overtakes a higher-priority issue with no dependency edge to disclose it.
+
+Ordering is now a total function of its input: the final tiebreak is the issue
+number, so the same Ready set always yields a byte-identical line regardless of
+the order the conductor assembled it in.
+
+Errors fail loudly instead of degrading. A cycle, an edge onto an issue that is
+neither Ready nor declared closed, or a malformed record exits non-zero; Phase 6
+says to fix the input and re-invoke, and **never** to hand-write the line. An
+empty Ready set returns no line rather than one with an empty issue list, which
+would parse as a well-formed run-list containing nothing.
+
+The grammar now lives in a builder plus one prose quotation in
+`next-mode.md` §3 — two places, not the three the first design would have had,
+because Phase 8 names a *field* rather than a format. The remaining pair is held
+together by a test that reads the prose off disk (see `gotchas.md`, "A rule
+written in two files drifts").
+
+`Scripts/build_run_list.py` uses **underscores** where its five siblings use
+hyphens. The siblings are only ever executed; this one is imported by its tests,
+and `import build-run-list` is not valid Python.
+
+Costs: one more `make lint` prerequisite and one more CI `Lint` step, and the
+`Lint` job's `Checkout` had to widen from `swift` to `swift || markdown` so the
+anti-drift cases can read the skill prose. The conductor must still assemble the
+script's input — Phase 3's marker *parsing* remains prose, so `buildMarker` still
+has no counterpart in code.
+
+## Alternatives considered
+
+**A `mode` switch on `.claude/workflows/triage-issues.js`.** One file would own
+both fixed formats. Rejected: its `meta` declares `model: 'opus'` and a `Triage`
+phase that a zero-agent invocation makes untrue, its validation prelude is shaped
+for the fan-out, and the testability problem above remains.
+
+**A second workflow script, `.claude/workflows/triage-run-list.js`.** The
+original plan. Rejected in review: it manufactures a test shim, a main-guard, and
+an unresolved question about zero-agent workflow runs — none of which exist for
+an ordinary module.
+
+**Leaving the sort in the conductor and mechanising only the line.** Rejected:
+the line would then be a faithful rendering of an ordering nothing checks, which
+moves the drift one step back rather than removing it.
+
+## Related
+
+* [0016](0016-panel-jurors-and-workflows-directory.md) — why `.claude/workflows/`
+  exists and what belongs there.
+* [0023](0023-python-strict-parser-for-fixture-hygiene.md) — the same choice of
+  an independent Python checker over an in-language test.
+* [0026](0026-unattended-selection-needs-an-author-check.md) — the authorisation
+  gate that sits upstream of this ordering, in `next-mode.md` §2.

--- a/knowledge/decisions/README.md
+++ b/knowledge/decisions/README.md
@@ -44,6 +44,7 @@ always fair game.
 | [0024](0024-two-way-witness-guard.md) | Keep the defaulted-witness guard, as a two-way completeness oracle | 2026-08-14 | Accepted (in 20.0.0, unreleased) |
 | [0025](0025-redact-transport-error-payload.md) | Redact the transport error carried by `TMDbError.network` | 2026-08-20 | Accepted (in 20.0.0, unreleased) |
 | [0026](0026-unattended-selection-needs-an-author-check.md) | An unattended run must not read its authorisation from the work it selected | 2026-08-20 | Accepted (unreleased — tooling only) |
+| [0027](0027-run-list-ordering-in-scripts.md) | Compute the triage run-list in `Scripts/`, not in a workflow | 2026-08-20 | Accepted (unreleased — tooling only) |
 
 > **Keep the Status column true.** "In X, unreleased" becomes "shipped in X" when
 > X is **tagged** — a `CHANGELOG.md` section is not a release. For breaking changes

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -25,7 +25,7 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
 
 ---
 
-## 2026-08-20 — ✨ Assemble the triage run-list in code (issue #471, PR #TBD) · full
+## 2026-08-20 — ✨ Assemble the triage run-list in code (issue #471, #476) · full
 
 - **Phases / skills:** 0–8 pre-PR. Full weight — small diff, but reflexive
   (`.claude/skills/**` + `Scripts/**`) and it changes an unattended decision

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -25,6 +25,68 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
 
 ---
 
+## 2026-08-20 — ✨ Assemble the triage run-list in code (issue #471, PR #TBD) · full
+
+- **Phases / skills:** 0–8 pre-PR. Full weight — small diff, but reflexive
+  (`.claude/skills/**` + `Scripts/**`) and it changes an unattended decision
+  path, so both Phase 4/5 self-skips were overridden. Skills: `review-plan`
+  (3 critics), `review-changes` (`force-review`, fan-out — with the five
+  Swift lenses **replaced** by ones fitting a Python + prose diff), a targeted
+  2-lens converge pass, `security-review`, `capture-knowledge`.
+  `consulted:` gotchas *No workflow runs `make`*, *The `Workflow` tool resolves
+  a repo-relative `scriptPath`*, *The `Workflow` tool's contract is the schema
+  authority*, *A rule written in two files drifts*; wiki
+  *a-rule-stated-in-two-files-has-already-drifted*,
+  *never-ask-a-model-for-a-stable-fingerprint*.
+  `reconciled:` 0 in scope / 0 reclaimed / 0 resumable / 0 reported. Every
+  prior run file was already closed.
+  `swept:` `Makefile`, `.github/workflows/ci.yml`,
+  `.claude/skills/{lint,triage-issues,deliver}/**` → the mirrored-check registry
+  rewritten (five → six); `check-defaulted-witnesses.py`'s `make lint` + CI note
+  verified still true; none deleted.
+
+- **What worked — review found every substantive defect; writing the code did
+  not.** Three algorithm errors, each of which would have shipped as a silently
+  wrong *order* under a correctly-formatted line: a topological sort does not
+  promote an unblocker (precedence ≠ promotion); separating contenders by
+  swapping them leaves them adjacent; and the fixed band-check compared only the
+  new neighbour, not the jumped range, so a P1 could overtake a P0 with no
+  dependency edge to disclose it. The first two came from `/review-plan` — i.e.
+  **before** the wrong code existed — which is the cheapest place they could
+  have been caught.
+
+- **What worked — the anti-drift test caught its own author.** The test that
+  reads the skill prose off disk failed on a grammar template introduced by the
+  same commit that deleted the original. A test asserting against a literal
+  would have passed.
+
+- **Friction — four of my own tests could not fail.** `assertIn(" -->", text)`
+  was satisfied by unrelated HTML comments; `build(x) == build(x)` reduced to
+  `once == once` because the sort is permutation-invariant; the collection floor
+  had 8 tests of slack; and the gate itself exited 0 on an empty run. All four
+  are the same shape as the defect under test — a green indistinguishable from
+  "nobody looked" — written *while actively thinking about that failure mode*.
+  Writing a test does not mean writing a falsifiable one; the check is "make it
+  fail once".
+
+- **Deviations:** (1) `Scripts/build_run_list.py`, not the plan's
+  `build-run-list.py` — its tests import it and a hyphen is not importable.
+  The rubric was left naming the hyphenated path and the grader flagged the
+  discrepancy rather than it being quietly reconciled. (2) `/review-changes`'
+  fan-out lenses were swapped for the diff's actual subject matter; the five
+  stock lenses are Swift-specific and would have returned five empty reports,
+  which reads as coverage. (3) Two decisions were escalated mid-`/deliver`
+  (vehicle, and whether the mode split was scope creep) because the critics
+  overturned a user choice — Phase 2 has no branch for that, so it was handled
+  as an ordinary question.
+
+- **One improvement:** `/review-changes` §2b hard-codes five Swift lenses, and
+  the skill's own `force-review` path anticipates non-Swift diffs but only
+  offers the *single-reviewer* escape. A `full`-weight non-Swift diff therefore
+  has no sanctioned fan-out, and the choice to substitute lenses was made
+  ad hoc. Worth giving §2b a script-and-prose lens set the way §0 already gives
+  the single-reviewer path a script-focused brief.
+
 ## 2026-08-20 — ✨ `/deliver next` — select and plan the top Ready issue (#474) · full
 
 - **Phases / skills:** 0–8 pre-PR. Full weight — prose-only diff (~900 lines,
@@ -809,72 +871,6 @@ the board's Ready execution order.
   after adding tests, `/test` should confirm the new ones **by name**, not by
   total.
 
-## 2026-08-12 — 🐛 Decode empty-string credit dates as nil (#432) · full
-
-- **Phases / skills:** 0–11; **full** (a `Decodable`/`CodingKeys` change is a
-  named risky surface), so the 3-critic `/review-plan` ran and Phase 6 used an
-  independent grader. `/review-changes` took the single-reviewer path (555 lines,
-  one cohesive unit). `consulted:` gotchas *Guard consistently within a type*,
-  *Sweep the failure class, not the property name*, *Model-decode equality tests*,
-  *`Date(iso8601:)` is not visible to `TMDbIntegrationTests`*; api-notes
-  *Verify optionality against real responses*, *`/company/{id}` nullability*;
-  issues #418, #426, #430 for scope boundaries.
-- **Worked — the #404 failure-class sweep, in both directions.** The plan reached
-  Phase 0 having excluded the URL decodes from a *single* spot-check of one
-  record. Sweeping the whole `/credit/{id}` tree over 300 live records instead
-  both **cleared** those five URL decodes with a measurement (`null`-bearing,
-  never `""`) and **found a bug the issue never mentioned**: `credit_type:
-  "creator"` throws today. Without the sweep the first would have been an
-  assertion a reviewer could reasonably reject, and the second would have
-  shipped undiscovered.
-- **Worked — the critics found the false green I had built in.** All three
-  returned `sound-with-fixes` and every load-bearing claim I checked held up.
-  The best catch was mine to be embarrassed by: **no fixture in my test list
-  omitted `character`**, so a `decode`-instead-of-`decodeIfPresent` slip in
-  either hand-written init would have compiled, passed everything, and broken
-  36% of live credits. Re-sourcing both blank-date fixtures to **crew** credits
-  fixed it for free — TMDb omits `character` entirely on crew credits, so one
-  fixture now covers an empty date *and* an absent optional.
-- **Worked — reconciling a 2-vs-1 critic split on evidence rather than vote.**
-  One critic read *Guard consistently within a type* as requiring
-  `decodeNonEmptyURLIfPresent` on the image paths. The rule is about one **value
-  class** diverging (`Company.logoPath` vs `Company.Parent.logoPath`), not a date
-  differing from a URL — and guarding would have made `CreditMovie` the lone
-  divergence across ~20 models. The gotcha now records that scope explicitly, so
-  the next reader doesn't re-derive it.
-- **Friction — the worktree Bash guard.** A worktree-isolated session refuses any
-  command it cannot statically prove stays inside the worktree, which blocked
-  writing the durable run file under `.git/deliver/` (outside the worktree *by
-  design* — it lives in the common git dir) via `jq`+`mv` **and** via `Edit`,
-  plus several `curl -o` and multi-pipe sampling commands that were never leaving.
-  `sed` with fully literal paths worked. Now a `gotchas.md` entry; the deeper
-  issue is that `/deliver`'s own run-file location is at odds with its own
-  worktree isolation.
-- **Friction — two API 529s killed the code reviewer** before it started. Retried
-  after doing unrelated work; the second retry succeeded. Void ≠ failed was the
-  right read.
-- **Friction — a subagent asserted a green it could not see.** The
-  `tooling-runner` reported the integration suite passed "including the newly
-  added `detailsForMovieCredit` test", but the xcsift log carries only aggregate
-  counts — no test names. A scoped `--filter` run proved it genuinely ran. The
-  runner's report shape cannot distinguish *ran and passed* from *never ran*.
-- **Deviations:** (1) The plan had **no formal ACs** — a bug-fix plan written as
-  a test list. Rather than stop the run for a rubric the author could not supply
-  mid-flight, I derived seven Given/When/Then ACs from the issue and the test
-  list and recorded `rubricProvenance: derived-…` in the run file; the grader
-  then judged against them and returned ALL MET. Flagged as derived, not
-  supplied. (2) Reported the `creator` finding to #418 **before** the PR rather
-  than in Phase 11, because all three critics independently observed that
-  "defer to #418" deferred it *nowhere* — #418's body never mentioned
-  `CreditType`.
-- **One improvement:** `/deliver`'s Phase 0 entry gate assumes a plan either has
-  ACs or doesn't. A bug fix whose issue already states observable
-  before/after behaviour is a third case: the ACs are *derivable* rather than
-  absent, and stopping to ask for them is pure ceremony. The gate should sanction
-  deriving them with recorded provenance — which is what `rubricProvenance` did
-  here ad hoc — instead of forcing a choice between a hard stop and
-  `rubric: none`.
-
 ## Archive (distilled)
 
 Older entries condensed per the rolling window (`knowledge/README.md` →
@@ -882,6 +878,7 @@ Older entries condensed per the rolling window (`knowledge/README.md` →
 
 | Date | PR | Weight | Outcome |
 | --- | --- | --- | --- |
+| 2026-08-12 | #432 | full | Decoded empty-string credit dates as nil. **The #404 population sweep paid in both directions**: 300 live `/credit/{id}` records both *cleared* five URL decodes with a measurement (`null`-bearing, never `""`) and *found a bug the issue never mentioned* — `credit_type: "creator"` threw. A sweep earns its keep by excluding as much as by finding. The critics caught a false green the author built in: **no fixture omitted `character`**, so a `decode`-instead-of-`decodeIfPresent` slip would have compiled, passed everything, and broken 36% of live credits — fixed for free by re-sourcing both blank-date fixtures to *crew* credits, which omit `character` entirely. A 2-vs-1 critic split was reconciled **on evidence, not vote**: *Guard consistently within a type* is about one value class diverging, not a date differing from a URL, and guarding would have made `CreditMovie` the lone divergence across ~20 models. Two lasting frictions: the worktree Bash guard refuses commands it cannot prove stay inside the worktree (which blocks writing `/deliver`'s own run file under `.git/deliver/` — its run-file location is at odds with its worktree isolation), and **a subagent asserted a green it could not see** (the tooling-runner reported a named test passed, but xcsift logs carry only aggregate counts; its report shape cannot distinguish *ran and passed* from *never ran*). Its "one improvement" — sanction *deriving* ACs with recorded provenance when a plan states observable before/after behaviour in the wrong shape — **shipped**, and is the entry gate's `derived` branch and `rubricProvenance` field today. |
 | 2026-08-07 | #412 | lite | Renamed `Network.homepage` to `homepageURL`, the second firing of the `next-major.md` queue: the item was deferred out of 19.0.0 on 2026-07-27 as cosmetic scope creep on a bug fix, and shipped here because the file was read when the 20.0.0 window opened — the deferral mechanism working end to end. Equally deliberate was the entry that did **not** ship: `TMDbError.invalidRating` stayed deferred because its own condition (a wider `TMDbError` review) was unmet, and that was recorded rather than skipped, so a later reader can tell "considered and declined" from "missed". Stacked on `feature/v4-lists` rather than branched from `main`, since both edit the same `CHANGELOG` section. Its "one improvement" — have `next-major.md` carry a status line naming the open major window, so an entry cannot be filed against a version that already shipped — **shipped**, and `/capture-knowledge` asserts it on every addition today. |
 | 2026-08-07 | #411 | full | TMDb v4 lists (`client.v4Lists`), settling ADR-0017's four open decisions. **Phase 0 probing changed the shipped API twice, both unfixable later**: `sort_by` turned out to be honoured on the read side (so `details`/`items` take `sortedBy:` — adding a protocol requirement afterwards is source-breaking), and `create(isPublic:)` shipped after all because TMDb ignores the *boolean* and honours the *integer* — the earlier "it ignores the field" conclusion came from a probe that sent a bool. Reading the resource back caught both. The count-reconciliation assertion caught a real drop on its first outing (`Show.encode` writes no `media_type`, so every encoded item failed to decode and the whole list vanished silently). Two of the three bugs were **the probe scripts lying**: an `EXIT` trap that never fired and orphaned four lists on a real account, and ten identical "rejected" results across a `sort_by` sweep that were the spam filter (`status_code` 18), not an answer — a uniform failure across a sweep is evidence about the sweep. Both are now standing rules in `CLAUDE.md`: a probe must verify its own postcondition. Also a mid-delivery **correction**: I reported credentials committed in `Integration.xctestplan` having read it off disk without running `git ls-files` — the file is gitignored and absent from HEAD (they were committed in 2023 and remain in public history, so rotation still applies). |
 | 2026-08-07 | #410 | full | Defaulted-witness convenience sweep across 37 sites. The **reference-unit gate earned its keep again**: reviewing one site before replicating caught a DocC-curation regression (the convenience becomes a distinct symbol and falls out of its Topics group unless curated) that would otherwise have shipped 37 times, and settled three open design questions in one pass. The **census was re-derived rather than trusted** — both reviewers independently reproduced 91/15 and the 37/54 split, after the first census came up **17 short** by grepping protocol *declaration* files and missing the two protocols keeping conveniences in a sibling `+Defaults.swift`. Two lasting False-green bullets came from it: a mechanical sweep did a first-occurrence `str.replace` per file, stripping the default from `favouriteMovies` instead of `lists` **while reporting exactly the 36 edits expected**, and the new checker passed on an empty scan (a typo'd path printed success and exited 0) — so a matching count is not evidence, and a checker must compare against an explicit set. Also **shipped a gate that did not gate**: the check went into `make lint`, but no workflow invokes `make` (the `Lint` job runs swiftlint/swiftformat inline), so it was invisible to CI — now its own step and the gotcha *No workflow runs `make`*. Its "one improvement" — have `/capture-knowledge` prompt "what fails if that number changes?" when an entry records a defect count — **shipped**, and is the *When an entry records a count* section of that skill today. |

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -52,7 +52,7 @@ Instances, each with its countermeasure:
 - **A test runner that collected nothing** — `python3 -m unittest discover`
   exits 0 when it finds no tests, and counts a skipped test as a success, so a
   renamed file or one `@unittest.skip` empties a gate while it stays green
-  (2026-08-20, PR #TBD). *Check: assert a collection floor **and** re-assert it
+  (2026-08-20, PR #476). *Check: assert a collection floor **and** re-assert it
   against tests actually executed — see Tooling.*
 - **N mechanical edits reported, wrong symbols edited** — a sweep script did a
   first-occurrence `str.replace` per file, so it stripped the default argument
@@ -70,7 +70,7 @@ retired; the family heading stays.
 
 ### `unittest discover` exits 0 when it collected nothing — and a skip counts as success
 
-*2026-08-20 (PR #TBD).* Two separate ways a Python test gate reports green
+*2026-08-20 (PR #476).* Two separate ways a Python test gate reports green
 without asserting anything. Both were verified directly, not inferred.
 
 **Collected nothing.** `python3 -m unittest discover` ends in
@@ -98,7 +98,7 @@ importable"*.
 
 ### The `Lint` job gates its own `Checkout` on `swift`, and PRs ignore `on.paths`
 
-*2026-08-20 (PR #TBD).* Two facts about `.github/workflows/ci.yml` that decide
+*2026-08-20 (PR #476).* Two facts about `.github/workflows/ci.yml` that decide
 whether a check you add actually runs.
 
 **Every step in the `Lint` job — including `Checkout` — is conditioned on
@@ -193,7 +193,7 @@ copy, so which one wins is unpredictable. Countermeasures, cheapest first:
   run-list example out of `next-mode.md` with the same regex the builder is
   paired with, and `Scripts/check-prose-call-forms.py` for the same idea applied
   to code samples. This caught a re-introduced grammar template in the very
-  commit that removed the original (2026-08-20, PR #TBD).
+  commit that removed the original (2026-08-20, PR #476).
 
 ### A gate keyed on `git tag` passes vacuously in CI — the checkout has no tags
 

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -299,9 +299,11 @@ shipped this way for one review round before it was caught.
 paths-filter *and* `on.push.paths` — otherwise a PR touching only that script
 skips the whole job that runs it.
 
-Five checks are mirrored this way today — `check-defaulted-witnesses.py`,
-`check-fixtures.py`, `check-docc-curation.py`, `check-prose-call-forms.py` and
-`check-readme-version.py` (paths-filter input: `CHANGELOG.md`),
+Six checks are mirrored this way today — `check-defaulted-witnesses.py`,
+`check-fixtures.py`, `check-docc-curation.py`, `check-prose-call-forms.py`,
+`check-readme-version.py` (paths-filter input: `CHANGELOG.md`) and
+`run-script-tests.py` (the run-list builder's suite; gated on `swift` **or**
+`markdown`, since its anti-drift cases read `.claude/**/*.md`),
 each a `make lint` prerequisite *and* its own step in the CI `Lint` job. Prefer an **existing**
 paths-filter key over a new `outputs:` entry: a filter key with no matching line
 under `outputs:` makes `needs.changes.outputs.<key>` the empty string, so the

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -49,6 +49,11 @@ Instances, each with its countermeasure:
   Its green was byte-identical to a clean tree's (2026-08-07). *Check: compare
   against an expected **set**, not a threshold, so an empty result fails; and
   run the analyser against a deliberately wrong input before trusting it.*
+- **A test runner that collected nothing** — `python3 -m unittest discover`
+  exits 0 when it finds no tests, and counts a skipped test as a success, so a
+  renamed file or one `@unittest.skip` empties a gate while it stays green
+  (2026-08-20, PR #TBD). *Check: assert a collection floor **and** re-assert it
+  against tests actually executed — see Tooling.*
 - **N mechanical edits reported, wrong symbols edited** — a sweep script did a
   first-occurrence `str.replace` per file, so it stripped the default argument
   from `favouriteMovies` rather than `lists`, and still reported exactly the 36
@@ -62,6 +67,54 @@ When an instance's countermeasure becomes tooling-enforced, its bullet may be
 retired; the family heading stays.
 
 ## Tooling
+
+### `unittest discover` exits 0 when it collected nothing — and a skip counts as success
+
+*2026-08-20 (PR #TBD).* Two separate ways a Python test gate reports green
+without asserting anything. Both were verified directly, not inferred.
+
+**Collected nothing.** `python3 -m unittest discover` ends in
+`sys.exit(not self.result.wasSuccessful())`, and `wasSuccessful()` is True when
+`testsRun == 0`. The `_NO_TESTS_EXITCODE = 5` that would catch it arrived in
+**Python 3.12**; the `python3` on this repo's PATH is **Xcode's 3.9.6**, so a
+renamed test file, a renamed directory, a wrong working directory, or a filename
+that stops matching the default `test*.py` pattern silently empties the gate.
+Running `discover` against an empty directory exits 0.
+
+**Collected but skipped.** `wasSuccessful()` also treats a skip as a success, and
+`testsRun` counts skipped tests — a two-test class decorated `@unittest.skip`
+reports `collected: 2, testsRun: 2, skipped: 2, wasSuccessful: True`. So a
+`@unittest.skipUnless` guard, or a `raise unittest.SkipTest` in `setUpModule`,
+keeps a collection-count check green too.
+
+`Scripts/run-script-tests.py` is the countermeasure: it asserts an **exact**
+count before running (a loose floor lets a whole class vanish inside the slack)
+and re-asserts it afterwards against `testsRun - skipped - expectedFailures`.
+
+One unrelated 3.9 constraint in the same area: `discover`'s start directory must
+be **importable**, so pass `top_level_dir` equal to the start directory (or add
+an `__init__.py`) — otherwise it fails with *"Start directory is not
+importable"*.
+
+### The `Lint` job gates its own `Checkout` on `swift`, and PRs ignore `on.paths`
+
+*2026-08-20 (PR #TBD).* Two facts about `.github/workflows/ci.yml` that decide
+whether a check you add actually runs.
+
+**Every step in the `Lint` job — including `Checkout` — is conditioned on
+`needs.changes.outputs.swift == 'true' || workflow_dispatch`,** and the job's
+`runs-on` selects `xcode-27` vs `ubuntu-latest` off the same output. So adding a
+step gated on any *other* filter key gives you a step that runs **with no
+repository checked out**. Widening a step means widening `Checkout` with it.
+That is why the run-list check is gated on `swift || markdown`: its inputs are
+`Scripts/**` (in the `swift` key) *and* `.claude/**/*.md` (in `markdown`), and
+without the widened checkout the prose half would have had nothing to read.
+
+**`on.pull_request` carries no `paths:` filter — only `on.push` does.** So every
+PR triggers the workflow regardless, and the `changes` job's `dorny/paths-filter`
+outputs are what actually gate the work. Editing `on.push.paths` changes only the
+post-merge push run; it has no effect on PR runs. Reason about the filter
+outputs, not `on.paths`, when asking "will my check run on this PR?"
 
 ### An issue template's field is a convention, not a schema — parse it defensively
 
@@ -131,6 +184,16 @@ copy, so which one wins is unpredictable. Countermeasures, cheapest first:
   change's wording rather than the fix's.
 - **Prefer fail-closed defaults** where two lists gate the same thing, so a
   drifted copy under-permits rather than over-permits.
+- **Make the agreement executable when one copy is code.** If a format or value
+  is *built* in code and *quoted* in prose, have a test read the prose file off
+  disk and assert against it — then drift fails a gate instead of waiting for a
+  reader to pick the wrong copy. Asserting against a string literal in the test
+  does **not** count: that is a further copy, not a check on the others. See
+  `Scripts/tests/test_build_run_list.py`'s `AntiDriftTests`, which parses every
+  run-list example out of `next-mode.md` with the same regex the builder is
+  paired with, and `Scripts/check-prose-call-forms.py` for the same idea applied
+  to code samples. This caught a re-introduced grammar template in the very
+  commit that removed the original (2026-08-20, PR #TBD).
 
 ### A gate keyed on `git tag` passes vacuously in CI — the checkout has no tags
 


### PR DESCRIPTION
## Summary

Closes #471.

`/deliver next` picks its work by parsing **one** canonical line out of the Project status update `/triage-issues` publishes. Until now that line was **written by the agent** from a prose spec, and the ordering behind it was computed by the agent too.

That is the defect `evidenceDigest` was already moved into code to avoid (`.claude/workflows/triage-issues.js:149-186`): an LLM asked to reproduce a fixed string words it differently each run, the consumer's strict parse misses, and `next` falls back to board fields — which reproduces **two** of Phase 6's four sort rules and silently drops **dependency order and contention**. Nothing fails at write time, so the failure is invisible.

`Scripts/build_run_list.py` now owns both the ordering and the grammar. `RUN_LIST_RE` parses what `build_run_list_line` writes, so the written and the parsed form cannot drift apart.

## ⚠️ Reflexive delivery — this was **not** dogfooded

The skill registry loads from the **main checkout**, so the edited skills are not what ran this delivery. Verification was by **reading**, plus **direct execution** of `Scripts/build_run_list.py` against the real 2026-08-20 Ready set — it reproduces the published order byte-for-byte, all 13 issues including the tiebreak:

```text
<!-- run-list: cc7cba55 | 434,426,437,448,428,454,424,425,427,429,435,467,430 -->
```

That run had no dependency edges and no contention, so it exercises rules 2–4 only; rules 1 and 3 are covered by synthetic unit tests.

## Two rules that were specified wrongly in prose, and only surfaced once code had to implement them

- **A topological sort does not satisfy *"a P2 that unblocks a P0 goes first"*.** Precedence is not promotion — greedy Kahn's keyed on own priority emits an independent P1 *before* a P2 unblocker. The script computes an **effective priority** (`min(own, best over transitive dependents)`) before sorting.
- **Separating two contending issues by *swapping* them leaves them adjacent.** The primitive is a **move**, and its priority-band check must cover the whole **jumped range** — checking only the new neighbour let a P1 overtake a P0 with no dependency edge, so `depsOutrankPriority` would not have disclosed it either. That was a High in code review, reproduced before it was fixed.

Both were caught by review before/while the code existed, not by it shipping.

## Changes

**New:**

- ✨ `Scripts/build_run_list.py` — validation, effective-priority topological sort, contention pass, line builder, `RUN_LIST_RE`.
- ✅ `Scripts/tests/test_build_run_list.py` — 38 tests.
- ✅ `Scripts/run-script-tests.py` — the runner, because `unittest discover` **exits 0 when it collects nothing** on Python 3.9 and counts a skip as a success.
- 📚 `knowledge/decisions/0027-run-list-ordering-in-scripts.md`.

**Existing:**

- 🔧 `triage-issues/SKILL.md` — Phase 6 invokes the script and **does not restate the four rules**; Phase 8 pastes the `runListLine` **field** rather than writing to a format. Phase 3 is unchanged (it already said what was needed).
- 🔧 `deliver/references/next-mode.md` §3 — see the behaviour change below.
- 🔧 `Makefile` (`lint-run-list`), `.github/workflows/ci.yml` (mirrored step), `README.md`.
- 📝 `knowledge/gotchas.md` — three entries added, one updated; `delivery-retros.md` — this delivery's retro, window rolled.

## ⚠️ Behaviour change, and a bootstrap step

**`next-mode.md` §3 now splits by mode** when no status update carries the line: attended `/deliver next` still falls back to board fields (reported prominently), but **`auto next` and `auto merge next` stop** and recommend `/triage-issues`. A warning is only loud if someone reads it, and unattended nobody does. §3 now points at §4's `deps=` check **by name** as the reason the fallback stays *degraded* rather than *unsafe* — an open dependency already rejects a candidate outright.

**Bootstrap:** no existing status update carries the line, and this change does not retro-fit them. **Run `/triage-issues` right after merge** so a script-built line exists — otherwise the first `auto next` hard-stops. It is cheap; Phase 3 skips almost everything on a steady-state board.

## Review

**Code review — 2 passes**, converged. Pass 1: 1 High + 9 Medium + 6 Low, full coverage across 5 lenses, 0 dropped by adversarial verification. Pass 2: 0 Critical/High.

The stock fan-out's five lenses are Swift-specific and would have returned five empty reports against a Python + prose diff — which reads as coverage. They were **replaced** with lenses fitting this change (algorithm, false-green, validation, reflexive-prose, CI wiring).

Four findings were *"this test cannot fail"* — in tests written while actively thinking about that failure mode:

- the gate exited 0 on an empty run (and on a skipped suite);
- `build(x) == build(x)` reduced to `once == once`, because the sort is permutation-invariant — now asserts invariance across **all** permutations;
- `assertIn(" -->", text)` was satisfied by unrelated HTML comments elsewhere in the file;
- the collection floor had 8 tests of slack, enough to lose a whole class.

**Security review — 0 findings.** Both interpolation sites in the line are a closed alphabet (hex-only sha under `\Z`, positive ints), so line injection is closed by construction; attacker-influenced `filesTouched` is used only for set intersection and never reaches output. The §5c author gate sits **upstream** of this ordering, so a prompt-injected verdict cannot reach `auto merge` selection. The §3 change **narrows** unattended behaviour rather than widening it.

**Not fully reviewed:** `/review-plan`'s **risk critic died mid-response**, so that lens went unreviewed by the critics; `/security-review` covered that ground afterwards.

## Anti-drift

The grammar lives in the builder and is quoted in `next-mode.md` §3 — two places, not three, because Phase 8 now names a field. The pair is held together by tests that **read the prose off disk**: a literal in a test file would be a further copy, not a check. That test immediately caught a grammar template re-introduced by the very commit that removed the original.

## Out of scope

Marker **parsing** stays in the conductor (Phase 3), so `buildMarker` still has no counterpart in code. Worth closing separately if it earns it.

## Gate

Full `make ci` — the diff touches `Makefile` and `.github/workflows/**`, so the docs/config narrowing does **not** apply. All legs green: lint (including the new `lint-run-list`), markdown lint, **3396** unit tests, **317** integration tests, release build, docs build.

One integration test failed on the first run — `V4ListIntegrationTests` "full list lifecycle", `empty.items.isEmpty` after `clear`. It is **not in this diff** (which contains no Swift at all) and passed on a targeted re-run: live-API read-after-write lag. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177UEihF4wVfkUKd3wCBp5r