### PR TITLE
🐛 Model tagged images attached to a whole TV series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Breaking:** `TaggedImageMedia` gains a `tvSeries(TVSeriesListItem)` case, and
+  tagged images attached to a whole TV series stop being thrown away. TMDb sets a
+  tagged image's nested `media_type` to `"tv"` when the image belongs to a series
+  rather than to a movie or a single episode; the library modelled only the
+  latter two, so every such image was silently discarded while decoding the page.
+  It is not a rare shape — 56 of 219 rows across a live sample of 30 people, and
+  for a TV-heavy person it is most of the page (18 of 20 for person 17419).
+
+  It was worse than a short page. Because the rows were dropped *before* the
+  results array was assembled, a page whose images were all TV series decoded to
+  **no results at all** — and an empty page ends a `PagedAsyncSequence`. So
+  `allTaggedImages(forPerson:)` and `allTaggedImagesPages(forPerson:)` stopped
+  there and discarded every remaining page, rather than merely skipping rows.
+
+  This affects you at compile time only if you switch **exhaustively** over
+  `TaggedImageMedia` — add a `.tvSeries` branch, or a `default`. It is also
+  breaking *silently*: pages that were quietly short now return the missing rows,
+  so result counts grow, and code that treated "not `.movie`" as "must be an
+  episode", or that funnels the unexpected through a `default:` arm, changes
+  behaviour with nothing to stop it compiling.
+
+  A nested `media_type` this library still does not model — `tv_season` does
+  occur, rarely — is unaffected: it is skipped while decoding, exactly as before.
+
 - **Breaking:** `TMDbError.network(_:)` no longer hands your API key to whatever
   you log the error to. A `URLSession` failure carries the whole URL of the
   request that failed in its `NSError` `userInfo`, and for a client created with

--- a/Sources/TMDb/Domain/Models/TaggedImageMedia.swift
+++ b/Sources/TMDb/Domain/Models/TaggedImageMedia.swift
@@ -10,7 +10,10 @@ import Foundation
 ///
 /// A model representing the media associated with a tagged image.
 ///
-/// Tagged images can only be associated with movies or TV episodes.
+/// A tagged image can be associated with a movie, with a whole TV series, or
+/// with a single TV episode. TMDb occasionally tags an image with a media type
+/// this library does not model; such an image is skipped while decoding a page
+/// rather than failing the whole page.
 ///
 public enum TaggedImageMedia: Identifiable, Codable, Equatable, Hashable,
 Sendable {
@@ -23,6 +26,9 @@ Sendable {
         case .movie(let movie):
             movie.id
 
+        case .tvSeries(let tvSeries):
+            tvSeries.id
+
         case .tvEpisode(let tvEpisode):
             tvEpisode.id
         }
@@ -32,6 +38,11 @@ Sendable {
     /// Movie.
     ///
     case movie(MovieListItem)
+
+    ///
+    /// TV series.
+    ///
+    case tvSeries(TVSeriesListItem)
 
     ///
     /// TV episode.
@@ -48,6 +59,7 @@ extension TaggedImageMedia {
 
     private enum MediaType: String, Codable, Equatable {
         case movie
+        case tvSeries = "tv"
         case tvEpisode = "tv_episode"
     }
 
@@ -67,6 +79,9 @@ extension TaggedImageMedia {
         case .movie:
             self = try .movie(MovieListItem(from: decoder))
 
+        case .tvSeries:
+            self = try .tvSeries(TVSeriesListItem(from: decoder))
+
         case .tvEpisode:
             self = try .tvEpisode(TVEpisode(from: decoder))
         }
@@ -84,6 +99,13 @@ extension TaggedImageMedia {
         case .movie(let movie):
             try container.encode(MediaType.movie, forKey: .mediaType)
             try movie.encode(to: encoder)
+
+        case .tvSeries(let tvSeries):
+            try container.encode(
+                MediaType.tvSeries,
+                forKey: .mediaType
+            )
+            try tvSeries.encode(to: encoder)
 
         case .tvEpisode(let tvEpisode):
             try container.encode(

--- a/Tests/TMDbIntegrationTests/PersonIntegrationTests.swift
+++ b/Tests/TMDbIntegrationTests/PersonIntegrationTests.swift
@@ -113,6 +113,32 @@ struct PersonIntegrationTests {
         #expect(!taggedImageList.results.isEmpty)
     }
 
+    ///
+    /// Person 500 is tagged almost entirely in movies, so the test above never
+    /// exercised a TV series. Person 17419 is the opposite — most of page one is
+    /// tagged against the series rather than an episode of it, and every one of
+    /// those rows was silently discarded before `TaggedImageMedia.tvSeries`
+    /// existed.
+    ///
+    /// The drop count is deliberately not asserted here. `tv_season` also occurs
+    /// on this endpoint and is still unmodelled, so an exact count against live
+    /// data would fail for something the library is designed to skip.
+    ///
+    @Test("taggedImages for a person tagged against whole TV series")
+    func taggedImagesForPersonTaggedAgainstTVSeries() async throws {
+        let personID = 17419
+
+        let taggedImageList = try await personService
+            .taggedImages(forPerson: personID)
+
+        #expect(!taggedImageList.results.isEmpty)
+        #expect(
+            taggedImageList.results.contains {
+                if case .tvSeries = $0.media { true } else { false }
+            }
+        )
+    }
+
     @Test("translations")
     func translations() async throws {
         let personID = 500

--- a/Tests/TMDbTests/Domain/Models/TaggedImagePageableListTests.swift
+++ b/Tests/TMDbTests/Domain/Models/TaggedImagePageableListTests.swift
@@ -1,0 +1,170 @@
+//
+//  TaggedImagePageableListTests.swift
+//  TMDb
+//
+//  Copyright © 2026 Adam Young.
+//
+
+import Foundation
+import Testing
+@testable import TMDb
+
+@Suite(.tags(.models))
+struct TaggedImagePageableListTests {
+
+    @Test(
+        "JSON decoding of TaggedImagePageableList with mixed media types",
+        .tags(.decoding)
+    )
+    func decodeReturnsTaggedImagePageableList() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            TaggedImagePageableList.self,
+            fromResource: "tagged-image-pageable-list"
+        )
+
+        #expect(result.results.count == 5)
+        #expect(result.droppedItemCount == 0)
+
+        let tvSeriesImage = try #require(
+            result.results.first { $0.id == "598795c2c3a3680d5101954a" }
+        )
+        guard case .tvSeries(let tvSeries) = tvSeriesImage.media else {
+            Issue.record("Expected tvSeries media type")
+            return
+        }
+        #expect(tvSeries.name == "Breaking Bad")
+
+        let movieImage = try #require(
+            result.results.first { $0.id == "5c281e9392514138cbbfb676" }
+        )
+        guard case .movie(let movie) = movieImage.media else {
+            Issue.record("Expected movie media type")
+            return
+        }
+        #expect(movie.title == "Crazy Horse")
+
+        let episodeImage = try #require(
+            result.results.first { $0.id == "575112659251410885001698" }
+        )
+        guard case .tvEpisode = episodeImage.media else {
+            Issue.record("Expected tvEpisode media type")
+            return
+        }
+    }
+
+    ///
+    /// A page whose every row is a TV series used to decode to *no results at
+    /// all*, because each row was dropped before the results array was built.
+    /// An empty page ends a `PagedAsyncSequence`, so `allTaggedImages` stopped
+    /// there and discarded every later page too — the drop truncated the whole
+    /// sequence rather than merely shortening one page.
+    ///
+    @Test(
+        "JSON decoding of TaggedImagePageableList whose results are all TV series",
+        .tags(.decoding)
+    )
+    func decodeReturnsTaggedImagePageableListWhenAllResultsAreTVSeries() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            TaggedImagePageableList.self,
+            fromResource: "tagged-image-pageable-list-all-tv"
+        )
+
+        #expect(result.results.count == 3)
+        #expect(result.droppedItemCount == 0)
+        #expect(
+            result.results.allSatisfy {
+                if case .tvSeries = $0.media { true } else { false }
+            }
+        )
+    }
+
+    ///
+    /// `tv_season` is a real nested `media_type` on this endpoint — measured on
+    /// person 57755 (*True Detective* season 1) — that the library still does
+    /// not model. The values below are that row's, so this exercises a media
+    /// type TMDb actually sends rather than an invented one.
+    ///
+    @Test(
+        "JSON decoding of TaggedImagePageableList skips a result with an unmodelled media type",
+        .tags(.decoding)
+    )
+    func decodeSkipsResultWithUnmodelledMediaType() throws {
+        let json = """
+        {
+          "page": 0,
+          "results": [
+            {
+              "id": "52dbf5ab760ee3248d01db10",
+              "aspect_ratio": 0.667,
+              "file_path": "/gf5PFAwzcrRjd26zqcumqeMZV0W.jpg",
+              "height": 1500,
+              "width": 1000,
+              "image_type": "poster",
+              "vote_average": 0,
+              "vote_count": 0,
+              "media": {
+                "id": 59780,
+                "name": "Season 1",
+                "media_type": "tv_season",
+                "season_number": 1,
+                "show_id": 46648,
+                "episode_count": 8,
+                "air_date": "2014-01-12",
+                "vote_average": 8.7
+              }
+            }
+          ],
+          "total_pages": 1,
+          "total_results": 1
+        }
+        """
+
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            TaggedImagePageableList.self,
+            from: Data(json.utf8)
+        )
+
+        #expect(result.results.isEmpty)
+        #expect(result.droppedItemCount == 1)
+    }
+
+    ///
+    /// Decoded on its own — rather than inside a tolerant array — an unmodelled
+    /// media type must still surface as a `DecodingError`, so a consumer
+    /// decoding their own cached JSON can catch it by type.
+    ///
+    @Test(
+        "JSON decoding of TaggedImageMedia with an unmodelled media type throws",
+        .tags(.decoding)
+    )
+    func decodeTaggedImageMediaWithUnmodelledMediaTypeThrows() throws {
+        let json = """
+        {
+          "id": 59780,
+          "name": "Season 1",
+          "media_type": "tv_season",
+          "season_number": 1,
+          "show_id": 46648,
+          "episode_count": 8,
+          "air_date": "2014-01-12"
+        }
+        """
+
+        let error = #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder.theMovieDatabase.decode(
+                TaggedImageMedia.self,
+                from: Data(json.utf8)
+            )
+        }
+
+        let decodingError = try #require(error)
+        guard case .dataCorrupted = decodingError else {
+            Issue.record("Expected a dataCorrupted error")
+            return
+        }
+        #expect(
+            decodingError.unknownMediaType == UnknownMediaTypeError(rawValue: "tv_season")
+        )
+    }
+
+}

