### PR TITLE
🔧 Settle the skill-improvement-log decisions and apply the /review-knowledge audit

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -41,7 +41,9 @@ guidelines mark as "tool-permitting / local only":
 - **Apple API specifics** — use the sosumi MCP (`mcp__sosumi__*`) to check
   concurrency safety, availability, and behaviour rather than guessing.
 - **Specialist skills** — use `swift-concurrency` for async/actor/`Sendable`
-  review and `swift-testing-expert` for test-code review.
+  review and `swift-testing-expert` for test-code review. Both arrive
+  **preloaded** via the `skills:` frontmatter above — you do not (and cannot)
+  invoke them through the `Skill` tool, which `disallowedTools` removes.
 - **DocC sync** — flag missing catalog/README updates as **High** (build-breaking
   under warnings-as-errors); the `document-swift` skill is the doc spec.
 - **Do not build or run tests** — reviewing is a reading task, and the caller
@@ -55,7 +57,8 @@ guidelines mark as "tool-permitting / local only":
   **Half of this is enforced, half is not — know which.** The frontmatter's
   `disallowedTools` removes `Edit`/`Write`/`NotebookEdit` (you cannot modify
   the tree, so "produce findings, don't fix" is structural) and `Skill` (so
-  `/build`, `/test` and `/integration-test` are unreachable). `Bash` you keep,
+  `/build`, `/test` and `/integration-test` are unreachable — but the two
+  specialist skills survive, preloaded via `skills:`). `Bash` you keep,
   because you need `git diff` and `git log` — so **`make` and `swift build` are
   still physically reachable and the rule against them rests on you**. That is
   the one prohibition here with nothing behind it.

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -67,7 +67,8 @@ Non-negotiable. Do these by default, without being reminded.
    weight); the **run file** is the durable one, because the ledger does not
    survive `EnterWorktree`, an MCP reconnect, or a plan-mode exit. Phase 0
    writes it, Phase 1 records the reconcile into it, **Phases 4/5/6 each stamp
-   it on convergence** (`stamps.reviewedClean` / `securityClean` — that is what
+   it on convergence** (`stamps.reviewedClean` / `securityClean` /
+   `rubricGraded` — that is what
    makes a resume able to skip a pass already done), and **Phase 6 reads the
    rubric from it** — so a skipped step fails loudly at a later phase instead of
    silently. **Every phase that writes is named here**, so if a phase you are in
@@ -89,7 +90,11 @@ Non-negotiable. Do these by default, without being reminded.
    keeps one ledger sub-tree per deliverable.
 7. **Jot knowledge candidates the moment a learning occurs** (a lookup, a
    gotcha, a live-API surprise, a non-obvious decision) — one line each
-   (`<category>: <gist> [where]`), in the ledger. Phase 7 curates them;
+   (`<category>: <gist> [where]`), in the ledger. Mirror the list into the run
+   file (`deliverables.<n>.knowledgeCandidates`, via `deliver-runfile.py`) at
+   Phase 7 entry at the latest — the ledger does not survive `EnterWorktree`,
+   and the resume rule restores candidates from the file, so an unmirrored
+   list is one a resumed run silently loses. Phase 7 curates them;
    reconstruction later loses the best material.
 8. **Auto-start after plan-mode approval.** `ExitPlanMode` approval IS the
    start signal — invoke `/deliver` immediately; pause first only if
@@ -307,7 +312,8 @@ implementation = separate `/deliver` sessions.)
   moves it to **In progress** and Phase 10 to **In review**, so an unrecorded
   issue is one the board silently never reflects. It goes in the run file rather
   than the ledger for the usual reason — `EnterWorktree` clears the ledger.
-  A `next` run has already made the **In progress** move itself, at the pick —
+  A selection run — under either policy — has already made the **In progress**
+  move itself, at the pick —
   it has to claim the issue before the drafting window, or a concurrent session
   delivers the same one. Phase 1's move then finds it already set and no-ops.
   The claim carries an obligation: **any stop before the PR opens releases it
@@ -578,19 +584,19 @@ work is committed; re-confirm the weight from the diff. Four hard checkpoints:
 
 - **Run `swift build -c release` before declaring implementation done** —
   **directly via `Bash`, not `/build`**: `tooling-runner` exposes only
-  `build`, `build-tests`, `test` and `integration-test`, so there is no
+  `build`, `build-for-testing`, `test` and `integration-test`, so there is no
   delegated runner for the release build and asking for one silently gets
-  you a debug build. Use `make build-release`.
-  debug-green is not evidence the release gate passes. `swift build`,
+  you a debug build. Use `make build-release` — a green debug build is not
+  evidence the release gate passes. `swift build`,
   `--build-tests` and both suites all compile the package with
   `-enable-testing`; the release build does not, so **access-level and
   `@testable` mistakes fail there and nowhere else** — precisely what target
   extractions, new non-test targets, and visibility changes are made of. It is
   a ~30s check that guards `make build-release`, `make ci`, and the *Build for
   Release* steps of both CI Build and Test jobs. (Incident: PR #398 shipped a
-  `@testable import` inside a new non-test fixtures target; debug, `--build-tests`, 2869 unit and 291
-  integration tests all passed while release was red — caught only in code
-  review. See `knowledge/gotchas.md`.)
+  `@testable import` inside a new non-test fixtures target; the debug build,
+  `--build-tests` and both full suites were green while release was red —
+  caught only in code review. See `knowledge/gotchas.md`.)
 
 - **"Fix every instance of pattern X" → enumerate ALL sites up front** with a
   single **type-driven sweep**, listed in the test list before implementing —
@@ -656,7 +662,13 @@ still-broken); re-invoke; repeat until none remain. **Cap at 3 iterations**,
 then stop and surface. **Auto:** panel — proceed (note unresolved findings in
 the PR description) vs stop. Medium/Low: apply the cheap, clearly-correct
 ones; note the rest in the PR description. This is the **single substantive
-review** — `/pr` therefore runs in `reviewed` mode (Phase 9).
+review** — `/pr` therefore runs in `reviewed` mode (Phase 9). **On
+convergence, stamp the run file**:
+`python3 Scripts/deliver-runfile.py set <run file>
+deliverables.<n>.stamps.reviewedClean "<content hash>"` (hash recipe:
+[`references/worktree-lifecycle.md`](references/worktree-lifecycle.md)), and
+mirror any findings left unresolved into `deliverables.<n>.openFindings` in
+the same way — the ledger copy dies with the session.
 
 **Mutation-check before converging — a reflexive delivery that adds or
 changes a prose-asserting test** (`reflexive: true` *and* the diff touches a
@@ -682,7 +694,8 @@ converge with the Phase 4 loop: fix each **High** (and any Medium with a
 concrete attack path) test-first where reproducible, commit, re-invoke, cap
 at 3. **Auto:** panel — but a **credential leak or clear exploit is a hard
 stop even in auto**. This is the pipeline's **only** security gate (CI has no
-SAST). Surfaces that bite:
+SAST). On convergence, stamp `deliverables.<n>.stamps.securityClean` exactly
+as Phase 4 does. Surfaces that bite:
 [`references/review-loops.md`](references/review-loops.md).
 
 ## Phase 6 — Rubric verification (exit gate)
@@ -740,10 +753,12 @@ How it is graded depends on weight:
     Left unsaid, a thorough grader will run the whole of `make ci` — one did,
     for 72 minutes, including the 300-test live suite.
 
-Satisfied → mark off. Not → fix test-first, commit, re-verify (full weight:
-re-run the grader); a gap needing a plan change is noted in the PR
-description. *"Did we build what the plan said?"*, not *"did the build
-pass?"*.
+Satisfied → mark off, and stamp `deliverables.<n>.stamps.rubricGraded` with
+the same content hash and script as Phases 4 and 5 — the resume rule reads
+all three stamps, and an unstamped grade is one a resumed run repeats. Not →
+fix test-first, commit, re-verify (full weight: re-run the grader); a gap
+needing a plan change is noted in the PR description. *"Did we build what the
+plan said?"*, not *"did the build pass?"*.
 
 ## Phase 7 — Capture learnings
 
@@ -897,11 +912,14 @@ after the gate**. Guidance:
 - **Update the personal wiki** — best-effort, `propose_entry` only (never
   autonomous writes); degrade silently if absent.
 - **Recurring-pattern scan**: friction/deviations recurring across the last
-  ~12 retro entries → numbered proposals. **Consult
-  `skill-improvement-log.md` first** and skip anything already decided;
-  **wait for explicit approval on each proposal — never edit a skill file
-  unasked**; record **every** decision in the log (five-field format). No new
-  recurrence → say so and stop. **Auto:** **not delegable** — the panel has no
+  ~12 retro entries → numbered proposals — **plus every retro's "one
+  improvement" with no entry at all in the log, recurring or not**
+  (singletons included; the procedure is in `references/wrap-up.md`).
+  **Consult `skill-improvement-log.md` first** and skip anything already
+  decided; **wait for explicit approval on each proposal — never edit a skill
+  file unasked**; record **every** decision in the log (five-field format).
+  Neither a new recurrence nor an unrecorded one-improvement → say so and
+  stop. **Auto:** **not delegable** — the panel has no
   Phase 11 decision point and the script throws if asked for one. An unattended
   run must never edit and push the repo's own skill files (least of all the
   panel script itself), so in auto mode it **records every proposal in

--- a/.claude/skills/deliver/SKILL.md
+++ b/.claude/skills/deliver/SKILL.md
@@ -75,7 +75,15 @@ Non-negotiable. Do these by default, without being reminded.
    else did. (Two non-phase writers exist and are documented where they apply:
    an async run writes the file **before** any `ScheduleWakeup`, and Phase 1's
    adopt path flips `entry` before re-locking — see `references/`.) Location and schema:
-   [`references/worktree-lifecycle.md`](references/worktree-lifecycle.md). A
+   [`references/worktree-lifecycle.md`](references/worktree-lifecycle.md).
+   **Every run-file write after `EnterWorktree` goes through
+   `Scripts/deliver-runfile.py`** — the worktree guard refuses ad-hoc writes to
+   `.git/deliver/`, sometimes *silently* — and the script verifies its own
+   postcondition: exit 0 prints `verified: …`; anything else means the write
+   did **not** land and is a **hard stop** for the phase making it. Never
+   carry on assuming state you did not read back — the #493 delivery certified
+   a plan revision to the juror panel that two silent refusals had kept off
+   disk. A
    template→replicate delivery adds the **`Phase 4a — reference-unit
    review`** gate task, which **blocks Phase 9**. A multi-deliverable plan
    keeps one ledger sub-tree per deliverable.
@@ -566,7 +574,7 @@ Invoke **`/implement-plan`** (Canon TDD: list shown first, one failing test
 at a time, done only when the list is empty and both suites green). It
 commits at logical checkpoints — required: Phase 4 reviews **committed**
 history. Don't advance until `/test` **and** `/integration-test` pass and the
-work is committed; re-confirm the weight from the diff. Three hard checkpoints:
+work is committed; re-confirm the weight from the diff. Four hard checkpoints:
 
 - **Run `swift build -c release` before declaring implementation done** —
   **directly via `Bash`, not `/build`**: `tooling-runner` exposes only