--- a/Tests/TMDbTests/Domain/Models/TaggedImagePageableListTests.swift
+++ b/Tests/TMDbTests/Domain/Models/TaggedImagePageableListTests.swift
@@ -25,6 +25,12 @@ struct TaggedImagePageableListTests {
         #expect(result.results.count == 5)
         #expect(result.droppedItemCount == 0)
 
+        // `page` is 0, not 1: this endpoint ignores the `page` query parameter
+        // and reports 0 on every page. The fixture captures that verbatim.
+        #expect(result.page == 0)
+        #expect(result.totalPages == 2)
+        #expect(result.totalResults == 35)
+
         let tvSeriesImage = try #require(
             result.results.first { $0.id == "598795c2c3a3680d5101954a" }
         )
@@ -126,6 +132,52 @@ struct TaggedImagePageableListTests {
 
         #expect(result.results.isEmpty)
         #expect(result.droppedItemCount == 1)
+    }
+
+    ///
+    /// ADR-0019 limb 3. Only an unmodelled `media_type` may be skipped; a row
+    /// whose media type *is* modelled but whose payload is malformed must fail
+    /// the page loudly, or a decoder regression arrives as a quietly short
+    /// page. The row below is a well-formed `"tv"` tagged image with one
+    /// corrupted field.
+    ///
+    @Test(
+        "JSON decoding of a TaggedImagePageableList page whose TV series row is malformed throws",
+        .tags(.decoding)
+    )
+    func decodeWhenTVSeriesPageItemIsMalformedThrows() {
+        let json = """
+        {
+          "page": 0,
+          "results": [
+            {
+              "id": "598795c2c3a3680d5101954a",
+              "aspect_ratio": 0.667,
+              "file_path": "/ggFHVNu6YYI5L9pCfOacjizRGt.jpg",
+              "height": 3000,
+              "width": 2000,
+              "image_type": "poster",
+              "vote_average": 5.3,
+              "vote_count": 3,
+              "media": {
+                "id": "not-an-int",
+                "name": "Breaking Bad",
+                "original_name": "Breaking Bad",
+                "media_type": "tv"
+              }
+            }
+          ],
+          "total_pages": 1,
+          "total_results": 1
+        }
+        """
+
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder.theMovieDatabase.decode(
+                TaggedImagePageableList.self,
+                from: Data(json.utf8)
+            )
+        }
     }
 
     ///

--- a/Tests/TMDbTests/Domain/Models/TaggedImageTests.swift
+++ b/Tests/TMDbTests/Domain/Models/TaggedImageTests.swift
@@ -63,4 +63,54 @@ struct TaggedImageTests {
         #expect(episode.seasonNumber == 1)
     }
 
+    @Test(
+        "JSON decoding of TaggedImage with TV series media",
+        .tags(.decoding)
+    )
+    func decodeWithTVSeriesMediaReturnsTaggedImage() throws {
+        let result = try JSONDecoder.theMovieDatabase.decode(
+            TaggedImage.self,
+            fromResource: "tagged-image-tv-series"
+        )
+
+        #expect(result.id == "598795c2c3a3680d5101954a")
+        #expect(result.aspectRatio == 0.667)
+        #expect(result.imageType == "poster")
+        #expect(result.media.id == 1396)
+
+        guard case .tvSeries(let tvSeries) = result.media else {
+            Issue.record("Expected tvSeries media type")
+            return
+        }
+
+        #expect(tvSeries.name == "Breaking Bad")
+        #expect(tvSeries.originalName == "Breaking Bad")
+        #expect(tvSeries.firstAirDate == Date(iso8601: "2008-01-20T00:00:00Z"))
+        #expect(tvSeries.originCountries == ["US"])
+    }
+
+    @Test(
+        "JSON encoding of TaggedImage with TV series media",
+        .tags(.encoding)
+    )
+    func encodeWithTVSeriesMediaWritesTVMediaType() throws {
+        let taggedImage = try JSONDecoder.theMovieDatabase.decode(
+            TaggedImage.self,
+            fromResource: "tagged-image-tv-series"
+        )
+
+        let data = try JSONEncoder.theMovieDatabase.encode(taggedImage)
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        let media = try #require(object["media"] as? [String: Any])
+        #expect(media["media_type"] as? String == "tv")
+
+        let roundTripped = try JSONDecoder.theMovieDatabase.decode(
+            TaggedImage.self,
+            from: data
+        )
+        #expect(roundTripped == taggedImage)
+    }
+
 }

--- a/Tests/TMDbTests/Resources/json/tagged-image-pageable-list-all-tv.json
+++ b/Tests/TMDbTests/Resources/json/tagged-image-pageable-list-all-tv.json
@@ -1,0 +1,116 @@
+{
+  "id": 17419,
+  "page": 0,
+  "results": [
+    {
+      "aspect_ratio": 0.667,
+      "file_path": "/xL5yWkuH1PlmNJmpWvIxAfXvNXK.jpg",
+      "height": 2268,
+      "id": "598795c2c3a3680d5101954a",
+      "iso_3166_1": "HU",
+      "iso_639_1": "hu",
+      "vote_average": 1.75,
+      "vote_count": 4,
+      "width": 1512,
+      "image_type": "poster",
+      "media": {
+        "adult": false,
+        "backdrop_path": "/tsRy63Mu5cu8etL1X7ZLyf7UP1M.jpg",
+        "id": 1396,
+        "name": "Breaking Bad",
+        "original_name": "Breaking Bad",
+        "overview": "Walter White, a New Mexico chemistry teacher, is diagnosed with Stage III cancer and given a prognosis of only two years left to live. He becomes filled with a sense of fearlessness and an unrelenting desire to secure his family's financial future at any cost as he enters the dangerous world of drugs and crime.",
+        "poster_path": "/anFx9aTOOYqgS3v7x3R84Kz67ly.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          18,
+          80
+        ],
+        "popularity": 146.4569,
+        "first_air_date": "2008-01-20",
+        "softcore": false,
+        "vote_average": 8.9,
+        "vote_count": 18429,
+        "origin_country": [
+          "US"
+        ]
+      },
+      "media_type": "tv"
+    },
+    {
+      "aspect_ratio": 0.679,
+      "file_path": "/tApz4ai74BZM3D6Id7YEISysH65.jpg",
+      "height": 2945,
+      "id": "5ae9fb52925141247900aa57",
+      "iso_3166_1": "UA",
+      "iso_639_1": "uk",
+      "vote_average": 1.066,
+      "vote_count": 5,
+      "width": 2000,
+      "image_type": "poster",
+      "media": {
+        "adult": false,
+        "backdrop_path": "/tsRy63Mu5cu8etL1X7ZLyf7UP1M.jpg",
+        "id": 1396,
+        "name": "Breaking Bad",
+        "original_name": "Breaking Bad",
+        "overview": "Walter White, a New Mexico chemistry teacher, is diagnosed with Stage III cancer and given a prognosis of only two years left to live. He becomes filled with a sense of fearlessness and an unrelenting desire to secure his family's financial future at any cost as he enters the dangerous world of drugs and crime.",
+        "poster_path": "/anFx9aTOOYqgS3v7x3R84Kz67ly.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          18,
+          80
+        ],
+        "popularity": 146.4569,
+        "first_air_date": "2008-01-20",
+        "softcore": false,
+        "vote_average": 8.9,
+        "vote_count": 18429,
+        "origin_country": [
+          "US"
+        ]
+      },
+      "media_type": "tv"
+    },
+    {
+      "aspect_ratio": 0.68,
+      "file_path": "/7LUswjn6jgLxdJ4e6sgwkULXsZI.jpg",
+      "height": 1000,
+      "id": "5c047c020e0a26360e0c2b19",
+      "iso_3166_1": "US",
+      "iso_639_1": "en",
+      "vote_average": 4.3,
+      "vote_count": 15,
+      "width": 680,
+      "image_type": "poster",
+      "media": {
+        "adult": false,
+        "backdrop_path": "/tsRy63Mu5cu8etL1X7ZLyf7UP1M.jpg",
+        "id": 1396,
+        "name": "Breaking Bad",
+        "original_name": "Breaking Bad",
+        "overview": "Walter White, a New Mexico chemistry teacher, is diagnosed with Stage III cancer and given a prognosis of only two years left to live. He becomes filled with a sense of fearlessness and an unrelenting desire to secure his family's financial future at any cost as he enters the dangerous world of drugs and crime.",
+        "poster_path": "/anFx9aTOOYqgS3v7x3R84Kz67ly.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          18,
+          80
+        ],
+        "popularity": 146.4569,
+        "first_air_date": "2008-01-20",
+        "softcore": false,
+        "vote_average": 8.9,
+        "vote_count": 18429,
+        "origin_country": [
+          "US"
+        ]
+      },
+      "media_type": "tv"
+    }
+  ],
+  "total_pages": 2,
+  "total_results": 35
+}