@@ -592,6 +600,17 @@ work is committed; re-confirm the weight from the diff. Three hard checkpoints:
   `incomingCalls`, `goToImplementation`), not `grep`: a text pattern
   under-reports silently — ADR-0008's grep recipe found four of eight path
   interpolation sites, and the three it missed carried a credential (#421).
+- **An absence-shaped fix must be proven able to fail.** Trigger: the
+  acceptance criteria are phrased as an absence — *"X no longer appears / is
+  no longer sent / is redacted"*. Every test for such a fix asserts a
+  negative, and a negative passes just as happily when the value was never
+  there, the key was renamed upstream, or the code path is never reached at
+  all. Before declaring the test list empty: unwire the fix (revert its
+  production hunks locally), confirm the new tests go **red**, restore,
+  confirm green, and record the result in the retro. In #469 this one-minute
+  check was the only evidence the two wiring tests' green meant anything.
+  Positive-assertion deliveries skip it — the trigger is the ACs' phrasing,
+  not a blanket rule.
 - **Consult the specialist skills — mandatory, topic-triggered, including for
   fanned-out subagents.** `swift-concurrency` the moment actors,
   `@MainActor`, `Sendable`/`@unchecked Sendable`, locks, `Task`/task groups,
@@ -638,6 +657,19 @@ then stop and surface. **Auto:** panel — proceed (note unresolved findings in
 the PR description) vs stop. Medium/Low: apply the cheap, clearly-correct
 ones; note the rest in the PR description. This is the **single substantive
 review** — `/pr` therefore runs in `reviewed` mode (Phase 9).
+
+**Mutation-check before converging — a reflexive delivery that adds or
+changes a prose-asserting test** (`reflexive: true` *and* the diff touches a
+test asserting on skill/doc prose, e.g. under `Scripts/tests/`): the
+iteration cap is the wrong stopping signal for this class, because a passing
+prose test is not evidence — #482 shipped three assertions that passed while
+testing nothing, and two of its guards started green. So, for each rule the
+new tests guard: confirm the baseline is green, revert **that rule alone** in
+a scratch copy, and confirm the suite goes red *for that rule*; a guard that
+stays green is not a guard. Restore, and record the matrix in the retro. The
+three blind-assertion failure modes and the worked matrix:
+`knowledge/gotchas.md` → *A test that asserts on prose can be blind*. Swift
+suites are exempt — the compiler and `--Werror` already do this work.
 
 ## Phase 5 — Security review + fix loop
 

--- a/.claude/skills/deliver/references/auto-and-async.md
+++ b/.claude/skills/deliver/references/auto-and-async.md
@@ -3,11 +3,12 @@
 Read on demand when `/deliver auto` is invoked, or when queuing an unattended
 run. The one safety rule that lives in `SKILL.md` regardless: a **data-loss or
 breaking-change plan blocker is always a hard stop, even in auto** — it is
-never delegated to the panel. (Note: as of 2026-07, auto mode has not yet been
-exercised by a real delivery — validate against this spec on first use. The
-panel's two guard rails **have** been exercised: an unlisted `decision` and a
-conductor-supplied `recommendation` each throw before any agent spawns,
-verified 2026-07-29. The jurors themselves remain unexercised.)
+never delegated to the panel. (Auto mode is exercised: real unattended
+deliveries have run it — e.g. PRs #448, #474, #482 and #493 — and the juror
+panel has returned both `proceed` and `stop` verdicts, including #493's
+`phase2-blocker` stop. The panel's two guard rails are exercised too: an
+unlisted `decision` and a conductor-supplied `recommendation` each throw
+before any agent spawns, verified 2026-07-29.)
 
 ## Auto mode (unattended)
 
@@ -130,9 +131,10 @@ If you queue a `/deliver`, mind two things:
 - **Inline the whole plan + acceptance criteria in the trigger prompt.** A
   fresh session has no conversation history, and Phase 0's entry gate
   **requires ACs** — so the plan text and its ACs must travel *in* the prompt,
-  or the run stops at the gate immediately. **a selection run is the exception**, and
-  only in your own environment** — it derives both from the issue it picks, so
-  `/deliver auto merge next` and `/deliver auto merge issue <n>` need no plan in the prompt at all — both derive their ACs from the issue. That works from
+  or the run stops at the gate immediately. **A selection run is the
+  exception, and only in your own environment**: it derives the plan and its
+  ACs from the issue it picks, so `/deliver auto merge next` and
+  `/deliver auto merge issue <n>` need no plan in the prompt. That works from
   a CCR-spawned session, which keeps your user-scoped MCP; it does **not** work
   on a GitHub Actions runner, where the Projects MCP is not mounted and
   `gh project` fails for want of the `read:project` scope

--- a/.claude/skills/deliver/references/worktree-lifecycle.md
+++ b/.claude/skills/deliver/references/worktree-lifecycle.md
@@ -146,15 +146,31 @@ loudly instead of silently. **A missing run file at Phase 6 is a hard stop**,
 exactly as a dead grader is not a pass. `rubric: none` (present, empty) is the
 sanctioned rubric-less path and is *not* the same as a missing file.
 
-**Writing it from inside a worktree.** Phase 0 writes the file *before*
-`EnterWorktree`, so no guard applies there. Later updates do: a worktree-isolated
-session refuses `Bash` commands it cannot statically prove stay inside the
-worktree, and `.git/deliver/` is outside it **by design** (it lives in the common
-git dir). `Edit`/`Write` on that path are refused too. Use a single-purpose
-command with a **fully literal** path — `sed -i '' 's/…/…/' /abs/literal/path`
-works where the `jq`-to-temp-then-`mv` idiom is refused. Full workaround list:
-`knowledge/gotchas.md` → *In a worktree session, Bash refuses commands it can't
-prove stay inside it*.
+**Writing it from inside a worktree — use `Scripts/deliver-runfile.py`, and
+never assume a write landed.** Phase 0 writes the file *before* `EnterWorktree`,
+so no guard applies there. Later updates do: a worktree-isolated session refuses
+`Bash` commands it cannot statically prove stay inside the worktree, and
+`.git/deliver/` is outside it **by design** (it lives in the common git dir).
+`Edit`/`Write` on that path are refused too, and some `Bash` refusals are
+**silent** — a heredoc rewrite produced no output, no error and no write
+(PR #474), and in the #493 delivery two unnoticed refusals led the conductor to
+certify a plan revision to the juror panel that was not on disk. So every
+post-Phase-0 run-file update goes through the script (ADR-0015 addendum):
+
+```bash
+python3 Scripts/deliver-runfile.py set /abs/literal/.git/deliver/<id>.json \
+  deliverables.0.stamps.reviewedClean "<content hash>"
+```
+
+Single-purpose, fully literal arguments — the shape the guard accepts — and the
+script **verifies its own postcondition**: it re-reads the file from disk and
+exits non-zero (`2`) if the value is not there, printing `verified: <path> =
+<value>` when it is. **Treat any exit other than 0 as a hard stop on the phase's
+write, never as done** — a run-file write that reports nothing has told you
+nothing, and a phase that carries on regardless ends up certifying state that
+does not exist. Ad-hoc `sed`/heredoc routes are retired; the guard-shape detail
+lives in `knowledge/gotchas.md` → *In a worktree session, Bash refuses commands
+it can't prove stay inside it*.
 
 `rubricProvenance` records where the ACs came from — `supplied` when the plan
 carried them, or `derived — <source>` when Phase 0 derived them from a linked

--- a/.claude/skills/deliver/references/wrap-up.md
+++ b/.claude/skills/deliver/references/wrap-up.md
@@ -121,8 +121,9 @@ The loop that turns one-off retros into reviewed skill improvements:
    decision**, which is what the log is for. Without this step an improvement
    that never recurs is proposed by nobody: six went unrecorded this way.
 3. **Stop and ask.** **Do not edit any skill files.** Present the proposals
-   and wait for **explicit approval on each one**. If no *new* pattern recurs
-   across multiple entries, say so and stop — emit no proposals.
+   and wait for **explicit approval on each one**. If there is neither a *new*
+   pattern recurring across multiple entries **nor an unrecorded "one
+   improvement"** (step 2 above), say so and stop — emit no proposals.
    (**Auto:** **not delegable** — the panel has no Phase 11 decision point and
    the script throws if asked for one. Record every proposal in
    `skill-improvement-log.md` as `deferred — raised unattended, needs review`

--- a/.claude/skills/diagnose-ci-failure/SKILL.md
+++ b/.claude/skills/diagnose-ci-failure/SKILL.md
@@ -13,10 +13,13 @@ caused by the change under review** — a lint violation, a compile warning/erro
 a broken unit test, or a Linux-portability gap. Start from the diff, not from
 "maybe it's flaky".
 
-CI fans out into four real jobs (plus a `ci` gate job that only aggregates
-results). The diagnosis differs per job, so this skill is a **router**: identify
-the failing job, then follow the matching reference file for that job's causes,
-fixes, and local-reproduction command.
+CI fans out into six real jobs (plus a `changes` paths-filter job and a `ci`
+gate job that only aggregates results): `Lint`, `Lint Markdown`,
+`Build and Test` (macOS), `Build (<platform>)` (an iOS/tvOS/watchOS/visionOS
+simulator-build matrix), `Build and Test (Linux)`, and `Test (<timezone>)` (a
+time-zone matrix re-running the unit suites). The diagnosis differs per job, so
+this skill is a **router**: identify the failing job, then follow the matching
+reference file for that job's causes, fixes, and local-reproduction command.
 
 > **Wrong suite?** If the **Integration** workflow (the live-API suite from
 > `integration.yml`) failed — not a CI job — use `/diagnose-integration-failure`
@@ -26,8 +29,8 @@ fixes, and local-reproduction command.
 ## Agent Behaviour Contract
 
 1. **Identify the failing job first** — `Lint`, `Lint Markdown`, `Build and Test`
-   (macOS), or `Build and Test (Linux)`. Don't guess the cause before you know
-   the job.
+   (macOS), `Build (<platform>)`, `Build and Test (Linux)`, or
+   `Test (<timezone>)`. Don't guess the cause before you know the job.
 2. **Assume the change caused it.** CI gates the PR; read the diff and tie the
    failure to a changed file. Don't open with "transient" or "flaky".
 3. **Treat warnings as errors.** Build steps use `-warnings-as-errors` / `--Werror`
@@ -58,16 +61,24 @@ Use the first that applies:
 
 Once you know which job failed:
 
-- **Lint** (`swiftlint --strict` / `swiftformat --lint`)?
-  └─ `references/lint.md` — style/format violations + the version-drift gotcha
+- **Lint** (`swiftlint --strict` / `swiftformat --lint` / one of the six
+  `Scripts/*.py` gate steps)?
+  └─ `references/lint.md` — style/format violations, the Python gates, and the
+  version-drift gotcha
 - **Lint Markdown** (`markdownlint`)?
-  └─ `references/markdown.md` — README / DocC markdown rules
+  └─ `references/markdown.md` — README / DocC / `.claude/` / `knowledge/` rules
 - **Build and Test** — the **build** step failed?
   └─ `references/build.md` — compile errors and `--Werror` warnings
 - **Build and Test** — the **test** step failed?
   └─ `references/unit-tests.md` — failing `Suite/test`, fixture/model mismatch
+- **Build (iOS / tvOS / watchOS / visionOS)** — a simulator matrix build failed?
+  └─ `references/build.md` — platform-specific API availability; it is
+  `xcodebuild`, not SwiftPM, so `make build` green does not clear it
 - **Build and Test (Linux)** — fails on Linux but passes on macOS?
   └─ `references/linux.md` — Apple-only API gating, Foundation differences
+- **Test (America/Los_Angeles or Pacific/Auckland)** — the TZ matrix failed?
+  └─ `references/unit-tests.md` — a date/calendar assertion depending on the
+  runner's zone; reproduce with `TZ=<zone> make test`
 
 ## Triage-first playbook
 
@@ -101,8 +112,8 @@ directly):
 | File | Failing job | Covers |
 |------|-------------|--------|
 | `references/_index.md` | — | Navigation index by symptom |
-| `references/lint.md` | Lint | SwiftLint `--strict`, SwiftFormat `--lint`, pinned versions, drift |
-| `references/markdown.md` | Lint Markdown | markdownlint on README + DocC `.md` |
-| `references/build.md` | Build and Test (build step) | compile errors, `--Werror` warnings, release build |
-| `references/unit-tests.md` | Build and Test (test step) | Swift Testing failures, JSON fixture/model mismatch |
+| `references/lint.md` | Lint | SwiftLint `--strict`, SwiftFormat `--lint`, the six `Scripts/*.py` gates, pinned versions, drift |
+| `references/markdown.md` | Lint Markdown | markdownlint on README, `CLAUDE.md`, DocC, `.claude/`, `knowledge/`, `.github/*.md` |
+| `references/build.md` | Build and Test (build step); Build (\<platform\>) | compile errors, `--Werror` warnings, release build, simulator-matrix availability |
+| `references/unit-tests.md` | Build and Test (test step); Test (\<timezone\>) | Swift Testing failures, JSON fixture/model mismatch, TZ-matrix date dependencies |
 | `references/linux.md` | Build and Test (Linux) | Apple-only API gating, Foundation portability |

--- a/.claude/skills/diagnose-ci-failure/references/_index.md
+++ b/.claude/skills/diagnose-ci-failure/references/_index.md
@@ -8,11 +8,13 @@ matching file.
 
 | Failing job (`name:` in ci.yml) | Reference | When to use |
 |---|---|---|
-| **Lint** | [lint.md](lint.md) | `swiftlint --strict .` or `swiftformat --lint .` failed |
-| **Lint Markdown** | [markdown.md](markdown.md) | `markdownlint` failed on README or a DocC `.md` |
+| **Lint** | [lint.md](lint.md) | `swiftlint --strict .`, `swiftformat --lint .`, or one of the six `Scripts/*.py` gate steps failed |
+| **Lint Markdown** | [markdown.md](markdown.md) | `markdownlint` failed on README, `CLAUDE.md`, a DocC `.md`, `.claude/**`, `knowledge/**` or `.github/*.md` |
 | **Build and Test** (build step) | [build.md](build.md) | `swift build … -warnings-as-errors` failed (error or warning) |
 | **Build and Test** (test step) | [unit-tests.md](unit-tests.md) | `swift test` failed (filter covers all four unit-test targets) |
+| **Build (iOS / tvOS / watchOS / visionOS)** | [build.md](build.md) | the `xcodebuild` simulator matrix failed — platform availability/gating |
 | **Build and Test (Linux)** | [linux.md](linux.md) | Fails in the `swift:6.1-jammy` container but passes on macOS |
+| **Test (America/Los_Angeles or Pacific/Auckland)** | [unit-tests.md](unit-tests.md) | the TZ matrix failed — a date/calendar assertion depends on the runner's zone |
 
 ## By symptom
 
@@ -24,6 +26,9 @@ matching file.
 - SwiftLint `(rule_id)` violation → [lint.md](lint.md)
 - `superfluous_disable_command` on **unchanged** code → [lint.md](lint.md) (version drift)
 - SwiftFormat `--lint` reports a file would change → [lint.md](lint.md)
+- a `python3 Scripts/<name>.py` step failed (fixture / curation / prose / version / run-list) → [lint.md](lint.md)
+- fails only in `Build (<platform>)`, macOS build green → [build.md](build.md) (availability gating)
+- fails only in `Test (<timezone>)` → [unit-tests.md](unit-tests.md) (local-zone date dependency)
 - markdownlint `MD0xx` → [markdown.md](markdown.md)
 
 All paths share the [output format](../SKILL.md#output-format): **Summary / Cause / Fix**.

--- a/.claude/skills/diagnose-ci-failure/references/build.md
+++ b/.claude/skills/diagnose-ci-failure/references/build.md
@@ -50,3 +50,23 @@ surface as GitHub `::error::` annotations with `file:line`.
 **Summary:** Build and Test — build step — `error`/`warning` at `file:line`.
 **Cause:** the compile error or `--Werror` warning, tied to a changed file.
 **Fix:** resolve it at `file:line`; reproduce with `/build-for-testing`.
+
+## The `Build (<platform>)` simulator matrix
+
+`Build (iOS)` / `Build (tvOS)` / `Build (watchOS)` / `Build (visionOS)` are one
+matrix job that builds the `TMDb-Package` scheme with **`xcodebuild`** against a
+generic simulator destination — not SwiftPM — so a green `make build` does not
+clear it. A failure here and nowhere else is almost always **platform-specific
+API availability**: a symbol that does not exist on that platform, a missing
+`@available`/`#if canImport(...)` gate (the `TMDbIntelligence` surfaces are the
+usual suspects — `NaturalLanguage` and `FoundationModels` are gated per
+platform), or a watchOS/tvOS-only Foundation difference. `--Werror` applies
+here too, via `xcsift -f github-actions --Werror`.
+
+Reproduce from Xcode (the **TMDb** scheme against that platform's simulator),
+or read the flagged `file:line` — the availability fix is usually evident from
+the diagnostic without a local simulator build.
+
+**Summary:** Build (\<platform\>) — `error` at `file:line`.
+**Cause:** platform-specific availability/gating, tied to a changed file.
+**Fix:** add or correct the `@available` / `#if canImport` gate at `file:line`.

--- a/.claude/skills/diagnose-ci-failure/references/lint.md
+++ b/.claude/skills/diagnose-ci-failure/references/lint.md
@@ -1,14 +1,34 @@
-# Lint job failure (SwiftLint / SwiftFormat)
+# Lint job failure (SwiftLint / SwiftFormat / the Python gates)
 
-The **Lint** job runs on macOS with **pinned** tool versions so CI matches local
-`make lint` exactly:
+The **Lint** job runs eight check steps, mirroring local `make lint` exactly.
+The first two are the style tools; the other six are stdlib-only Python gates
+under `Scripts/`, each enforcing something no single-file linter can see:
 
-- `swiftlint --strict .` — every warning is an error.
-- `swiftformat --lint .` — fails if any file is not already formatted.
+| Step (ci.yml) | Command | Fails when |
+| --- | --- | --- |
+| SwiftLint | `swiftlint --strict .` | any lint warning (strict = warnings are errors) |
+| SwiftFormat | `swiftformat --lint .` | any file is not already formatted |
+| Defaulted-witness check | `python3 Scripts/check-defaulted-witnesses.py` | a protocol convenience would witness its own requirement (site count drifted) |
+| Fixture check | `python3 Scripts/check-fixtures.py` | a JSON fixture is invalid/camelCase/orphaned, or a `fromResource:` names a missing file |
+| DocC curation check | `python3 Scripts/check-docc-curation.py` | a public method is missing from its DocC curation page |
+| Prose call-form check | `python3 Scripts/check-prose-call-forms.py` | a ```swift sample in `README.md` / `**/*.docc/**` calls a service method that does not exist (name or labels) |
+| README version check | `python3 Scripts/check-readme-version.py` | `README.md`'s `.package(from:)` lags the newest `CHANGELOG.md` release |
+| Run-list builder check | `python3 Scripts/run-script-tests.py` | any suite under `Scripts/tests/` fails — the run-list builder, the `/deliver` selection-prose anti-drift cases, the `deliver-runfile.py` writer, the workflow cache-key/change-gate cases — or fewer tests were collected than the wrapper's exact floor |
 
-CI pins **SwiftLint `0.63.2`** and **SwiftFormat `0.61.1`** (downloaded as exact
-release binaries). Local versions must match (the local pin lives at
-`~/.local/bin/swiftlint`) or you get spurious failures on unchanged code.
+A Python-gate failure is **not** a formatting problem — `/format` will not fix
+it. Each script prints the defect and the file it found it in; reproduce with
+the exact `python3 Scripts/<name>.py` from the table.
+
+Two conditional-runner details worth knowing before you blame the environment:
+
+- The job picks its runner from the paths filter — macOS when the `swift` key
+  matched, `ubuntu-latest` otherwise — and gates each step separately. So a
+  markdown-only PR legitimately runs *only* the Run-list builder check, and a
+  version-only PR runs *only* the README version check; the skipped steps are
+  not failures.
+- CI pins **SwiftLint `0.63.2`** and **SwiftFormat `0.61.1`** (downloaded as
+  exact release binaries). Local versions must match (the local pin lives at
+  `~/.local/bin/swiftlint`) or you get spurious failures on unchanged code.
 
 ## Reading the failure
 
@@ -17,6 +37,8 @@ release binaries). Local versions must match (the local pin lives at
 - SwiftFormat `--lint` lists files it *would* change; it doesn't always say which
   rule. Run `swiftformat --lint --verbose .` locally to see the rules, or just
   format and diff.
+- A Python gate names its own failure precisely — read the script's output
+  first; each one's header comment documents its failure modes.
 
 ## Common causes & fixes
 
@@ -38,16 +60,22 @@ release binaries). Local versions must match (the local pin lives at
      cause — match the pin (`~/.local/bin/swiftlint`) rather than editing the
      flagged `// swiftlint:disable`.
 
+3. **A Python gate fired.** The change broke an invariant the gate guards — a
+   fixture went stale, a code sample calls a renamed method, a prose anti-drift
+   test lost its anchor text. Fix the *defect the script names* (the fixture,
+   the sample, the prose), not the script — and if the gate itself is wrong,
+   that is a reviewed change to `Scripts/`, never a skip.
+
 ## Reproduce locally
 
 - `/lint` — runs `make lint` **directly** (not via a subagent, and it writes no
-  log file): `swiftlint --strict .`, `swiftformat --lint .`, and the
-  `lint-witnesses` script. It is fast and low-output, so the output you need is
-  on stdout.
-- `/format` — auto-fixes, then re-run `/lint`.
+  log file): both style tools plus all six Python gates, in the same order as
+  CI. It is fast and low-output, so the output you need is on stdout.
+- A single gate: `python3 Scripts/<name>.py` from the table above.
+- `/format` — auto-fixes style, then re-run `/lint`.
 
 ## Output
 
-**Summary:** Lint job — SwiftLint/SwiftFormat — `rule_id` at `file:line`.
-**Cause:** the violation (or version drift) tied to a changed file.
-**Fix:** `/format` then `/lint`; or match the pinned tool version for drift.
+**Summary:** Lint job — the failing step — `rule_id` or script name at `file:line`.
+**Cause:** the violation (or version drift, or the gate's named defect) tied to a changed file.
+**Fix:** `/format` then `/lint` for style; the script's named fix for a gate; match the pinned tool version for drift.

--- a/.claude/skills/diagnose-ci-failure/references/markdown.md
+++ b/.claude/skills/diagnose-ci-failure/references/markdown.md
@@ -4,22 +4,23 @@ The **Lint Markdown** job runs in the
 `ghcr.io/igorshubovych/markdownlint-cli:v0.48.0` container and lints:
 
 ```bash
-markdownlint "README.md" "CLAUDE.md" "**/*.docc/**/*.md" ".claude/**/*.md"
+markdownlint "README.md" "CLAUDE.md" "**/*.docc/**/*.md" ".claude/**/*.md" "knowledge/**/*.md" ".github/*.md"
 ```
 
-Five path groups: `README.md`, `CLAUDE.md`, DocC catalog markdown
+Six path groups: `README.md`, `CLAUDE.md`, DocC catalog markdown
 (`Sources/**/*.docc/**/*.md`), **every skill and agent file under `.claude/`**,
-and **the knowledge base under `knowledge/`** — the last two are the most
-frequently edited, so a failure here is most often a skill edit or a captured
-entry, not a README one. The job runs only when the `markdown` paths filter
-matched one of those, or on `workflow_dispatch`.
+**the knowledge base under `knowledge/`**, and the top-level `.github/*.md`
+specs (`CODE_REVIEW.md`, `ISSUE_FILING.md`) — the `.claude/` and `knowledge/`
+groups are the most frequently edited, so a failure here is most often a skill
+edit or a captured entry, not a README one. The job runs only when the
+`markdown` paths filter matched one of those, or on `workflow_dispatch`.
 
 `knowledge/skill-improvement-log.md` carries a scoped
 `<!-- markdownlint-disable-file MD001 -->`: its entries are dated `###` headings
 with no `##` sections, which is the documented log shape. That is the only
 per-file exemption — don't add more without saying why in the file.
 
-Config is `.markdownlintrc`, shared by all five groups. Note **`MD013`
+Config is `.markdownlintrc`, shared by all six groups. Note **`MD013`
 (line-length) and `MD041` (first-line heading) are disabled**, so neither can
 be the cause — don't start there.
 
@@ -28,7 +29,6 @@ be the cause — don't start there.
 markdownlint emits `file:line[:col] MD0xx/rule-name <message>`. The `MD0xx`
 code maps to a rule; common ones in this repo:
 
-- **MD013** line-length — a prose line exceeds the configured limit.
 - **MD024** duplicate heading — two headings with the same text in one file.
 - **MD031 / MD032** — fenced code blocks / lists need surrounding blank lines.
 - **MD040** — fenced code block missing a language (` ``` ` → ` ```swift `/` ```text `).
@@ -54,8 +54,9 @@ be the failure. Read it before assuming a default limit applies.
 make lint-markdown
 ```
 
-(runs the same four `markdownlint` invocations as CI — verified identical to
-`.github/workflows/ci.yml`'s `Lint Markdown` step). Fix, re-run until clean.
+(lints the same file set as CI's `Lint Markdown` step, split across five
+`markdownlint` invocations — `Makefile`, target `lint-markdown` — where CI
+passes all six globs to one). Fix, re-run until clean.
 
 ## Output
 

--- a/.claude/skills/diagnose-ci-failure/references/unit-tests.md
+++ b/.claude/skills/diagnose-ci-failure/references/unit-tests.md
@@ -53,3 +53,24 @@ annotations with the failing `Suite/test` and `file:line`.
 **Summary:** Build and Test — test step — `Suite/test` at `file:line`.
 **Cause:** the assertion or fixture/model mismatch (name the fixture + model).
 **Fix:** update fixture `X.json` / model `Y` (or the assertion); re-run `/test`.
+
+## The `Test (<timezone>)` matrix
+
+`Test (America/Los_Angeles)` and `Test (Pacific/Auckland)` re-run the same four
+unit-test targets in the Linux container with `TZ` forced to a non-UTC zone —
+one behind UTC, one ahead, so a date that rolls over a midnight boundary fails
+in at least one of them. A failure **only** here is a time-zone dependency, not
+a general test failure: a `Date`/`Calendar` assertion that implicitly assumed
+the runner's zone, a fixture date decoded with day precision but compared
+through a local-zone calendar, or a formatter without an explicit
+`timeZone`/`calendar`.
+
+Reproduce locally with the zone that failed:
+
+```bash
+TZ=Pacific/Auckland make test
+```
+
+**Summary:** Test (\<timezone\>) — `Suite/test` at `file:line`.
+**Cause:** the assertion's implicit local-zone dependency (name the date and the boundary it crosses).
+**Fix:** pin the calendar/zone in the code or the test (GMT for day-precision dates — see `knowledge/gotchas.md`); re-run under both zones.

--- a/.claude/skills/fix-pr-checks/SKILL.md
+++ b/.claude/skills/fix-pr-checks/SKILL.md
@@ -117,7 +117,8 @@ Run the script below via the `Workflow` tool with
 the ledger's record for that check (omit on a first attempt). It is embedded
 here, not a file, because it runs **once per invocation** — the same rule that
 keeps `/review-plan`'s and `/review-changes`'s scripts embedded, while
-`deliver-panel.js` lives in `.claude/workflows/` (it runs six times per run).
+`deliver-panel.js` lives in `.claude/workflows/` (it runs at every panel
+decision point — seven of them — in a single run).
 Invoking this skill is itself the opt-in to call `Workflow`.
 
 The guards are **executable `throw`s, not instructions**: a malformed payload

--- a/.claude/skills/implement-plan/SKILL.md
+++ b/.claude/skills/implement-plan/SKILL.md
@@ -297,8 +297,8 @@ When every item is checked off:
 
 1. Run `/test` and `/integration-test` — both must pass (`CLAUDE.md` requires it).
    Then run `make build-release`: debug-green and release-red diverge exactly on
-   access-level and `@testable` mistakes, and #398 passed 2868 unit tests, 291
-   integration tests and `--build-tests` while the release build was broken.
+   access-level and `@testable` mistakes, and in #398 both full suites and
+   `--build-tests` were green while the release build was broken.
 2. Run `/lint` (and `/format` if needed); run `make build-docs` and
    `/lint`-markdown only if public API or docs changed.
 3. **Changed a literal string, symbol name or code sample? Grep for its

--- a/.claude/skills/lint/SKILL.md
+++ b/.claude/skills/lint/SKILL.md
@@ -13,10 +13,11 @@ own requirement), `lint-fixtures` (`check-fixtures.py`, JSON fixture hygiene),
 DocC page), `lint-prose` (`check-prose-call-forms.py`, code samples calling a
 method that does not exist), `lint-readme-version`
 (`check-readme-version.py`, README's `.package(from:)` vs the newest
-`CHANGELOG.md` release) and `lint-run-list` (`run-script-tests.py`, the
-`/triage-issues` run-list builder's own suite, including whether the skill prose
-still agrees with the grammar the builder defines) — then `swiftlint --strict .`,
-then `swiftformat --lint .`.
+`CHANGELOG.md` release) and `lint-run-list` (`run-script-tests.py` — despite
+the target's name, **every** suite under `Scripts/tests/`: the `/triage-issues`
+run-list builder, the `/deliver` selection-prose anti-drift cases, the
+`deliver-runfile.py` writer, and the workflow cache-key/change-gate cases) —
+then `swiftlint --strict .`, then `swiftformat --lint .`.
 
 Each script enforces something no single-file linter can see, and a failure in
 any of them is **not** a formatting problem: `/format` will not fix it.

--- a/.claude/skills/review-changes/SKILL.md
+++ b/.claude/skills/review-changes/SKILL.md
@@ -52,11 +52,13 @@ caller has decided the change carries risk the file extensions don't show.
 `/deliver` passes it for a **reflexive delivery** — one that rewrites the
 skills, agents or review spec the pipeline itself runs, where the diff is
 markdown but the blast radius is the pipeline (#407 shipped three defects
-exactly there). Take the §2a single-reviewer path with a brief aimed at the
-change's own subject matter: which rule changed, whether anything still
-depends on the old wording, and whether the new rule is enforced or merely
-stated. Without this the gate and the caller contradict each other and the
-skip silently wins.
+exactly there). **This override lifts the gate; it does not choose a path** —
+§1 still decides, and a caller-stated `full` weight still takes §2b (*Risk
+overrides size*), however prose-shaped the diff. Whichever path runs, aim its
+brief at the change's own subject matter: which rule changed, whether
+anything still depends on the old wording, and whether the new rule is
+enforced or merely stated. Without this the gate and the caller contradict
+each other and the skip silently wins.
 
 **If the only reviewable change is a script** (`.claude/workflows/` or
 `Scripts/`), take the §2a single-reviewer path with a **script-focused brief**

--- a/.claude/skills/review-pr-threads/SKILL.md
+++ b/.claude/skills/review-pr-threads/SKILL.md
@@ -78,12 +78,12 @@ For each unresolved thread:
    commit per fix, but `git push` **once** after all threads are handled (§3), so
    one review/CI cycle is triggered per sweep, not one per thread.
 3. **No fix warranted** (disagree / out of scope / a question / already done) →
-   when the reason is *out of scope* and the reviewer's point is sound, file it
+   make no code change; you'll say why in the reply. When the reason is *out of
+   scope* and the reviewer's point is sound, file it
    per [`.github/ISSUE_FILING.md`](../../../.github/ISSUE_FILING.md) and reply
    with the issue number. "Out of scope" with nothing behind it is how a valid
    review comment gets closed forever; a link is what makes it a deferral rather
    than a dismissal.
-   make no code change; you'll say why in the reply.
 4. **Reply** on the thread — what you assessed and whether you fixed it (include
    the commit SHA when you did). Use
    `mcp__github__add_reply_to_pull_request_comment` (owner/repo from `origin`,

--- a/.claude/skills/triage-issues/SKILL.md
+++ b/.claude/skills/triage-issues/SKILL.md
@@ -9,8 +9,10 @@ Grooms the **Backlog** column of the `TMDb` GitHub Project into a queue someone
 can work from without asking a question first.
 
 The board is at `github.com/users/adamayoung/projects/<n>`; issues live in
-`adamayoung/TMDb`. This skill **owns** the Ready test, the priority and size
-rubrics, and the wontfix rules — nothing else in the repo restates them.
+`adamayoung/TMDb`. This skill **owns** the Ready test, the four exits, the
+wontfix rules and the skip rule; the priority and size rubrics live in
+`.claude/workflows/triage-issues.js` (`RUBRIC`), the copy handed to every
+agent — nothing else in the repo restates any of them.
 Issue *creation* is owned by [`.github/ISSUE_FILING.md`](../../../.github/ISSUE_FILING.md);
 this skill consumes what that produces.
 

--- a/.github/CODE_REVIEW.md
+++ b/.github/CODE_REVIEW.md
@@ -73,13 +73,21 @@ inflate nitpicks to Critical.
 
   ```text
   Service (e.g. TMDbMovieService)
-  └── ErrorMappingAPIClient        (maps TMDbAPIError → public TMDbError)
-      └── TMDbAPIClient            (adds api_key, validates status, decodes)
-          └── HTTPClient (protocol)
-              └── CacheHTTPClient          (opt-in)
-                  └── RetryHTTPClient      (opt-in; exponential backoff)
-                      └── URLSessionHTTPClientAdapter  (or user-supplied client)
+  └── APIClient (protocol)
+      └── ErrorMappingAPIClient        (maps TMDbAPIError → public TMDbError)
+          └── UnmappedAPIClient (protocol)
+              └── TMDbAPIClient        (adds api_key, validates status, decodes)
+                  └── HTTPClient (protocol)
+                      └── CacheHTTPClient          (opt-in)
+                          └── RetryHTTPClient      (opt-in; exponential backoff)
+                              └── URLSessionHTTPClientAdapter  (or user-supplied client)
   ```
+
+  The two-protocol split is load-bearing: services depend on `APIClient` and
+  `TMDbAPIClient` conforms only to `UnmappedAPIClient`, so no service can be
+  wired to the unmapped client by accident (ADR-0001). **Check the invariant**:
+  a new service takes `APIClient`, never `UnmappedAPIClient`, and never does its
+  own error translation.
 
 - New services are constructed and exposed in `TMDbClient`'s private init;
   `TMDbFactory` vends only shared plumbing (`makeServiceDependencies`, the API

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,9 +370,11 @@ carried a bearer-like credential for two months (issue #421).
 ### Inside Xcode vs. terminal
 
 Outside Xcode (terminal Claude Code), the skills fall back to `make`
-(`make build` / `make test` / `make integration-test`). Inside Xcode (the native
-Claude Agent integration) use the `mcp__xcode-tools__*` tools — **not**
-`mcp__xcode__*` (a separate, redundant server). The full tool list, test-plan
+(`make build` / `make test` / `make integration-test`); the `mcp__xcode__*`
+server that `.mcp.json` registers is what a terminal session gets, but the
+`make` route is preferred there. Inside Xcode (the native
+Claude Agent integration) use the `mcp__xcode-tools__*` tools — which exist
+**only** inside that integration, not in a terminal session. The full tool list, test-plan
 selection (**TMDb** unit / **Integration**), and the xcsift output-formatting
 details (`-f toon` local vs `-f github-actions` CI, `--Werror`, `pipefail`) are in
 [`knowledge/gotchas.md`](knowledge/gotchas.md) under **Tooling**.
@@ -447,9 +449,13 @@ error on *unchanged* files is almost always a version-drift artifact (a
 rule's behaviour changed between versions), not a real violation — check
 `swiftlint version` against the pin before editing the flagged code.
 
-### Auto-formatting on edit (PostToolUse hooks)
+### Edit hooks (PreToolUse guard + PostToolUse auto-formatting)
 
-Two `PostToolUse` hooks (in `.claude/settings.json`) run automatically after every
+Three hooks in `.claude/settings.json` fire around every `Edit`/`Write`. A
+`PreToolUse` hook **refuses any edit while the checkout is on `main`** (exit 2
+with a message) — the enforcement behind the *Branching* rule below, so the
+failure mode is a hard refusal, not a silent bad commit. Two `PostToolUse`
+hooks then run after every
 `Edit`/`Write`, so files are reshaped on disk **after** you write them:
 
 - **`.swift`** → `swiftlint --fix` then `swiftformat`.
@@ -533,8 +539,9 @@ Structural pattern for a new service:
 2. Models in `Domain/Models/` conform to `Codable`, `Equatable`, `Hashable`,
    `Sendable`.
 3. Construct and expose the service in `TMDbClient.swift`'s private init.
-   `TMDbFactory` vends only shared plumbing (`makeServiceDependencies`,
-   `httpClient(wrapping:)`) — services are **not** registered there.
+   `TMDbFactory` vends the shared plumbing — `makeServiceDependencies`,
+   `httpClient(wrapping:)`, and the three API-client factories (`apiClient`,
+   `authAPIClient`, `v4APIClient`) — but services are **not** registered there.
 4. Unit tests with JSON fixtures (`Tests/TMDbTests/Resources/`) **and** integration
    tests (`Tests/TMDbIntegrationTests/`).
 
@@ -584,7 +591,9 @@ declaration has an accurate `///`, and simplify where you can.
 
 **CRITICAL: Never make changes directly on `main`.** All changes —
 features, fixes, documentation, configuration — MUST be made on a
-branch created from `main`.
+branch created from `main`. This is **enforced**, not just stated: a
+`PreToolUse` hook in `.claude/settings.json` refuses `Edit`/`Write` while the
+checkout is on `main`.
 
 Before editing any file, verify you are on a branch other than `main`:
 

--- a/Scripts/deliver-runfile.py
+++ b/Scripts/deliver-runfile.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Read and update /deliver's durable run file — and PROVE every write landed.
+
+The run file lives at `<main checkout>/.git/deliver/<id>.json` (ADR-0015):
+deliberately outside the working tree, so it can never enter a diff and it
+survives `ExitWorktree(remove)`. But a worktree-isolated session's Bash guard
+refuses commands it cannot statically prove stay inside the worktree, and
+`.git/` is outside it BY DESIGN — so ad-hoc run-file writes fight the guard,
+and some refusals are SILENT: a `python3 - <<EOF` heredoc rewriting the file
+produced no output, no error and no write (PR #474), and in the #493 delivery
+two refused writes went unnoticed and the conductor certified to the auto-mode
+juror panel a revision that was not on disk.
+
+This script is the sanctioned route (skill-improvement-log 2026-08-22 decision
+on the 2026-08-21/#490 and 2026-08-12/#440 entries). Two properties carry the
+whole value:
+
+  1. INVOKABLE PAST THE GUARD. `python3 Scripts/deliver-runfile.py set <literal
+     path> <path> <value>` is a single-purpose command with fully literal
+     arguments — the shape the guard accepts — and the out-of-worktree write
+     happens inside the interpreter, where no static check applies.
+
+  2. IT VERIFIES ITS OWN POSTCONDITION. After writing, it re-opens the file
+     fresh from disk and asserts the value at the path is the one requested;
+     a mismatch is a loud non-zero exit, never a shrug. A run-file write that
+     reports nothing has told you nothing (`knowledge/gotchas.md` → the silent
+     heredoc refusal), and CLAUDE.md's probe rule applies to state writers
+     too: a script must verify the state it claims to have left.
+
+Design rules, learned the hard way elsewhere in Scripts/:
+
+  * REFUSE a missing intermediate path segment rather than creating it. A typo
+    (`deliverable.0.stamps`, `stamps.reviewedclean`) that silently grows a
+    parallel tree is a false green: the write "succeeds" while every later
+    reader — Phase 6's gate included — sees the old value. Only the FINAL
+    segment may be new, because schema fields legitimately appear over a run's
+    life (`claimHandedBack`, `locationDeviation`).
+
+  * The write is atomic (temp file + os.replace in the same directory), so a
+    crash mid-write can never leave a half-JSON run file for the next phase's
+    hard stop to trip over.
+
+Usage:
+  deliver-runfile.py get <file> <dotted.path>
+  deliver-runfile.py set <file> <dotted.path> <value>
+
+Paths are dot-separated; an integer segment indexes an array
+(`deliverables.0.stamps.reviewedClean`). `set` parses <value> as JSON first
+(`null`, `true`, `42`, `{"a":1}`, `["x"]` arrive typed) and falls back to a
+bare string — pass explicit JSON (`'"null"'`) to force a string that would
+otherwise parse.
+
+Exit codes: 0 ok · 1 usage/file/path error (nothing written) · 2 postcondition
+failed (the write did NOT land — treat as a hard stop, never assume it did).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+
+def parse_value(raw: str):
+    """JSON first, bare string as the fallback."""
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+def split_path(dotted: str) -> list[str]:
+    segments = dotted.split(".")
+    if not dotted or any(s == "" for s in segments):
+        fail(f"invalid path {dotted!r} — empty segment")
+    return segments
+
+
+def fail(message: str, code: int = 1) -> None:
+    print(f"deliver-runfile: {message}", file=sys.stderr)
+    sys.exit(code)
+
+
+def load(file: Path) -> dict:
+    if not file.is_file():
+        fail(f"{file} does not exist — Phase 0 writes the initial file before EnterWorktree")
+    try:
+        with open(file, encoding="utf-8") as handle:
+            return json.load(handle)
+    except json.JSONDecodeError as error:
+        fail(f"{file} is not valid JSON ({error}) — refusing to touch it")
+    raise AssertionError("unreachable")
+
+
+def descend(node, segments: list[str], dotted: str, *, for_write: bool):
+    """Walk to the PARENT of the final segment, refusing missing intermediates.
+
+    Returns (parent, final_segment). For arrays the segment must be a valid
+    in-range integer — a write never grows or creates an array through a path.
+    """
+    walked: list[str] = []
+    for segment in segments[:-1]:
+        walked.append(segment)
+        where = ".".join(walked)
+        if isinstance(node, list):
+            index = array_index(segment, node, where)
+            node = node[index]
+        elif isinstance(node, dict):
+            if segment not in node:
+                fail(f"path segment {where!r} does not exist — refusing to create intermediate structure (a typo'd path silently writing a parallel tree is the false green this script exists to prevent)")
+            node = node[segment]
+        else:
+            fail(f"path segment {where!r} is a {type(node).__name__}, not an object or array — cannot descend into it")
+    final = segments[-1]
+    if isinstance(node, list):
+        array_index(final, node, dotted)
+    elif not isinstance(node, dict):
+        fail(f"parent of {dotted!r} is a {type(node).__name__}, not an object or array")
+    elif not for_write and final not in node:
+        fail(f"path {dotted!r} does not exist in the file")
+    return node, final
+
+
+def array_index(segment: str, node: list, where: str) -> int:
+    try:
+        index = int(segment)
+    except ValueError:
+        fail(f"path segment {where!r} addresses an array — expected an integer index, got {segment!r}")
+    if not 0 <= index < len(node):
+        fail(f"index {index} at {where!r} is out of range for an array of {len(node)}")
+    return index
+
+
+def read_at(data, segments: list[str], dotted: str):
+    parent, final = descend(data, segments, dotted, for_write=False)
+    return parent[int(final)] if isinstance(parent, list) else parent[final]
+
+
+def write_file(file: Path, data: dict) -> None:
+    """Atomic replace in the file's own directory."""
+    descriptor, temp_path = tempfile.mkstemp(dir=file.parent, prefix=file.name, suffix=".tmp")
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=2)
+            handle.write("\n")
+        os.replace(temp_path, file)
+    finally:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+
+
+def command_get(file: Path, dotted: str) -> None:
+    value = read_at(load(file), split_path(dotted), dotted)
+    print(json.dumps(value))
+
+
+def command_set(file: Path, dotted: str, raw: str) -> None:
+    value = parse_value(raw)
+    segments = split_path(dotted)
+    data = load(file)
+    parent, final = descend(data, segments, dotted, for_write=True)
+    if isinstance(parent, list):
+        parent[int(final)] = value
+    else:
+        parent[final] = value
+    write_file(file, data)
+
+    # The postcondition: re-read from DISK, not from the object just mutated in
+    # memory — the in-memory copy is exactly what a suppressed write leaves
+    # looking correct.
+    landed = read_at(load(file), segments, dotted)
+    if landed != value:
+        fail(
+            f"POSTCONDITION FAILED — wrote {dotted} = {json.dumps(value)} but the file "
+            f"on disk holds {json.dumps(landed)}. The write did NOT land; treat this as "
+            "a hard stop, never as done.",
+            code=2,
+        )
+    print(f"verified: {dotted} = {json.dumps(landed)} in {file}")
+
+
+def main(argv: list[str]) -> None:
+    if len(argv) >= 3 and argv[0] == "get" and len(argv) == 3:
+        command_get(Path(argv[1]), argv[2])
+    elif len(argv) == 4 and argv[0] == "set":
+        command_set(Path(argv[1]), argv[2], argv[3])
+    else:
+        fail("usage: deliver-runfile.py get <file> <dotted.path> | set <file> <dotted.path> <value>")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/Scripts/run-script-tests.py
+++ b/Scripts/run-script-tests.py
@@ -38,9 +38,9 @@ TESTS = ROOT / "Scripts" / "tests"
 # diff-visible bump in the same commit that adds a test, which is the only
 # enforcement a "remember to update this" comment ever really has.
 #
-# Currently: 38 in test_build_run_list.py + 11 in test_deliver_selection_prose.py
-# + 26 in test_workflow_gates.py.
-EXPECTED_MINIMUM = 75
+# Currently: 38 in test_build_run_list.py + 13 in test_deliver_runfile.py
+# + 11 in test_deliver_selection_prose.py + 26 in test_workflow_gates.py.
+EXPECTED_MINIMUM = 88
 
 
 def main() -> None:

--- a/Scripts/tests/test_deliver_runfile.py
+++ b/Scripts/tests/test_deliver_runfile.py
@@ -1,0 +1,165 @@
+"""Tests for Scripts/deliver-runfile.py — the self-verifying run-file writer.
+
+Two kinds of case, deliberately:
+
+  * CLI-contract cases run the real script in a subprocess, because exit codes
+    ARE the contract — the /deliver conductor branches on them, and code 2
+    (postcondition failed) must be distinguishable from code 1 (refused,
+    nothing written).
+
+  * A MUTATION case imports the module and suppresses `write_file`, proving
+    the postcondition check can actually fail. A verifier only ever seen
+    passing is exactly the blind-guard shape this repo keeps shipping
+    (`knowledge/gotchas.md` → "A test that asserts on prose can be blind");
+    the writer built to end that class must not repeat it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = ROOT / "Scripts" / "deliver-runfile.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("deliver_runfile", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+SAMPLE = {
+    "id": "sample-run",
+    "weight": "full",
+    "reflexive": False,
+    "reconciled": None,
+    "deliverables": [
+        {
+            "title": "one",
+            "issue": 490,
+            "stamps": {"reviewedClean": None, "securityClean": None},
+            "status": "open",
+        }
+    ],
+}
+
+
+class DeliverRunfileTests(unittest.TestCase):
+    def setUp(self) -> None:
+        import tempfile
+
+        self._dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._dir.cleanup)
+        self.file = Path(self._dir.name) / "run.json"
+        self.file.write_text(json.dumps(SAMPLE, indent=2))
+
+    def read(self) -> dict:
+        return json.loads(self.file.read_text())
+
+    # -- set: the happy paths ------------------------------------------------
+
+    def test_set_top_level_string(self) -> None:
+        result = run_cli("set", str(self.file), "weight", "lite")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("verified: weight", result.stdout)
+        self.assertEqual(self.read()["weight"], "lite")
+
+    def test_set_nested_stamp_through_array_index(self) -> None:
+        result = run_cli("set", str(self.file), "deliverables.0.stamps.reviewedClean", "abc123")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.read()["deliverables"][0]["stamps"]["reviewedClean"], "abc123")
+
+    def test_set_json_typed_values(self) -> None:
+        for raw, expected in [("true", True), ("null", None), ("42", 42), ('{"inScope": 1}', {"inScope": 1})]:
+            with self.subTest(raw=raw):
+                result = run_cli("set", str(self.file), "reconciled", raw)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(self.read()["reconciled"], expected)
+
+    def test_set_new_final_key_is_allowed(self) -> None:
+        result = run_cli("set", str(self.file), "deliverables.0.claimHandedBack", "2026-08-22T00:00:00Z")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.read()["deliverables"][0]["claimHandedBack"], "2026-08-22T00:00:00Z")
+
+    def test_forced_string_via_explicit_json(self) -> None:
+        result = run_cli("set", str(self.file), "weight", '"null"')
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.read()["weight"], "null")
+
+    # -- set: the refusals, all exit 1 with the file untouched ---------------
+
+    def test_missing_intermediate_refused(self) -> None:
+        before = self.read()
+        result = run_cli("set", str(self.file), "selection.claimed", "true")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("does not exist", result.stderr)
+        self.assertEqual(self.read(), before, "a refused write must leave the file untouched")
+
+    def test_array_index_out_of_range_refused(self) -> None:
+        result = run_cli("set", str(self.file), "deliverables.3.status", "open")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("out of range", result.stderr)
+
+    def test_non_integer_array_segment_refused(self) -> None:
+        result = run_cli("set", str(self.file), "deliverables.first.status", "open")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("integer index", result.stderr)
+
+    def test_missing_file_refused(self) -> None:
+        result = run_cli("set", str(self.file.parent / "absent.json"), "weight", "lite")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("does not exist", result.stderr)
+
+    def test_invalid_json_file_refused_and_untouched(self) -> None:
+        self.file.write_text("{not json")
+        result = run_cli("set", str(self.file), "weight", "lite")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("not valid JSON", result.stderr)
+        self.assertEqual(self.file.read_text(), "{not json")
+
+    # -- get ----------------------------------------------------------------
+
+    def test_get_reads_nested_value(self) -> None:
+        result = run_cli("get", str(self.file), "deliverables.0.issue")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout), 490)
+
+    def test_get_missing_path_is_an_error(self) -> None:
+        result = run_cli("get", str(self.file), "deliverables.0.pr")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("does not exist", result.stderr)
+
+    # -- the postcondition can actually fire ---------------------------------
+
+    def test_postcondition_screams_when_the_write_is_suppressed(self) -> None:
+        """Mutation check: no-op the write, the verifier must exit 2.
+
+        This is the silent-refusal scenario from PR #474 reproduced on
+        purpose — the environment swallows the write, nothing errors, and the
+        only thing standing between that and a false "done" is the re-read.
+        """
+        module = load_module()
+        module.write_file = lambda file, data: None
+        with self.assertRaises(SystemExit) as caught:
+            module.command_set(self.file, "weight", "lite")
+        self.assertEqual(caught.exception.code, 2)
+        self.assertEqual(self.read()["weight"], "full", "the suppressed write must not have landed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/tests/test_deliver_runfile.py
+++ b/Scripts/tests/test_deliver_runfile.py
@@ -52,7 +52,7 @@ SAMPLE = {
         {
             "title": "one",
             "issue": 490,
-            "stamps": {"reviewedClean": None, "securityClean": None},
+            "stamps": {"reviewedClean": None, "securityClean": None, "rubricGraded": None},
             "status": "open",
         }
     ],

--- a/knowledge/decisions/0015-durable-deliver-run-state.md
+++ b/knowledge/decisions/0015-durable-deliver-run-state.md
@@ -95,6 +95,10 @@ for anything git can settle.**
 
 ## Addendum (2026-08-22) — writes are script-mediated and self-verifying
 
+*(An extending addendum, per the index README's immutability rule: nothing
+above is reversed — the location and every property chosen for it stand; this
+adds the write route that makes them reachable in practice.)*
+
 The location stands; the write route it implied did not survive contact with
 the worktree guard. A worktree-isolated session's `Bash` guard refuses commands
 it cannot statically prove stay inside the worktree, and `.git/deliver/` is

--- a/knowledge/decisions/0015-durable-deliver-run-state.md
+++ b/knowledge/decisions/0015-durable-deliver-run-state.md
@@ -92,3 +92,34 @@ for anything git can settle.**
   signal; a mid-phase crash leaves it confidently wrong.
 - **`.build/deliver/`.** More discoverable, already gitignored — but
   per-worktree (breaks batch state) and destroyed by `make clean`.
+
+## Addendum (2026-08-22) — writes are script-mediated and self-verifying
+
+The location stands; the write route it implied did not survive contact with
+the worktree guard. A worktree-isolated session's `Bash` guard refuses commands
+it cannot statically prove stay inside the worktree, and `.git/deliver/` is
+outside it **by design** — so every post-`EnterWorktree` update fought the
+guard, across five recorded deliveries (#432, #440, #476, #486, #490;
+`skill-improvement-log.md`, the 2026-08-12 and 2026-08-21 entries, decided
+together here). The escalation that forced the decision: some refusals are
+**silent** (PR #474), and in the #493 delivery two unnoticed refusals led the
+conductor to certify a plan revision to the auto-mode juror panel that was not
+on disk — a false certification to the mechanism that stands in for the user,
+not a slower write.
+
+**Decision.** Every run-file write after `EnterWorktree` goes through
+`Scripts/deliver-runfile.py` (`set <literal file> <dotted.path> <value>`): a
+single-purpose, literal-argument command — the shape the guard accepts — whose
+out-of-worktree write happens inside the interpreter, past static analysis.
+The script **verifies its own postcondition**: it re-reads the file from disk
+and exits `2` when the value is not there, so a swallowed write is loud. Its
+callers treat any non-zero exit as a **hard stop** for the phase making the
+write — the independent mitigation that holds even if the file ever moves.
+Phase 0's initial write (before `EnterWorktree`, unguarded) stays a plain
+`Write`.
+
+**Alternatives rejected here.** Moving the file under the worktree — forfeits
+the batch-state and `ExitWorktree(remove)`-survival properties this ADR chose
+the location for. Teaching the guard about the common git dir — the guard is
+harness behaviour, not this repo's to change. Leaving the workaround as prose —
+that was the status quo, and it produced #493.

--- a/knowledge/decisions/0023-python-strict-parser-for-fixture-hygiene.md
+++ b/knowledge/decisions/0023-python-strict-parser-for-fixture-hygiene.md
@@ -1,10 +1,8 @@
-# 23. Enforce fixture hygiene with an independent strict parser, not a Swift test
+# ADR-0023: Enforce fixture hygiene with an independent strict parser, not a Swift test
 
-Date: 2026-08-14
-
-## Status
-
-Accepted (unreleased — tooling only)
+- **Status:** Accepted (unreleased — tooling only)
+- **Date:** 2026-08-14
+- **Deciders:** Adam Young
 
 ## Context
 

--- a/knowledge/decisions/0027-run-list-ordering-in-scripts.md
+++ b/knowledge/decisions/0027-run-list-ordering-in-scripts.md
@@ -1,7 +1,8 @@
-# 0027 — Compute the triage run-list in `Scripts/`, not in a workflow
+# ADR-0027: Compute the triage run-list in `Scripts/`, not in a workflow
 
-* **Status:** Accepted (unreleased — tooling only)
-* **Date:** 2026-08-20
+- **Status:** Accepted (unreleased — tooling only)
+- **Date:** 2026-08-20
+- **Deciders:** Adam Young
 
 ## Context
 
@@ -57,11 +58,11 @@ the same single-ownership rule `/triage-issues` already applies to its rubrics.
 **The ordering is now testable, and two defects fell out of testing it that had
 been specified wrongly in prose for as long as the prose existed:**
 
-* *A topological sort does not satisfy "a P2 that unblocks a P0 goes first."*
+- *A topological sort does not satisfy "a P2 that unblocks a P0 goes first."*
   Precedence is not promotion — greedy Kahn's keyed on own priority emits an
   independent P1 before a P2 unblocker. The script computes an **effective
   priority** (`min(own, best over transitive dependents)`) before sorting.
-* *Separating two contending issues by swapping them is a no-op* — they stay
+- *Separating two contending issues by swapping them is a no-op* — they stay
   adjacent. The primitive is a **move**, and its priority-band check must cover
   the whole **jumped range**, not just the new neighbour, or the separator
   overtakes a higher-priority issue with no dependency edge to disclose it.
@@ -110,9 +111,9 @@ moves the drift one step back rather than removing it.
 
 ## Related
 
-* [0016](0016-panel-jurors-and-workflows-directory.md) — why `.claude/workflows/`
+- [0016](0016-panel-jurors-and-workflows-directory.md) — why `.claude/workflows/`
   exists and what belongs there.
-* [0023](0023-python-strict-parser-for-fixture-hygiene.md) — the same choice of
+- [0023](0023-python-strict-parser-for-fixture-hygiene.md) — the same choice of
   an independent Python checker over an in-language test.
-* [0026](0026-unattended-selection-needs-an-author-check.md) — the authorisation
+- [0026](0026-unattended-selection-needs-an-author-check.md) — the authorisation
   gate that sits upstream of this ordering, in `next-mode.md` §2.

--- a/knowledge/decisions/0028-selection-policy-as-a-token-of-mode.md
+++ b/knowledge/decisions/0028-selection-policy-as-a-token-of-mode.md
@@ -1,7 +1,8 @@
 # ADR-0028: A selection policy is a token of `mode`, not a field beside it
 
-**Status:** Accepted (2026-08-20)
-**Context:** issue 481 — `/deliver` gains `issue <n>` alongside `next`
+- **Status:** Accepted (unreleased — tooling only)
+- **Date:** 2026-08-20
+- **Deciders:** Adam Young (issue 481 — `/deliver` gains `issue <n>` alongside `next`)
 
 ## Context
 

--- a/knowledge/decisions/README.md
+++ b/knowledge/decisions/README.md
@@ -12,7 +12,13 @@ once both numbered `0010`; the model-tier one was renumbered to `0014` by the
 mind — write a new one and mark the old **Superseded by [ADR-XXXX]**, with a
 forward link in the superseded file and a back link in the new one. Correcting a
 factual error, a stale status, or a broken link is *not* a change of mind and is
-always fair game.
+always fair game. **A dated addendum is also fair game, within one boundary**:
+it may *extend or harden* the recorded decision (a new mechanism serving the
+same choice, evidence that firmed it up, an implementation route the original
+left open) but must not *reverse* any part of it — the moment an addendum would
+change what was decided, it is a new ADR that supersedes or amends the old one.
+ADR-0014, ADR-0015 and ADR-0016 all carry addenda of this extending kind; this
+paragraph is what sanctions them (2026-08-22 audit).
 
 ## Index
 

--- a/knowledge/delivery-retros.md
+++ b/knowledge/delivery-retros.md
@@ -6,7 +6,9 @@ backfilled once the PR opens), newest at the top. A noteworthy watch-phase event
 is appended post-gate as an optional *watch:* line — an uneventful watch adds
 nothing. The point is **continuous improvement**: when the same friction or
 deviation recurs across entries, fold the fix into the relevant skill. Keep each
-entry to a handful of bullets — a log, not a ceremony.
+entry to a handful of bullets — a log, not a ceremony. **Scope: `/deliver` runs
+only** — direct commits, improvement-application PRs and audit PRs deliberately
+write no entry here, so a gap in the dates is not a missing retro.
 
 Format: **Feature / PR** · date · **weight** · *phases completed / skills
 invoked* · `consulted:` · `reconciled:` · `swept:` · *what worked* · *friction*
@@ -901,215 +903,6 @@ the board's Ready execution order.
   but neither covers a one-liner changed in passing. Logged in
   `skill-improvement-log.md`.
 
-## 2026-08-13 — 🔧 Move the `/review-knowledge` audit round to Opus (#451) · full
-
-- **Phases / skills:** 0–8 pre-PR. Full weight and reflexive (`.claude/skills/**`),
-  so Phases 4 and 5 ran with their no-Swift self-skip overridden. Skills:
-  `review-plan`, `review-changes` (`force-review`), `security-review`,
-  `capture-knowledge`.
-  `consulted:` gotchas *False green*, *Edits can land in the main checkout*,
-  *In a worktree session Bash refuses commands it can't prove stay inside it*,
-  *EnterWorktree branch name*, *Workflow resolves a repo-relative scriptPath*,
-  *git ls-tree empty hash*, *markdownlint line-leading number-sign*;
-  **ADR-0014** (governing — both proposed changes contradicted it), ADR-0016;
-  wiki *keep-adversarial-reviewers-independent*,
-  *a-detector-whose-green-looks-the-same-when-it-didnt-run*,
-  *an-unenforceable-process-rule-gets-silently-skipped*.
-  `reconciled:` 0 in scope / 0 reclaimed / 0 resumable / 0 reported.
-  `swept:` `.claude/skills/review-knowledge/SKILL.md` → 3 `gotchas.md` entries
-  written or extended, 1 factual correction in `decisions/0016` (embedded-script
-  count 3 → 4); historical `skill-improvement-log.md` entries left untouched
-  (append-only decision memory); `gotchas.md:59` re-read, still true.
-- **Worked — Phase 0's knowledge consult caught that the whole plan was
-  ADR-governed.** ADR-0014 pins every model tier in `.claude/`, and both proposed
-  changes contradicted it: one reversed its six-day-old addendum, the other
-  partially re-opened an alternative it had explicitly rejected with a revisit
-  trigger that had not fired. Without that read this would have shipped as a
-  config tweak that silently reversed a recorded decision.
-- **Worked — the plan critics changed the shape of the delivery, not just its
-  details.** They killed `effort: high → xhigh` (thinking bills as output at 5×
-  input, so moving two variables would have made the saving unmeasurable and left
-  a regression with two suspects); caught that a conditional `meta.model` would be
-  a temporal-dead-zone `ReferenceError` shipping unexercised, since a reflexive
-  delivery cannot dogfood; and showed the second change's trigger could never fire
-  for reflexive `.claude/` diffs — the class this repo's defect record is made of.
-  Scope went from two changes to one on that evidence; the dropped one is issue
-  #450.
-- **Worked — the code reviewer caught a falsehood in the durable record.**
-  ADR-0020 and the log both claimed *in the past tense* that a GitHub issue had
-  been filed. None had. In a delivery specifically about sharpening the audit that
-  hunts exactly that class of claim.
-- **Worked — a reviewer conceding cleanly on evidence it lacked.** It flagged
-  `meta.phases[].model` as an invented key (High, correctly, from where it sat —
-  the `code-reviewer` agent has no `Workflow` tool and the schema is documented
-  nowhere in the tree). Given the contract it withdrew in full and named its own
-  reasoning error: it had read *absence of the situation* as *avoidance of the
-  field*. Captured as a gotcha.
-- **Friction — the review machinery cost far more than the change saves.**
-  ~1.36M subagent tokens on the plan review, ~284k across two code-review rounds,
-  ~74k grading — for a 6-file markdown diff whose benefit is roughly a quarter off
-  one periodic skill's run. Full weight was the right call for a reflexive change;
-  the problem is that full weight currently means the same machinery for a
-  6-file prose diff as for a multi-service Swift feature.
-- **Friction — the worktree `Bash` guard cost ~8 extra round trips.** Every
-  run-file update, the content stamp and the script parse-check had to be
-  decomposed into single-purpose commands; `$'\t'` quoting was refused outright.
-  Captured.
-- **Deviations:** (1) the ADR was authored in **Phase 3, inside the diff**, not
-  Phase 7 — on the critics' finding that Phase 7's contract permits writing
-  nothing, so a governance record deferred to it is unenforced. This is the
-  sanctioned inline-capture exception. (2) Phase 5 was analysed directly rather
-  than fanned out: every changed file is markdown and the skill's own rule 16
-  excludes documentation findings, so a fan-out was structurally guaranteed
-  empty. Recorded as a visible choice rather than a silent narrowing.
-- **One improvement:** scale Phase 2 and Phase 4 by **diff shape**, not weight
-  alone. `full` currently fixes both risk *and* machinery, so a reflexive prose
-  change — which genuinely needs the adversarial lens — pays for fan-out breadth
-  sized for a multi-service Swift diff. A reflexive-but-small shape wants the
-  critics (they earned their keep here) at a smaller fan-out. Raise against the
-  binary-weight decision deliberately, since that vocabulary is itself a recorded
-  narrowing.
-- **Also noted:** my own AC3 was written too literally — its second clause
-  required *every* `fable` hit to sit in one of two named buckets, which would
-  have demanded deleting true, unrelated history. The independent grader graded
-  the reasonable reading and disclosed the strict one rather than silently
-  passing. Write rubric clauses that scope to the change, not to the whole tree.
-
-## 2026-08-13 — 🐛 Exclude tvOS/watchOS from the FoundationModels planner (#449) · full
-
-- **Phases / skills:** 0–8 pre-PR. Full weight, but with two pieces of machinery
-  deliberately not used (below): `/review-plan`'s critics and
-  `/review-changes`'s fan-out. Skills: `implement-plan`, `review-changes`,
-  `security-review`, `capture-knowledge`.
-  `consulted:` gotchas *No workflow runs make*, *tooling-runner runs in the main
-  checkout*, *Bash refuses commands it can't prove stay inside the worktree*,
-  *Edits can land in the main checkout*, *EnterWorktree branch name*,
-  *FoundationModels/CoreImage watchOS* (retired by this delivery),
-  *NaturalLanguageSearchService is not platform-gated*, *git ls-tree empty
-  hash*; wiki *before-bumping-a-pinned-ci-toolchain-version-verify-the-runner-
-  image-ships-it*, *a-detector-whose-green-looks-the-same-when-it-didnt-run*,
-  *fix-orphaned-platform-gated-api* (ADR-0010 background).
-  `reconciled:` 0 in scope / 0 reclaimed / 0 resumable / 0 reported.
-  `swept:` `.github/workflows/ci.yml` → 1 entry retired, 2 rewritten; 5 citing
-  entries re-read and left unchanged.
-- **Worked — probing the platforms before accepting the reported fix found a
-  second break.** The issue proposed `&& !os(tvOS)` at four sites and had
-  verified it on 18.2.0. Building the *unfixed* tree for all five Apple
-  platforms first showed watchOS was also red, and `!os(tvOS)` does not fix it:
-  the SDK's availability is asymmetric per symbol, so only the file touching
-  `SystemLanguageModel` breaks there. Shipping the reported patch verbatim
-  would have left watchOS broken and looked like a complete fix.
-- **Worked — the reviewer found a pre-existing false green two lines from the
-  diff.** The aggregate `ci` job never checked the `changes` job's result, and
-  every job is `if: always()` — so a failed paths-filter left all five jobs
-  exiting `success` having done nothing, on a ruleset that requires `CI`. Fixed
-  here because it is the same failure family the delivery exists to close.
-- **Worked — settling a finding by executing it rather than arguing it.** The
-  reviewer flagged that `xcsift --Werror` on a four-SDK `xcodebuild` might fail
-  on Apple's own header warnings — a false *red*, and explicitly "cannot be
-  settled by reading". One cold piped build per new platform answered it (exit
-  0), which is cheaper than the paragraph of speculation it replaced.
-- **Friction — the weight vocabulary did not fit the diff.** Full weight
-  prescribes the fan-out `/review-changes`, but its five dimensions are all
-  Swift lenses (correctness, concurrency, architecture, testing, api-docs) and
-  the risk in this diff was 74 lines of GitHub Actions YAML. A fan-out would
-  have spent four lenses on a five-line Swift change and still had nobody
-  reviewing the workflow. Took the single-reviewer path with a targeted brief.
-- **Friction — the `markdownlint --fix` hook silently corrupted a knowledge
-  entry** by rewriting a line-leading `#416` into an H1, destroying the
-  sentence and then failing the gate on a heading I never wrote. Captured as a
-  gotcha; it will recur, because this repo cites `#NNN` constantly and wraps
-  prose at 80 columns.
-- **Friction (self-inflicted) — ran `make lint` three times** for a diff of five
-  one-line `#if` changes and a doc comment. The `PostToolUse` hook already
-  formats each file on write; `--strict` is the gate and `make ci` runs it. The
-  user pointed this out mid-run.
-- **Deviations:** (1) skipped `/review-plan`'s critics — the plan had been
-  adversarially verified empirically before `/deliver` was invoked, by testing
-  the reporter's proposed fix and finding it insufficient; (2) single-reviewer
-  `/review-changes` at full weight, per the friction above; (3) skipped the
-  standalone `/integration-test` at Phase 3 — the diff is compile-time-only and
-  a provable macOS no-op, the integration target's *compilation* is proven by
-  `--build-tests`, and `make ci` runs the live suite at Phase 9 anyway (the
-  #401 economy); (4) ran `/security-review` inline rather than via sub-tasks,
-  the surface being one workflow file; (5) let the Phase 6 grader run its own
-  platform builds, against the skill's execution cap — the rubric was
-  build-shaped, so having it trust my logs would have made it non-independent
-  on exactly the criteria that mattered.
-- **One improvement:** `/review-changes`'s fan-out has no dimension for CI /
-  workflow changes, so any diff whose risk is in `.github/workflows/` is either
-  reviewed by five Swift lenses or, as here, routed to the single-reviewer path
-  by hand. A sixth `ci-workflow` dimension (gate integrity, false-green paths,
-  secret exposure, cache keys) would make the fan-out usable for
-  infrastructure diffs instead of only Swift ones.
-
-## 2026-08-12 — 🐛 Surface task cancellation as `TMDbError.cancelled` (#433) · full
-
-- **Phases / skills:** 0–8 pre-PR. Full weight: three-critic `/review-plan`, the
-  fan-out + adversarial-verify `/review-changes`, independent grader.
-  `consulted:` ADR-0001/0003/0012/0013, `next-major.md` (the `invalidRating`
-  entry, settled here), gotchas *Swift concurrency* §853-950 (all four entries),
-  `swift-concurrency` skill; wiki *semantic-errors-not-transport-errors*,
-  *treat-review-findings-as-hypotheses*, *for-a-sendable-test-double-reach-for-a-
-  lock-before-an-actor*.
-- **Worked — the plan critics changed the design, not just the wording.** All
-  three independently found a bug the issue never mentioned: a cancelled
-  natural-language search was wrapped as `.planningFailed`, which `canFallBack`
-  treats as fallback-eligible, so `TMDbIntelligence` issued *three fresh live
-  searches on an already-cancelled task* — the library itself doing the
-  "re-run work the user cancelled" harm #419 was filed about. That became Part 4.
-  They also killed two defects that would have shipped: the detection predicate
-  would have swallowed `URLSession.invalidateAndCancel()` as a user cancellation,
-  and `(error as? URLError)` may not match what corelibs-foundation raises on
-  Linux — where the integration test meant to prove it never runs.
-- **Worked — the simplicity critic reversed my Part 2 design, for the better.**
-  I had planned a waiter registry on the actor. The `DataTaskBox`-style
-  `ResumeOnce` box it proposed instead is smaller, touches none of ADR-0013's
-  commit machinery, and *removes* a hang class (late registration) rather than
-  adding one. Its decisive argument was that `onCancel` is synchronous, so a lock
-  beats an actor — which is the wiki entry I had already read and not applied.
-- **Worked — mutation-testing a review finding.** The fan-out claimed the
-  executor-path `catch` arm was untested. Rather than trust or dismiss it, I
-  mutated the arm and re-ran: it failed with `planningFailed(underlying:
-  .cancelled)`, proving both the finding and, after the fix, the new test.
-- **Friction — `.build` contention shaped the schedule, not just the tokens.**
-  Phases 4 and 5 read the same commits and feel parallel, but one scratch dir
-  means they must be serial; every reviewer prompt needed an explicit "do not
-  build". Worth it: full 5/5 dimension coverage, 1 finding dropped by refutation.
-- **Deviations:** (1) test-first per *cohesive unit*, not per test — the
-  exhaustive switches acted as the red signal for the mapping sites, but that is
-  a looser loop than `canon-tdd` prescribes. (2) I skipped a test my own plan
-  listed (composing `TMDbAPIClient` over `RetryHTTPClient`); the grader caught
-  it. (3) The rubric named AC4 in terms the critics later proved unachievable,
-  so it was narrowed mid-run, and AC8 added for Part 4 — both flagged to the
-  user rather than quietly restated.
-- **One improvement — Phase 6 grades AC-shaped knowledge work that Phase 7 has
-  not done yet.** AC6 ("ADR-0018 exists, ADR-0013 amended, `next-major.md` entry
-  removed") failed the first grading *purely* because capture runs after the
-  rubric gate. The criterion was correct and the ordering is deliberate, but a
-  knowledge-shaped AC is guaranteed to fail its first grading. Either `/deliver`
-  should grade knowledge ACs after Phase 7, or Phase 0 should refuse to accept
-  one — worth a wrap-up scan proposal if it recurs.
-- **`swept:`** one stale claim retired — the prefetch-forwarding testing gotcha
-  still described the `Task.checkCancellation()` guard this change replaced;
-  annotated rather than deleted, since its actor-recorder advice still holds. No
-  `Makefile`/`Package.swift`/workflow/`.claude` changes, so the target-layout
-  half is n/a.
-- **`watch:`** the Linux CI job caught a **production** bug that every other gate
-  missed. In `ResumeOnce.resume(_:)` a local named `continuation` shadowed the
-  stored property *inside its own initialiser*, so `guard let continuation` read
-  uninitialised stack memory. On Darwin that garbage was `nil` and the code
-  behaved perfectly — 3144 macOS tests, `make ci`, two review passes, a security
-  review and an independent grader all green. On Linux it was non-`nil` and
-  segfaulted in `swift_retain`, wedging the runner so hard it ignored both
-  GitHub's concurrency cancel and `gh run cancel`. Three lessons, all captured:
-  a full green `make ci` **never builds for Linux**, so a hand-rolled concurrency
-  primitive needs `make test-linux` *before* the PR; `.timeLimit` cannot rescue a
-  task parked on an unresumed continuation (the timeout blocks with it), so my
-  earlier claim that it "turns a hang into a failure" was overstated and is now
-  corrected in the suite comment; and a diff-reading reviewer cannot see this
-  class of bug — `claude-review` explicitly approved the file.
-
 ## Archive (distilled)
 
 Older entries condensed per the rolling window (`knowledge/README.md` →
@@ -1117,6 +910,9 @@ Older entries condensed per the rolling window (`knowledge/README.md` →
 
 | Date | PR | Weight | Outcome |
 | --- | --- | --- | --- |
+| 2026-08-13 | #451 | full | Moved `/review-knowledge`'s audit round to Opus (ADR-0020). **Phase 0's knowledge consult caught that the whole plan was ADR-governed**: both proposed changes contradicted ADR-0014 — one reversed its six-day-old addendum, the other re-opened an explicitly rejected alternative — so without that read a config tweak would have silently reversed a recorded decision. The plan critics changed the delivery's shape, killing `effort: high → xhigh` (thinking bills as output at 5× input, so moving two variables at once would have left a regression with two suspects) and dropping the conditional-Fable-escalation half entirely (deferred as issue #450, later closed to the log). The code reviewer caught a **falsehood in the durable record** — ADR-0020 and the log both claimed in the past tense that an issue had been filed; none had. Its lasting friction: ~1.7M review tokens for a 6-file markdown diff, the origin of the "scale machinery by diff shape" thread that landed as `/review-changes`' *Risk overrides size* rule (#462). Also ~8 extra round trips to the worktree `Bash` guard for run-file writes — one of the five recurrences behind `Scripts/deliver-runfile.py`. |
+| 2026-08-13 | #449 | full | Excluded tvOS/watchOS from the FoundationModels planner. **Probing all five platforms before accepting the reported fix found a second break**: the issue's `&& !os(tvOS)` was verified on 18.2.0, but building the unfixed tree everywhere showed watchOS red too, with asymmetric per-symbol SDK availability — the reported patch verbatim would have shipped looking complete while leaving watchOS broken. The reviewer found a pre-existing false green two lines from the diff (the aggregate `ci` job never checked the `changes` job's result, so a failed paths-filter passed all five jobs having done nothing), and a might-be-red finding was settled by **executing it** — one cold piped build per platform — rather than arguing it. Full weight did not fit a diff whose risk was 74 lines of YAML: took the single-reviewer path with a targeted brief, and its "one improvement" — a `ci-workflow` dimension for `/review-changes`' fan-out (gate integrity, false-green paths, secret exposure, cache keys) — **remains open**. Also the `markdownlint --fix` hook rewrote a line-leading `#416` into an H1, corrupting a knowledge entry; captured, and it will recur. |
+| 2026-08-12 | #433 | full | Surfaced task cancellation as `TMDbError.cancelled` (ADR-0018). All three plan critics independently found a bug the issue never mentioned — a cancelled natural-language search wrapped as `.planningFailed` was fallback-eligible, so the library issued three fresh live searches on an already-cancelled task — and the simplicity critic reversed the Part 2 design to a `ResumeOnce` lock-box (`onCancel` is synchronous, so a lock beats an actor), removing a hang class. A review finding was **mutation-tested** rather than trusted or dismissed. Its `watch:` line is the file's starkest lesson: Linux CI caught a **production** bug every other gate missed — a local `continuation` shadowed the stored property inside its own initialiser, reading uninitialised stack memory that was benignly `nil` on Darwin (3144 green macOS tests, two reviews, a security review, an independent grader) and segfaulted in `swift_retain` on Linux — so a hand-rolled concurrency primitive needs `make test-linux` **before** the PR, and a diff-reading reviewer cannot see this class. Its knowledge-shaped AC6 failed the first grading purely by capture-after-grading ordering, which became Phase 0's drop-a-knowledge-shaped-AC rule (#439). |
 | 2026-08-12 | #440 | full | Adopted a single decode-tolerance policy. The lasting practice is **promoting a failure-class sweep from a plan bullet to a blocking ledger task**: all three critics graded the blast-radius audit as revision 1's weakest part because it swept by *name* and missed every synthesized decoder, and the promoted gate is what found the delivery's worst bug — `TVSeriesDetailsResponse.lists` typed `MediaPageableList` when `/tv/{id}/lists` returns summaries with no `media_type`, so tightening tolerance would have turned a silent empty array into a thrown call. A process step that exists only in prose gets skipped under momentum; one that blocks a task does not. The sweep also earned its keep by **excluding**: it disproved the plan's own "one confirmed hardening needed" claim (1,046/1,046 clean) and showed a 9%-null figure recorded for `/company/{id}` does not transfer to `/search/company`. Three of the author's load-bearing claims were each caught by a different stage (critic, reviewer, security), and a peer session landed #436 into `main` mid-flight, costing a rebase. Its "one improvement" — `/test` should confirm new tests **by name**, not by aggregate count, since "3147 passed" reads identically whether a new test ran or never compiled in — remains open. |
 | 2026-08-12 | #432 | full | Decoded empty-string credit dates as nil. **The #404 population sweep paid in both directions**: 300 live `/credit/{id}` records both *cleared* five URL decodes with a measurement (`null`-bearing, never `""`) and *found a bug the issue never mentioned* — `credit_type: "creator"` threw. A sweep earns its keep by excluding as much as by finding. The critics caught a false green the author built in: **no fixture omitted `character`**, so a `decode`-instead-of-`decodeIfPresent` slip would have compiled, passed everything, and broken 36% of live credits — fixed for free by re-sourcing both blank-date fixtures to *crew* credits, which omit `character` entirely. A 2-vs-1 critic split was reconciled **on evidence, not vote**: *Guard consistently within a type* is about one value class diverging, not a date differing from a URL, and guarding would have made `CreditMovie` the lone divergence across ~20 models. Two lasting frictions: the worktree Bash guard refuses commands it cannot prove stay inside the worktree (which blocks writing `/deliver`'s own run file under `.git/deliver/` — its run-file location is at odds with its worktree isolation), and **a subagent asserted a green it could not see** (the tooling-runner reported a named test passed, but xcsift logs carry only aggregate counts; its report shape cannot distinguish *ran and passed* from *never ran*). Its "one improvement" — sanction *deriving* ACs with recorded provenance when a plan states observable before/after behaviour in the wrong shape — **shipped**, and is the entry gate's `derived` branch and `rubricProvenance` field today. |
 | 2026-08-07 | #412 | lite | Renamed `Network.homepage` to `homepageURL`, the second firing of the `next-major.md` queue: the item was deferred out of 19.0.0 on 2026-07-27 as cosmetic scope creep on a bug fix, and shipped here because the file was read when the 20.0.0 window opened — the deferral mechanism working end to end. Equally deliberate was the entry that did **not** ship: `TMDbError.invalidRating` stayed deferred because its own condition (a wider `TMDbError` review) was unmet, and that was recorded rather than skipped, so a later reader can tell "considered and declined" from "missed". Stacked on `feature/v4-lists` rather than branched from `main`, since both edit the same `CHANGELOG` section. Its "one improvement" — have `next-major.md` carry a status line naming the open major window, so an entry cannot be filed against a version that already shipped — **shipped**, and `/capture-knowledge` asserts it on every addition today. |

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -863,13 +863,19 @@ so it also blocks commands that were never leaving. Seen refusing:
   defeat the static check. Rewrite the pattern without it (here,
   `awk '$4 !~ /^knowledge\//'` over `git ls-tree`'s tab-separated output).
 
-Workarounds, in order of preference: keep each command **single-purpose with
-fully literal paths** (`sed -i '' 's/…/…/' /abs/literal/path` succeeded where the
-`jq`+`mv` equivalent was refused); write scratch output **inside** the worktree
-under `.build/` (gitignored); or delegate the work to a subagent, which is not
-subject to the caller's guard. `Edit`/`Write` on a path outside the worktree are
-refused too, with a pointer to the worktree copy — which is wrong for
-`.git/`-relative state, so reach for `sed` there.
+**For the `/deliver` run file the sanctioned route is now
+`Scripts/deliver-runfile.py`** (ADR-0015 addendum, 2026-08-22):
+`python3 Scripts/deliver-runfile.py set /abs/literal/path <dotted.path> <value>`
+is single-purpose with literal arguments — the shape the guard accepts — and it
+verifies its own postcondition, so a swallowed write exits non-zero instead of
+looking like success. For everything else, workarounds in order of preference:
+keep each command **single-purpose with fully literal paths** (`sed -i ''
+'s/…/…/' /abs/literal/path` succeeded where the `jq`+`mv` equivalent was
+refused); write scratch output **inside** the worktree under `.build/`
+(gitignored); or delegate the work to a subagent, which is not subject to the
+caller's guard. `Edit`/`Write` on a path outside the worktree are refused too,
+with a pointer to the worktree copy — which is wrong for `.git/`-relative
+state, so reach for the script (run file) or `sed` (anything else) there.
 
 **Some refusals are silent — assume nothing landed until you check.** *2026-08-20
 (PR #474).* A `python3 - <<'EOF'` heredoc rewriting the `/deliver` run file in
@@ -888,7 +894,10 @@ cp /abs/literal/worktree/.build/deliver-tmp/run.json /abs/literal/.git/deliver/<
 ```
 
 Whatever route you take, **verify with a `grep` for a string you just wrote**.
-A write to `.git/` that reports nothing has told you nothing.
+A write to `.git/` that reports nothing has told you nothing. For the run file
+that verification is built in now — `Scripts/deliver-runfile.py` re-reads the
+file and exits `2` when the value is not on disk — so the staged-`cp` idiom
+above survives only for *other* out-of-worktree writes.
 
 ### `deliver-panel`'s `artifacts` must be an **array**, not a string
 

--- a/knowledge/gotchas.md
+++ b/knowledge/gotchas.md
@@ -1,10 +1,12 @@
 # Gotchas & Lookups
 
 Implementation quirks, tooling traps, and things that needed a lookup to resolve.
-Within each section, **dated entries are newest-first** and undated evergreen
-conventions sit at the bottom. Keep each entry short, and **date every entry
-that records an observation** (an undated entry can never be aged out); link an
-ADR if a decision came out of it. Cite the **PR** that did the work, not the
+Entries are **grouped by topic within each section** (not strictly
+newest-first — related traps sit together so a reader finds the family, not
+just the latest instance). Keep each entry short, and **date every entry
+that records an observation** (an undated entry can never be aged out; a few
+undated evergreen conventions exist and are convention-shaped on purpose); link
+an ADR if a decision came out of it. Cite the **PR** that did the work, not the
 issue — see `README.md`.
 
 ## False green — the recurring failure family
@@ -96,7 +98,7 @@ be **importable**, so pass `top_level_dir` equal to the start directory (or add
 an `__init__.py`) — otherwise it fails with *"Start directory is not
 importable"*.
 
-### The `Lint` job gates its own `Checkout` on `swift`, and PRs ignore `on.paths`
+### A `Lint` step gated more widely than `Checkout` runs with no repository — and PRs ignore `on.paths`
 
 *2026-08-20 (PR #476).* Two facts about `.github/workflows/ci.yml` that decide
 whether a check you add actually runs.
@@ -178,7 +180,7 @@ at the moment you notice it, not a tidiness issue.
 - **An enumeration inside a single file.** A third test was added to a section,
   and two other lists in the *same file* still enumerated only the first two.
 
-*Recurred 2026-08-20 (issue 481), four more times, in the delivery whose whole
+*Recurred 2026-08-20 (#482), four more times, in the delivery whose whole
 purpose was closing this class.* The reflexive set turned out to have a **third**
 copy (`deliver/references/worktree-lifecycle.md`) missing `.claude/workflows/**`,
 while `SKILL.md` asserted the set was "quoted in exactly one other place". Then
@@ -220,7 +222,7 @@ copy, so which one wins is unpredictable. Countermeasures, cheapest first:
 
 ### A test that asserts on prose can be blind — mutation-test it, don't read the green
 
-*2026-08-20 (PR for issue 481).* This repo now guards prose rules with tests that
+*2026-08-20 (#482).* This repo now guards prose rules with tests that
 read the skill files off disk (`Scripts/tests/test_deliver_selection_prose.py`,
 `test_build_run_list.py`'s `AntiDriftTests`). Those tests are the countermeasure
 for the entry above — and in one delivery **three** of them passed while checking
@@ -258,8 +260,8 @@ Two of those started GREEN. Prefer asserting a **canonical phrase** (here
 
 ### Anti-drift tests must enumerate with `git ls-files`, never a filesystem glob
 
-*2026-08-20 (PR for issue 481).* `.claude/worktrees/` is gitignored
-(`.gitignore:19`) but **present on disk**, and it holds a complete second copy of
+*2026-08-20 (#482).* `.claude/worktrees/` is gitignored
+(`.gitignore:18`) but **present on disk**, and it holds a complete second copy of
 every skill file — one per in-flight `/deliver` run, and concurrent runs are
 explicitly sanctioned. So a test globbing `.claude/**/*.md` walks *other
 branches'* checkouts: it is red locally and green in CI, non-deterministically,
@@ -429,10 +431,15 @@ while the PR merges green. Adding a job means editing both. This is the same
 hardcoded-in-N-places trap `CLAUDE.md` records for test-target names — which is
 now **five** sites, the fifth being the `unit-test-timezones` matrix job.
 
-Note also that every job is gated on `needs.changes.outputs.swift == 'true'`, and
-the aggregate treats `skipped` as a pass. That is fine for a build job, but it
-means a behaviour change that touches no `*.swift` — a JSON fixture, a workflow —
-is not covered by the jobs that would have proven it.
+Note also that the aggregate treats `skipped` as a pass, so the paths filter
+decides what a green `ci` check actually proved. The `swift` key is deliberately
+wider than `*.swift` — it includes `Tests/TMDbTests/Resources/**` (fixtures are
+a build input of `TMDbTests`), `Package.swift`, `Scripts/**`, `Makefile`,
+`Sources/TMDb/TMDb.docc/**`, `README.md` and `.github/workflows/ci.yml` — so a
+fixture-only or ci.yml-only change *does* run the build/test jobs. The residual
+gap is narrower: a PR touching only a **non-ci** workflow (`claude.yml`,
+`codeql.yml`, `documentation.yml`, `integration*.yml`) sets only `markdown`, so
+the build/test jobs skip and the aggregate passes on skips.
 
 ### No workflow runs `make` — a check added to a `make` target does not reach CI
 

--- a/knowledge/next-major.md
+++ b/knowledge/next-major.md
@@ -7,7 +7,9 @@ them at release time — they missed the 19.0.0 window as a result.
 
 **Read this when:** you open a `[X.0.0]` section in `CHANGELOG.md` (the
 sentinel comment there points here), or a plan already contains one breaking
-change (batch deliberately, or record why not).
+change (batch deliberately, or record why not) — and **`/cut-release` reads it
+before tagging**, which is the backstop for entries queued after the CHANGELOG
+section was already open.
 **Write to it** via `/capture-knowledge` whenever a fix is rejected or
 deferred *because* it is breaking. **Remove an entry when it ships** (the
 CHANGELOG records it) or is rejected outright (record that in
@@ -21,7 +23,7 @@ CHANGELOG records it) or is rejected outright (record that in
 > `skill-improvement-log.md` entry of the same date. Anything added here now is
 > queued for **21.0.0** unless 20.0.0 is still untagged when you read this.
 >
-> **Still untagged as of 2026-08-13** (latest tag is `19.0.0`), so the two
+> **Still untagged as of 2026-08-22** (latest tag is `19.0.0`), so the two
 > `TMDbIntelligence` vocabulary entries added that day are deferred by **scope
 > choice, not by the window** — they were consciously left out of issue #420's
 > delivery to keep its diff focused, and could still land in 20.0.0 if someone

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -64,6 +64,8 @@ those two runs stay comparable.
 
 ---
 
+### 2026-08-22 — /review-knowledge run · 8 agents · 1364117 tokens · 0 critical / 12 major / 27 minor
+
 ### 2026-08-21 — The run file lives where the worktree guard forbids writing (#490) · applied
 
 - **Pattern:** `/deliver`'s run file is specified to live at
@@ -74,17 +76,19 @@ those two runs stay comparable.
   fights the guard. The friction appears in **four** retro entries
   (`delivery-retros.md`: #432, #476, #486, and this delivery), and #432 states
   the contradiction outright — *"its run-file location is at odds with its
-  worktree isolation"*. It is not in this log, so it has recurred four times
-  without ever being raised as a proposal.
+  worktree isolation"*. It had been raised once before — the 2026-08-12 #440
+  entry below, same root cause, decided together with this one — and recurred
+  four more times in between without the two ever being connected.
 
   The failure is not a hard block — it is a tax. The refusal message asks you to
   "split it into plain, separate commands", so each write becomes write-a-script
   then run-it, and long heredocs are refused where shorter writes to the same
   path succeed (it keys on complexity, not permissions). This delivery paid it
   roughly six times: every `stamps` update, the reconcile record, the rubric,
-  and the plan file. `worktree-lifecycle.md` already documents the workaround —
-  a fully literal path with a single-purpose command — which is evidence the
-  friction is known and has been absorbed rather than fixed.
+  and the plan file. `worktree-lifecycle.md` documented the workaround —
+  a fully literal path with a single-purpose command — which was evidence the
+  friction was known and had been absorbed; it stayed absorbed rather than
+  fixed until this entry's decision.
 
 - **Decision:** **applied** (Adam's review, 2026-08-22, this PR — deciding this
   entry and the 2026-08-12 #440 entry together, same root cause). Option (a)
@@ -126,10 +130,10 @@ those two runs stay comparable.
   from the artifact it told me to check"*. So the failure mode is not slower
   writes; it is a **false certification to the mechanism that stands in for the
   user in auto mode**, which the run then had to disclose and re-panel to clear.
-  Weigh option (a) accordingly — and note that whichever option is chosen, the
-  cheap independent mitigation is to have every phase that writes state re-read
-  it and assert the change is present, treating a mismatch as a hard stop. That
-  mitigation is worth applying even if the file never moves.
+  This recurrence is what forced option (a) — and the independent mitigation it
+  called for (every state write re-read and asserted, mismatch = hard stop) is
+  now the script's own postcondition check, applied whatever happens to the
+  file's location.
 
 ### 2026-08-20 — Prove an absence-shaped test fails without the fix (#469) · applied
 
@@ -1135,6 +1139,9 @@ those two runs stay comparable.
   wrong.
 - **Reconsider when:** a deliberate major-version bump is on the table for other
   reasons — then reconsider as part of a broader `TMDbError` review, never alone.
+  *Closed retroactively by the 2026-08-12 entry above: the condition was met
+  when issue #419 reopened `TMDbError`, the question was re-examined there, and
+  the merge was rejected outright — never for the merge itself.*
 
 ### 2026-06-30 — Align `Network` to `Company` (rename `homepage`, force `logoPath` non-optional) · rejected
 

--- a/knowledge/skill-improvement-log.md
+++ b/knowledge/skill-improvement-log.md
@@ -64,7 +64,7 @@ those two runs stay comparable.
 
 ---
 
-### 2026-08-21 — The run file lives where the worktree guard forbids writing (#490) · deferred
+### 2026-08-21 — The run file lives where the worktree guard forbids writing (#490) · applied
 
 - **Pattern:** `/deliver`'s run file is specified to live at
   `.git/deliver/<id>.json` — deliberately, so it cannot enter a diff and
@@ -86,24 +86,33 @@ those two runs stay comparable.
   a fully literal path with a single-purpose command — which is evidence the
   friction is known and has been absorbed rather than fixed.
 
-- **Decision:** **deferred — raised unattended, needs review.** This run was
-  `/deliver auto next`; Phase 11 is not a delegable decision point, and a
-  proposal that would edit the pipeline's own skills must not be applied by an
-  unattended run.
+- **Decision:** **applied** (Adam's review, 2026-08-22, this PR — deciding this
+  entry and the 2026-08-12 #440 entry together, same root cause). Option (a)
+  plus the independent mitigation the evidence below called for:
+  `Scripts/deliver-runfile.py` is the sanctioned route for every
+  post-`EnterWorktree` run-file write — a single-purpose, literal-argument
+  command the guard accepts — and it **verifies its own postcondition** (re-reads
+  the file from disk, exits `2` when the value is not there), with callers
+  treating any non-zero exit as a hard stop. Landed in
+  `Scripts/deliver-runfile.py` + a `Scripts/tests/test_deliver_runfile.py`
+  suite (including a mutation case proving the verifier can fail),
+  `deliver/SKILL.md` Contract §6, `references/worktree-lifecycle.md`,
+  `knowledge/gotchas.md`, and an ADR-0015 addendum. The file stays at
+  `.git/deliver/` — the batch/teardown survival properties ADR-0015 chose are
+  kept.
 
-- **Rationale:** four recurrences without a log entry is exactly the shape this
-  log exists to stop — each delivery re-derives the same workaround from
-  scratch. Three shapes are worth weighing, and the choice is a real judgement
-  rather than an obvious fix: (a) keep the location and make the workaround
-  first-class — a tiny `Scripts/deliver-runfile.py` with a fixed literal path
-  that the guard accepts, called by every phase that stamps; (b) move the file
-  inside the worktree and accept losing the batch/teardown survival properties
-  ADR-0015 chose it for; (c) leave it, and treat the tax as the cost of the
-  isolation guarantee. (a) looks cheapest and preserves the ADR's reasoning, but
-  it adds a script to the reflexive set.
+- **Rationale:** of the three shapes weighed at deferral — (a) make the
+  workaround first-class as a script; (b) move the file into the worktree,
+  losing ADR-0015's batch properties; (c) absorb the tax — (a) is the only one
+  that keeps the ADR's structural guarantee *and* closes the #493 failure mode,
+  because the postcondition check turns a silent refusal into a loud stop
+  wherever the file lives. The script does join the pipeline's reflexive
+  surface; its own test suite (run by `make lint` via
+  `Scripts/run-script-tests.py`) is the compensating gate.
 
-- **Reconsider when:** a human reviews this entry, or the guard's behaviour
-  changes such that `.git/`-adjacent writes stop being refused.
+- **Reconsider when:** n/a (applied). If the guard ever refuses the script
+  invocation itself, the fallback is delegating the write to a subagent (not
+  subject to the caller's guard) — never an unverified ad-hoc write.
 
 - **Evidence added 2026-08-21 (PR #493), not a new proposal.** A fifth
   recurrence, and it **falsifies this entry's own severity assessment**: "not a
@@ -122,7 +131,7 @@ those two runs stay comparable.
   it and assert the change is present, treating a mismatch as a hard stop. That
   mitigation is worth applying even if the file never moves.
 
-### 2026-08-20 — Prove an absence-shaped test fails without the fix (#469) · deferred
+### 2026-08-20 — Prove an absence-shaped test fails without the fix (#469) · applied
 
 - **Pattern:** the **False green** family, in its absence-assertion form. When a
   fix means "this value must no longer appear", every test asserts a negative —
@@ -136,19 +145,53 @@ those two runs stay comparable.
   "found" and "nothing found" were byte-identical; a cached SwiftLint false
   green; a check re-read from an earlier tip) and heads `gotchas.md`, but every
   instance so far has been caught after the fact rather than by a step.
-- **Decision:** **deferred — raised unattended, needs review.** Nothing applied.
-  The candidate is a Phase 3 checkpoint for redaction/absence-shaped work:
-  before declaring implementation done, unwire the fix, confirm the new tests
-  fail, restore. Scope is the open question — a blanket rule would be noise on
-  the many deliveries whose assertions are positive, so it likely wants a
-  trigger ("the acceptance criteria are phrased as *X no longer appears*")
-  rather than an unconditional step.
-- **Rationale:** raised by an autonomous `/deliver auto` run, which must not
-  edit the pipeline's own skills without review. Recording it here rather than
-  applying it is the Phase 11 contract for auto mode.
-- **Reconsider when:** Adam reviews this entry — or when a second delivery whose
-  fix is an absence ships a test that would have passed without the fix, which
-  would make the trigger condition concrete rather than hypothetical.
+- **Decision:** **applied** (Adam's review, 2026-08-22, this PR). `/deliver`
+  Phase 3 gains a fourth hard checkpoint — *An absence-shaped fix must be
+  proven able to fail* — with exactly the trigger this entry proposed: it fires
+  only when the acceptance criteria are phrased as an absence (*"X no longer
+  appears / is no longer sent / is redacted"*). Before declaring the test list
+  empty: unwire the fix, confirm the new tests go red, restore, confirm green,
+  record in the retro. Positive-assertion deliveries pay nothing.
+- **Rationale:** a negative assertion passes just as happily when the value was
+  never there, the key was renamed upstream, or the code path is never reached
+  — so for this class the revert-and-demand-red minute is the only evidence
+  that separates "the fix works" from "the test cannot tell". Scoping by the
+  ACs' phrasing keeps it off the majority of deliveries, whose assertions are
+  positive and already policed by the compiler and the existing gates.
+- **Reconsider when:** n/a (applied). If the trigger proves too narrow — an
+  absence-shaped fix arriving without absence-phrased ACs — widen the trigger
+  wording, not the checkpoint into a blanket rule.
+
+### 2026-08-20 — Mutation-check a reflexive delivery's anti-drift tests · applied
+
+- **Pattern:** a **fifth** instance of the partial-sweep family, but with a new
+  twist that none of the four existing rules reach: in PR #482 the sweep *was*
+  performed and the executable check *was* added — and the check was **blind**.
+  Three assertions passed while testing nothing (a line window bleeding into the
+  neighbouring bullet; a string-replace that updated a docstring but not the
+  regex it described; narrative prose about a past drift supplying the very
+  token under test). Two only broke once deliberately broken. Meanwhile rounds 2
+  and 3 of the review each found defects **in the previous round's fixes**, so
+  Phase 4's 3-iteration cap was measuring the wrong thing.
+- **Decision:** **applied** (Adam's review, 2026-08-22, this PR — closes issue
+  #485, which carried the fix sketch). `/deliver` Phase 4 gains a
+  *mutation-check before converging* step, scoped exactly as filed: it fires
+  only when `reflexive: true` **and** the diff adds or changes a
+  prose-asserting test. For each rule the new tests guard — baseline green,
+  revert that rule alone in a scratch copy, demand red *for that rule*,
+  restore — with the matrix recorded in the retro, and
+  `knowledge/gotchas.md` → *A test that asserts on prose can be blind* linked
+  rather than restated. Swift suites stay exempt.
+- **Rationale:** the four existing sweep rules all assume that *doing* the sweep
+  is the hard part. This class is different — the sweep was done and encoded in a
+  test, and the test was the thing that lied. The countermeasure is cheap
+  (revert each guarded rule, demand red, confirm the baseline is green) and it is
+  the only evidence that separates "fixed" from "looks fixed" when the deliverable
+  is prose. Recorded in `knowledge/gotchas.md` → *A test that asserts on prose can
+  be blind* with the worked matrix.
+- **Reconsider when:** n/a (applied). The scope stands as filed — widening it
+  to every delivery would demand a mutation pass on Swift suites, where the
+  compiler and `--Werror` already do this work.
 
 ### 2026-08-14 — Review granularity keys on risk surface, not diff shape · applied
 
@@ -252,35 +295,6 @@ those two runs stay comparable.
   general rule: for a named "every instance of X" task, require the enumeration
   to be pasted into the test list with its source (LSP query vs grep), so the
   instrument is visible in review rather than inferred.
-
----
-
-### 2026-08-20 — Mutation-check a reflexive delivery's anti-drift tests · deferred
-
-- **Pattern:** a **fifth** instance of the partial-sweep family, but with a new
-  twist that none of the four existing rules reach: in PR #482 the sweep *was*
-  performed and the executable check *was* added — and the check was **blind**.
-  Three assertions passed while testing nothing (a line window bleeding into the
-  neighbouring bullet; a string-replace that updated a docstring but not the
-  regex it described; narrative prose about a past drift supplying the very
-  token under test). Two only broke once deliberately broken. Meanwhile rounds 2
-  and 3 of the review each found defects **in the previous round's fixes**, so
-  Phase 4's 3-iteration cap was measuring the wrong thing.
-- **Decision:** **deferred — raised unattended, needs review.** `/deliver auto`
-  must not edit and push the repo's own skill files, so no skill file was
-  touched. Filed as issue #485 with the fix sketch instead, so the proposal is
-  actionable rather than only logged.
-- **Rationale:** the four existing sweep rules all assume that *doing* the sweep
-  is the hard part. This class is different — the sweep was done and encoded in a
-  test, and the test was the thing that lied. The countermeasure is cheap
-  (revert each guarded rule, demand red, confirm the baseline is green) and it is
-  the only evidence that separates "fixed" from "looks fixed" when the deliverable
-  is prose. Recorded in `knowledge/gotchas.md` → *A test that asserts on prose can
-  be blind* with the worked matrix.
-- **Reconsider when:** Adam reviews issue #485. Keep it scoped to
-  `reflexive: true` deliveries that add or change a prose-asserting test —
-  widening it to every delivery would demand a mutation pass on Swift suites,
-  where the compiler and `--Werror` already do this work.
 
 ---
 
@@ -522,7 +536,7 @@ those two runs stay comparable.
   ACs to be quoted in the PR body for inspection, not merely disclosed as
   derived.
 
-### 2026-08-12 — ADR-0015's run-file location is unreachable from a background delivery (#440) · deferred
+### 2026-08-12 — ADR-0015's run-file location is unreachable from a background delivery (#440) · applied
 
 - **Pattern:** first occurrence, but structural rather than incidental, so it will
   recur on every background `/deliver`. [ADR-0015](decisions/0015-durable-deliver-run-state.md)
@@ -533,24 +547,25 @@ those two runs stay comparable.
   tool, and then blocked a Bash heredoc to the same path. So the location the ADR
   mandates is unreachable exactly when `/deliver` runs unattended, which is the
   case the durable file exists for.
-- **Decision:** **deferred — raised in an unattended background run, needs
-  review; nothing applied.** Worked around by writing to
-  `<worktree>/.build/deliver-run.json` (gitignored via `/.build`, untouched by any
-  `make ci` step since `clean` is a separate target) and recording a
-  `locationDeviation` field in the file itself. Options for review: (a) teach the
-  isolation guard that the repo's *common git dir* is a sanctioned write target;
-  (b) amend ADR-0015 to put the file under the worktree with an explicit
-  cross-worktree-batch caveat; (c) leave it, and have `/deliver` fall back with a
-  recorded deviation, which is what happened here.
+- **Decision:** **applied 2026-08-22** — closed by the same decision as the
+  2026-08-21 #490 entry (same root cause): every post-`EnterWorktree` run-file
+  write now goes through `Scripts/deliver-runfile.py`, which the guard accepts
+  and which verifies its own postcondition; the location is unchanged, so
+  ADR-0015's batch properties survive. Of the three options this entry listed —
+  (a) teach the guard about the common git dir; (b) move the file under the
+  worktree; (c) keep the recorded-deviation fallback — none was taken as
+  written: (a) is harness behaviour, not this repo's to change, and the script
+  achieves its effect from inside the repo. At the time, the run worked around
+  it by writing to `<worktree>/.build/deliver-run.json` (gitignored via
+  `/.build`) with a `locationDeviation` field recorded in the file itself.
 - **Rationale:** the workaround is sound for a single-deliverable run — the file
   survives the whole delivery and Phase 6 read the rubric from it as designed.
   It is only *unsound for a batch*, where ADR-0015's whole point is that
   deliverable 1's `ExitWorktree(remove)` must not destroy deliverables 2..N's
   state. That case did not arise here, so applying a fix blind would be guessing
   at which of three quite different remedies the user wants.
-- **Reconsider when:** a multi-deliverable `/deliver` runs in a background
-  session — where the workaround is genuinely wrong, not merely non-canonical —
-  or the user picks one of the three options.
+- **Reconsider when:** n/a (applied — see the 2026-08-21 entry for the decision
+  and where it landed).
 
 ### 2026-08-12 — A well-formed tooling-runner report can still assert an unobserved green (#432) · applied
 
@@ -1350,13 +1365,21 @@ those two runs stay comparable.
   critics may cite" (never "load opinions to agree with"), and only after
   confirming wiki MCP reachability inside the review-plan Workflow.
 
-### 2026-06-18 — File-based `.claude/deliver-state.json` ledger · deferred
+### 2026-06-18 — File-based `.claude/deliver-state.json` ledger · applied
 
 - **Pattern:** the `TaskCreate` phase ledger is ephemeral; a long interrupted
   session has no durable recovery path beyond "read the ledger if it survived".
-- **Decision:** **deferred.** Not implemented.
-- **Rationale:** `TaskCreate` + the checkpoint commits + git history already give
-  a real recovery path; a committed JSON state file adds PR noise (or, if
-  gitignored, isn't on the branch for anyone else).
-- **Reconsider when:** interruptions actually bite — and even then prefer the
-  lighter "checkpoint the ledger into the PR description" over a new state machine.
+- **Decision:** originally **deferred** (not implemented) — and **closed as
+  applied on 2026-08-22**: [ADR-0015](decisions/0015-durable-deliver-run-state.md)
+  (2026-07-29) built the durable state this entry deferred, as a run file at
+  `.git/deliver/<id>.json` rather than a committed working-tree file — which
+  also dissolves this entry's PR-noise objection, since `.git/` cannot enter a
+  diff. Later hardened with script-mediated, self-verifying writes (the
+  2026-08-21 entry above).
+- **Rationale:** the reconsider condition ("interruptions actually bite") was
+  met by the evidence that drove ADR-0015 — four of eleven analysed sessions
+  ended "partially achieved" because work outran the transcript — and nobody
+  came back to close this entry.
+- **Reconsider when:** n/a (applied via ADR-0015). *Closed retroactively by the
+  2026-08-22 log review — a stale `deferred` in this file is a live defect: the
+  scan reads it as the current state of a settled question.*

--- a/knowledge/tmdb-api-notes.md
+++ b/knowledge/tmdb-api-notes.md
@@ -2,7 +2,11 @@
 
 Behaviours of the **live** TMDb API discovered while implementing — the things the
 docs don't say, or say wrongly. This is an API-client library, so these recur.
-Newest at the top; cite the endpoint and the date observed.
+Newest at the top; cite the endpoint and **the date observed** for every entry
+that records a measurement (a section preamble date counts when it names which
+entries it covers). A handful of undated entries are working *conventions* —
+how to read the spec, how to decide optionality — not observations, and carry
+no date on purpose: a convention cannot go stale the way a measurement can.
 
 ## v4 API
 
@@ -498,7 +502,8 @@ empty strings, not `null` and not absent. `TVSeriesTranslationData` types
 
 ## Response shapes
 
-*All three measured 2026-08-14 while re-capturing orphaned fixtures (#457).*
+*Measured 2026-08-14 while re-capturing orphaned fixtures (#457), except where
+an entry carries its own date.*
 
 ### `/tv/{id}/watch/providers` keys `results` by country — an object, not an array
 


### PR DESCRIPTION
## Summary

Two pieces of reviewed work in one PR, per Adam's direction: **apply the three actions from the skill-improvement-log review** (with the recommended decisions), and **run `/review-knowledge`** with its consensus applied so the audit rides this PR.

Closes #485

### 1. The run-file/worktree-guard decision (log entries 2026-08-21/#490 and 2026-08-12/#440, decided together)

- **`Scripts/deliver-runfile.py`** — the sanctioned route for every post-`EnterWorktree` run-file write: a single-purpose, literal-argument command the worktree guard accepts, whose write happens inside the interpreter. It **verifies its own postcondition** — re-reads the file from disk and exits `2` when the value is not there — so the #474 silent-refusal failure (and #493's false certification to the juror panel) becomes a loud hard stop instead of an invisible non-write.
- 13-test suite in `Scripts/tests/test_deliver_runfile.py`, including a **mutation case** that suppresses the write and demands the verifier scream (exit 2). `run-script-tests.py`'s exact floor bumped 75 → 88.
- `deliver/SKILL.md` Contract §6, `worktree-lifecycle.md`, and `gotchas.md` all route writes through the script; **ADR-0015 addendum** records the decision. The file stays at `.git/deliver/` — ADR-0015's batch/teardown survival properties are kept.

### 2. The two false-green countermeasures (accepted as scoped)

- **`/deliver` Phase 3, fourth hard checkpoint** — an absence-shaped fix must be proven able to fail: when the ACs read "X no longer appears", unwire the fix, demand red, restore. Triggered by the ACs' phrasing only (log entry 2026-08-20/#469).
- **`/deliver` Phase 4, mutation-check before converging** — for `reflexive: true` deliveries that add or change a prose-asserting test: baseline green, revert each guarded rule alone, demand red for that rule. Scoped exactly per issue #485's sketch; Swift suites exempt.

### 3. Log housekeeping

- 2026-06-18 file-based-ledger `deferred` closed retroactively as applied via ADR-0015 (a stale deferred is a live defect for the dedup scan).
- The out-of-order 2026-08-20 mutation-check entry moved back to newest-first position.
- Credential rotation — flagged outstanding since the #441–#446 audit but never tracked — filed as **issue #497** (only the account owner can rotate).

### 4. `/review-knowledge` run (8 agents, ~1.36M tokens; 0 critical / 12 major / 27 minor consensus; 0 refuted)

All mechanical, confirmed findings applied — highlights:

- **`.claude/` tree**: `/review-changes`' force-review no longer silently downgrades a full-weight reflexive diff to the single-reviewer path; `/deliver` gains the stamp-writing steps for all three run-file stamps (`rubricGraded` was named by no phase) and mirrors `openFindings`/`knowledgeCandidates` into the run file; Phase 11 regains wrap-up.md's raise-unrecorded-singletons rule; `/diagnose-ci-failure` now routes all **six** real CI jobs (the platform and time-zone matrices had no route) and its lint/markdown references describe the current eight-step Lint job and six-glob markdown lint; assorted garbled sentences, stale counts and the auto-mode-"unexercised" claim corrected.
- **`CLAUDE.md`**: the TMDbFactory self-contradiction fixed, the xcode-MCP guidance now matches what a terminal session actually gets, and the `PreToolUse` main-branch guard hook is documented where the Branching rule states it.
- **`knowledge/`**: the gotchas "every job is gated on swift" paragraph — false at birth — rewritten to the present tree; the retro window distilled back to 12 entries with a scope note; the ADR index README now codifies the extending-addendum pattern the tree already practices (resolving the immutability findings against ADR-0015/0016); three ADR headers normalised to the template; stale cites, an off-by-one `file:line`, and this PR's own half-updated log entries fixed (the audit caught three defects in this PR's first commit — it earned its keep immediately).
- **First run record** appended to the log in ADR-0020's sanctioned shape. Backfilling PR #468's audit was **declined**: its token count and severity split are unrecoverable in the mandated shape, and a malformed line breaks the two-consecutive-runs comparison the shape exists for.
- Three findings are machinery, not prose, and were **filed instead of applied**: #498 (a `check-knowledge-hygiene.py` lint gate), #499 (the triage marker lacks the `verifiedBy` fact skip-condition 4 reads), #500 (`/capture-knowledge` should verify checkable claims at write time).
- One open question deliberately left for Adam: whether `.mcp.json`'s `xcode` server registration should be dropped as redundant (the prose contradiction is fixed either way).

## Verification

- `python3 Scripts/run-script-tests.py` — 88/88 green (includes the new writer suite and the prose anti-drift suites over the edited skill files).
- `make lint` + `make lint-markdown` green — the `/pr`-sanctioned narrowed gate (no `*.swift`, `Makefile`, `Package.swift`, workflows, fixtures or `.docc` in the diff; the new Python is gated by `make lint`'s own `lint-run-list` target, which ran).
- Reflexive change: the edited skills cannot be dogfooded before merge (registry loads from the main checkout) — verified by reading; the run-file script itself **is** exercised, by its suite and its postcondition test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01KvDtcr5yAan1CrtQtT5Q1x>