--- a/Tests/TMDbTests/Resources/json/tagged-image-pageable-list.json
+++ b/Tests/TMDbTests/Resources/json/tagged-image-pageable-list.json
@@ -1,0 +1,181 @@
+{
+  "id": 17419,
+  "page": 0,
+  "results": [
+    {
+      "aspect_ratio": 1.778,
+      "file_path": "/7curP36mz5ld6C4fx8PhXlpGL2t.jpg",
+      "height": 1080,
+      "id": "575112659251410885001698",
+      "iso_3166_1": "XX",
+      "iso_639_1": "xx",
+      "vote_average": 0.0,
+      "vote_count": 0,
+      "width": 1920,
+      "image_type": "still",
+      "media": {
+        "id": 1193036,
+        "name": "Episode 387",
+        "overview": "Bill's guests tonight include Oscar-nominated actor Bryan Cranston, \"Savage Love\" columnist Dan Savage, \"¡Adios, America!\" author and she-witch Ann Coulter, Reason.com editor-in-chief Nick Gillespie, and Cliffside Malibu's Richard Taite.",
+        "media_type": "tv_episode",
+        "vote_average": 7.0,
+        "vote_count": 1,
+        "air_date": "2016-05-06",
+        "episode_number": 15,
+        "episode_type": "standard",
+        "production_code": "",
+        "runtime": 60,
+        "season_number": 14,
+        "show_id": 4419,
+        "still_path": "/7curP36mz5ld6C4fx8PhXlpGL2t.jpg"
+      },
+      "media_type": "episode"
+    },
+    {
+      "aspect_ratio": 0.667,
+      "file_path": "/xL5yWkuH1PlmNJmpWvIxAfXvNXK.jpg",
+      "height": 2268,
+      "id": "598795c2c3a3680d5101954a",
+      "iso_3166_1": "HU",
+      "iso_639_1": "hu",
+      "vote_average": 1.75,
+      "vote_count": 4,
+      "width": 1512,
+      "image_type": "poster",
+      "media": {
+        "adult": false,
+        "backdrop_path": "/tsRy63Mu5cu8etL1X7ZLyf7UP1M.jpg",
+        "id": 1396,
+        "name": "Breaking Bad",
+        "original_name": "Breaking Bad",
+        "overview": "Walter White, a New Mexico chemistry teacher, is diagnosed with Stage III cancer and given a prognosis of only two years left to live. He becomes filled with a sense of fearlessness and an unrelenting desire to secure his family's financial future at any cost as he enters the dangerous world of drugs and crime.",
+        "poster_path": "/anFx9aTOOYqgS3v7x3R84Kz67ly.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          18,
+          80
+        ],
+        "popularity": 146.4569,
+        "first_air_date": "2008-01-20",
+        "softcore": false,
+        "vote_average": 8.9,
+        "vote_count": 18429,
+        "origin_country": [
+          "US"
+        ]
+      },
+      "media_type": "tv"
+    },
+    {
+      "aspect_ratio": 0.679,
+      "file_path": "/tApz4ai74BZM3D6Id7YEISysH65.jpg",
+      "height": 2945,
+      "id": "5ae9fb52925141247900aa57",
+      "iso_3166_1": "UA",
+      "iso_639_1": "uk",
+      "vote_average": 1.066,
+      "vote_count": 5,
+      "width": 2000,
+      "image_type": "poster",
+      "media": {
+        "adult": false,
+        "backdrop_path": "/tsRy63Mu5cu8etL1X7ZLyf7UP1M.jpg",
+        "id": 1396,
+        "name": "Breaking Bad",
+        "original_name": "Breaking Bad",
+        "overview": "Walter White, a New Mexico chemistry teacher, is diagnosed with Stage III cancer and given a prognosis of only two years left to live. He becomes filled with a sense of fearlessness and an unrelenting desire to secure his family's financial future at any cost as he enters the dangerous world of drugs and crime.",
+        "poster_path": "/anFx9aTOOYqgS3v7x3R84Kz67ly.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          18,
+          80
+        ],
+        "popularity": 146.4569,
+        "first_air_date": "2008-01-20",
+        "softcore": false,
+        "vote_average": 8.9,
+        "vote_count": 18429,
+        "origin_country": [
+          "US"
+        ]
+      },
+      "media_type": "tv"
+    },
+    {
+      "aspect_ratio": 0.68,
+      "file_path": "/7LUswjn6jgLxdJ4e6sgwkULXsZI.jpg",
+      "height": 1000,
+      "id": "5c047c020e0a26360e0c2b19",
+      "iso_3166_1": "US",
+      "iso_639_1": "en",
+      "vote_average": 4.3,
+      "vote_count": 15,
+      "width": 680,
+      "image_type": "poster",
+      "media": {
+        "adult": false,
+        "backdrop_path": "/tsRy63Mu5cu8etL1X7ZLyf7UP1M.jpg",
+        "id": 1396,
+        "name": "Breaking Bad",
+        "original_name": "Breaking Bad",
+        "overview": "Walter White, a New Mexico chemistry teacher, is diagnosed with Stage III cancer and given a prognosis of only two years left to live. He becomes filled with a sense of fearlessness and an unrelenting desire to secure his family's financial future at any cost as he enters the dangerous world of drugs and crime.",
+        "poster_path": "/anFx9aTOOYqgS3v7x3R84Kz67ly.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          18,
+          80
+        ],
+        "popularity": 146.4569,
+        "first_air_date": "2008-01-20",
+        "softcore": false,
+        "vote_average": 8.9,
+        "vote_count": 18429,
+        "origin_country": [
+          "US"
+        ]
+      },
+      "media_type": "tv"
+    },
+    {
+      "aspect_ratio": 0.667,
+      "file_path": "/3MGq5stpFuYwk30lJY4iq2afrSp.jpg",
+      "height": 750,
+      "id": "5c281e9392514138cbbfb676",
+      "iso_3166_1": "IT",
+      "iso_639_1": "it",
+      "vote_average": 0.0,
+      "vote_count": 0,
+      "width": 500,
+      "image_type": "poster",
+      "media": {
+        "adult": false,
+        "backdrop_path": "/j7uYD3EazOrtz4jjpizIdABWqdi.jpg",
+        "id": 315955,
+        "title": "Crazy Horse",
+        "original_title": "Crazy Horse",
+        "overview": "The legendary Native American chieftain refuses to go with his people peacefully to the reservation and starts a rebellion.",
+        "poster_path": "/7r4ZsO94xsywEJ3ZH8JHjDhj8EG.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          10752,
+          28,
+          18,
+          37
+        ],
+        "popularity": 1.2548,
+        "release_date": "1996-07-07",
+        "softcore": false,
+        "video": false,
+        "vote_average": 8.7,
+        "vote_count": 11
+      },
+      "media_type": "movie"
+    }
+  ],
+  "total_pages": 2,
+  "total_results": 35
+}

--- a/Tests/TMDbTests/Resources/json/tagged-image-tv-series.json
+++ b/Tests/TMDbTests/Resources/json/tagged-image-tv-series.json
@@ -1,0 +1,36 @@
+{
+  "aspect_ratio": 0.667,
+  "file_path": "/xL5yWkuH1PlmNJmpWvIxAfXvNXK.jpg",
+  "height": 2268,
+  "id": "598795c2c3a3680d5101954a",
+  "iso_3166_1": "HU",
+  "iso_639_1": "hu",
+  "vote_average": 1.75,
+  "vote_count": 4,
+  "width": 1512,
+  "image_type": "poster",
+  "media": {
+    "adult": false,
+    "backdrop_path": "/tsRy63Mu5cu8etL1X7ZLyf7UP1M.jpg",
+    "id": 1396,
+    "name": "Breaking Bad",
+    "original_name": "Breaking Bad",
+    "overview": "Walter White, a New Mexico chemistry teacher, is diagnosed with Stage III cancer and given a prognosis of only two years left to live. He becomes filled with a sense of fearlessness and an unrelenting desire to secure his family's financial future at any cost as he enters the dangerous world of drugs and crime.",
+    "poster_path": "/anFx9aTOOYqgS3v7x3R84Kz67ly.jpg",
+    "media_type": "tv",
+    "original_language": "en",
+    "genre_ids": [
+      18,
+      80
+    ],
+    "popularity": 146.4569,
+    "first_air_date": "2008-01-20",
+    "softcore": false,
+    "vote_average": 8.9,
+    "vote_count": 18429,
+    "origin_country": [
+      "US"
+    ]
+  },
+  "media_type": "tv"
+}

--- a/knowledge/decisions/0019-decode-tolerance-policy.md
+++ b/knowledge/decisions/0019-decode-tolerance-policy.md
@@ -120,6 +120,11 @@ into "swallow anything".
   sampled tagged images are `tv` — roughly 13.5% of every tagged-images page is
   discarded, and far more for TV-heavy people. That was previously invisible and
   is now counted. Modelling `tv` is a separate feature decision.
+  **Settled 2026-08-20 (#437):** that decision was taken — `TaggedImageMedia`
+  gained a `tvSeries(TVSeriesListItem)` case in 20.0.0, so `tv` now decodes
+  rather than being counted. This is limb 1 continuing to work, not a change to
+  it: `tv_season` was found on the same endpoint in the same sweep, is still
+  unmodelled, and is still skipped and counted.
 
 ## Alternatives considered
 

--- a/knowledge/decisions/0019-decode-tolerance-policy.md
+++ b/knowledge/decisions/0019-decode-tolerance-policy.md
@@ -120,7 +120,7 @@ into "swallow anything".
   sampled tagged images are `tv` — roughly 13.5% of every tagged-images page is
   discarded, and far more for TV-heavy people. That was previously invisible and
   is now counted. Modelling `tv` is a separate feature decision.
-  **Settled 2026-08-20 (#437):** that decision was taken — `TaggedImageMedia`
+  **Settled 2026-08-20 (#486):** that decision was taken — `TaggedImageMedia`
   gained a `tvSeries(TVSeriesListItem)` case in 20.0.0, so `tv` now decodes
   rather than being counted. This is limb 1 continuing to work, not a change to
   it: `tv_season` was found on the same endpoint in the same sweep, is still

--- a/knowledge/decisions/0021-extensible-public-vocabularies.md
+++ b/knowledge/decisions/0021-extensible-public-vocabularies.md
@@ -48,6 +48,18 @@ and whether it carries a payload:
 | in-process, payload-free, growable | **extensible struct** | `SearchPlan.Intent`, `SearchPlan.ListKind`, `NaturalLanguageSearchAvailability.Reason` |
 | in-process, payload-carrying, growable | enum + **reserved growth slot** | `SearchDegradation.other(String)` |
 
+**The table has three rows, not four, and the missing fourth is deliberate.** A
+*wire-decoded, payload-carrying* vocabulary looks like a gap in the grid, and it
+is not one: that cell is a **media-type discriminator**, and
+[ADR-0019](0019-decode-tolerance-policy.md) limb 1 already governs it — the
+unmodelled value is skipped from its nearest enclosing tolerant array and
+counted, never widened into a growth slot. This ADR covers limb-2 *value* enums
+only. The distinction is easy to lose: while adding `TaggedImageMedia.tvSeries`
+(#437) the plan claimed this fourth row was needed, and two of three plan
+critics agreed before the limb boundary was re-read. If you find yourself
+reaching for a new row here, check first whether what you have is a
+discriminator.
+
 The **extensible struct** is a public struct wrapping an `internal` backing enum:
 
 ```swift

--- a/knowledge/decisions/0021-extensible-public-vocabularies.md
+++ b/knowledge/decisions/0021-extensible-public-vocabularies.md
@@ -55,7 +55,7 @@ is not one: that cell is a **media-type discriminator**, and
 unmodelled value is skipped from its nearest enclosing tolerant array and
 counted, never widened into a growth slot. This ADR covers limb-2 *value* enums
 only. The distinction is easy to lose: while adding `TaggedImageMedia.tvSeries`
-(#437) the plan claimed this fourth row was needed, and two of three plan
+(#486) the plan claimed this fourth row was needed, and two of three plan
 critics agreed before the limb boundary was re-read. If you find yourself
 reaching for a new row here, check first whether what you have is a
 discriminator.

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -25,7 +25,7 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
 
 ---
 
-## 2026-08-21 — 🐛 Model tagged images attached to a whole TV series (#TBD) · full
+## 2026-08-21 — 🐛 Model tagged images attached to a whole TV series (#486) · full
 
 - **Phases / skills:** 0–8 pre-PR, `auto next` (unattended; selection off the
   board's Ready column, no supplied plan). Full weight — small diff, but it

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -25,6 +25,79 @@ invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *frict
 
 ---
 
+## 2026-08-21 — 🐛 Model tagged images attached to a whole TV series (#TBD) · full
+
+- **Phases / skills:** 0–8 pre-PR, `auto next` (unattended; selection off the
+  board's Ready column, no supplied plan). Full weight — small diff, but it
+  touches `Decodable`/`CodingKeys` and adds a public enum case, so risk
+  overrode size. Skills: self-drafted plan, `review-plan` (3 critics, 20
+  findings, 2 blockers), `implement-plan`, `review-changes` (§2b fan-out),
+  `security-review`, independent rubric grader, `capture-knowledge`.
+  Three juror panels ruled in place of user stops, all 3-0.
+  `consulted:` `tmdb-api-notes.md` §427, ADR-0019, ADR-0021, gotchas
+  *Check how a page is built before reasoning about its decode tolerance*,
+  *Carry a decode marker inside a `DecodingError`*,
+  *A fixture the author invented tests the author's belief*.
+  `swept:` n/a (no infra files in the diff) → citation scan of `knowledge/` and
+  `.claude/` for `TaggedImage`; `next-major.md:68` reviewed and left (still
+  true); ADR-0019:119-123 reconciled in the implementation commit.
+
+- **What worked — widening a sweep that already looked conclusive.** A
+  12-person / 378-row probe returned exactly three nested `media_type` values
+  (`movie` 334, `tv` 38, `tv_episode` 6) and read as proof the vocabulary closed
+  at three. Widening to 30 people surfaced a fourth, `tv_season`, at **one row
+  in 219**. That single row reversed a decision: the plan had a live
+  `droppedItemCount == 0` assertion, a risk critic objected, I adjudicated
+  *against* them, and the new evidence made them right — the assertion would
+  have turned the weekly cron red for something the library is designed to skip.
+  It was dropped, and the exact count is asserted on frozen fixtures instead.
+
+- **What worked — rejecting a majority finding on evidence rather than count.**
+  Two of three critics wanted a fourth row in ADR-0021's table for a
+  "wire-decoded, payload-carrying" vocabulary. Reading ADR-0019:44-51 showed the
+  cell is a *media-type discriminator*, already governed by limb 1; ADR-0021
+  covers limb-2 value enums only. The gap was my own plan's miscategorisation,
+  not the ADR's. Three independent jurors upheld the rejection. The signpost
+  now lives in ADR-0021 itself, because a 3-of-4 error rate on a boundary
+  question will recur.
+
+- **Friction — two false-green near-misses, both in the reporting layer.** The
+  scoped test runner listed twelve names under a suite it labelled "(6 tests)"
+  and did not name the new throw-test, then on a re-run attributed
+  pageable-list tests to `PersonTaggedImagesRequestTests`. Both were reporting
+  artefacts — the tests had run — but the only way to know that was to re-run
+  narrower and read the names. A report that mis-groups its results cannot
+  answer "did *my* test execute", which is the one question a scoped run exists
+  to answer.
+
+- **Friction — the worktree Bash guard, again.** Long heredocs are refused as
+  "too complex to verify that it stays inside the worktree" while shorter writes
+  to the same path succeed, so it is length and complexity, not permissions.
+  Cost roughly six retries; the workaround is splitting every write into
+  create-then-run, and chunking long documents into one `>` plus appends. A
+  quoted heredoc also passed `"\\n"` through literally, emitting a stray `\n`
+  line into a test file.
+
+- **Deviations:** (1) Three fixtures ship, not the planned four — a captured
+  fixture cannot back a throwing test, since `decode(_:fromResource:)` calls
+  `Issue.record` before rethrowing, and an unreferenced fixture fails
+  `check-fixtures.py` as an orphan; the throw case uses inline JSON carrying the
+  real captured row. (2) The page fixture is a trimmed row-subset, not the
+  verbatim 20-row page, which was 25KB for no added decoder coverage. (3) The
+  live `droppedItemCount` assertion was cut, per the sweep above. (4) The run
+  file's `stamps` live under `deliverables[0]`, not at top level; two stamps
+  were written to a stray top-level key and had to be moved.
+
+- **One improvement:** `CLAUDE.md` already says a **uniform** result across a
+  sweep is evidence about the sweep until the error body says otherwise. The
+  same shape applies one step out: a sweep that returns **only values you
+  already model** cannot distinguish "the vocabulary is closed" from "the sample
+  missed the tail", because the tail is exactly what a modelled-values-only
+  result hides. That is what made 378 rows look conclusive at 12 people and
+  wrong at 30. Worth stating alongside the existing rule, since the failure mode
+  is *confidence produced by the sample's own blind spot* rather than by too few
+  records.
+
 ## 2026-08-20 — ✨ Assemble the triage run-list in code (issue #471, #476) · full
 
 - **Phases / skills:** 0–8 pre-PR. Full weight — small diff, but reflexive

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -758,7 +758,7 @@ A write to `.git/` that reports nothing has told you nothing.
 
 ### `deliver-panel`'s `artifacts` must be an **array**, not a string
 
-*2026-08-21 (#TBD).* `.claude/workflows/deliver-panel.js:94` does
+*2026-08-21 (#486).* `.claude/workflows/deliver-panel.js:94` does
 `(input.artifacts || []).join('\n')`. Pass a newline-joined string — the obvious
 thing, since that is what the jurors end up reading — and `.join` is not a
 function on it, so the workflow throws at `workflow.js:88` **before any juror
@@ -1221,7 +1221,7 @@ because Linux uses swift-corelibs-foundation's separate implementation.
 
 ### An all-dropped page doesn't shorten the sequence — it ends it
 
-*2026-08-21 (#TBD).* Decode tolerance and auto-pagination interact, and the
+*2026-08-21 (#486).* Decode tolerance and auto-pagination interact, and the
 interaction is worse than either alone. `PagedAsyncSequence` stops when a page
 comes back with an empty `results` array — reasonably, since that is what the
 last page looks like. But a tolerant container drops unmodelled rows *before*
@@ -1241,7 +1241,7 @@ When you add or reason about a tolerant array, ask whether it sits behind a
 
 ### Capture a fixture *from* the live page — don't paste the page in whole
 
-*2026-08-21 (#TBD).* "Use real API responses, not assumptions" is right about
+*2026-08-21 (#486).* "Use real API responses, not assumptions" is right about
 *provenance* and says nothing about *size*. A verbatim 20-row tagged-images page
 came to 25KB — twice the largest fixture in the repo and four times the largest
 `*-pageable-list.json` — because 18 of its rows were the same series repeated.
@@ -1256,7 +1256,7 @@ invented one.
 
 ### A captured fixture cannot back a *throwing* decode test
 
-*2026-08-21 (#TBD).* Two rules collide. `decode(_:fromResource:)`
+*2026-08-21 (#486).* Two rules collide. `decode(_:fromResource:)`
 (`Tests/TMDbTests/TestUtils/JSONDecoder+DecodeFromFile.swift:24`) calls
 `Issue.record` before it rethrows, so a test asserting the decode *throws* fails
 anyway — the recorded issue is a failure even though `#expect(throws:)` was

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -756,6 +756,19 @@ cp /abs/literal/worktree/.build/deliver-tmp/run.json /abs/literal/.git/deliver/<
 Whatever route you take, **verify with a `grep` for a string you just wrote**.
 A write to `.git/` that reports nothing has told you nothing.
 
+### `deliver-panel`'s `artifacts` must be an **array**, not a string
+
+*2026-08-21 (#TBD).* `.claude/workflows/deliver-panel.js:94` does
+`(input.artifacts || []).join('\n')`. Pass a newline-joined string — the obvious
+thing, since that is what the jurors end up reading — and `.join` is not a
+function on it, so the workflow throws at `workflow.js:88` **before any juror
+spawns**. The failure surfaces as a dead panel, and a dead panel is a `stop`, so
+a type slip in one argument reads as an adversarial verdict against the work.
+
+The panel's own docs (`SKILL.md`, `references/auto-and-async.md`) list
+`artifacts` among the facts-only arguments without stating its type, which is
+what makes the string look right. Pass `["path", "path"]`.
+
 ### The `Workflow` tool resolves a repo-relative `scriptPath`
 
 *2026-07-29.* The three embedded-script skills describe `scriptPath` only as
@@ -1206,7 +1219,57 @@ any question about whether a custom error survives a given platform's
 `JSONDecoder` — a `DecodingError` is that decoder's own currency, which matters
 because Linux uses swift-corelibs-foundation's separate implementation.
 
+### An all-dropped page doesn't shorten the sequence — it ends it
+
+*2026-08-21 (#TBD).* Decode tolerance and auto-pagination interact, and the
+interaction is worse than either alone. `PagedAsyncSequence` stops when a page
+comes back with an empty `results` array — reasonably, since that is what the
+last page looks like. But a tolerant container drops unmodelled rows *before*
+assembling `results`, so a page whose rows are **all** unmodelled decodes to
+zero results and is indistinguishable from the end of the data.
+
+`allTaggedImages(forPerson:)` did exactly this: person 17419's first page was 18
+`tv` rows out of 20, and pages that were entirely `tv` terminated the sequence
+and discarded every later page. The visible symptom is a short *sequence*, not a
+short page, so it does not look like a decode problem at all.
+
+When you add or reason about a tolerant array, ask whether it sits behind a
+`PagedAsyncSequence`. If it does, "we skip a few rows" is not the worst case —
+"we silently stop" is.
+
 ## Testing
+
+### Capture a fixture *from* the live page — don't paste the page in whole
+
+*2026-08-21 (#TBD).* "Use real API responses, not assumptions" is right about
+*provenance* and says nothing about *size*. A verbatim 20-row tagged-images page
+came to 25KB — twice the largest fixture in the repo and four times the largest
+`*-pageable-list.json` — because 18 of its rows were the same series repeated.
+The bulk bought no extra decoder coverage at all.
+
+Trim to a **row-subset of the captured page**: keep one row per decode branch
+you need to exercise, keep every field of the rows you keep, and change no
+values. That stays measured — every byte still came off the wire — while landing
+in line with its siblings (the trimmed version was 6KB). Deleting whole rows is
+safe; editing fields inside a row is what turns a captured fixture into an
+invented one.
+
+### A captured fixture cannot back a *throwing* decode test
+
+*2026-08-21 (#TBD).* Two rules collide. `decode(_:fromResource:)`
+(`Tests/TMDbTests/TestUtils/JSONDecoder+DecodeFromFile.swift:24`) calls
+`Issue.record` before it rethrows, so a test asserting the decode *throws* fails
+anyway — the recorded issue is a failure even though `#expect(throws:)` was
+satisfied. Sidestepping that by adding the fixture but not loading it through
+the helper leaves it unreferenced, and `Scripts/check-fixtures.py` rejects an
+orphan.
+
+So there is no shape in which a `.json` file under `Resources/json/` can carry a
+throwing case. Use **inline JSON in the test**, pasted from the real captured
+record so it is still measured rather than invented, and decode it with
+`from: Data(json.utf8)`. `MediaListTests` is the worked example. The practical
+consequence when planning: a change needing both a skip case and a throw case
+ships one fewer fixture than it looks like it should.
 
 ### `MockURLProtocol`'s statics are process-global — a test that reads them back is order-dependent
 

--- a/knowledge/tmdb-api-notes.md
+++ b/knowledge/tmdb-api-notes.md
@@ -424,13 +424,30 @@ Not measurable here: the whole **v4** surface (no MCP tooling) and the
 `PageableListResult<TVEpisode>` and `<MediaListSummary>` have never decoded a
 real row in CI.
 
-### `TaggedImageMedia` models only `movie` and `tv_episode`
+### `TaggedImageMedia` dropped every `tv` row until 20.0.0
 
 *2026-08-12, N=229 across 11 people.* The nested `media.media_type` was `movie`
-165, **`tv` 31**, `tv_episode` 33 — so ~13.5% of every tagged-images page is
+165, **`tv` 31**, `tv_episode` 33 — so ~13.5% of every tagged-images page was
 discarded, and far more for TV-heavy people (person 17419 lost 18 of 20 on page
-one). Tracked as #437; a tolerance policy cannot recover these, because the
-library has nowhere to put a series — the fix is a new case.
+one). **Fixed in 20.0.0 (#437):** `TaggedImageMedia` now has a
+`tvSeries(TVSeriesListItem)` case, so `tv` decodes. The drop was worse than a
+short page — an all-`tv` page decoded to *zero* results, and an empty page ends a
+`PagedAsyncSequence`, so `allTaggedImages` stopped there and lost every later
+page too.
+
+*2026-08-20, N=219 across 30 people (re-sampled for #437).* `movie` 109, `tv` 56,
+`tv_episode` 53 — and **`tv_season` 1** (person 57755, *True Detective* S1). The
+vocabulary on this endpoint is **not** closed at three: a 12-person / 378-row
+sweep the same day found only movie/tv/tv_episode and looked conclusive, and
+widening it to 30 people falsified that. `tv_season` remains unmodelled and is
+still skipped. Two consequences worth keeping: **do not** assert an exact
+`droppedItemCount` against this endpoint live (ADR-0019's carve-out applies), and
+the 56 `tv` rows span 13 distinct series with all five of `TVSeriesListItem`'s
+non-optional fields present and non-null on every one.
+
+The endpoint also **ignores the `page` query parameter**: `?page=1`, `?page=2`
+and `?page=3` return identical result ids, and the `page` field is always `0`
+despite a `total_pages` above 1. `allTaggedImages` therefore yields duplicates.
 
 Note also that the **top-level** `media_type` on a tagged image uses a *different
 vocabulary* from the nested one: `episode` where the nested object says

--- a/knowledge/tmdb-api-notes.md
+++ b/knowledge/tmdb-api-notes.md
@@ -429,13 +429,13 @@ real row in CI.
 *2026-08-12, N=229 across 11 people.* The nested `media.media_type` was `movie`
 165, **`tv` 31**, `tv_episode` 33 — so ~13.5% of every tagged-images page was
 discarded, and far more for TV-heavy people (person 17419 lost 18 of 20 on page
-one). **Fixed in 20.0.0 (#437):** `TaggedImageMedia` now has a
+one). **Fixed in 20.0.0 (#486):** `TaggedImageMedia` now has a
 `tvSeries(TVSeriesListItem)` case, so `tv` decodes. The drop was worse than a
 short page — an all-`tv` page decoded to *zero* results, and an empty page ends a
 `PagedAsyncSequence`, so `allTaggedImages` stopped there and lost every later
 page too.
 
-*2026-08-20, N=219 across 30 people (re-sampled for #437).* `movie` 109, `tv` 56,
+*2026-08-20, N=219 across 30 people (re-sampled for #486).* `movie` 109, `tv` 56,
 `tv_episode` 53 — and **`tv_season` 1** (person 57755, *True Detective* S1). The
 vocabulary on this endpoint is **not** closed at three: a 12-person / 378-row
 sweep the same day found only movie/tv/tv_episode and looked conclusive, and


### PR DESCRIPTION
## Summary

Closes #437.

TMDb sets a tagged image's nested `media_type` to `"tv"` when the image belongs to a **series** rather than to a movie or a single episode. `TaggedImageMedia` modelled only the latter two, so every such row was silently discarded while decoding the page.

It is not a rare shape — **56 of 219 rows** across a live sample of 30 people, and for a TV-heavy person it is most of the page (18 of 20 for person 17419).

And it was worse than a short page. The rows were dropped *before* the results array was assembled, so a page whose images were all TV series decoded to **no results at all** — and an empty page ends a `PagedAsyncSequence`. So `allTaggedImages(forPerson:)` and `allTaggedImagesPages(forPerson:)` stopped there and discarded every *remaining* page, rather than merely skipping rows.

## Changes

**Model:**
- 🐛 `TaggedImageMedia` gains `case tvSeries(TVSeriesListItem)` with wire value `"tv"`, mirroring the existing `Media.tvSeries` precedent, and fills the three exhaustive switches — including the `id` switch, which the issue body missed.

**Tests:**
- ✅ Decode and encode of a `"tv"` tagged image (round-trip equality; emitted `media_type` is `"tv"`).
- ✅ A mixed page (1 movie / 3 tv / 1 tv_episode) and an **all-TV** page — the latter being the regression guard for the sequence-truncation bug above, since it previously decoded to zero results.
- ✅ Both remaining ADR-0019 limbs for the new branch: an unmodelled `media_type` is skipped and counted (limb 1) and throws when decoded standalone, while a *modelled* row with a malformed payload still fails the whole page (limb 3).
- ✅ A live integration test against person 17419. The pre-existing person-500 test is unchanged.

**Documentation / knowledge:**
- 📝 `CHANGELOG.md` records both halves of the break — see *Breaking changes* below.
- 📝 `tmdb-api-notes.md` carries both sweeps, plus a separate finding: this endpoint **ignores the `page` query parameter** (pages 1/2/3 return identical ids and `page` is always `0`), so `allTaggedImages` yields duplicates.
- 📝 ADR-0019 records that modelling `tv` is now done; ADR-0021 gains a note that its table has three rows *on purpose*.

## Breaking changes

Two, and the second is silent:

1. **Source.** An exhaustive `switch` over `TaggedImageMedia` needs a `.tvSeries` branch, or a `default`.
2. **Behaviour, silently.** Pages that were quietly short now return the missing rows, so result counts grow. Code that treated "not `.movie`" as "must be an episode", or funnels the unexpected through a `default:` arm, changes behaviour with nothing to stop it compiling.

Both land in the open, unreleased `20.0.0` window.

## Notes for review

- **The live drop-count is deliberately not asserted.** A 12-person / 378-row sweep found exactly three media types and looked conclusive; widening it to 30 people surfaced a fourth — `tv_season` (person 57755) — at one row in 219. It remains unmodelled and is still skipped, so an exact live count would turn the weekly cron red for something the library is designed to do. The exact count *is* asserted on the frozen fixtures. ADR-0019's carve-out at `:110-114` covers this.
- **Three fixtures ship, not four.** A captured fixture cannot back a *throwing* decode test — `decode(_:fromResource:)` calls `Issue.record` before rethrowing, and an unreferenced fixture fails `check-fixtures.py` as an orphan. The throw case uses inline JSON carrying the real captured `tv_season` row.
- **Two follow-ups are being filed** rather than folded in here: modelling `tv_season`, and the endpoint ignoring `?page=`.

## Benefits

- **Correctness**: a documented, measurable ~25% of tagged-image rows stop vanishing, and TV-heavy people stop losing whole pages.
- **Coverage**: all three ADR-0019 limbs are now pinned for this type, where only two were before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)